### PR TITLE
Metatags API rate limit increase

### DIFF
--- a/apps/web/app/api/metatags/route.ts
+++ b/apps/web/app/api/metatags/route.ts
@@ -20,7 +20,7 @@ export async function GET(req: NextRequest) {
   });
   if (!session?.email) {
     const ip = ipAddress(req) || LOCALHOST_IP;
-    const { success } = await ratelimit(10, "1s").limit(ip);
+    const { success } = await ratelimit(10, "1 s").limit(ip);
     if (!success) {
       return new Response("Don't DDoS me pls 🥺", { status: 429 });
     }

--- a/apps/web/app/api/metatags/route.ts
+++ b/apps/web/app/api/metatags/route.ts
@@ -20,7 +20,7 @@ export async function GET(req: NextRequest) {
   });
   if (!session?.email) {
     const ip = ipAddress(req) || LOCALHOST_IP;
-    const { success } = await ratelimit().limit(ip);
+    const { success } = await ratelimit(10, "1s").limit(ip);
     if (!success) {
       return new Response("Don't DDoS me pls 🥺", { status: 429 });
     }


### PR DESCRIPTION
Hi there!

Can you increase the rate-limit of the metatags api to match what's listed on https://dub.co/docs/api-reference/rate-limits?

I'm not hitting it continuously for my use-case, but when a user loads a page with a lot of links to be processed I'd like to be able to show the previews somewhat quickly.

Thanks!