### PR TITLE
Fix key.endsWith isn't a function when creating a link

### DIFF
--- a/apps/web/ui/modals/add-edit-link-modal/index.tsx
+++ b/apps/web/ui/modals/add-edit-link-modal/index.tsx
@@ -258,7 +258,7 @@ function AddEditLinkModal({
   const welcomeFlow = pathname === "/welcome";
   const keyRef = useRef<HTMLInputElement>(null);
   useEffect(() => {
-    if (key && key.endsWith("-copy")) {
+    if (typeof key === 'string' && key.endsWith('-copy')) {
       keyRef.current?.select();
     }
   }, [key]);


### PR DESCRIPTION
This doesn't happen in prod but when I try creating a link on my local environment, if no key is generated (maybe because of the fact that it takes too long in dev, or because I'm missing some dependency or env var), since no string is there, the UI throws this error. 


https://github.com/dubinc/dub/assets/8325094/bfef163c-df50-45fa-9519-19eecaeb07a9

I thought that it wouldn't hurt to add a typecheck to the key to harden the UI and prevent this issue. 


https://github.com/dubinc/dub/assets/8325094/234fd5e3-1cd0-4f09-8ec4-60310b97a44f

