### PR TITLE
fix(api): reorder `trim()` method calls in Zod schema

### DIFF
--- a/apps/web/lib/zod/schemas/tags.ts
+++ b/apps/web/lib/zod/schemas/tags.ts
@@ -38,17 +38,17 @@ export const createTagBodySchema = z
   .object({
     name: z
       .string()
+      .trim()
       .min(1)
       .max(50)
-      .trim()
       .describe("The name of the tag to create."),
     color: tagColorSchema.describe(
       `The color of the tag. If not provided, a random color will be used from the list: ${tagColors.join(", ")}.`,
     ),
     tag: z
       .string()
-      .min(1)
       .trim()
+      .min(1)
       .describe("The name of the tag to create.")
       .openapi({ deprecated: true }),
   })

--- a/apps/web/lib/zod/schemas/utm.ts
+++ b/apps/web/lib/zod/schemas/utm.ts
@@ -1,39 +1,45 @@
 import z from "@/lib/zod";
 
 export const createUTMTemplateBodySchema = z.object({
-  name: z.string().min(1).max(50).trim(),
+  name: z.string().trim().min(1, "UTM name is required").max(50),
   utm_source: z
     .string()
+    .trim()
     .max(190)
     .nullish()
     .transform((v) => v ?? null)
     .describe("The UTM source of the short link."),
   utm_medium: z
     .string()
+    .trim()
     .max(190)
     .nullish()
     .transform((v) => v ?? null)
     .describe("The UTM medium of the short link."),
   utm_campaign: z
     .string()
+    .trim()
     .max(190)
     .nullish()
     .transform((v) => v ?? null)
     .describe("The UTM campaign of the short link."),
   utm_term: z
     .string()
+    .trim()
     .max(190)
     .nullish()
     .transform((v) => v ?? null)
     .describe("The UTM term of the short link."),
   utm_content: z
     .string()
+    .trim()
     .max(190)
     .nullish()
     .transform((v) => v ?? null)
     .describe("The UTM content of the short link."),
   ref: z
     .string()
+    .trim()
     .max(190)
     .nullish()
     .transform((v) => v ?? null)


### PR DESCRIPTION
## What does this PR do?

- [x] Moves `trim()` method to be called before `min(1)` to resolve validation issues.
- [x] Adds `trim()` to all UTM fields in UTM Create schema.

Fixes: #1647

## How to test?

Make sure that creating a UTM template with only whitespace characters is prevented. You should see "UTM name is required" error toast.