### PR TITLE
Validation added for 🗺️

### DIFF
--- a/apps/web/ui/modals/add-edit-link-modal/index.tsx
+++ b/apps/web/ui/modals/add-edit-link-modal/index.tsx
@@ -607,7 +607,7 @@ function AddEditLinkModal({
                     id={`key-${randomIdx}`}
                     required
                     // allow letters, numbers, '-', '/' and emojis
-                    pattern="[\p{L}\p{N}\p{Pd}\/\p{Emoji}]+"
+                    pattern="[\p{L}\p{N}\p{Pd}\/\p{Emoji}\/🗺️]+"
                     onInvalid={(e) => {
                       e.currentTarget.setCustomValidity(
                         "Only letters, numbers, '-', '/', and emojis are allowed.",


### PR DESCRIPTION
fixes #780 

I have added validation for this emoji since our pattern `[\p{L}\p{N}\p{Pd}\/\p{Emoji}]+
` was failing to recognize it as emoji. However, there might be a lot of similar cases in future since new emojis are regularly added to unicode. 

Using this [Library](https://github.com/mathiasbynens/emoji-regex) is a better solution since it generates the regex pattern at build time based on Unicode. Moreover, it can be updated whenever new emojis are added. 

