### PR TITLE
feat: add search.google.com to the list of allowed ggl.link

### DIFF
--- a/packages/utils/src/constants/dub-domains.ts
+++ b/packages/utils/src/constants/dub-domains.ts
@@ -100,6 +100,7 @@ export const DUB_DOMAINS = [
             "calendar.google.com",
             "maps.google.com",
             "photos.google.com",
+            "search.google.com",
             "googleblog.com",
             "developers.googleblog.com",
             "chromewebstore.google.com",


### PR DESCRIPTION
Resolve problem preventing the use of search.google.com links with ggl.link

<img width="437" alt="error" src="https://github.com/user-attachments/assets/2d98f318-0ccf-441c-961a-ac2388659daf">
