### PR TITLE
Stripe integration webhook support

### DIFF
--- a/apps/web/app/api/webhooks/[webhookId]/route.tsx
+++ b/apps/web/app/api/webhooks/[webhookId]/route.tsx
@@ -1,0 +1,57 @@
+import prisma from "@/lib/prisma";
+import { stripe } from "@/lib/stripe";
+
+const SUPPORTED_STRIPE_EVENTS = ["customer.created", "charge.succeeded"];
+
+// POST /api/webhooks/[webhookId]
+export async function POST(
+  request: Request,
+  { params }: { params: { webhookId: string } }
+) {
+  const webhook = await prisma.webhook.findOne({
+    where: {
+      id: params.webhookId,
+    },
+    include: {
+      project: true,
+    },
+  });
+  if (!webhook) {
+    return new Response("Dub webhook endpoint not found", { status: 404 });
+  }
+ 
+  const payload = await request.json();
+  if (!SUPPORTED_STRIPE_EVENTS.includes(payload.type)) {
+    return new Response("Unsupported event type", { status: 400 });
+  }
+
+  const event = stripe.webhooks.constructEvent(
+    payload,
+    request.headers.get("stripe-signature") as string,
+    webhook.webhookSecret
+  );
+  if (event.type !== payload.type) {
+    return new Response("Event type mismatch", { status: 400 });
+  }
+
+  switch (event.type) {
+    case "customer.created":
+      handleCustomerCreated(event.data.object);
+      break;
+    case "charge.succeeded":
+      handleChargeSucceeded(event.data.object);
+      break;
+  }
+};
+
+// This event will check the metadata of the customer to see if they have a Dub id.
+// If it does, we will look up the information and append more metadata to the customer.
+const handleCustomerCreated = (customer: any) => {
+  console.log("New customer created", customer);
+}
+
+// This event will check the customer of the charge to see if they have a Dub id.
+// If it does, we will look up the information and append metadata to the charge.
+const handleChargeSucceeded = (charge: any) => {
+  console.log("Charge succeeded", charge);
+}

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -110,8 +110,9 @@ model Project {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  inviteCode  String? @unique
-  metadata    Json?    @default("{\"defaultDomains\":[\"dub.sh\",\"chatg.pt\",\"spti.fi\",\"amzn.id\"]}")
+  inviteCode String?  @unique
+  metadata   Json?    @default("{\"defaultDomains\":[\"dub.sh\",\"chatg.pt\",\"spti.fi\",\"amzn.id\"]}")
+  Webhook    Webhook?
 }
 
 model ProjectInvite {
@@ -231,7 +232,7 @@ model Link {
   tagId String?
 
   // (Upcoming) multiple link tags
-  tags  LinkTag[]
+  tags LinkTag[]
 
   // Comments on the particular shortlink
   comments String? @db.LongText
@@ -253,12 +254,12 @@ model Link {
 }
 
 model Tag {
-  id        String   @id @default(cuid())
+  id        String    @id @default(cuid())
   name      String
-  color     String   @default("blue")
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-  project   Project  @relation(fields: [projectId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+  color     String    @default("blue")
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+  project   Project   @relation(fields: [projectId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   projectId String
   links     Link[]
   linksNew  LinkTag[]
@@ -307,4 +308,16 @@ model jackson_ttl {
   expiresAt BigInt
 
   @@index([expiresAt], map: "_jackson_ttl_expires_at")
+}
+
+model Webhook {
+  id                      String   @id @default(cuid())
+  projectId               String
+  project                 Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  webhookSecret           String
+  stripeRestrictedApiKeys String
+  createdAt               DateTime @default(now())
+
+  @@unique([projectId])
+  @@index([projectId])
 }


### PR DESCRIPTION
This is a spike for the Stripe integration. Basically, we want the ability to:
1. Update a customer with additional metadata if they came to a customer application through a Dub link
2. Tracks conversions (payments/revenue) that are from those customers - so we can handle analytics + payouts. 

This builds upon our analytics SDK + affiliate features we will be releasing. 

Process for a customer to set up:
1. Create a _Webhook Endpoint_ in the Dub dashboard - they are returned a _Webhook Endpoint_ then a form is shown with 2 inputs - _Stripe Webhook Secret_ and _Stripe Restricted API Key_
2. Create a Stripe Webhook in the Stripe dashboard with 2 event types - `customer.created`, `charge.succeeded`.
4. Get the Stripe Webhook Secret and put it in the input in the Dub dashboard
5. Create a Stripe Restricted API Key in Stripe with the persmissions set to `Charges:READ` and `Customers:WRITE`.
6. Take the Stripe Restricted API key and put it in the input in the Dub dashboard
7. Submit the form in Dub dashboard.

Then the customer will need to update their Stripe integration so they send the necessary ID in the metadata of the customer to Stripe. More on this later when we launch the analytics SDK.

Once that is all done, the Dub API will be able to monitor customers created in the customers Stripe account that came from Dub links and charges that originated from those users. It will append more information to the customer metadata in Stripe like what link they came from and if it was an affiliate, who the affiliate was. It will also be able to monitor charges and attribute that revenue to users that came from Dub links and if it was an affiliate, who the affiliate was. All this will be available in the Dub dashboard. 

Notes 🗒️
- The UI still needs to be designed/built
- This is an MVP attempt, in the future we will support a Stripe Partner app that does most of this automatically. 