### PR TITLE
Changing overflow on help popup to hide horizontal scroll bar

### DIFF
--- a/apps/web/ui/layout/help/help-section.tsx
+++ b/apps/web/ui/layout/help/help-section.tsx
@@ -14,7 +14,7 @@ export function HelpSection() {
 
   return (
     <motion.div
-      className="w-full overflow-scroll sm:w-[32rem]"
+      className="w-full overflow-y-scroll sm:w-[32rem]"
       animate={{
         height: resizeObserverEntry?.borderBoxSize[0].blockSize ?? "auto",
         maxHeight: "calc(100vh - 10rem)",


### PR DESCRIPTION
There is an unnecessary horizontal scrollbar on the help popup due to the class `overflow-scroll` so this PR changes the class to `overflow-y-scroll`
![Screenshot 2024-10-10 at 1 55 51 PM](https://github.com/user-attachments/assets/c5e8f543-368d-4ade-9fbc-06d0ba46e465)
![Screenshot 2024-10-10 at 1 56 38 PM](https://github.com/user-attachments/assets/aa873c8f-00b6-475d-b707-2bcbfb87708d)
