### PR TITLE
feat: add `photos.google.com` to the list of allowed `ggl.link`

### DIFF
--- a/packages/utils/src/constants/dub-domains.ts
+++ b/packages/utils/src/constants/dub-domains.ts
@@ -99,6 +99,7 @@ export const DUB_DOMAINS = [
             "drive.google.com",
             "calendar.google.com",
             "maps.google.com",
+            "photos.google.com",
             "googleblog.com",
             "developers.googleblog.com",
             "chromewebstore.google.com",


### PR DESCRIPTION
Fixes following issue 👇🏼 

![image](https://github.com/user-attachments/assets/59edd444-e093-4bdf-85a8-e17763f41f3b)
