### PR TITLE
Fix filter select conflicts

### DIFF
--- a/packages/ui/src/filter/filter-select.tsx
+++ b/packages/ui/src/filter/filter-select.tsx
@@ -367,11 +367,11 @@ function FilterButton({
       onPointerDown={(e) => {
         e.preventDefault();
       }}
-      onPointerUp={(e) => {
+      onPointerUp={() => {
         onSelect();
       }}
       onSelect={onSelect}
-      value={label}
+      value={label + option?.value}
     >
       <span className="shrink-0 text-gray-600">
         {isReactNode(Icon) ? Icon : <Icon className="h-4 w-4" />}


### PR DESCRIPTION
Right now, our `Filter.Select` component can potentially have a conflict if two items have the same label

This PR adds a "pseudo" suffix to the Command.Item value with the value that's passed in

The downside is you can also filter by those values, but since those are usually randomly-generated unique IDs it shouldn't be too bad

Before:

https://github.com/user-attachments/assets/d0638702-ee79-40d6-aed6-2bbacfe2d3fe

After:

https://github.com/user-attachments/assets/73eb8bc4-31f0-4d20-970e-e626ae882f62

