### PR TITLE
Improve the integration installation

### DIFF
--- a/apps/web/app/api/oauth/token/exchange-code-for-token.ts
+++ b/apps/web/app/api/oauth/token/exchange-code-for-token.ts
@@ -2,6 +2,7 @@ import { DubApiError } from "@/lib/api/errors";
 import { OAUTH_CONFIG } from "@/lib/api/oauth/constants";
 import { createToken, generateCodeChallengeHash } from "@/lib/api/oauth/utils";
 import { hashToken } from "@/lib/auth";
+import { installIntegration } from "@/lib/integrations/install";
 import { generateRandomName } from "@/lib/names";
 import { prisma } from "@/lib/prisma";
 import z from "@/lib/zod";
@@ -172,24 +173,13 @@ export const exchangeAuthCodeForToken = async (
   );
 
   const { userId, projectId, scopes } = accessCode;
-  const { integrationId } = app;
 
   // Install the app
   // We only support one token per client per user per workspace at a time
-  const installation = await prisma.installedIntegration.upsert({
-    create: {
-      userId,
-      projectId,
-      integrationId,
-    },
-    update: {},
-    where: {
-      userId_integrationId_projectId: {
-        userId,
-        projectId,
-        integrationId,
-      },
-    },
+  const installation = await installIntegration({
+    userId,
+    workspaceId: projectId,
+    integrationId: app.integrationId,
   });
 
   await prisma.$transaction([

--- a/apps/web/app/api/slack/callback/route.ts
+++ b/apps/web/app/api/slack/callback/route.ts
@@ -6,7 +6,11 @@ import { SlackCredential } from "@/lib/integrations/slack/type";
 import { prisma } from "@/lib/prisma";
 import { redis } from "@/lib/upstash";
 import z from "@/lib/zod";
-import { APP_DOMAIN_WITH_NGROK, getSearchParams } from "@dub/utils";
+import {
+  APP_DOMAIN_WITH_NGROK,
+  getSearchParams,
+  SLACK_INTEGRATION_ID,
+} from "@dub/utils";
 import { Project } from "@prisma/client";
 import { redirect } from "next/navigation";
 
@@ -80,7 +84,7 @@ export const GET = async (req: Request) => {
     };
 
     await installIntegration({
-      integrationSlug: "slack",
+      integrationId: SLACK_INTEGRATION_ID,
       userId: session.user.id,
       workspaceId,
       credentials,

--- a/apps/web/app/api/stripe/connect/callback/route.ts
+++ b/apps/web/app/api/stripe/connect/callback/route.ts
@@ -3,7 +3,7 @@ import { installIntegration } from "@/lib/integrations/install";
 import { prisma } from "@/lib/prisma";
 import { redis } from "@/lib/upstash";
 import z from "@/lib/zod";
-import { APP_DOMAIN, getSearchParams } from "@dub/utils";
+import { APP_DOMAIN, getSearchParams, STRIPE_INTEGRATION_ID } from "@dub/utils";
 import { redirect } from "next/navigation";
 import { NextRequest } from "next/server";
 
@@ -69,7 +69,7 @@ export const GET = async (req: NextRequest) => {
     });
 
     await installIntegration({
-      integrationSlug: "stripe",
+      integrationId: STRIPE_INTEGRATION_ID,
       userId: session.user.id,
       workspaceId: workspace.id,
     });

--- a/apps/web/emails/integration-installed.tsx
+++ b/apps/web/emails/integration-installed.tsx
@@ -1,0 +1,74 @@
+import { DUB_WORDMARK } from "@dub/utils";
+import {
+  Body,
+  Container,
+  Head,
+  Heading,
+  Html,
+  Img,
+  Link,
+  Preview,
+  Section,
+  Tailwind,
+  Text,
+} from "@react-email/components";
+import Footer from "./components/footer";
+
+export default function IntegrationInstalled({
+  email = "panic@thedis.co",
+  workspace = {
+    name: "Acme, Inc",
+    slug: "acme",
+  },
+  integration = {
+    name: "Slack",
+    slug: "slack",
+  },
+}: {
+  email: string;
+  workspace: {
+    name: string;
+    slug: string;
+  };
+  integration: {
+    name: string;
+    slug: string;
+  };
+}) {
+  return (
+    <Html>
+      <Head />
+      <Preview>An integration has been added to your workspace</Preview>
+      <Tailwind>
+        <Body className="mx-auto my-auto bg-white font-sans">
+          <Container className="mx-auto my-10 max-w-[500px] rounded border border-solid border-gray-200 px-10 py-5">
+            <Section className="mt-8">
+              <Img
+                src={DUB_WORDMARK}
+                height="40"
+                alt="Dub.co"
+                className="mx-auto my-0"
+              />
+            </Section>
+            <Heading className="mx-0 my-7 p-0 text-center text-xl font-semibold text-black">
+              An integration has been added to your workspace
+            </Heading>
+            <Text className="text-sm leading-6 text-black">
+              The <strong>{integration.name}</strong> integration has been added
+              to your workspace {workspace.name} on Dub.
+            </Text>
+            <Section className="mb-8 mt-4 text-center">
+              <Link
+                className="rounded-full bg-black px-6 py-3 text-center text-[12px] font-semibold text-white no-underline"
+                href={`https://app.dub.co/${workspace.slug}/settings/integrations/${integration.slug}`}
+              >
+                View installed integration
+              </Link>
+            </Section>
+            <Footer email={email} />
+          </Container>
+        </Body>
+      </Tailwind>
+    </Html>
+  );
+}

--- a/apps/web/ui/oauth-apps/add-edit-app-form.tsx
+++ b/apps/web/ui/oauth-apps/add-edit-app-form.tsx
@@ -63,11 +63,15 @@ export default function AddOAuthAppForm({
   });
 
   useEffect(() => {
+    if (oAuthApp) {
+      return;
+    }
+
     setData((prev) => ({
       ...prev,
-      slug: slugify(name),
+      slug: slugify(prev.name),
     }));
-  }, [data.name]);
+  }, [data.name, oAuthApp]);
 
   useEffect(() => {
     if (oAuthApp) {

--- a/packages/utils/src/constants/index.ts
+++ b/packages/utils/src/constants/index.ts
@@ -4,6 +4,7 @@ export * from "./countries";
 export * from "./domains";
 export * from "./dub-domains";
 export * from "./framer-motion";
+export * from "./integrations";
 export * from "./layout";
 export * from "./localhost";
 export * from "./main";

--- a/packages/utils/src/constants/integrations.ts
+++ b/packages/utils/src/constants/integrations.ts
@@ -1,0 +1,2 @@
+export const SLACK_INTEGRATION_ID = "clzu59rx9000110bm5fnlzwuj";
+export const STRIPE_INTEGRATION_ID = "clzra1ya60001wnj4a89zcg9h";

--- a/packages/utils/src/constants/misc.ts
+++ b/packages/utils/src/constants/misc.ts
@@ -33,6 +33,3 @@ export const PAGINATION_LIMIT = 100;
 export const TWO_WEEKS_IN_SECONDS = 60 * 60 * 24 * 14;
 
 export const DUB_FOUNDING_DATE = new Date("2022-09-22T00:00:00.000Z");
-
-export const SLACK_INTEGRATION_ID = "clzu59rx9000110bm5fnlzwuj";
-export const STRIPE_INTEGRATION_ID = "clzra1ya60001wnj4a89zcg9h";


### PR DESCRIPTION
1. Send an email after the integration installation
2. Use `installIntegration` in the OAuth installation process