### PR TITLE
Quick Fix: Inconsistent Error Responses for Invalid JSON in API Requests 

### DIFF
--- a/apps/web/app/api/links/[linkId]/route.ts
+++ b/apps/web/app/api/links/[linkId]/route.ts
@@ -5,6 +5,7 @@ import {
   transformLink,
   updateLink,
 } from "@/lib/api/links";
+import { parseRequestBody } from "@/lib/api/utils";
 import { withWorkspace } from "@/lib/auth";
 import prisma from "@/lib/prisma";
 import { NewLinkProps } from "@/lib/types";
@@ -55,7 +56,8 @@ export const PATCH = withWorkspace(
       });
     }
 
-    const body = updateLinkBodySchema.parse(await req.json());
+    const bodyRaw = await parseRequestBody(req);
+    const body = updateLinkBodySchema.parse(bodyRaw);
 
     // Add body onto existing link but maintain NewLinkProps form for processLink
     const updatedLink = {

--- a/apps/web/app/api/links/bulk/route.ts
+++ b/apps/web/app/api/links/bulk/route.ts
@@ -1,5 +1,6 @@
 import { DubApiError, exceededLimitError } from "@/lib/api/errors";
 import { bulkCreateLinks, combineTagIds, processLink } from "@/lib/api/links";
+import { parseRequestBody } from "@/lib/api/utils";
 import { withWorkspace } from "@/lib/auth";
 import prisma from "@/lib/prisma";
 import { ProcessedLinkProps } from "@/lib/types";
@@ -16,7 +17,8 @@ export const POST = withWorkspace(
           "Missing workspace. Bulk link creation is only available for custom domain workspaces.",
       });
     }
-    const links = bulkCreateLinksBodySchema.parse(await req.json());
+    const bodyRaw = await parseRequestBody(req);
+    const links = bulkCreateLinksBodySchema.parse(bodyRaw);
     if (
       workspace.linksUsage + links.length > workspace.linksLimit &&
       (workspace.plan === "free" || workspace.plan === "pro")


### PR DESCRIPTION
When sending invalid JSON to **PATCH**  `/links/{linkId}` and **POST** `/links/bulk`, we're getting an _"internal server error"_  instead of the more helpful _"bad request"_ error.
However, **POST** `/links` gets it right and tells us it's a "bad request" due to invalid JSON.

I believe this will help everyone using the API to have a smoother and more predictable experience.

I've already fixed it by first checking:
```ts
const bodyRaw = await parseRequestBody(req);
const links = bulkCreateLinksBodySchema.parse(bodyRaw);
```
I hope this helps make Dub better!