### PR TITLE
OpenAPI spec: Add error responses as reusable component

### DIFF
--- a/apps/web/lib/openapi/index.ts
+++ b/apps/web/lib/openapi/index.ts
@@ -1,5 +1,6 @@
 import { ZodOpenApiObject } from "zod-openapi";
 
+import { openApiErrorResponses } from "@/lib/openapi/responses";
 import { LinkSchema } from "@/lib/zod/schemas/links";
 import { TagSchema } from "@/lib/zod/schemas/tags";
 import { WorkspaceSchema } from "@/lib/zod/schemas/workspaces";
@@ -52,6 +53,9 @@ export const openApiObject: ZodOpenApiObject = {
         description: "Default authentication mechanism",
         scheme: "bearer",
       },
+    },
+    responses: {
+      ...openApiErrorResponses,
     },
   },
 };


### PR DESCRIPTION
Before: `229.85 KB` 
After: `88.57 KB` 