### PR TITLE
Return 404 on link not found

### DIFF
--- a/lib/middleware/link.ts
+++ b/lib/middleware/link.ts
@@ -63,6 +63,6 @@ export default async function LinkMiddleware(
     }
   } else {
     // short link not found, redirect to root
-    return NextResponse.redirect(new URL("/", req.url), REDIRECT_HEADERS);
+    return new NextResponse(null, { status: 404 });
   }
 }


### PR DESCRIPTION
Current Behaviour:
- When the link is expired or if the link is a bad one, the site shown is dub.sh landing page. Which would get users confused
https://github.com/steven-tey/dub/blob/1b0e3caf554743145f68818f8e3474050aa4c674/lib/middleware/link.ts#L66C5-L66C5

Change:
- Added a 404 return status using NextResponse in the LinkMiddleware.

Let me know if anything has to change 🙂
