### PR TITLE
Update SVG props to fix docs MDX warnings

### DIFF
--- a/apps/docs/integrations.mdx
+++ b/apps/docs/integrations.mdx
@@ -81,10 +81,10 @@ description: "Integrate Dub.co with your favorite tools and services."
         xmlns="http://www.w3.org/2000/svg"
         className="h-8 w-8"
       >
-        <g clip-path="url(#clip0_1218_28)">
+        <g clipPath="url(#clip0_1218_28)">
           <path
             fillRule="evenodd"
-            clip-rule="evenodd"
+            clipRule="evenodd"
             d="M227.987 113.987L216.097 125.89L170.987 80.7803V56.987L227.987 113.987ZM114.039 0L102.149 11.8901L147.246 56.987H171.039L114.039 0ZM88.5212 25.5177L76.6181 37.4208L96.1972 56.987H119.99L88.5212 25.5177ZM171.039 108.048V131.842L190.54 151.408L202.443 139.518L171.039 108.048ZM164.18 152.238L170.987 145.43H82.5177V56.987L75.7104 63.8073L62.9386 51.1003L51.0484 62.9905L63.8073 75.7623L56.987 82.5177V96.1454L37.4208 76.5662L25.5177 88.4693L56.987 119.939V147.168L11.8901 102.097L0 113.987L114.039 227.987L125.942 216.097L80.8321 170.987H108.061L139.531 202.469L151.434 190.566L131.855 170.987H145.482L152.29 164.18L165.061 176.939L176.952 165.048L164.18 152.238Z"
             fill="#FF6363"
           />
@@ -104,7 +104,7 @@ description: "Integrate Dub.co with your favorite tools and services."
     title="Pipedream"
     icon={
       <svg
-        enable-background="new 0 0 600 600"
+        enableBackground="new 0 0 600 600"
         version="1.1"
         viewBox="0 0 600 600"
         xmlSpace="preserve"
@@ -133,7 +133,7 @@ description: "Integrate Dub.co with your favorite tools and services."
     title="Dropshare"
     icon={
       <svg
-        enable-background="new 0 0 192 192"
+        enableBackground="new 0 0 192 192"
         version="1.1"
         viewBox="0 0 192 192"
         xmlSpace="preserve"
@@ -162,7 +162,7 @@ description: "Integrate Dub.co with your favorite tools and services."
         <g
           id="Page-1"
           stroke="none"
-          stroke-width="1"
+          strokeWidth="1"
           fill="none"
           fillRule="evenodd"
         >


### PR DESCRIPTION
The docs currently log some warnings, like this one:
```
Warning: Invalid DOM property `stroke-width`. Did you mean `strokeWidth`?
```

This PR fixes those props.