### PR TITLE
Update .env copy command in Local Development doc

### DIFF
--- a/apps/docs/local-development.mdx
+++ b/apps/docs/local-development.mdx
@@ -94,7 +94,7 @@ pnpm i -g mintlify
 Convert the `.env.example` file to `.env`:
 
 ```bash
-cp .env.example .env
+cp apps/web/.env.example apps/web/.env
 ```
 
 You can start filling in the first few environment variables:


### PR DESCRIPTION
The [Local Development docs page](https://dub.co/docs/local-development#step-1-local-setup) currently instructs the user to run `cp .env.example .env`, but `.env.example` is in the `apps/web` directory, not the root.

This PR updates the command to `cp apps/web/.env.example apps/web/.env`. Alternatively, we could add an instruction to navigate into `apps/web` before running the `cp` command.