### PR TITLE
Fix typo in page export: InitesPage -> InvitesPage

### DIFF
--- a/apps/web/app/app.dub.co/(auth)/invites/[code]/page.tsx
+++ b/apps/web/app/app.dub.co/(auth)/invites/[code]/page.tsx
@@ -9,7 +9,7 @@ import { Suspense } from "react";
 
 export const runtime = "nodejs";
 
-export default function InitesPage({
+export default function InvitesPage({
   params,
 }: {
   params: {


### PR DESCRIPTION
This PR fixes a small typo in the export name of the InitesPage component, changing it to InvitesPage for better clarity and consistency.

The typo doesn't seem to cause any functional issues, but i think correcting it helps with readability and avoids potential confusion for future contributors.

Let me know if you'd like me to adjust anything!