### PR TITLE
Hotfix: Fix MDX parsing issue in integrations

### DIFF
--- a/apps/docs/integrations/make.mdx
+++ b/apps/docs/integrations/make.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Make.com (Planned)"
-description: "Make.com <> Dub Integration"
+description: "Make.com x Dub Integration"
 ---
 
 We are planning to add a Make.com integration for Dub soon. Feel free to thumbs-up this page to help us prioritize this feature.

--- a/apps/docs/integrations/pipedream.mdx
+++ b/apps/docs/integrations/pipedream.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Pipedream (Planned)"
-description: "Pipedream <> Dub Integration"
+description: "Pipedream x Dub Integration"
 ---
 
 We are planning to add a Pipedream integration for Dub soon. Feel free to thumbs-up this page to help us prioritize this feature.

--- a/apps/docs/integrations/raycast.mdx
+++ b/apps/docs/integrations/raycast.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Raycast (Planned)"
-description: "Raycast <> Dub Integration"
+description: "Raycast x Dub Integration"
 ---
 
 We are planning to add a Raycast integration for Dub soon. Feel free to thumbs-up this page to help us prioritize this feature.

--- a/apps/docs/integrations/zapier.mdx
+++ b/apps/docs/integrations/zapier.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Zapier (Planned)"
-description: "Zapier <> Dub Integration"
+description: "Zapier x Dub Integration"
 ---
 
 We are planning to add a Zapier integration for Dub soon. Feel free to thumbs-up this page to help us prioritize this feature.


### PR DESCRIPTION
We recently introduced markdown in the description, but it appears that it wasn't error handled properly. As a result, `<>` is parsed as invalid MDX, which throws and error.

This PR fixes that error by replacing it with `x`. In the future, it will be fixed by fixing it so that when it errors, it just displays the string.