### PR TITLE
Fix link creation UI hanging in Safari

### DIFF
--- a/apps/web/ui/modals/add-edit-link-modal/index.tsx
+++ b/apps/web/ui/modals/add-edit-link-modal/index.tsx
@@ -351,8 +351,8 @@ function AddEditLinkModal({
                     router.push("/links");
                     setShowAddEditLinkModal(false);
                   }
-                  // copy shortlink to clipboard when adding a new link (if document is focused)
-                  if (!props && document.hasFocus()) {
+                  // copy shortlink to clipboard when adding a new link
+                  if (!props) {
                     try {
                       await navigator.clipboard.writeText(
                         linkConstructor({

--- a/apps/web/ui/modals/add-edit-link-modal/index.tsx
+++ b/apps/web/ui/modals/add-edit-link-modal/index.tsx
@@ -353,14 +353,22 @@ function AddEditLinkModal({
                   }
                   // copy shortlink to clipboard when adding a new link (if document is focused)
                   if (!props && document.hasFocus()) {
-                    await navigator.clipboard.writeText(
-                      linkConstructor({
-                        // remove leading and trailing slashes
-                        key: data.key.replace(/^\/+|\/+$/g, ""),
-                        domain,
-                      }),
-                    );
-                    toast.success("Copied shortlink to clipboard!");
+                    try {
+                      await navigator.clipboard.writeText(
+                        linkConstructor({
+                          // remove leading and trailing slashes
+                          key: data.key.replace(/^\/+|\/+$/g, ""),
+                          domain,
+                        }),
+                      );
+                      toast.success("Copied shortlink to clipboard!");
+                    } catch (e) {
+                      console.error(
+                        "Failed to automatically copy shortlink to clipboard.",
+                        e,
+                      );
+                      toast.success("Successfully created link!");
+                    }
                   } else {
                     toast.success("Successfully updated shortlink!");
                   }


### PR DESCRIPTION
Safari seems to have an issue with using `navigator.clipboard` to copy text without it being the direct result of a user action. In this case waiting for a request before copying the shortlink seems to be the issue.

We could probably investigate some other solutions, maybe even optimistically copying, but for now this seems to fix the UI hanging in Safari.

Closes #684 