### PR TITLE
ENG-292: Use `InfoTooltip` instead of "Pro" `BadgeTooltip` for upgraded workspaces

### DIFF
--- a/apps/web/ui/modals/add-edit-link-modal/android-section.tsx
+++ b/apps/web/ui/modals/add-edit-link-modal/android-section.tsx
@@ -1,8 +1,8 @@
 import { LinkProps } from "@/lib/types";
-import { BadgeTooltip, SimpleTooltipContent, Switch } from "@dub/ui";
+import { ProBadgeTooltip } from "@/ui/shared/pro-badge-tooltip";
+import { SimpleTooltipContent, Switch } from "@dub/ui";
 import { FADE_IN_ANIMATION_SETTINGS } from "@dub/utils";
 import { motion } from "framer-motion";
-import { Crown } from "lucide-react";
 import { Dispatch, SetStateAction, useEffect, useState } from "react";
 
 export default function AndroidSection({
@@ -36,7 +36,7 @@ export default function AndroidSection({
           <h2 className="text-sm font-medium text-gray-900">
             Android Targeting
           </h2>
-          <BadgeTooltip
+          <ProBadgeTooltip
             content={
               <SimpleTooltipContent
                 title="Redirect your Android users to a different link."
@@ -44,12 +44,7 @@ export default function AndroidSection({
                 href="https://dub.co/help/article/device-targeting"
               />
             }
-          >
-            <div className="flex items-center space-x-1">
-              <Crown size={12} />
-              <p>PRO</p>
-            </div>
-          </BadgeTooltip>
+          />
         </div>
         <Switch fn={() => setEnabled(!enabled)} checked={enabled} />
       </div>

--- a/apps/web/ui/modals/add-edit-link-modal/cloaking-section.tsx
+++ b/apps/web/ui/modals/add-edit-link-modal/cloaking-section.tsx
@@ -1,18 +1,13 @@
 import { LinkProps } from "@/lib/types";
 import { AlertCircleFill, CheckCircleFill } from "@/ui/shared/icons";
-import {
-  BadgeTooltip,
-  LoadingSpinner,
-  SimpleTooltipContent,
-  Switch,
-} from "@dub/ui";
+import { ProBadgeTooltip } from "@/ui/shared/pro-badge-tooltip";
+import { LoadingSpinner, SimpleTooltipContent, Switch } from "@dub/ui";
 import {
   FADE_IN_ANIMATION_SETTINGS,
   fetcher,
   getUrlFromString,
 } from "@dub/utils";
 import { motion } from "framer-motion";
-import { Crown } from "lucide-react";
 import { Dispatch, SetStateAction, useEffect, useState } from "react";
 import useSWR from "swr";
 
@@ -43,7 +38,7 @@ export default function CloakingSection({
       <div className="flex items-center justify-between">
         <div className="flex items-center justify-between space-x-2">
           <h2 className="text-sm font-medium text-gray-900">Link Cloaking</h2>
-          <BadgeTooltip
+          <ProBadgeTooltip
             content={
               <SimpleTooltipContent
                 title="Mask your destination URL so your users only see the short link in the browser address bar."
@@ -51,12 +46,7 @@ export default function CloakingSection({
                 href="https://dub.co/help/article/link-cloaking"
               />
             }
-          >
-            <div className="flex items-center space-x-1">
-              <Crown size={12} />
-              <p>PRO</p>
-            </div>
-          </BadgeTooltip>
+          />
         </div>
         <Switch fn={() => setEnabled(!enabled)} checked={enabled} />
       </div>

--- a/apps/web/ui/modals/add-edit-link-modal/expiration-section.tsx
+++ b/apps/web/ui/modals/add-edit-link-modal/expiration-section.tsx
@@ -1,6 +1,6 @@
 import { LinkProps } from "@/lib/types";
+import { ProBadgeTooltip } from "@/ui/shared/pro-badge-tooltip";
 import {
-  BadgeTooltip,
   ExpandingArrow,
   InfoTooltip,
   SimpleTooltipContent,
@@ -13,7 +13,6 @@ import {
   parseDateTime,
 } from "@dub/utils";
 import { motion } from "framer-motion";
-import { Crown } from "lucide-react";
 import { Dispatch, SetStateAction, useEffect, useRef, useState } from "react";
 
 export default function ExpirationSection({
@@ -48,7 +47,7 @@ export default function ExpirationSection({
       <div className="flex items-center justify-between">
         <div className="flex items-center justify-between space-x-2">
           <h2 className="text-sm font-medium text-gray-900">Link Expiration</h2>
-          <BadgeTooltip
+          <ProBadgeTooltip
             content={
               <SimpleTooltipContent
                 title="Set an expiration date for your links – after which it won't be accessible."
@@ -56,12 +55,7 @@ export default function ExpirationSection({
                 href="https://dub.co/help/article/link-expiration"
               />
             }
-          >
-            <div className="flex items-center space-x-1">
-              <Crown size={12} />
-              <p>PRO</p>
-            </div>
-          </BadgeTooltip>
+          />
         </div>
         <Switch fn={() => setEnabled(!enabled)} checked={enabled} />
       </div>

--- a/apps/web/ui/modals/add-edit-link-modal/geo-section.tsx
+++ b/apps/web/ui/modals/add-edit-link-modal/geo-section.tsx
@@ -1,8 +1,9 @@
 import { LinkProps } from "@/lib/types";
-import { BadgeTooltip, SimpleTooltipContent, Switch } from "@dub/ui";
+import { ProBadgeTooltip } from "@/ui/shared/pro-badge-tooltip";
+import { SimpleTooltipContent, Switch } from "@dub/ui";
 import { COUNTRIES, FADE_IN_ANIMATION_SETTINGS } from "@dub/utils";
 import { motion } from "framer-motion";
-import { Crown, Trash } from "lucide-react";
+import { Trash } from "lucide-react";
 import { Dispatch, SetStateAction, useEffect, useState } from "react";
 
 export default function GeoSection({
@@ -44,7 +45,7 @@ export default function GeoSection({
       <div className="flex items-center justify-between">
         <div className="flex items-center justify-between space-x-2">
           <h2 className="text-sm font-medium text-gray-900">Geo Targeting</h2>
-          <BadgeTooltip
+          <ProBadgeTooltip
             content={
               <SimpleTooltipContent
                 title="Redirect your users to different links based on their location."
@@ -52,12 +53,7 @@ export default function GeoSection({
                 href="https://dub.co/help/article/geo-targeting"
               />
             }
-          >
-            <div className="flex items-center space-x-1">
-              <Crown size={12} />
-              <p>PRO</p>
-            </div>
-          </BadgeTooltip>
+          />
         </div>
         <Switch fn={() => setEnabled(!enabled)} checked={enabled} />
       </div>

--- a/apps/web/ui/modals/add-edit-link-modal/ios-section.tsx
+++ b/apps/web/ui/modals/add-edit-link-modal/ios-section.tsx
@@ -1,8 +1,8 @@
 import { LinkProps } from "@/lib/types";
-import { BadgeTooltip, SimpleTooltipContent, Switch } from "@dub/ui";
+import { ProBadgeTooltip } from "@/ui/shared/pro-badge-tooltip";
+import { SimpleTooltipContent, Switch } from "@dub/ui";
 import { FADE_IN_ANIMATION_SETTINGS } from "@dub/utils";
 import { motion } from "framer-motion";
-import { Crown } from "lucide-react";
 import { Dispatch, SetStateAction, useEffect, useState } from "react";
 
 export default function IOSSection({
@@ -34,7 +34,7 @@ export default function IOSSection({
       <div className="flex items-center justify-between">
         <div className="flex items-center justify-between space-x-2">
           <h2 className="text-sm font-medium text-gray-900">iOS Targeting</h2>
-          <BadgeTooltip
+          <ProBadgeTooltip
             content={
               <SimpleTooltipContent
                 title="Redirect your iOS users to a different link."
@@ -42,12 +42,7 @@ export default function IOSSection({
                 href="https://dub.co/help/article/device-targeting"
               />
             }
-          >
-            <div className="flex items-center space-x-1">
-              <Crown size={12} />
-              <p>PRO</p>
-            </div>
-          </BadgeTooltip>
+          />
         </div>
         <Switch fn={() => setEnabled(!enabled)} checked={enabled} />
       </div>

--- a/apps/web/ui/modals/add-edit-link-modal/og-section.tsx
+++ b/apps/web/ui/modals/add-edit-link-modal/og-section.tsx
@@ -2,9 +2,9 @@ import { resizeImage } from "@/lib/images";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { LinkProps } from "@/lib/types";
 import { UploadCloud } from "@/ui/shared/icons";
+import { ProBadgeTooltip } from "@/ui/shared/pro-badge-tooltip";
 import { UpgradeToProToast } from "@/ui/shared/upgrade-to-pro-toast";
 import {
-  BadgeTooltip,
   ButtonTooltip,
   LoadingCircle,
   LoadingSpinner,
@@ -18,7 +18,7 @@ import { FADE_IN_ANIMATION_SETTINGS, truncate } from "@dub/utils";
 import va from "@vercel/analytics";
 import { useCompletion } from "ai/react";
 import { motion } from "framer-motion";
-import { Crown, Link2 } from "lucide-react";
+import { Link2 } from "lucide-react";
 import { Dispatch, SetStateAction, useEffect, useState } from "react";
 import TextareaAutosize from "react-textarea-autosize";
 import { toast } from "sonner";
@@ -177,7 +177,7 @@ export default function OGSection({
           <h2 className="text-sm font-medium text-gray-900">
             Custom Social Media Cards
           </h2>
-          <BadgeTooltip
+          <ProBadgeTooltip
             content={
               <SimpleTooltipContent
                 title="Customize how your links look when shared on social media."
@@ -185,12 +185,7 @@ export default function OGSection({
                 href="https://dub.co/help/article/custom-social-media-cards"
               />
             }
-          >
-            <div className="flex items-center space-x-1">
-              <Crown size={12} />
-              <p>PRO</p>
-            </div>
-          </BadgeTooltip>
+          />
         </div>
         <Switch
           fn={() => setData((prev) => ({ ...prev, proxy: !proxy }))}

--- a/apps/web/ui/modals/add-edit-link-modal/password-section.tsx
+++ b/apps/web/ui/modals/add-edit-link-modal/password-section.tsx
@@ -1,9 +1,9 @@
 import { LinkProps } from "@/lib/types";
 import { Eye, EyeOff } from "@/ui/shared/icons";
-import { BadgeTooltip, SimpleTooltipContent, Switch } from "@dub/ui";
+import { ProBadgeTooltip } from "@/ui/shared/pro-badge-tooltip";
+import { SimpleTooltipContent, Switch } from "@dub/ui";
 import { FADE_IN_ANIMATION_SETTINGS } from "@dub/utils";
 import { motion } from "framer-motion";
-import { Crown } from "lucide-react";
 import { Dispatch, SetStateAction, useEffect, useState } from "react";
 
 export default function PasswordSection({
@@ -39,7 +39,7 @@ export default function PasswordSection({
           <h2 className="text-sm font-medium text-gray-900">
             Password Protection
           </h2>
-          <BadgeTooltip
+          <ProBadgeTooltip
             content={
               <SimpleTooltipContent
                 title="Restrict access to your short links by encrypting it with a password."
@@ -47,12 +47,7 @@ export default function PasswordSection({
                 href="https://dub.co/help/article/password-protected-links"
               />
             }
-          >
-            <div className="flex items-center space-x-1">
-              <Crown size={12} />
-              <p>PRO</p>
-            </div>
-          </BadgeTooltip>
+          />
         </div>
         <Switch fn={() => setEnabled(!enabled)} checked={enabled} />
       </div>

--- a/apps/web/ui/shared/pro-badge-tooltip.tsx
+++ b/apps/web/ui/shared/pro-badge-tooltip.tsx
@@ -3,10 +3,10 @@ import { BadgeTooltip, InfoTooltip, type TooltipProps } from "@dub/ui";
 import { Crown } from "lucide-react";
 
 /**
- * A dynamic badge w/ tooltip based on the workspace plan:
+ * A dynamic badge/icon w/ tooltip based on the workspace plan:
  *
  * For a free workspace: a "Pro" badge
- * For a Pro workspace: an info badge (question mark circle icon)
+ * For a Pro workspace: an info icon (question mark circle)
  */
 export function ProBadgeTooltip(props: Omit<TooltipProps, "children">) {
   const { plan } = useWorkspace();

--- a/apps/web/ui/shared/pro-badge-tooltip.tsx
+++ b/apps/web/ui/shared/pro-badge-tooltip.tsx
@@ -1,0 +1,24 @@
+import useWorkspace from "@/lib/swr/use-workspace";
+import { BadgeTooltip, InfoTooltip, type TooltipProps } from "@dub/ui";
+import { Crown } from "lucide-react";
+
+/**
+ * A dynamic badge w/ tooltip based on the workspace plan:
+ *
+ * For a free workspace: a "Pro" badge
+ * For a Pro workspace: an info badge (question mark circle icon)
+ */
+export function ProBadgeTooltip(props: Omit<TooltipProps, "children">) {
+  const { plan } = useWorkspace();
+
+  return plan === "free" ? (
+    <BadgeTooltip {...props}>
+      <div className="flex items-center space-x-1">
+        <Crown size={12} />
+        <p className="uppercase">Pro</p>
+      </div>
+    </BadgeTooltip>
+  ) : (
+    <InfoTooltip {...props} />
+  );
+}

--- a/packages/ui/src/tooltip.tsx
+++ b/packages/ui/src/tooltip.tsx
@@ -17,7 +17,7 @@ export function TooltipProvider({ children }: { children: ReactNode }) {
   );
 }
 
-interface TooltipProps {
+export interface TooltipProps {
   children: ReactNode;
   content: ReactNode | string;
   side?: "top" | "bottom" | "left" | "right";


### PR DESCRIPTION
| Free Workspace | Pro Workspace |
| - | - |
| ![Screenshot 2024-04-27 at 11 09 21 PM](https://github.com/dubinc/dub/assets/2547408/0b53bad3-d2d4-46aa-900a-8e435ae8ed8b) | ![Screenshot 2024-04-27 at 11 09 31 PM](https://github.com/dubinc/dub/assets/2547408/04b82d37-712e-479c-9361-1f84a1e4374a) |
