### PR TITLE
fix settings layout sticky navbar for mobile devices

### DIFF
--- a/apps/web/ui/layout/settings-layout.tsx
+++ b/apps/web/ui/layout/settings-layout.tsx
@@ -21,8 +21,8 @@ export default function SettingsLayout({
           </div>
         </MaxWidthWrapper>
       </div>
-      <MaxWidthWrapper className="grid items-start gap-5 py-10 md:grid-cols-5">
-        <div className="sticky top-36 flex gap-1 md:grid">
+      <MaxWidthWrapper className="grid items-start gap-5 pb-10 pt-2 md:grid-cols-5">
+        <div className="sticky top-[calc(7rem-2px)] pt-8 bg-white flex gap-1 md:grid z-20">
           {tabs.map(({ name, segment }) => (
             <NavLink segment={segment}>{name}</NavLink>
           ))}


### PR DESCRIPTION
Before :
settings page sticky navbar does not have background color and z-index , so it not look correct on mobile screen 
 
![settings-page-link-does-not have-background](https://github.com/steven-tey/dub/assets/97441447/7c924957-1ec7-4a11-a10a-30316cdc7eb0)
![before-settings-page-links-overflowing](https://github.com/steven-tey/dub/assets/97441447/95f4e3f7-f82b-447d-bb8e-e085266c4000)

After:
added background-color and z-Index to setting-page sticky navbar  
![after-fix-settings-page-sticky-navbar](https://github.com/steven-tey/dub/assets/97441447/c964628c-76a3-426f-89a9-da93bc8c38ce)
