### PR TITLE
Feat: Added title and description to the link card

### DIFF
--- a/apps/web/ui/links/link-card.tsx
+++ b/apps/web/ui/links/link-card.tsx
@@ -75,8 +75,9 @@ export default function LinkCard({
     tags,
     comments,
     user,
+    title,
+    description,
   } = props;
-
   const searchParams = useSearchParams();
 
   const [primaryTags, additionalTags] = useMemo(() => {
@@ -314,6 +315,7 @@ export default function LinkCard({
                     />
                   }
                 >
+                  <div>{title}</div>
                   <div className="max-w-[140px] -translate-x-2 cursor-not-allowed truncate text-sm font-semibold text-gray-400 line-through sm:max-w-[300px] sm:text-base md:max-w-[360px] xl:max-w-[500px]">
                     {linkConstructor({
                       domain,
@@ -323,26 +325,29 @@ export default function LinkCard({
                   </div>
                 </Tooltip>
               ) : (
-                <a
-                  className={cn(
-                    "max-w-[140px] truncate text-sm font-semibold text-blue-800 sm:max-w-[300px] sm:text-base md:max-w-[360px] xl:max-w-[500px]",
-                    {
-                      "text-gray-500": archived || expired,
-                    },
-                  )}
-                  href={linkConstructor({
-                    domain,
-                    key,
-                  })}
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  {linkConstructor({
-                    domain,
-                    key,
-                    pretty: true,
-                  })}
-                </a>
+                <Tooltip content={description && <div className="w-full p-4 text-sm">{description}</div>}>
+                  <a
+                    className={cn(
+                      "max-w-[140px] sm:max-w-[300px] md:max-w-[360px] xl:max-w-[500px] truncate text-sm font-semibold text-blue-800",
+                      {
+                        "text-gray-500": archived || expired,
+                      },
+                    )}
+                    href={linkConstructor({
+                      domain,
+                      key,
+                    })}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    {title && (
+                      <div className="text-black-800">
+                        {title} - {linkConstructor({ domain, key, pretty: true })}
+                      </div>
+                    )}
+                    {!title && linkConstructor({ domain, key, pretty: true })}
+                  </a>
+                </Tooltip>
               )}
               <CopyButton
                 value={linkConstructor({


### PR DESCRIPTION
#682 
Hi,

I've enabled displaying both the title and description in the link card. The description now appears in a tooltip, visible only when present. I've also ensured the title is shown at the start of the link which is also visible only when present-

<img width="1004" alt="Screenshot 2024-04-16 at 12 40 14 AM" src="https://github.com/dubinc/dub/assets/65942102/2329aced-4787-4669-8791-7f58a3ed933d">


