### PR TITLE
Fix: Prisma schema push with sql_require_primary_key enabled

### DIFF
--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -60,6 +60,7 @@ model Session {
 }
 
 model VerificationToken {
+  id         String   @id @default(cuid())
   identifier String
   token      String   @unique
   expires    DateTime
@@ -112,11 +113,12 @@ model Project {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  inviteCode  String? @unique
+  inviteCode     String?          @unique
   defaultDomains DefaultDomains[]
 }
 
 model ProjectInvite {
+  id        String   @id @default(cuid())
   email     String
   expires   DateTime
   project   Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
@@ -128,17 +130,11 @@ model ProjectInvite {
 }
 
 model DefaultDomains {
-  id                String   @id @default(cuid())
-  dubsh             Boolean  @default(true)
-  chatgpt           Boolean  @default(true)
-  sptifi            Boolean  @default(true)
-  gitnew            Boolean  @default(true)
-  amznid            Boolean  @default(true)
-  loooooooong       Boolean  @default(false)
-  projectId         String   @unique
-  project           Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  id        String  @id @default(cuid())
+  implet    Boolean @default(true)
+  projectId String  @unique
+  project   Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
 }
-
 
 enum Role {
   owner
@@ -170,17 +166,17 @@ model SentEmail {
 }
 
 model Domain {
-  id          String    @id @default(cuid())
-  slug        String    @unique
-  verified    Boolean   @default(false)
-  placeholder String    @default("https://dub.co/help/article/what-is-dub")
+  id          String   @id @default(cuid())
+  slug        String   @unique
+  verified    Boolean  @default(false)
+  placeholder String   @default("https://dub.co/help/article/what-is-dub")
   description String?
-  primary     Boolean   @default(false)
-  archived    Boolean   @default(false)
-  expiredUrl  String? @db.LongText // URL to redirect to for expired links
-  lastChecked DateTime  @default(now())
+  primary     Boolean  @default(false)
+  archived    Boolean  @default(false)
+  expiredUrl  String?  @db.LongText // URL to redirect to for expired links
+  lastChecked DateTime @default(now())
   links       Link[]
-  project     Project?  @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  project     Project? @relation(fields: [projectId], references: [id], onDelete: Cascade)
   projectId   String?
 
   // TODO: migrate these attributes to Link model
@@ -191,8 +187,8 @@ model Domain {
   publicStats Boolean   @default(false)
 
   // these attributes will exist on both Link and Domain models
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   @@index(projectId)
   @@index(clicks(sort: Desc))
@@ -201,14 +197,14 @@ model Domain {
 }
 
 model Link {
-  id          String    @id @default(cuid())
-  domain      String // domain of the link (e.g. dub.sh) – also stored on Redis
-  key         String // key of the link (e.g. /github) – also stored on Redis
-  url         String    @db.LongText // target url (e.g. https://github.com/dubinc/dub) – also stored on Redis
-  archived    Boolean   @default(false) // whether the link is archived or not
-  expiresAt   DateTime? // when the link expires – stored on Redis via ttl
-  expiredUrl  String?   @db.LongText // URL to redirect the user to when the link is expired
-  password    String? // password to access the link
+  id         String    @id @default(cuid())
+  domain     String // domain of the link (e.g. dub.sh) – also stored on Redis
+  key        String // key of the link (e.g. /github) – also stored on Redis
+  url        String    @db.LongText // target url (e.g. https://github.com/dubinc/dub) – also stored on Redis
+  archived   Boolean   @default(false) // whether the link is archived or not
+  expiresAt  DateTime? // when the link expires – stored on Redis via ttl
+  expiredUrl String?   @db.LongText // URL to redirect the user to when the link is expired
+  password   String? // password to access the link
 
   proxy       Boolean @default(false) // Proxy to use custom OG tags (stored on redis) – if false, will use OG tags from target url
   title       String? // OG title for the link (e.g. Dub.co - Open-Source Link Management Infrastructure)
@@ -252,7 +248,7 @@ model Link {
   tagId String?
 
   // (Upcoming) multiple link tags
-  tags  LinkTag[]
+  tags LinkTag[]
 
   // Comments on the particular shortlink
   comments String? @db.LongText
@@ -274,12 +270,12 @@ model Link {
 }
 
 model Tag {
-  id        String   @id @default(cuid())
+  id        String    @id @default(cuid())
   name      String
-  color     String   @default("blue")
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-  project   Project  @relation(fields: [projectId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+  color     String    @default("blue")
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+  project   Project   @relation(fields: [projectId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   projectId String
   links     Link[]
   linksNew  LinkTag[]

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -130,10 +130,15 @@ model ProjectInvite {
 }
 
 model DefaultDomains {
-  id        String  @id @default(cuid())
-  implet    Boolean @default(true)
-  projectId String  @unique
-  project   Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  id          String  @id @default(cuid())
+  dubsh       Boolean @default(true)
+  chatgpt     Boolean @default(true)
+  sptifi      Boolean @default(true)
+  gitnew      Boolean @default(true)
+  amznid      Boolean @default(true)
+  loooooooong Boolean @default(false)
+  projectId   String  @unique
+  project     Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
 }
 
 enum Role {


### PR DESCRIPTION
This PR will fix the Prrisma db push or prisma migrate deplyo errror on e.g. DigitalOcean managed MySql databases:

```
Unable to create or change a table without a primary key, when the system variable 'sql_require_primary_key' is set.
Add a primary key to the table or unset this variable to avoid this message.
Note that tables without a primary key can cause performance problems in row-based replication, so please consult your DBA before changing this setting.
```

The error was cause by two missing primary-keys in the "VerificationToken" and "ProjectInvite" tables.