### PR TITLE
Fix Typo in v1_events.pipe

### DIFF
--- a/packages/tinybird/pipes/v1_events.pipe
+++ b/packages/tinybird/pipes/v1_events.pipe
@@ -9,7 +9,7 @@ SQL >
 
     %
     SELECT link_id, domain, key
-    from dub_links_metadata_lambda
+    from dub_links_metadata_latest
     WHERE
         workspace_id
         = {{


### PR DESCRIPTION
I was unable to ```tb push``` until i found that typo and changed it