### PR TITLE
fix: special characters bypassing premium key validation

### DIFF
--- a/apps/web/lib/api/links.ts
+++ b/apps/web/lib/api/links.ts
@@ -252,6 +252,8 @@ export function processKey(key: string) {
   }
   // remove all leading and trailing slashes from key
   key = key.replace(/^\/+|\/+$/g, "");
+  // replace all special characters 
+  key = key.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
   if (key.length === 0) {
     return null;
   }


### PR DESCRIPTION
Makes sure to replace all special characters like à, è, ü, etc. with latin characters so they can't bypass premium key validation