### PR TITLE
feat: add lock icon to protected link cards

### DIFF
--- a/apps/web/ui/links/link-card.tsx
+++ b/apps/web/ui/links/link-card.tsx
@@ -44,6 +44,7 @@ import {
   MessageCircle,
   QrCode,
   TimerOff,
+  Lock,
 } from "lucide-react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
@@ -66,6 +67,7 @@ export default function LinkCard({
     domain,
     url,
     rewrite,
+    password,
     expiresAt,
     createdAt,
     lastClicked,
@@ -395,6 +397,19 @@ export default function LinkCard({
                   }
                 >
                   <EyeOff className="xs:block hidden h-4 w-4 text-gray-500" />
+                </Tooltip>
+              )}
+              {password && (
+                <Tooltip
+                  content={
+                    <SimpleTooltipContent
+                      title="This link is password-protected."
+                      cta="Learn more."
+                      href={`${HOME_DOMAIN}/help/article/password-protected-links`}
+                    />
+                  }
+                >
+                  <Lock className="xs:block hidden h-4 w-4 text-gray-500" />
                 </Tooltip>
               )}
               <a


### PR DESCRIPTION
Small change, helps differentiate links more similar to cloaked links.
![image](https://github.com/dubinc/dub/assets/7025343/9dbbdb59-9ed3-4370-ab87-0aed3eb1c3ef)
