### PR TITLE
Remove extra word from self-hosting.mdx

### DIFF
--- a/apps/docs/self-hosting.mdx
+++ b/apps/docs/self-hosting.mdx
@@ -41,7 +41,7 @@ First, you'll need to clone the Dub.co repo and install the dependencies.
 
 First, clone the [Dub repo](https://d.to/github) into a public GitHub repository. If you are planning to distribute the code, make sure to keep the source code public to comply with our [AGPLv3 license](https://d.to/license).
 
-    ```bash Terminal Terminal
+    ```bash Terminal
     git clone https://github.com/dubinc/dub.git
     ```
 


### PR DESCRIPTION
Removes extra text of `Terminal` in the code snippet example.