### PR TITLE
fix(ui): handle non-domain titles in DomainCardTitleColumn component

### DIFF
--- a/apps/web/ui/domains/domain-card-title-column.tsx
+++ b/apps/web/ui/domains/domain-card-title-column.tsx
@@ -46,7 +46,6 @@ export function DomainCardTitleColumn({
           ) : (
             <div
               className="truncate text-sm font-medium"
-              title={domain}
             >
               {domain}
             </div>

--- a/apps/web/ui/domains/domain-card-title-column.tsx
+++ b/apps/web/ui/domains/domain-card-title-column.tsx
@@ -44,9 +44,7 @@ export function DomainCardTitleColumn({
               {punycode(domain)}
             </a>
           ) : (
-            <div
-              className="truncate text-sm font-medium"
-            >
+            <div className="truncate text-sm font-medium">
               {domain}
             </div>
           )}

--- a/apps/web/ui/domains/domain-card-title-column.tsx
+++ b/apps/web/ui/domains/domain-card-title-column.tsx
@@ -1,5 +1,5 @@
 import { ArrowTurnRight2, Flag2, Globe } from "@dub/ui/src/icons";
-import { cn, getPrettyUrl, punycode, isValidUrl } from "@dub/utils";
+import { cn, getPrettyUrl, isValidUrl, punycode } from "@dub/utils";
 import { Star } from "lucide-react";
 
 export function DomainCardTitleColumn({
@@ -44,9 +44,7 @@ export function DomainCardTitleColumn({
               {punycode(domain)}
             </a>
           ) : (
-            <div className="truncate text-sm font-medium">
-              {domain}
-            </div>
+            <div className="truncate text-sm font-medium">{domain}</div>
           )}
 
           {primary ? (

--- a/apps/web/ui/domains/domain-card-title-column.tsx
+++ b/apps/web/ui/domains/domain-card-title-column.tsx
@@ -1,5 +1,5 @@
 import { ArrowTurnRight2, Flag2, Globe } from "@dub/ui/src/icons";
-import { cn, getPrettyUrl, punycode } from "@dub/utils";
+import { cn, getPrettyUrl, punycode, isValidUrl } from "@dub/utils";
 import { Star } from "lucide-react";
 
 export function DomainCardTitleColumn({
@@ -17,6 +17,7 @@ export function DomainCardTitleColumn({
   primary?: boolean;
   defaultDomain?: boolean;
 }) {
+  const isDomainUrl = isValidUrl(`http://${domain}`);
   return (
     <div className="flex min-w-0 items-center gap-4">
       <div className="hidden rounded-full border border-gray-200 sm:block">
@@ -32,15 +33,24 @@ export function DomainCardTitleColumn({
       </div>
       <div className="overflow-hidden">
         <div className="flex items-center gap-1.5 sm:gap-2.5">
-          <a
-            href={`http://${domain}`}
-            target="_blank"
-            rel="noreferrer"
-            className="truncate text-sm font-medium"
-            title={punycode(domain)}
-          >
-            {punycode(domain)}
-          </a>
+          {isDomainUrl ? (
+            <a
+              href={`http://${domain}`}
+              target="_blank"
+              rel="noreferrer"
+              className="truncate text-sm font-medium"
+              title={punycode(domain)}
+            >
+              {punycode(domain)}
+            </a>
+          ) : (
+            <div
+              className="truncate text-sm font-medium"
+              title={domain}
+            >
+              {domain}
+            </div>
+          )}
 
           {primary ? (
             <span className="xs:px-3 xs:py-1 flex items-center gap-1 rounded-full bg-sky-400/[.15] px-1.5 py-0.5 text-xs font-medium text-sky-600">


### PR DESCRIPTION
[![Bug Video](https://github.com/user-attachments/assets/f90ea944-b3c1-4991-8ad7-06a98163b7d0)](https://github.com/user-attachments/assets/f90ea944-b3c1-4991-8ad7-06a98163b7d0)

This pull request addresses an issue in the `DomainCardTitleColumn` component where titles passed as props were incorrectly assumed to be domains. When non-domain titles were provided, the component attempted to render them as links to `http://<title>`, leading to incorrect behavior.

#### Changes

- **Updated `DomainCardTitleColumn` component:**
  - **Rendering Logic:**
    - Utilized the `isValidUrl` function to check if the `title` is a valid URL.
    - If `title` is a valid URL, render it as a clickable link.
    - If not, render `title` as plain text within a `<div>` element, maintaining consistent styling.

#### Before and After

**Before Fix:**

- Non-domain titles were rendered as links pointing to `http://<title>`, which was incorrect and could lead to broken links.

**After Fix:**

- Non-domain titles are rendered correctly as plain text.
- Titles that are valid URLs continue to be rendered as clickable links.