### PR TITLE
FIX: Metatag-Edge case fix, resolves #427

### DIFF
--- a/apps/web/app/api/links/check-conversion-script/route.ts
+++ b/apps/web/app/api/links/check-conversion-script/route.ts
@@ -17,7 +17,7 @@ export async function GET(req: NextRequest) {
     // ping URL to see if the dubcdn.com/analytics/script.js script is installed
     const res = await fetchWithTimeout(url, {
       headers: {
-        "User-Agent": "Dub.co Bot",
+        "User-Agent": "Dub.co",
       },
     });
 

--- a/apps/web/app/api/metatags/utils.ts
+++ b/apps/web/app/api/metatags/utils.ts
@@ -7,7 +7,7 @@ import { parse } from "node-html-parser";
 export const getHtml = async (url: string) => {
   return await fetchWithTimeout(url, {
     headers: {
-      "User-Agent": "Dub.co Bot",
+      "User-Agent": "Dub.co",
     },
   })
     .then((r) => r.text())

--- a/packages/utils/src/functions/is-iframeable.ts
+++ b/packages/utils/src/functions/is-iframeable.ts
@@ -8,7 +8,7 @@ export const isIframeable = async ({
 }) => {
   const res = await fetch(url, {
     headers: {
-      "User-Agent": "Dub.co Bot",
+      "User-Agent": "Dub.co",
     },
   });
 


### PR DESCRIPTION
The issue of not showing metadata in some edge case websites is because they have blocked bots User-Agent, and while fetching the metadata the user agent is defined as `Dub.co Bot` in request headers, which are blocked by the host website.
The simple solution is to remove the term `bot` from the header which i figured out after debugging for 4 days 😑. @steven-tey . Please review this.

https://github.com/user-attachments/assets/5ec4028b-505d-4e2c-8f7a-9735c6e2ff9f



