### PR TITLE
Update `getLinkOrThrow` to accept `workspaceId` instead of `workspace` object.

### DIFF
--- a/apps/web/app/api/analytics/export/route.ts
+++ b/apps/web/app/api/analytics/export/route.ts
@@ -27,7 +27,7 @@ export const GET = withWorkspace(
 
     if (linkId || externalId || (domain && key)) {
       link = await getLinkOrThrow({
-        workspace: workspace,
+        workspaceId: workspace.id,
         linkId,
         externalId,
         domain,

--- a/apps/web/app/api/analytics/route.ts
+++ b/apps/web/app/api/analytics/route.ts
@@ -47,7 +47,7 @@ export const GET = withWorkspace(
 
     if (linkId || externalId || (domain && key)) {
       link = await getLinkOrThrow({
-        workspace: workspace,
+        workspaceId: workspace.id,
         linkId,
         externalId,
         domain,

--- a/apps/web/app/api/dashboards/route.ts
+++ b/apps/web/app/api/dashboards/route.ts
@@ -28,7 +28,7 @@ export const POST = withWorkspace(
     const { domain, key } = domainKeySchema.parse(searchParams);
 
     const link = await getLinkOrThrow({
-      workspace,
+      workspaceId: workspace.id,
       domain,
       key,
     });

--- a/apps/web/app/api/events/export/route.ts
+++ b/apps/web/app/api/events/export/route.ts
@@ -60,7 +60,9 @@ export const GET = withWorkspace(
     }
 
     const link =
-      domain && key ? await getLinkOrThrow({ workspace, domain, key }) : null;
+      domain && key
+        ? await getLinkOrThrow({ workspaceId: workspace.id, domain, key })
+        : null;
 
     validDateRangeForPlan({
       plan: workspace.plan,

--- a/apps/web/app/api/events/route.ts
+++ b/apps/web/app/api/events/route.ts
@@ -24,7 +24,7 @@ export const GET = withWorkspace(
 
     if (linkId || externalId || (domain && key)) {
       link = await getLinkOrThrow({
-        workspace: workspace,
+        workspaceId: workspace.id,
         linkId,
         externalId,
         domain,

--- a/apps/web/app/api/links/[linkId]/dashboard/route.ts
+++ b/apps/web/app/api/links/[linkId]/dashboard/route.ts
@@ -11,7 +11,7 @@ export const GET = withWorkspace(
 
     const link = await getLinkOrThrow({
       linkId,
-      workspace,
+      workspaceId: workspace.id,
     });
 
     const dashboard = await prisma.dashboard.findUnique({

--- a/apps/web/app/api/links/[linkId]/route.ts
+++ b/apps/web/app/api/links/[linkId]/route.ts
@@ -20,7 +20,7 @@ import { NextResponse } from "next/server";
 export const GET = withWorkspace(
   async ({ headers, workspace, params }) => {
     const link = await getLinkOrThrow({
-      workspace,
+      workspaceId: workspace.id,
       linkId: params.linkId,
     });
 
@@ -57,7 +57,7 @@ export const GET = withWorkspace(
 export const PATCH = withWorkspace(
   async ({ req, headers, workspace, params }) => {
     const link = await getLinkOrThrow({
-      workspace,
+      workspaceId: workspace.id,
       linkId: params.linkId,
     });
 
@@ -173,7 +173,7 @@ export const PUT = PATCH;
 export const DELETE = withWorkspace(
   async ({ headers, params, workspace }) => {
     const link = await getLinkOrThrow({
-      workspace,
+      workspaceId: workspace.id,
       linkId: params.linkId,
     });
 

--- a/apps/web/app/api/links/[linkId]/transfer/route.ts
+++ b/apps/web/app/api/links/[linkId]/transfer/route.ts
@@ -21,7 +21,7 @@ const transferLinkBodySchema = z.object({
 export const POST = withWorkspace(
   async ({ req, headers, session, params, workspace }) => {
     const link = await getLinkOrThrow({
-      workspace,
+      workspaceId: workspace.id,
       linkId: params.linkId,
     });
 

--- a/apps/web/app/api/links/info/route.ts
+++ b/apps/web/app/api/links/info/route.ts
@@ -22,7 +22,7 @@ export const GET = withWorkspace(
     }
 
     const link = await getLinkOrThrow({
-      workspace,
+      workspaceId: workspace.id,
       linkId,
       externalId,
       domain,

--- a/apps/web/lib/actions/invite-partner.ts
+++ b/apps/web/lib/actions/invite-partner.ts
@@ -30,7 +30,7 @@ export const invitePartnerAction = authActionClient
       }),
 
       getLinkOrThrow({
-        workspace,
+        workspaceId: workspace.id,
         linkId,
       }),
     ]);

--- a/apps/web/lib/api/links/get-link-or-throw.ts
+++ b/apps/web/lib/api/links/get-link-or-throw.ts
@@ -1,10 +1,9 @@
 import { prisma } from "@/lib/prisma";
-import { WorkspaceWithUsers } from "@/lib/types";
 import { Link } from "@prisma/client";
 import { DubApiError } from "../errors";
 
 interface GetLinkParams {
-  workspace: Pick<WorkspaceWithUsers, "id">;
+  workspaceId: string;
   linkId?: string;
   externalId?: string;
   domain?: string;
@@ -13,11 +12,10 @@ interface GetLinkParams {
 
 // Find link
 export const getLinkOrThrow = async (params: GetLinkParams) => {
-  let { workspace, domain, key, externalId } = params;
+  let { workspaceId, domain, key, externalId } = params;
   let link: Link | null = null;
 
   const linkId = params.linkId || params.externalId || undefined;
-  const { id: workspaceId } = workspace;
 
   if (domain && (!key || key === "")) {
     key = "_root";
@@ -68,7 +66,7 @@ export const getLinkOrThrow = async (params: GetLinkParams) => {
   if (link.projectId !== workspaceId) {
     throw new DubApiError({
       code: "unauthorized",
-      message: `Link does not belong to workspace ws_${workspace.id}.`,
+      message: `Link does not belong to workspace ws_${workspaceId}.`,
     });
   }
 


### PR DESCRIPTION
…` object.