### PR TITLE
fix: 'Save Changes' button remaining disabled after correcting input …

### DIFF
--- a/apps/web/ui/modals/link-builder/index.tsx
+++ b/apps/web/ui/modals/link-builder/index.tsx
@@ -161,23 +161,18 @@ function LinkBuilderInner({
       Disable save if:
       - modal is not open
       - saving is in progress
-      - key is invalid
-      - url is invalid
       - for an existing link, there's no changes
     */
     return Boolean(
       !showLinkBuilder ||
         isSubmitting ||
         isSubmitSuccessful ||
-        errors.key ||
-        errors.url ||
         (props && !isDirty),
     );
   }, [
     showLinkBuilder,
     isSubmitting,
     isSubmitSuccessful,
-    errors,
     props,
     isDirty,
   ]);


### PR DESCRIPTION
Fixes #1318

[![Bug Video](https://github.com/user-attachments/assets/5d17c684-d99d-40d1-9650-8e5ba18427d7)](https://github.com/user-attachments/assets/5d17c684-d99d-40d1-9650-8e5ba18427d7)


**Problem:**

- When an invalid destination URL or key is entered and the form is submitted, the "Save Changes" button becomes disabled due to validation errors.
- After correcting the invalid input, the button remains disabled, preventing users from resubmitting the form unless they close and reopen the modal.

**Solution:**

- Removed `errors.key` and `errors.url` from the `saveDisabled` calculation in the `LinkBuilder` component.
- This change allows the "Save Changes" button to remain enabled even when there are validation errors, enabling users to correct inputs and resubmit without having to restart the process.

**Changes:**

- Modified `saveDisabled` in `apps/web/ui/modals/link-builder/index.tsx` to exclude `errors.key` and `errors.url`.