### PR TITLE
Add missing titles to events table columns

### DIFF
--- a/apps/web/ui/analytics/events/events-table.tsx
+++ b/apps/web/ui/analytics/events/events-table.tsx
@@ -101,12 +101,16 @@ export default function EventsTable() {
               {getValue() ? (
                 <>
                   <QRCode className="size-4 shrink-0" />
-                  <span className="truncate">QR scan</span>
+                  <span className="truncate" title="QR scan">
+                    QR scan
+                  </span>
                 </>
               ) : (
                 <>
                   <CursorRays className="size-4 shrink-0" />
-                  <span className="truncate">Link click</span>
+                  <span className="truncate" title="Link click">
+                    Link click
+                  </span>
                 </>
               )}
             </div>
@@ -119,7 +123,11 @@ export default function EventsTable() {
           accessorKey: "event_name",
           enableHiding: false,
           cell: ({ getValue }) =>
-            getValue() || <span className="text-gray-400">-</span>,
+            (
+              <span className="truncate" title={getValue()}>
+                {getValue()}
+              </span>
+            ) || <span className="text-gray-400">-</span>,
         },
         // Sale invoice ID
         {
@@ -128,7 +136,11 @@ export default function EventsTable() {
           accessorKey: "invoice_id",
           maxSize: 200,
           cell: ({ getValue }) =>
-            getValue() || <span className="text-gray-400">-</span>,
+            (
+              <span className="truncate" title={getValue()}>
+                {getValue()}
+              </span>
+            ) || <span className="text-gray-400">-</span>,
         },
         {
           id: "link",
@@ -171,7 +183,7 @@ export default function EventsTable() {
           cell: ({ getValue }) => {
             const display = getValue().name || getValue().email || "Unknown";
             return (
-              <div className="flex items-center gap-3">
+              <div className="flex items-center gap-3" title={display}>
                 <img
                   alt={display}
                   src={getValue().avatar}
@@ -190,7 +202,10 @@ export default function EventsTable() {
             filterParams: ({ getValue }) => ({ continent: getValue() }),
           },
           cell: ({ getValue }) => (
-            <div className="flex items-center gap-3">
+            <div
+              className="flex items-center gap-3"
+              title={CONTINENTS[getValue()] ?? "Unknown"}
+            >
               <ContinentIcon display={getValue()} className="size-4 shrink-0" />
               <span className="truncate">
                 {CONTINENTS[getValue()] ?? "Unknown"}
@@ -206,7 +221,10 @@ export default function EventsTable() {
             filterParams: ({ getValue }) => ({ country: getValue() }),
           },
           cell: ({ getValue }) => (
-            <div className="flex items-center gap-3">
+            <div
+              className="flex items-center gap-3"
+              title={COUNTRIES[getValue()] ?? getValue()}
+            >
               {getValue() === "Unknown" ? (
                 <Globe className="size-4 shrink-0" />
               ) : (
@@ -228,7 +246,7 @@ export default function EventsTable() {
           accessorKey: "city",
           minSize: 160,
           cell: ({ getValue, row }) => (
-            <div className="flex items-center gap-3">
+            <div className="flex items-center gap-3" title={getValue()}>
               {row.original.country === "Unknown" ? (
                 <Globe className="size-4 shrink-0" />
               ) : (
@@ -250,7 +268,7 @@ export default function EventsTable() {
             filterParams: ({ getValue }) => ({ device: getValue() }),
           },
           cell: ({ getValue }) => (
-            <div className="flex items-center gap-3">
+            <div className="flex items-center gap-3" title={getValue()}>
               <DeviceIcon
                 display={capitalize(getValue()) ?? getValue()}
                 tab="devices"
@@ -265,7 +283,7 @@ export default function EventsTable() {
           header: "Browser",
           accessorKey: "browser",
           cell: ({ getValue }) => (
-            <div className="flex items-center gap-3">
+            <div className="flex items-center gap-3" title={getValue()}>
               <DeviceIcon
                 display={capitalize(getValue()) ?? getValue()}
                 tab="browsers"
@@ -280,7 +298,7 @@ export default function EventsTable() {
           header: "OS",
           accessorKey: "os",
           cell: ({ getValue }) => (
-            <div className="flex items-center gap-3">
+            <div className="flex items-center gap-3" title={getValue()}>
               <DeviceIcon
                 display={capitalize(getValue()) ?? getValue()}
                 tab="os"
@@ -295,7 +313,7 @@ export default function EventsTable() {
           header: "Referer",
           accessorKey: "referer",
           cell: ({ getValue }) => (
-            <div className="flex items-center gap-3">
+            <div className="flex items-center gap-3" title={getValue()}>
               {getValue() === "(direct)" ? (
                 <Link2 className="h-4 w-4" />
               ) : (
@@ -314,7 +332,9 @@ export default function EventsTable() {
           accessorKey: "ip",
           cell: ({ getValue }) =>
             getValue() ? (
-              <span className="truncate">{getValue()}</span>
+              <span className="truncate" title={getValue()}>
+                {getValue()}
+              </span>
             ) : (
               <Tooltip content="We do not record IP addresses for EU users.">
                 <span className="cursor-default truncate underline decoration-dotted">

--- a/packages/ui/src/table/table.tsx
+++ b/packages/ui/src/table/table.tsx
@@ -259,7 +259,7 @@ export function Table<T>({
                       }}
                     >
                       <div className="flex w-full items-center justify-between overflow-hidden truncate">
-                        <div className="min-w-0 shrink grow">
+                        <div className="min-w-0 shrink grow truncate">
                           {flexRender(
                             cell.column.columnDef.cell,
                             cell.getContext(),


### PR DESCRIPTION
Adds missing titles to events table columns. We could do tooltips instead if we'd like, but we'd probably still want a hover delay so they're not too obnoxious.