### PR TITLE
Fix filter dropdown size changing when loading

### DIFF
--- a/packages/ui/src/filter/filter-select.tsx
+++ b/packages/ui/src/filter/filter-select.tsx
@@ -172,7 +172,7 @@ export function FilterSelect({
                   ) : (
                     <Command.Loading>
                       <div
-                        className="flex items-center justify-center px-2 py-4"
+                        className="-m-2 flex items-center justify-center"
                         style={mainListDimensions.current}
                       >
                         <LoadingSpinner />


### PR DESCRIPTION
Prevents the filter dropdown from getting a little larger while loading options, instead maintaining the size from the previous list state.