### PR TITLE
fix(ui): correct toast message on domain archive/unarchive undo action

### DIFF
--- a/apps/web/ui/modals/archive-domain-modal.tsx
+++ b/apps/web/ui/modals/archive-domain-modal.tsx
@@ -31,6 +31,14 @@ const sendArchiveRequest = ({
   });
 };
 
+const revalidateDomains = () => {
+  return mutate(
+    (key) => typeof key === "string" && key.startsWith("/api/domains"),
+    undefined,
+    { revalidate: true },
+  );
+};
+
 function ArchiveDomainModal({
   showArchiveDomainModal,
   setShowArchiveDomainModal,
@@ -63,13 +71,7 @@ function ArchiveDomainModal({
       return;
     }
 
-    await mutate(
-      (key) => typeof key === "string" && key.startsWith("/api/domains"),
-      undefined,
-      {
-        revalidate: true,
-      },
-    );
+    revalidateDomains();
     setShowArchiveDomainModal(false);
     toastWithUndo({
       id: "domain-archive-undo-toast",
@@ -89,12 +91,8 @@ function ArchiveDomainModal({
       {
         loading: "Undo in progress...",
         error: "Failed to roll back changes. An error occurred.",
-        success: async () => {
-          await mutate(
-            (key) => typeof key === "string" && key.startsWith("/api/domains"),
-            undefined,
-            { revalidate: true },
-          );
+        success: () => {
+          revalidateDomains();
           return "Undo successful! Changes reverted.";
         },
       },


### PR DESCRIPTION
### What does this PR do?

Fixes #1652. `toast.promise` expects a function for success/error messages that returns either a `ReactNode` or a `string` — it does not support `Promises`. Using async/await caused the UI bug described in the issue.

### How to test?

1. Head over your `Settings > Domains` page
2. Archive any domain you have and click the "Undo" button in a toast
3. You should see a human-readable success messsage
4. Same when undoing the unarchive action
