### PR TITLE
Add support for empty blacklist lists

### DIFF
--- a/apps/web/lib/edge-config.ts
+++ b/apps/web/lib/edge-config.ts
@@ -13,6 +13,7 @@ export const isBlacklistedDomain = async (domain: string) => {
     blacklistedTerms = [];
   }
   const domainToTest = getDomainWithoutWWW(domain) || domain;
+  if (blacklistedDomains.length === 0) return false;
   return (
     blacklistedDomains.includes(domainToTest) ||
     new RegExp(blacklistedTerms.join("|")).test(domainToTest)
@@ -37,6 +38,7 @@ export const isBlacklistedKey = async (key: string) => {
   } catch (e) {
     blacklistedKeys = [];
   }
+  if (blacklistedKeys.length === 0) return false;
   return new RegExp(blacklistedKeys.join("|"), "i").test(key);
 };
 
@@ -60,6 +62,7 @@ export const isBlacklistedEmail = async (email: string) => {
   } catch (e) {
     blacklistedEmails = [];
   }
+  if (blacklistedEmails.length === 0) return false;
   return new RegExp(blacklistedEmails.join("|"), "i").test(email);
 };
 


### PR DESCRIPTION
There's an edge case for blacklist checks where it returns `true` if the list is empty. This means if there was an exception thrown or there were no results, it would return `true` and thus block the request. This can be seen in the local dev experience because there are no results by default. This PR should fix that.