### PR TITLE
Various link-related UI changes and fixes

### DIFF
--- a/apps/web/app/expired/page.tsx
+++ b/apps/web/app/expired/page.tsx
@@ -15,7 +15,7 @@ export default async function ExpiredPage() {
   return (
     <main className="flex min-h-screen flex-col justify-between">
       <Nav />
-      <div className="mx-2 my-10 flex max-w-md flex-col items-center space-y-5 px-2.5 text-center sm:mx-auto sm:max-w-lg sm:px-0 lg:mb-16">
+      <div className="mx-2 my-10 flex max-w-md flex-col items-center space-y-5 px-2.5 text-center sm:mx-auto sm:max-w-lg sm:px-0 lg:mb-16 z-10">
         <div className="mx-auto flex h-20 w-20 items-center justify-center rounded-full border border-gray-300 bg-white/30">
           <TimerOff className="h-6 w-6 text-gray-400" />
         </div>

--- a/apps/web/app/inspect/[domain]/[key]/card.tsx
+++ b/apps/web/app/inspect/[domain]/[key]/card.tsx
@@ -2,6 +2,7 @@ import { BlurImage, CopyButton } from "@dub/ui";
 import { GOOGLE_FAVICON_URL, getApexDomain, linkConstructor } from "@dub/utils";
 import Script from "next/script";
 import ReportButton from "./report";
+import { Globe } from "lucide-react";
 
 export default function LinkInspectorCard({
   domain,
@@ -19,13 +20,19 @@ export default function LinkInspectorCard({
       <Script src="https://tally.so/widgets/embed.js" strategy="lazyOnload" />
       <div className="flex w-full items-center justify-between rounded-md border border-gray-300 bg-white p-3">
         <div className="flex items-center space-x-3">
-          <BlurImage
-            src={`${GOOGLE_FAVICON_URL}${apexDomain}`}
-            alt={apexDomain}
-            className="pointer-events-none h-10 w-10 rounded-full"
-            width={20}
-            height={20}
-          />
+          {apexDomain ? (
+            <BlurImage
+              src={`${GOOGLE_FAVICON_URL}${apexDomain}`}
+              alt={apexDomain}
+              className="pointer-events-none h-10 w-10 rounded-full"
+              width={20}
+              height={20}
+            />
+          ) : (
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-gray-100">
+              <Globe className="h-5 w-5 text-gray-600" />
+            </div>
+          )}
           <div>
             <div className="flex items-center space-x-1 sm:space-x-2">
               <a

--- a/apps/web/app/inspect/[domain]/[key]/page.tsx
+++ b/apps/web/app/inspect/[domain]/[key]/page.tsx
@@ -63,7 +63,7 @@ export default async function InspectPage({
     <>
       <main className="flex min-h-screen flex-col justify-between">
         <Nav />
-        <div className="mx-2 my-10 flex max-w-md flex-col space-y-5 px-2.5 text-center sm:mx-auto sm:max-w-lg sm:px-0 lg:mb-16">
+        <div className="mx-2 my-10 flex max-w-md flex-col space-y-5 px-2.5 text-center sm:mx-auto sm:max-w-lg sm:px-0 lg:mb-16 z-10">
           <h1 className="font-display text-5xl font-extrabold leading-[1.15] text-black sm:text-6xl sm:leading-[1.15]">
             Link Inspector
           </h1>

--- a/apps/web/ui/analytics/bar-list.tsx
+++ b/apps/web/ui/analytics/bar-list.tsx
@@ -160,13 +160,14 @@ export function LineItem({
   const { queryParams } = useRouterStuff();
 
   const lineItem = useMemo(() => {
+    const apexDomain = tab === "link" ? data ? getApexDomain(data.url) : null : getApexDomain(title);
     return (
       <div className="z-10 flex items-center space-x-2 px-2">
-        {tab === "link" ? (
+        {tab === "link" && apexDomain ? (
           data ? (
             <BlurImage
-              src={`${GOOGLE_FAVICON_URL}${getApexDomain(data.url)}`}
-              alt={getApexDomain(data.url)}
+              src={`${GOOGLE_FAVICON_URL}${apexDomain}`}
+              alt={apexDomain}
               className="h-5 w-5 rounded-full"
               width={20}
               height={20}
@@ -174,10 +175,10 @@ export function LineItem({
           ) : (
             <div className="h-5 w-5 animate-pulse rounded-full bg-gray-100" />
           )
-        ) : tab === "url" ? (
+        ) : tab === "url" && apexDomain ? (
           <BlurImage
-            src={`${GOOGLE_FAVICON_URL}${getApexDomain(title)}`}
-            alt={getApexDomain(title)}
+            src={`${GOOGLE_FAVICON_URL}${apexDomain}`}
+            alt={apexDomain}
             className="h-5 w-5 rounded-full"
             width={20}
             height={20}

--- a/apps/web/ui/analytics/top-links.tsx
+++ b/apps/web/ui/analytics/top-links.tsx
@@ -1,7 +1,7 @@
 import { TopLinksTabs } from "@/lib/analytics";
 import { LoadingSpinner, Modal, Switch, useRouterStuff } from "@dub/ui";
 import { fetcher, linkConstructor } from "@dub/utils";
-import { Maximize, X } from "lucide-react";
+import { Link2, Maximize, X } from "lucide-react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { useContext, useEffect, useState } from "react";
@@ -39,7 +39,7 @@ export default function TopLinks() {
       tab={tab}
       data={
         data?.map((d) => ({
-          icon: null,
+          icon: <Link2 className="h-4 w-4" />,
           title: d[tab],
           href: queryParams({
             set: {

--- a/apps/web/ui/links/link-card.tsx
+++ b/apps/web/ui/links/link-card.tsx
@@ -45,6 +45,7 @@ import {
   QrCode,
   TimerOff,
   Lock,
+  Globe,
 } from "lucide-react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
@@ -260,7 +261,7 @@ export default function LinkCard({
                 )}
               </div>
             </Tooltip>
-          ) : (
+          ) : apexDomain ? (
             <BlurImage
               src={`${GOOGLE_FAVICON_URL}${apexDomain}`}
               alt={apexDomain}
@@ -268,6 +269,10 @@ export default function LinkCard({
               width={20}
               height={20}
             />
+          ) : (
+            <div className="flex h-8 w-8 items-center justify-center rounded-full bg-gray-100 px-0 sm:h-10 sm:w-10">
+              <Globe className="h-4 w-4 text-gray-600 sm:h-5 sm:w-5" />
+            </div>
           )}
           {/* 
             Here, we're manually setting ml-* values because if we do space-x-* in the parent div, 

--- a/apps/web/ui/modals/add-edit-link-modal/index.tsx
+++ b/apps/web/ui/modals/add-edit-link-modal/index.tsx
@@ -52,6 +52,7 @@ import Preview from "./preview";
 import RewriteSection from "./rewrite-section";
 import TagsSection from "./tags-section";
 import UTMSection from "./utm-section";
+import { Globe } from "lucide-react";
 
 function AddEditLinkModal({
   showAddEditLinkModal,
@@ -213,15 +214,20 @@ function AddEditLinkModal({
     // if the link is password protected, or if it's a new link and there's no URL yet, return the default Dub logo
     // otherwise, get the favicon of the URL
     const url = password || !debouncedUrl ? null : debouncedUrl || props?.url;
+    const apexDomain = url ? getApexDomain(url) : null;
 
-    return url ? (
+    return url ? apexDomain ? (
       <BlurImage
-        src={`${GOOGLE_FAVICON_URL}${getApexDomain(url)}`}
+        src={`${GOOGLE_FAVICON_URL}${apexDomain}`}
         alt="Logo"
         className="h-10 w-10 rounded-full"
         width={20}
         height={20}
       />
+    ) : (
+      <div className="flex h-10 w-10 items-center justify-center rounded-full bg-gray-100">
+        <Globe className="h-5 w-5 text-gray-600" />
+      </div>
     ) : (
       <Logo />
     );

--- a/apps/web/ui/modals/add-edit-link-modal/preview.tsx
+++ b/apps/web/ui/modals/add-edit-link-modal/preview.tsx
@@ -97,6 +97,9 @@ export default function Preview({
               </div>
             )}
           </div>
+          {hostname && (
+            <p className="mt-2 text-[0.8rem] text-[#606770]">From {hostname}</p>
+          )}
         </div>
 
         {/* Facebook */}


### PR DESCRIPTION
This PR was initially to somewhat [make mailto: links work](https://github.com/dubinc/dub/discussions/304), but found some UI bugs while looking into it. `mailto:` links seem to work locally, but don't work in production (it seems to add a `/` at the beginning while redirecting). These changes can at least help with making sure other protocols can work without UI issues.

---

Link inspection (and expired link pages) now properly draw over the background:

| Old | New |
|-|-|
| ![brave_f65jxkP6yH](https://github.com/dubinc/dub/assets/7025343/c91591dd-e541-477e-a59b-41ca634ca910) | ![brave_EjgLqy0bOC](https://github.com/dubinc/dub/assets/7025343/df48ad21-7110-43ff-9836-8ddff6a401e6)|

A fallback icon is used if `getApexDomain()` fails to return a domain

| Old | New |
|-|-|
| ![brave_wIa4QPE8b7](https://github.com/dubinc/dub/assets/7025343/eb0aca10-305f-4b02-8f2f-4a242fda9ac3) | ![brave_TSmWsRSeGV](https://github.com/dubinc/dub/assets/7025343/40997447-76f2-496f-920f-08c05bc8633b) |
| ![brave_FrddPgjqqX](https://github.com/dubinc/dub/assets/7025343/fcf85a3f-648f-490e-9a96-41f6750147aa) | ![brave_ezeQtDY3XA](https://github.com/dubinc/dub/assets/7025343/373de056-fb89-4b5f-839b-9a2ace29b086) |

Added a hostname footer to the Twitter link preview (since this shows up normally on Twitter)

![brave_U6N13ved5i](https://github.com/dubinc/dub/assets/7025343/94d07478-af3e-45e3-9d3b-5561573c0dfc)