### PR TITLE
ENG-266: Fix user survey popup animation

### DIFF
--- a/apps/web/ui/layout/user-survey/index.tsx
+++ b/apps/web/ui/layout/user-survey/index.tsx
@@ -38,53 +38,62 @@ export function UserSurveyPopupInner() {
 
   return (
     <motion.div
+      initial={{ opacity: 0, translateY: 50 }}
       animate={{
-        height: resizeObserverEntry?.borderBoxSize[0].blockSize ?? "auto",
+        opacity: 1,
+        translateY: 0,
       }}
-      transition={{ type: "spring", duration: 0.3 }}
+      exit={{ opacity: 0, y: "100%" }}
       className="fixed bottom-4 z-50 mx-2 overflow-hidden rounded-lg border border-gray-200 bg-white shadow-md sm:left-4 sm:mx-auto sm:max-w-sm"
     >
-      <div className="p-4" ref={contentWrapperRef}>
-        <button
-          className="absolute right-2.5 top-2.5 rounded-full p-1 transition-colors hover:bg-gray-100 active:scale-90"
-          onClick={hidePopup}
-        >
-          <X className="h-4 w-4 text-gray-500" />
-        </button>
-        <UserSurveyContext.Provider value={{ status }}>
-          <SurveyForm
-            onSubmit={async (source) => {
-              setStatus("loading");
-              try {
-                await fetch("/api/user", {
-                  method: "PUT",
-                  headers: {
-                    "Content-Type": "application/json",
-                  },
-                  body: JSON.stringify({ source }),
-                });
-                setStatus("success");
-                setTimeout(hidePopup, 3000);
-              } catch (e) {
-                toast.error("Error saving response. Please try again.");
-                setStatus("idle");
-              }
-            }}
-          />
-          <AnimatePresence>
-            {status === "success" && (
-              <motion.div
-                initial={{ opacity: 0, y: 10 }}
-                animate={{ opacity: 1, y: 0 }}
-                className="absolute inset-0 flex flex-col items-center justify-center space-y-3 bg-white text-sm"
-              >
-                <CheckCircleFill className="h-8 w-8 text-green-500" />
-                <p className="text-gray-500">Thank you for your response!</p>
-              </motion.div>
-            )}
-          </AnimatePresence>
-        </UserSurveyContext.Provider>
-      </div>
+      <motion.div
+        animate={{
+          height: resizeObserverEntry?.borderBoxSize[0].blockSize ?? "auto",
+        }}
+        transition={{ type: "spring", duration: 0.3 }}
+      >
+        <div className="p-4" ref={contentWrapperRef}>
+          <button
+            className="absolute right-2.5 top-2.5 rounded-full p-1 transition-colors hover:bg-gray-100 active:scale-90"
+            onClick={hidePopup}
+          >
+            <X className="h-4 w-4 text-gray-500" />
+          </button>
+          <UserSurveyContext.Provider value={{ status }}>
+            <SurveyForm
+              onSubmit={async (source) => {
+                setStatus("loading");
+                try {
+                  await fetch("/api/user", {
+                    method: "PUT",
+                    headers: {
+                      "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({ source }),
+                  });
+                  setStatus("success");
+                  setTimeout(hidePopup, 3000);
+                } catch (e) {
+                  toast.error("Error saving response. Please try again.");
+                  setStatus("idle");
+                }
+              }}
+            />
+            <AnimatePresence>
+              {status === "success" && (
+                <motion.div
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  className="absolute inset-0 flex flex-col items-center justify-center space-y-3 bg-white text-sm"
+                >
+                  <CheckCircleFill className="h-8 w-8 text-green-500" />
+                  <p className="text-gray-500">Thank you for your response!</p>
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </UserSurveyContext.Provider>
+        </div>
+      </motion.div>
     </motion.div>
   );
 }

--- a/packages/ui/src/popup.tsx
+++ b/packages/ui/src/popup.tsx
@@ -25,17 +25,7 @@ export function Popup({
   return (
     <ClientOnly>
       <PopupContext.Provider value={{ hidePopup }}>
-        <AnimatePresence>
-          {!hidden && (
-            <motion.div
-              initial={{ opacity: 0, translateY: 50 }}
-              animate={{ opacity: 1, translateY: 0 }}
-              exit={{ opacity: 0, y: "100%" }}
-            >
-              {children}
-            </motion.div>
-          )}
-        </AnimatePresence>
+        <AnimatePresence>{!hidden && children}</AnimatePresence>
       </PopupContext.Provider>
     </ClientOnly>
   );

--- a/packages/ui/src/popup.tsx
+++ b/packages/ui/src/popup.tsx
@@ -1,4 +1,4 @@
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence } from "framer-motion";
 import Cookies from "js-cookie";
 import { ReactNode, createContext, useState } from "react";
 import { ClientOnly } from "./client-only";


### PR DESCRIPTION
The popup animation was a little glitchy on some pages due to how we animating the transforms outside of the `position: fixed` element.

To keep the `Popup` component unopinionated, I moved the animations out of `Popup` and into `UserSurveyPopupInner`, rather than move the `fixed` positioning and other styles into `Popup`.

Tip: hide whitespace changes when viewing the diff!