### PR TITLE
Fix docs

### DIFF
--- a/apps/docs/self-hosting/guide.mdx
+++ b/apps/docs/self-hosting/guide.mdx
@@ -105,7 +105,7 @@ Next, you'll need to set up the Upstash Redis database:
 
 ![Upstash Redis tokens](/images/upstash-redis-tokens.png)
 
-4. Navigate to the [QStash tab](https://console.upstash.com/qstash) and copy the `QSTASH_URL`, `QSTASH_CURRENT_SIGNING_KEY`, and `QSTASH_NEXT_SIGNING_KEY` from the **Request Builder** section into your `.env` file.
+4. Navigate to the [QStash tab](https://console.upstash.com/qstash) and copy the `QSTASH_TOKEN`, `QSTASH_CURRENT_SIGNING_KEY`, and `QSTASH_NEXT_SIGNING_KEY` from the **Request Builder** section into your `.env` file.
 
 ![Upstash QStash tokens](/images/upstash-qstash-tokens.png)
 


### PR DESCRIPTION
### Description
`guide.mdx` incorrectly states that `QSTASH_URL` needs to be copied. The `QSTASH_TOKEN` is needed, not `QSTASH_URL`.