### PR TITLE
Fix: Dub branding on password protected page

### DIFF
--- a/apps/web/app/protected/[domain]/[key]/page.tsx
+++ b/apps/web/app/protected/[domain]/[key]/page.tsx
@@ -39,7 +39,7 @@ export async function generateMetadata({
   }
 
   return constructMetadata({
-    title: link.project?.plan === "free" ? `${title} - Dub.co` : title,
+    title: isDubDomain(domain) || link.project?.plan === "free" ? `${title} - Dub.co` : title,
     description,
     image,
     ...(!isDubDomain(domain) &&
@@ -127,7 +127,7 @@ export default async function PasswordProtectedLinkPage({
             </a>
           )}
           <h3 className="text-xl font-semibold">
-            {link.project?.plan === "free" ? `${title} - Dub.co` : title}
+            {isDubDomain(domain) || link.project?.plan === "free" ? `${title} - Dub.co` : title}
           </h3>
           <p className="text-sm text-gray-500">{description}</p>
         </div>

--- a/apps/web/app/protected/[domain]/[key]/page.tsx
+++ b/apps/web/app/protected/[domain]/[key]/page.tsx
@@ -4,7 +4,7 @@ import prisma from "@/lib/prisma";
 import PasswordForm from "./form";
 import { notFound, redirect } from "next/navigation";
 
-const title = "Password Required – Dub.co";
+const title = "Password Required";
 const description =
   "This link is password protected. Please enter the password to view it.";
 const image = "https://dub.co/_static/password-protected.png";
@@ -39,7 +39,7 @@ export async function generateMetadata({
   }
 
   return constructMetadata({
-    title,
+    title: link.project?.plan === "free" ? `${title} - Dub.co` : title,
     description,
     image,
     ...(!isDubDomain(domain) &&
@@ -126,7 +126,9 @@ export default async function PasswordProtectedLinkPage({
               <Logo />
             </a>
           )}
-          <h3 className="text-xl font-semibold">{title}</h3>
+          <h3 className="text-xl font-semibold">
+            {link.project?.plan === "free" ? `${title} - Dub.co` : title}
+          </h3>
           <p className="text-sm text-gray-500">{description}</p>
         </div>
         <PasswordForm />


### PR DESCRIPTION
Issue: #525

Removes `Dub.co` from being appended if the project is on a paid plan on the password protected page.
