### PR TITLE
docs: updated broken LICENSE link in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
     <img src="https://img.shields.io/twitter/follow/dubdotco?style=flat&label=%40dubdotco&logo=twitter&color=0bf&logoColor=fff" alt="Twitter" />
   </a>
   <a href="https://news.ycombinator.com/item?id=32939407"><img src="https://img.shields.io/badge/Hacker%20News-255-%23FF6600" alt="Hacker News"></a>
-  <a href="https://github.com/dubinc/dub/blob/main/LICENSE">
+  <a href="https://github.com/dubinc/dub/blob/main/LICENSE.md">
     <img src="https://img.shields.io/github/license/dubinc/dub?label=license&logo=github&color=f80&logoColor=fff" alt="License" />
   </a>
 </p>


### PR DESCRIPTION
## What's changed?

The license button in the Readme was redirecting the user to ["LICENSE"](https://github.com/dubinc/dub/blob/main/LICENSE) as the file in this directory is not in Markdown format and was not being described in the url.

Therefore, the link has been updated to [LICENSE](https://github.com/dubinc/dub/blob/main/LICENSE.md), adding `.md` to the end.

## Ideas

With GitHub's new Readme presentation format, it would also be nice to take the user who wants to see the license to the other tab.

Updating the license badge link to [`dubinc/dub`?tab=AGPL-3.0-1-ov-file](https://github.com/dubinc/dub?tab=AGPL-3.0-1-ov-file) instead of [LICENSE.md](https://github.com/dubinc/dub/blob/main/LICENSE.md).
