### PR TITLE
Unable to exit the search bar using the ESC key

### DIFF
--- a/apps/web/ui/shared/search-box.tsx
+++ b/apps/web/ui/shared/search-box.tsx
@@ -54,6 +54,8 @@ export const SearchBox = forwardRef(
       ) {
         e.preventDefault();
         inputRef.current?.focus();
+      } else if (e.key === "Escape") {
+        inputRef.current?.blur();
       }
     }, []);
 


### PR DESCRIPTION
Add Escape key functionality to blur the search input, fixing issue #1780.