### PR TITLE
Merge code samples into OAS for Mintlify

### DIFF
--- a/.github/workflows/merge_code_samples.yaml
+++ b/.github/workflows/merge_code_samples.yaml
@@ -1,0 +1,18 @@
+name: Merge Code Samples Into OpenAPI Schema
+permissions:
+  checks: write
+  contents: write
+  pull-requests: write
+  statuses: write
+"on":
+  schedule:
+    - cron: 0 0 * * *
+jobs:
+  generate:
+    uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@v15
+    with:
+      mode: pr
+      speakeasy_version: latest
+    secrets:
+      github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,0 +1,14 @@
+workflowVersion: 1.0.0
+speakeasyVersion: latest
+sources:
+  merge-code-samples-into-spec:
+    inputs:
+      - location: http://api.dub.co
+    overlays:
+      - location: registry.speakeasyapi.dev/dub/dub/code-samples-typescript-my-first-target:main
+      - location: registry.speakeasyapi.dev/dub/dub/code-samples-go-my-first-target:main
+      - location: registry.speakeasyapi.dev/dub/dub/code-samples-python-my-first-target:main
+      - location: registry.speakeasyapi.dev/dub/dub/code-samples-php-my-first-target:main
+      - location: registry.speakeasyapi.dev/dub/dub/code-samples-ruby-my-first-target:main
+    output: ./apps/docs/dub-openapi.yaml
+targets: { }

--- a/apps/docs/mint.json
+++ b/apps/docs/mint.json
@@ -30,7 +30,7 @@
     "name": "Dashboard",
     "url": "https://app.dub.co"
   },
-  "openapi": "http://api.dub.co",
+  "openapi": "/dub-openapi.yaml",
   "tabs": [
     {
       "name": "API Reference",


### PR DESCRIPTION
- Adds Speakeasy `workflow.yaml` to pull code samples from Speakeasy and overlay them onto Dub OAS
- Adds GitHub action to run the above Speakeasy workflow on a cron (daily), or when manually triggered
- Updates `mint.json` to read from overlaid OAS rather than directly from `api.dub.co`