### PR TITLE
fix: prevent parent drawers from closing when canceling nested drawers

### DIFF
--- a/apps/web/ui/modals/accept-invite-modal.tsx
+++ b/apps/web/ui/modals/accept-invite-modal.tsx
@@ -89,7 +89,8 @@ function AcceptInviteModal({
           <div className="flex flex-col space-y-6 bg-gray-50 px-4 py-8 text-left sm:px-16">
             <Button
               text="Back to dashboard"
-              onClick={() => {
+              onClick={(e) => {
+                e.stopPropagation();
                 router.push("/");
                 setShowAcceptInviteModal(false);
               }}

--- a/apps/web/ui/modals/add-bank-account-modal.tsx
+++ b/apps/web/ui/modals/add-bank-account-modal.tsx
@@ -140,7 +140,10 @@ const AddBankAccountForm = ({ closeModal }: AddBankAccountFormProps) => {
           text="Cancel"
           className="h-9 w-fit"
           disabled={isSubmitting || isExecuting}
-          onClick={closeModal}
+          onClick={(e) => {
+            e.stopPropagation();
+            closeModal();
+          }}
         />
 
         <Button

--- a/apps/web/ui/modals/deposit-funds-modal.tsx
+++ b/apps/web/ui/modals/deposit-funds-modal.tsx
@@ -105,7 +105,10 @@ const DepositFundsForm = ({ closeModal }: { closeModal: () => void }) => {
           text="Cancel"
           className="h-9 w-fit"
           disabled={isSubmitting || isExecuting}
-          onClick={closeModal}
+          onClick={(e) => {
+            e.stopPropagation();
+            closeModal();
+          }}
         />
 
         <Button

--- a/apps/web/ui/modals/link-builder/advanced-modal.tsx
+++ b/apps/web/ui/modals/link-builder/advanced-modal.tsx
@@ -176,7 +176,8 @@ function AdvancedModal({
               <button
                 type="button"
                 className="text-xs font-medium text-gray-700 transition-colors hover:text-gray-950"
-                onClick={() => {
+                onClick={(e) => {
+                  e.stopPropagation();
                   setValueParent("externalId", null, { shouldDirty: true });
                   setValueParent("identifier", null, { shouldDirty: true });
                   setShowAdvancedModal(false);
@@ -192,7 +193,10 @@ function AdvancedModal({
               variant="secondary"
               text="Cancel"
               className="h-9 w-fit"
-              onClick={() => setShowAdvancedModal(false)}
+              onClick={(e) => {
+                e.stopPropagation();
+                setShowAdvancedModal(false)
+              }}
             />
             <Button
               type="submit"

--- a/apps/web/ui/modals/link-builder/expiration-modal.tsx
+++ b/apps/web/ui/modals/link-builder/expiration-modal.tsx
@@ -231,7 +231,8 @@ function ExpirationModal({
               <button
                 type="button"
                 className="text-xs font-medium text-gray-700 transition-colors hover:text-gray-950"
-                onClick={() => {
+                onClick={(e) => {
+                  e.stopPropagation();
                   setValueParent("expiresAt", null, { shouldDirty: true });
                   setValueParent("expiredUrl", null, { shouldDirty: true });
                   setShowExpirationModal(false);
@@ -247,7 +248,8 @@ function ExpirationModal({
               variant="secondary"
               text="Cancel"
               className="h-9 w-fit"
-              onClick={() => {
+              onClick={(e) => {
+                e.stopPropagation();
                 reset();
                 setShowExpirationModal(false);
               }}

--- a/apps/web/ui/modals/link-builder/og-modal.tsx
+++ b/apps/web/ui/modals/link-builder/og-modal.tsx
@@ -436,7 +436,8 @@ function OGModalInner({
                 <button
                   type="button"
                   className="text-xs font-medium text-gray-700 transition-colors hover:text-gray-950"
-                  onClick={() => {
+                  onClick={(e) => {
+                    e.stopPropagation();
                     setValueParent("proxy", false, { shouldDirty: true });
                     setShowOGModal(false);
                   }}
@@ -451,7 +452,8 @@ function OGModalInner({
                 variant="secondary"
                 text="Cancel"
                 className="h-9 w-fit"
-                onClick={() => {
+                onClick={(e) => {
+                  e.stopPropagation();
                   reset();
                   setShowOGModal(false);
                 }}

--- a/apps/web/ui/modals/link-builder/password-modal.tsx
+++ b/apps/web/ui/modals/link-builder/password-modal.tsx
@@ -176,7 +176,8 @@ function PasswordModalInner({
             <button
               type="button"
               className="text-xs font-medium text-gray-700 transition-colors hover:text-gray-950"
-              onClick={() => {
+              onClick={(e) => {
+                e.stopPropagation();
                 setValueParent("password", null, { shouldDirty: true });
                 setShowPasswordModal(false);
               }}
@@ -191,7 +192,8 @@ function PasswordModalInner({
             variant="secondary"
             text="Cancel"
             className="h-9 w-fit"
-            onClick={() => {
+            onClick={(e) => {
+              e.stopPropagation();
               reset();
               setShowPasswordModal(false);
             }}

--- a/apps/web/ui/modals/link-builder/targeting-modal.tsx
+++ b/apps/web/ui/modals/link-builder/targeting-modal.tsx
@@ -365,7 +365,8 @@ function TargetingModal({
                 <button
                   type="button"
                   className="text-xs font-medium text-gray-700 transition-colors hover:text-gray-950"
-                  onClick={() => {
+                  onClick={(e) => {
+                    e.stopPropagation();
                     setValueParent("ios", null, { shouldDirty: true });
                     setValueParent("android", null, { shouldDirty: true });
                     setValueParent("geo", null, { shouldDirty: true });
@@ -382,7 +383,8 @@ function TargetingModal({
                 variant="secondary"
                 text="Cancel"
                 className="h-9 w-fit"
-                onClick={() => {
+                onClick={(e) => {
+                  e.stopPropagation();
                   reset();
                   setShowTargetingModal(false);
                 }}

--- a/apps/web/ui/modals/link-builder/utm-modal.tsx
+++ b/apps/web/ui/modals/link-builder/utm-modal.tsx
@@ -255,7 +255,8 @@ function UTMModalInner({ setShowUTMModal }: UTMModalProps) {
             variant="secondary"
             text="Cancel"
             className="h-9 w-fit"
-            onClick={() => {
+            onClick={(e) => {
+              e.stopPropagation();
               reset();
               setShowUTMModal(false);
             }}

--- a/apps/web/ui/modals/link-qr-modal.tsx
+++ b/apps/web/ui/modals/link-qr-modal.tsx
@@ -335,7 +335,8 @@ function LinkQRModalInner({
           variant="secondary"
           text="Cancel"
           className="h-9 w-fit"
-          onClick={() => {
+          onClick={(e) => {
+            e.stopPropagation();
             setShowLinkQRModal(false);
           }}
         />


### PR DESCRIPTION
## What does this PR do?

Fixes #1624 — an issue where clicking the "Cancel" button in a nested drawer unintentionally closed its parent drawer.

## ⚠️ Key Dub.co & Vaul Implementation Details
1. **React Portals Usage**: Both Radix dialogs and Vaul drawers are rendered using [React portals](https://react.dev/reference/react-dom/createPortal), allowing them to appear outside their parent component in the DOM hierarchy.
2. **Pseudo-Nested Drawers**: While Vaul drawers may appear visually nested, they are not implemented using the `<Drawer.NestedRoot />` API. Instead, they are treated as siblings in the DOM structure. Refer to the [Vaul documentation on nested drawers](https://vaul.emilkowal.ski/default#nested-drawers) for details.
3. **`onPointerDownOutside` Behavior**: Radix dialogs and Vaul drawers trigger the `onPointerDownOutside` callback when a click occurs outside these components. This callback can be leveraged to prevent unintended dismissals.

## ⚠️ Reproduction

Based on my analysis, the issue occurs under the following conditions:

1. **Vaul Drawers Only**: The issue is specific to Vaul drawers; Radix dialogs do not exhibit this behavior.
2. **First Nested Drawer**: The problem arises only when opening the first nested drawer. Deeper (2+ level) nested drawers are unaffected and require no fixes.

The exact reason for this behavior remains unclear. It may vary across different machines or operating systems, likely depending on Vaul's internal implementation details.

## Probable root cause...

lies in **event bubbling** and the fact that both "parent" and "child" drawers are rendered in a portal, making them DOM siblings instead of a parent-child relationship. When clicking a button in the child drawer triggers the event, it bubbles up to the parent drawer's `onClick` handler (if one exists) or a handler managing the parent drawer's state.

Now, if we take into account that additional detail about the `onPointerDownOutside callback`, we might see that the core problem arises from how the browser and event listeners interpret removing elements from the DOM during event propagation.

### Why the Parent Drawer Detects an "Outside Click"

When you click the button in the child drawer, the following sequence occurs:

1. The `pointerdown` event is dispatched and captured in the DOM.
2. The event starts bubbling up from the target (button) to the ancestors.
3. The child drawer is removed _synchronously_ during event propagation, as it is triggered by the `onclick` callback. While React queues state updates internally (i.e. removal is in fact _asynchronous_), the process is executed extremely quickly.
5. The removal of the child drawer's DOM causes the button (event target) to no longer exist in the DOM when the `onPointerDownOutside` check is executed.

As a result, the parent drawer interprets the `pointerdown` event as happening outside its boundaries, even though the event originated from inside the child drawer.

### Key Takeaway

In a nutshell, 

1. When you click the button, it triggers the `onclick` and `pointerdown` events.
2. `onClick` removes the child drawer synchronously during the event handling phase.
3. By the time the `onPointerDownOutside` callback checks for "outside clicks," the child drawer no longer exists in the DOM, and the event target (button) appears "outside" the parent drawer.

This happens because:

1. The DOM is modified mid-event propagation.
2. Event propagation and DOM updates are asynchronous: React’s DOM updates (e.g., removing the child drawer) can cause the element's parentage to "shift" during the event lifecycle, leading to unexpected behavior.

## Possible Fixes

### Prevent Synchronous Drawer Removal

Defer the removal of the child drawer slightly, allowing the `onPointerDownOutside` check to complete before the DOM changes:

```jsx
const closeChildDrawer = () => {
  setTimeout(() => setChildDrawerVisible(false), 0);
};
```
This ensures the parent drawer still sees the event as occurring "inside" during the check.

### Stop Event Propagation

Use `e.stopPropagation()` in the child drawer's button click handler to prevent the event from being detected by the parent's `onPointerDownOutside` logic:

```jsx
<button
  onClick={(e) => {
    e.stopPropagation();
    closeChildDrawer();
  }}
>
  Close Child
</button>
```

### Customize `onPointerDownOutside`

We're using libraries (Radix UI, Vaul) that provide the `onPointerDownOutside` callback, hence we can customize the behavior to avoid treating clicks inside the child drawer as "outside" clicks.

For example, we can add a condition to the callback:

```jsx
onPointerDownOutside={(e) => {
  // Prevent dismissal when clicking inside a toast
  if (
    e.target instanceof Element &&
    (e.target.closest("[data-sonner-toast]") ||
      e.target.closest("[data-vaul-drawer]"))
  ) {
    e.preventDefault();
  }
}}
```

## In Summary

The fixes (like `e.stopPropagation()` or `setTimeout()`) address symptoms, but the root cause is how the bubbling events interact with our drawer closure logic. Ideally, the best solution would be to leverage Vaul's `<Drawer.NestedRoot />` API. However, this would require a significant refactoring and restructuring of the modal system. Such a task is time-intensive and best handled by the core team to ensure it does not disrupt the app's core functionality.

Another potential solution involves preventing unintended event bubbling at its source. However, since Vaul is an external library, this approach is not feasible for us and I'm not quite sure this is something Vaul should cover.

As a result, this PR aims to highlight the issue while implementing the most straightforward, controlled, and efficient fix: stopping event propagation in child modals' "Cancel" button events. This approach resolves the bug promptly without overhauling the existing structure.

## Testing

This fix was tested by:

1. Opening a parent drawer with a nested drawer.
2. Cancelling the nested drawer and verifying the parent drawer remains open.
3. Confirming other functionalities of both parent and nested drawers remain unaffected.