### PR TITLE
Escape `debouncedUrl` before send to api to support url with query

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dub/ui",
   "description": "UI components for Dub.co",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "sideEffects": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/ui/src/link-preview.tsx
+++ b/packages/ui/src/link-preview.tsx
@@ -23,7 +23,7 @@ export function LinkPreview({ defaultUrl }: { defaultUrl?: string }) {
     title: string | null;
     description: string | null;
     image: string | null;
-  }>(debouncedUrl && `/api/metatags?url=${debouncedUrl}`, fetcher, {
+  }>(debouncedUrl && `/api/metatags?url=${encodeURIComponent(debouncedUrl)}`, fetcher, {
     revalidateOnFocus: false,
   });
 


### PR DESCRIPTION
Current the metatags tool doesn't work if the target url have query (check screenshot below). This PR is about to fix it
![CleanShot 2024-04-17 at 23 27 31@2x](https://github.com/dubinc/dub/assets/16853175/cc61de12-b5d0-44cf-a744-2c335485f86c)

Check out the live url https://dub.co/tools/metatags?url=https%3A%2F%2Fogcool.vercel.app%2Fpreview%3Fname%3DWave%26d%3DeyJtb2RpZmljYXRpb25zIjpbeyJuYW1lIjoiVGV4dCIsInRleHQiOiJTbyBmdWNraW5nIGdvb2QifV0sInRlbXBsYXRlSWQiOiJ0cGxfVG5sbFBnMENrUCJ9
