### PR TITLE
fix: close popover when switching key in LinkCard component

### DIFF
--- a/apps/web/ui/links/link-card.tsx
+++ b/apps/web/ui/links/link-card.tsx
@@ -234,6 +234,7 @@ export default function LinkCard({
     ) {
       setSelected(false);
       e.preventDefault();
+      setOpenPopover(false);
       switch (key) {
         case "e":
           setShowAddEditLinkModal(true);


### PR DESCRIPTION
### This PR fixes

#1023 

### Solution
Ensuring that the popover is hidden immediately upon any modal-triggering keyboard shortcut, thus preventing it from overlaying the modal.

### Screen Recorder

**Before Changes:**
https://www.loom.com/share/b6260197b30d4579bcb0b2c2042d23d1?sid=b8f72b40-830a-4fac-beee-694cfd459e22

**After Changes:**
https://www.loom.com/share/28e4a6e96741460095b812d166b57fa0?sid=1d955e65-92c7-4038-a026-555624a7d0ae