### PR TITLE
Align `useMediaQuery` breakpoints with Tailwind

### DIFF
--- a/packages/ui/src/hooks/use-media-query.ts
+++ b/packages/ui/src/hooks/use-media-query.ts
@@ -3,11 +3,11 @@ import { useEffect, useState } from "react";
 function getDevice(): "mobile" | "tablet" | "desktop" | null {
   if (typeof window === "undefined") return null;
 
-  return window.matchMedia("(max-width: 640px)").matches
-    ? "mobile"
-    : window.matchMedia("(min-width: 641px) and (max-width: 1024px)").matches
+  return window.matchMedia("(min-width: 1024px)").matches
+    ? "desktop"
+    : window.matchMedia("(min-width: 640px)").matches
       ? "tablet"
-      : "desktop";
+      : "mobile";
 }
 
 function getDimensions() {


### PR DESCRIPTION
Previously, `useMediaQuery`'s `tablet` started at 641px, while Tailwind's `sm` started at 640px. Now both will start at 640px.

This caused issues such as [ENG-372](https://linear.app/dubinc/issue/ENG-372)