### PR TITLE
Changed to default to sort options number of clicks by taking sort op…

### DIFF
--- a/apps/web/ui/links/link-sort.tsx
+++ b/apps/web/ui/links/link-sort.tsx
@@ -26,7 +26,7 @@ export default function LinkSort() {
   const { queryParams } = useRouterStuff();
 
   const selectedSort = useMemo(() => {
-    return sortOptions.find((s) => s.slug === sort) || sortOptions[0];
+    return sortOptions.find((s) => s.slug === sort) || sortOptions[1];
   }, [sort]);
 
   return (


### PR DESCRIPTION
Fixing #328 as part of a class assignment where I must work on an open-source project. This issue states that the filter should be automatically set to a number of clicks instead of the date, as he prefers to see popular links as opposed to recent links. I agree that more popular links should shown and therefore made the default.