### PR TITLE
fix: redirection to login page on cancelling of consent of oauth providers

### DIFF
--- a/apps/web/lib/auth/options.ts
+++ b/apps/web/lib/auth/options.ts
@@ -278,6 +278,7 @@ export const authOptions: NextAuthOptions = {
     },
   },
   pages: {
+    signIn: "/login",
     error: "/login",
   },
   callbacks: {


### PR DESCRIPTION
### Summary

Fixes [#1429](https://github.com/dubinc/dub/issues/1429)
This PR aims to fix the issue which is raised under #1429. To summarise the issue here, when a user selected any OAuth provider to log in but then cancels on the permission page, it was not getting redirected to the default login page. This issue was instead causing the redirection to be handled via the nextauth's default redirection mechanism since it was not able to find our own signin route. More details on the issue can be found in the issue link added above.

### Changes

Added a signIn route in the pages configuration of nextAuth options. 

### Screenshot/Video of the fix:

https://github.com/user-attachments/assets/45723130-0298-4229-a16d-4e821d7143c3

### References:
https://github.com/nextauthjs/next-auth/discussions/3682