### PR TITLE
Fix truncated focus

### DIFF
--- a/packages/ui/src/animated-size-container.tsx
+++ b/packages/ui/src/animated-size-container.tsx
@@ -38,7 +38,6 @@ const AnimatedSizeContainer = forwardRef<
     return (
       <motion.div
         ref={forwardedRef}
-        className={cn("overflow-hidden", className)}
         animate={{
           width: width
             ? resizeObserverEntry?.contentRect?.width ?? "auto"


### PR DESCRIPTION
I removed the overflow-hidden class from the AnimatedSizeContainer component. After reviewing its usage, I did not find any display issues.

Before:
<img width="940" alt="Screenshot 2024-12-21 at 21 49 18" src="https://github.com/user-attachments/assets/8f0beb83-8762-4be4-ba12-7a92775c500d" />
After:
<img width="1138" alt="Screenshot 2024-12-21 at 21 50 38" src="https://github.com/user-attachments/assets/98500936-b0e2-45d6-819f-a028c4819216" />
