### PR TITLE
Fix link modal domain `<select>` font size

### DIFF
--- a/apps/web/ui/modals/add-edit-link-modal/index.tsx
+++ b/apps/web/ui/modals/add-edit-link-modal/index.tsx
@@ -603,7 +603,7 @@ function AddEditLinkModal({
                           setData({ ...data, domain: e.target.value });
                         }}
                         className={cn(
-                          "max-w-[12rem] rounded-l-md border border-r-0 border-gray-300 bg-gray-50 pl-4 pr-8 text-sm text-gray-500 focus:border-gray-300 focus:outline-none focus:ring-0",
+                          "max-w-[12rem] rounded-l-md border border-r-0 border-gray-300 bg-gray-50 pl-4 pr-8 text-gray-500 focus:border-gray-300 focus:outline-none focus:ring-0 sm:text-sm",
                           props && lockKey && "cursor-not-allowed",
                           loading && "w-[6rem] text-transparent",
                         )}


### PR DESCRIPTION
Makes domain `<select>` font size match key `<input>`