### PR TITLE
Fix `CalendarDays` icon

### DIFF
--- a/packages/ui/src/icons/nucleo/calendar-days.tsx
+++ b/packages/ui/src/icons/nucleo/calendar-days.tsx
@@ -2,68 +2,82 @@ import { SVGProps } from "react";
 
 export function CalendarDays(props: SVGProps<SVGSVGElement>) {
   return (
-    <svg viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <svg
+      height="18"
+      width="18"
+      viewBox="0 0 18 18"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
       <g fill="currentColor">
-        <path
-          d="M2.25 4.75C2.25 3.64543 3.14543 2.75 4.25 2.75H13.75C14.8546 2.75 15.75 3.64543 15.75 4.75V6.25H2.25V4.75Z"
-          fill="currentColor"
-          fillOpacity="0.3"
-          stroke="none"
-        />
-        <path
-          d="M5.75 2.75V0.75"
+        <line
           fill="none"
           stroke="currentColor"
           strokeLinecap="round"
           strokeLinejoin="round"
           strokeWidth="1.5"
+          x1="5.75"
+          x2="5.75"
+          y1="2.75"
+          y2=".75"
         />
-        <path
-          d="M12.25 2.75V0.75"
+        <line
           fill="none"
           stroke="currentColor"
           strokeLinecap="round"
           strokeLinejoin="round"
           strokeWidth="1.5"
+          x1="12.25"
+          x2="12.25"
+          y1="2.75"
+          y2=".75"
         />
-        <path
-          d="M13.75 2.75H4.25C3.14543 2.75 2.25 3.64543 2.25 4.75V13.25C2.25 14.3546 3.14543 15.25 4.25 15.25H13.75C14.8546 15.25 15.75 14.3546 15.75 13.25V4.75C15.75 3.64543 14.8546 2.75 13.75 2.75Z"
+        <line
           fill="none"
           stroke="currentColor"
           strokeLinecap="round"
           strokeLinejoin="round"
           strokeWidth="1.5"
+          x1="2.25"
+          x2="15.75"
+          y1="6.25"
+          y2="6.25"
         />
-        <path
-          d="M2.25 6.25H15.75"
+        <rect
+          height="12.5"
+          width="13.5"
           fill="none"
+          rx="2"
+          ry="2"
           stroke="currentColor"
           strokeLinecap="round"
           strokeLinejoin="round"
           strokeWidth="1.5"
+          x="2.25"
+          y="2.75"
         />
         <path
-          d="M9 8.25C8.449 8.25 8 8.699 8 9.25C8 9.801 8.449 10.25 9 10.25C9.551 10.25 10 9.801 10 9.25C10 8.699 9.551 8.25 9 8.25Z"
+          d="M9,8.25c-.551,0-1,.449-1,1s.449,1,1,1,1-.449,1-1-.449-1-1-1Z"
           fill="currentColor"
           stroke="none"
         />
         <path
-          d="M12.5 10.25C13.051 10.25 13.5 9.801 13.5 9.25C13.5 8.699 13.051 8.25 12.5 8.25C11.949 8.25 11.5 8.699 11.5 9.25C11.5 9.801 11.949 10.25 12.5 10.25Z"
+          d="M12.5,10.25c.551,0,1-.449,1-1s-.449-1-1-1-1,.449-1,1,.449,1,1,1Z"
           fill="currentColor"
           stroke="none"
         />
         <path
-          d="M9 11.25C8.449 11.25 8 11.699 8 12.25C8 12.801 8.449 13.25 9 13.25C9.551 13.25 10 12.801 10 12.25C10 11.699 9.551 11.25 9 11.25Z"
+          d="M9,11.25c-.551,0-1,.449-1,1s.449,1,1,1,1-.449,1-1-.449-1-1-1Z"
           fill="currentColor"
           stroke="none"
         />
         <path
-          d="M5.5 11.25C4.949 11.25 4.5 11.699 4.5 12.25C4.5 12.801 4.949 13.25 5.5 13.25C6.051 13.25 6.5 12.801 6.5 12.25C6.5 11.699 6.051 11.25 5.5 11.25Z"
+          d="M5.5,11.25c-.551,0-1,.449-1,1s.449,1,1,1,1-.449,1-1-.449-1-1-1Z"
           fill="currentColor"
           stroke="none"
         />
         <path
-          d="M12.5 11.25C11.949 11.25 11.5 11.699 11.5 12.25C11.5 12.801 11.949 13.25 12.5 13.25C13.051 13.25 13.5 12.801 13.5 12.25C13.5 11.699 13.051 11.25 12.5 11.25Z"
+          d="M12.5,11.25c-.551,0-1,.449-1,1s.449,1,1,1,1-.449,1-1-.449-1-1-1Z"
           fill="currentColor"
           stroke="none"
         />


### PR DESCRIPTION
We should be using the Outline version instead of Outline Duo

| Before | After |
|--------|--------|
| ![Screenshot 2024-12-20 at 2 26 52 PM](https://github.com/user-attachments/assets/8a33f3e9-e29c-4db8-90c0-57f12b76c83a) | ![Screenshot 2024-12-20 at 2 26 38 PM](https://github.com/user-attachments/assets/a3d9f17c-91b4-456c-84cf-ffa882fd7aa8) |
