### PR TITLE
Rename `dub_links_metadata_lambda` to `dub_links_metadata_latest`

### DIFF
--- a/packages/tinybird/pipes/v1_events.pipe
+++ b/packages/tinybird/pipes/v1_events.pipe
@@ -11,7 +11,7 @@ SQL >
 
     %
     SELECT link_id, domain, key
-    from dub_links_metadata_lambda
+    from dub_links_metadata_latest
     WHERE
         workspace_id
         = {{


### PR DESCRIPTION
When following [the guide](https://dub.co/docs/local-development) for setting up dub for local development, I ran into failure when running `tb push` (see bellow). I believe it's due to a typo in a TinyBird table, this PR fixes it.

Am I right in assuming that it's a typo?


## tb push error

```
...
** 'v1_browsers' created
** Running 'v1_events'
Error:
** Failed running ./pipes/v1_events.pipe:
** Failed pushing pipe v1_events: Resource 'dub_links_metadata_lambda' not found
```