### PR TITLE
Add "Expired Link" page for expired links

### DIFF
--- a/apps/docs/api-reference/endpoint/bulk-create-links.mdx
+++ b/apps/docs/api-reference/endpoint/bulk-create-links.mdx
@@ -11,8 +11,8 @@ description: Bulk create up to 100 links for the authenticated project.
 <Warning>
   Bulk link creation does not support the following features: [Link
   cloaking](https://dub.co/help/article/how-to-create-link#link-cloaking),
-  [Custom social media
-  cards](https://dub.co/help/article/how-to-create-link#custom-social-media-cards)
+  [Custom social media cards](https://dub.co/help/article/how-to-create-link#custom-social-media-cards), 
+  [Expiration date](https://dub.co/help/article/how-to-create-link#expiration-date)
 </Warning>
 
 <RequestExample>

--- a/apps/web/app/api/callback/expire/route.ts
+++ b/apps/web/app/api/callback/expire/route.ts
@@ -19,8 +19,6 @@ export async function POST(req: Request) {
     return new Response("Missing link ID", { status: 200 });
   }
 
-  console.log({ linkId });
-
   const link = await prisma.link.findUnique({
     where: {
       id: linkId,
@@ -36,8 +34,11 @@ export async function POST(req: Request) {
     return new Response("Link not found", { status: 200 });
   }
 
-  if (!link.expiresAt || link.expiresAt < new Date()) {
-    return new Response("Link already expired", { status: 200 });
+  if (!link.expiresAt || link.expiresAt > new Date()) {
+    return new Response(
+      "Link is not expired or does not have an expiration date",
+      { status: 200 },
+    );
   }
 
   const { domain, key } = link;

--- a/apps/web/app/api/callback/expire/route.ts
+++ b/apps/web/app/api/callback/expire/route.ts
@@ -1,0 +1,57 @@
+import { receiver } from "@/lib/cron";
+import prisma from "@/lib/prisma";
+import { redis } from "@/lib/upstash";
+
+export async function POST(req: Request) {
+  const body = await req.json();
+  if (process.env.VERCEL === "1") {
+    const isValid = await receiver.verify({
+      signature: req.headers.get("Upstash-Signature") || "",
+      body: JSON.stringify(body),
+    });
+    if (!isValid) {
+      return new Response("Unauthorized", { status: 401 });
+    }
+  }
+
+  const { linkId } = body;
+  if (!linkId) {
+    return new Response("Missing link ID", { status: 200 });
+  }
+
+  console.log({ linkId });
+
+  const link = await prisma.link.findUnique({
+    where: {
+      id: linkId,
+    },
+    select: {
+      domain: true,
+      key: true,
+      expiresAt: true,
+    },
+  });
+
+  if (!link) {
+    return new Response("Link not found", { status: 200 });
+  }
+
+  if (!link.expiresAt || link.expiresAt < new Date()) {
+    return new Response("Link already expired", { status: 200 });
+  }
+
+  const { domain, key } = link;
+
+  const redisLink = await redis.get(`${domain}:${key}`);
+
+  if (!redisLink) {
+    return new Response("Link not found", { status: 404 });
+  }
+
+  await redis.set(`${domain}:${key}`, {
+    ...redisLink,
+    expired: true,
+  });
+
+  return new Response("Successfully expired link", { status: 200 });
+}

--- a/apps/web/app/expired/[domain]/[key]/page.tsx
+++ b/apps/web/app/expired/[domain]/[key]/page.tsx
@@ -1,0 +1,54 @@
+import { getLinkViaEdge } from "@/lib/planetscale";
+import { Background, Footer, Nav } from "@dub/ui";
+import { constructMetadata } from "@dub/utils";
+import { TimerOff } from "lucide-react";
+import { notFound } from "next/navigation";
+
+export const runtime = "edge";
+
+export const metadata = constructMetadata({
+  title: "Expired Link – Dub.co",
+  description:
+    "This link has expired. Please contact the owner of this link to get a new one.",
+  noIndex: true,
+});
+
+export default async function ExpiredPage({
+  params,
+}: {
+  params: { domain: string; key: string };
+}) {
+  const domain = params.domain;
+  const key = decodeURIComponent(params.key);
+
+  const data = await getLinkViaEdge(domain, key);
+
+  // if the link doesn't exist
+  if (!data) {
+    notFound();
+  }
+
+  return (
+    <main className="flex min-h-screen flex-col justify-between">
+      <Nav />
+      <div className="mx-2 my-10 flex max-w-md flex-col items-center space-y-5 px-2.5 text-center sm:mx-auto sm:max-w-lg sm:px-0 lg:mb-16">
+        <div className="mx-auto flex h-20 w-20 items-center justify-center rounded-full border border-gray-300 bg-white/30">
+          <TimerOff className="h-6 w-6 text-gray-400" />
+        </div>
+        <h1 className="font-display text-5xl font-bold">Expired Link</h1>
+        <p className="text-lg text-gray-600">
+          This link has expired. Please contact the owner of this link to get a
+          new one.
+        </p>
+        <a
+          href="https://dub.co"
+          className="rounded-full bg-gray-800 px-10 py-2 font-medium text-white transition-colors hover:bg-black"
+        >
+          Create Your Free Branded Link
+        </a>
+      </div>
+      <Footer />
+      <Background />
+    </main>
+  );
+}

--- a/apps/web/app/protected/[domain]/[key]/page.tsx
+++ b/apps/web/app/protected/[domain]/[key]/page.tsx
@@ -4,7 +4,7 @@ import prisma from "@/lib/prisma";
 import PasswordForm from "./form";
 import { notFound, redirect } from "next/navigation";
 
-const title = "Password Required";
+const title = "Password Required – Dub.co";
 const description =
   "This link is password protected. Please enter the password to view it.";
 const image = "https://dub.co/_static/password-protected.png";

--- a/apps/web/lib/api/links.ts
+++ b/apps/web/lib/api/links.ts
@@ -509,7 +509,7 @@ export async function addLink(link: LinkProps) {
   if (expiresAt && new Date(expiresAt) > new Date()) {
     await qstash.publishJSON({
       url: `${APP_DOMAIN_WITH_NGROK}/api/callback/expire`,
-      delay: new Date(expiresAt).getTime() - new Date().getTime(),
+      delay: (new Date(expiresAt).getTime() - new Date().getTime()) / 1000,
       body: {
         linkId: response.id,
       },
@@ -663,7 +663,8 @@ export async function editLink({
       ? [
           qstash.publishJSON({
             url: `${APP_DOMAIN_WITH_NGROK}/api/callback/expire`,
-            delay: new Date(expiresAt).getTime() - new Date().getTime(),
+            delay:
+              (new Date(expiresAt).getTime() - new Date().getTime()) / 1000,
             body: {
               linkId: id,
             },

--- a/apps/web/lib/api/links.ts
+++ b/apps/web/lib/api/links.ts
@@ -7,6 +7,7 @@ import {
 import prisma from "@/lib/prisma";
 import { redis } from "@/lib/upstash";
 import {
+  APP_DOMAIN_WITH_NGROK,
   DEFAULT_REDIRECTS,
   DUB_DOMAINS,
   DUB_PROJECT_ID,
@@ -23,7 +24,7 @@ import cloudinary from "cloudinary";
 import { isIframeable } from "../middleware/utils";
 import { LinkProps, ProjectProps } from "../types";
 import { Session } from "../auth";
-import { SetCommandOptions } from "@upstash/redis";
+import { qstash } from "../cron";
 
 export async function getLinksForProject({
   projectId,
@@ -221,7 +222,7 @@ export async function processLink({
   session?: Session;
   bulk?: boolean;
 }) {
-  let { domain, key, url, image, rewrite, geo } = payload;
+  let { domain, key, url, image, rewrite, expiresAt, geo } = payload;
 
   // url checks
   if (!url) {
@@ -390,6 +391,13 @@ export async function processLink({
         status: 422,
       };
     }
+    if (expiresAt) {
+      return {
+        link: payload,
+        error: "You cannot set expiry dates with bulk link creation.",
+        status: 422,
+      };
+    }
     const exists = await checkIfKeyExists(domain, key);
     if (exists) {
       return {
@@ -469,14 +477,14 @@ export async function addLink(link: LinkProps) {
           rewrite: true,
           iframeable: await isIframeable({ url, requestDomain: domain }),
         }),
+        expired: expiresAt && new Date(expiresAt) < new Date(),
         ...(ios && { ios }),
         ...(android && { android }),
         ...(geo && { geo }),
       },
       {
         nx: true,
-        ...(expiresAt && { exat: new Date(expiresAt).getTime() / 1000 }),
-      } as SetCommandOptions,
+      },
     ),
   ]);
 
@@ -496,13 +504,24 @@ export async function addLink(link: LinkProps) {
       },
     });
   }
+
+  // if link expires, schedule a job to expire it
+  if (expiresAt && new Date(expiresAt) > new Date()) {
+    await qstash.publishJSON({
+      url: `${APP_DOMAIN_WITH_NGROK}/api/callback/expire`,
+      delay: new Date(expiresAt).getTime() - new Date().getTime(),
+      body: {
+        linkId: response.id,
+      },
+    });
+  }
   return response;
 }
 
 export async function bulkCreateLinks(links: LinkProps[]) {
   if (links.length === 0) return [];
   const pipeline = redis.pipeline();
-  links.forEach(({ domain, key, url, expiresAt, password }) => {
+  links.forEach(({ domain, key, url, password }) => {
     const hasPassword = password && password.length > 0 ? true : false;
     pipeline.set(
       `${domain}:${key}`,
@@ -512,8 +531,7 @@ export async function bulkCreateLinks(links: LinkProps[]) {
       },
       {
         nx: true,
-        ...(expiresAt && { exat: new Date(expiresAt).getTime() / 1000 }),
-      } as SetCommandOptions,
+      },
     );
   });
 
@@ -628,24 +646,30 @@ export async function editLink({
       : cloudinary.v2.uploader.destroy(`${domain}/${key}`, {
           invalidate: true,
         }),
-    redis.set(
-      `${domain}:${key}`,
-      {
-        url: encodeURIComponent(url),
-        password: hasPassword,
-        proxy,
-        ...(rewrite && {
-          rewrite: true,
-          iframeable: await isIframeable({ url, requestDomain: domain }),
-        }),
-        ...(ios && { ios }),
-        ...(android && { android }),
-        ...(geo && { geo }),
-      },
-      {
-        ...(expiresAt && { exat: new Date(expiresAt).getTime() / 1000 }),
-      } as SetCommandOptions,
-    ),
+    redis.set(`${domain}:${key}`, {
+      url: encodeURIComponent(url),
+      password: hasPassword,
+      proxy,
+      ...(rewrite && {
+        rewrite: true,
+        iframeable: await isIframeable({ url, requestDomain: domain }),
+      }),
+      expired: expiresAt && new Date(expiresAt) < new Date(),
+      ...(ios && { ios }),
+      ...(android && { android }),
+      ...(geo && { geo }),
+    }),
+    ...(expiresAt && new Date(expiresAt) > new Date()
+      ? [
+          qstash.publishJSON({
+            url: `${APP_DOMAIN_WITH_NGROK}/api/callback/expire`,
+            delay: new Date(expiresAt).getTime() - new Date().getTime(),
+            body: {
+              linkId: id,
+            },
+          }),
+        ]
+      : []),
     // if key is changed: rename resource in Cloudinary, delete the old key in Redis and change the clicks key name
     ...(changedDomain || changedKey
       ? [

--- a/apps/web/lib/middleware/link.ts
+++ b/apps/web/lib/middleware/link.ts
@@ -48,6 +48,7 @@ export default async function LinkMiddleware(
     proxy?: boolean;
     rewrite?: boolean;
     iframeable?: boolean;
+    expired?: boolean;
     ios?: string;
     android?: string;
     geo?: object;
@@ -62,19 +63,21 @@ export default async function LinkMiddleware(
     proxy,
     rewrite,
     iframeable,
+    expired,
     ios,
     android,
     geo,
   } = response || {};
 
   if (target) {
-    // only show inspect model if the link is not password protected
+    // only show inspect modal if the link is not password protected
     if (inspectMode && !password) {
       return NextResponse.rewrite(
         new URL(`/inspect/${domain}/${encodeURIComponent(key)}`, req.url),
       );
     }
 
+    // if the link is password protected
     if (password) {
       const pw = req.nextUrl.searchParams.get("pw");
 
@@ -90,6 +93,13 @@ export default async function LinkMiddleware(
         // strip it from the URL if it's correct
         req.nextUrl.searchParams.delete("pw");
       }
+    }
+
+    // if the link has expired
+    if (expired) {
+      return NextResponse.rewrite(
+        new URL(`/expired/${domain}/${encodeURIComponent(key)}`, req.url),
+      );
     }
 
     // only track the click when there is no `dub-no-track` header

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,7 +24,7 @@
     "@splinetool/react-spline": "^2.2.6",
     "@splinetool/runtime": "^0.9.481",
     "@stripe/stripe-js": "^1.44.1",
-    "@upstash/qstash": "^0.3.6",
+    "@upstash/qstash": "^2.3.0",
     "@upstash/ratelimit": "^0.3.6",
     "@upstash/redis": "^1.25.1",
     "@vercel/analytics": "^1.0.0",

--- a/apps/web/ui/links/link-card.tsx
+++ b/apps/web/ui/links/link-card.tsx
@@ -40,6 +40,7 @@ import {
   EyeOff,
   MessageCircle,
   QrCode,
+  TimerOff,
 } from "lucide-react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
@@ -59,6 +60,7 @@ export default function LinkCard({
     domain,
     url,
     rewrite,
+    expiresAt,
     createdAt,
     lastClicked,
     archived,
@@ -122,6 +124,8 @@ export default function LinkCard({
       clicks: 0,
     },
   });
+
+  const expired = expiresAt && new Date(expiresAt) < new Date();
 
   const { setShowArchiveLinkModal, ArchiveLinkModal } = useArchiveLinkModal({
     props,
@@ -225,10 +229,20 @@ export default function LinkCard({
       )}
       <div className="relative flex items-center justify-between">
         <div className="relative flex shrink items-center">
-          {archived ? (
-            <Tooltip content="This link is archived. It will still work, but won't be shown in your dashboard.">
+          {archived || expired ? (
+            <Tooltip
+              content={
+                archived
+                  ? "This link is archived. It will still work, but won't be shown in your dashboard."
+                  : "This link has expired. It will still show up in your dashboard, but users will get an 'Expired' page when they click on it."
+              }
+            >
               <div className="flex h-8 w-8 items-center justify-center rounded-full bg-gray-300 px-0 sm:h-10 sm:w-10">
-                <Archive className="h-4 w-4 text-gray-500 sm:h-5 sm:w-5" />
+                {archived ? (
+                  <Archive className="h-4 w-4 text-gray-500 sm:h-5 sm:w-5" />
+                ) : (
+                  <TimerOff className="h-4 w-4 text-gray-500 sm:h-5 sm:w-5" />
+                )}
               </div>
             </Tooltip>
           ) : (
@@ -269,7 +283,7 @@ export default function LinkCard({
                   className={cn(
                     "w-full max-w-[140px] truncate text-sm font-semibold text-blue-800 sm:max-w-[300px] sm:text-base md:max-w-[360px] xl:max-w-[500px]",
                     {
-                      "text-gray-500": archived,
+                      "text-gray-500": archived || expired,
                     },
                   )}
                   href={linkConstructor({ key, domain })}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,8 +71,8 @@ importers:
         specifier: ^1.44.1
         version: 1.44.1
       '@upstash/qstash':
-        specifier: ^0.3.6
-        version: 0.3.6
+        specifier: ^2.3.0
+        version: 2.3.0
       '@upstash/ratelimit':
         specifier: ^0.3.6
         version: 0.3.6(@babel/core@7.17.8)(react-dom@18.2.0)
@@ -8009,6 +8009,13 @@ packages:
     resolution: {integrity: sha512-NKN4jbPhB5lfHoSIaU7AuQ3F+yGS20e/FBRiUuPetcKoi354wHhKj9AJFfkFT5SSeLq0XEsXRNynm8gqCS4HjQ==}
     dependencies:
       '@deno/shim-crypto': 0.3.1
+    dev: false
+
+  /@upstash/qstash@2.3.0:
+    resolution: {integrity: sha512-p4L1n5/OWk8UUJJ6S5iInx+1YXm1LseTXthuFhJ7dY08NSKkGGJqipjH4/2jTxxhXMiXARRng+SQyF71NTnnBA==}
+    dependencies:
+      crypto-js: 4.2.0
+      jose: 4.15.4
     dev: false
 
   /@upstash/ratelimit@0.3.6(@babel/core@7.17.8)(react-dom@18.2.0):


### PR DESCRIPTION
If you set an expiration date for your link, the user will see an "Expired Link" page when they try to access the link after the expiration date ([example](https://dub.sh/expire)).

![CleanShot 2023-12-19 at 16 35 17](https://github.com/dubinc/dub/assets/28986134/9214f4b4-50ba-4f0d-859d-09023f61e502)
