### PR TITLE
Refactor QStash signature verification to use raw request body

### DIFF
--- a/apps/web/app/api/cron/domains/configure-dns/route.ts
+++ b/apps/web/app/api/cron/domains/configure-dns/route.ts
@@ -9,9 +9,10 @@ export const dynamic = "force-dynamic";
 */
 export async function POST(req: Request) {
   try {
-    const body = await req.json();
-    await verifyQstashSignature({ req, body });
-    const { domain } = body;
+    const rawBody = await req.text();
+    await verifyQstashSignature({ req, rawBody });
+
+    const { domain } = JSON.parse(rawBody);
 
     const res = await configureDNS({ domain });
     console.log("Dynadot DNS configured.", res);

--- a/apps/web/app/api/cron/domains/delete/route.ts
+++ b/apps/web/app/api/cron/domains/delete/route.ts
@@ -18,11 +18,10 @@ const schema = z.object({
 // POST /api/cron/domains/delete
 export async function POST(req: Request) {
   try {
-    const body = await req.json();
+    const rawBody = await req.text();
+    await verifyQstashSignature({ req, rawBody });
 
-    await verifyQstashSignature({ req, body });
-
-    const { domain, workspaceId } = schema.parse(body);
+    const { domain, workspaceId } = schema.parse(JSON.parse(rawBody));
 
     const domainRecord = await prisma.domain.findUnique({
       where: {

--- a/apps/web/app/api/cron/domains/transfer/route.ts
+++ b/apps/web/app/api/cron/domains/transfer/route.ts
@@ -19,11 +19,12 @@ export const dynamic = "force-dynamic";
 
 export async function POST(req: Request) {
   try {
-    const body = await req.json();
+    const rawBody = await req.text();
+    await verifyQstashSignature({ req, rawBody });
 
-    await verifyQstashSignature({ req, body });
-
-    const { currentWorkspaceId, newWorkspaceId, domain } = schema.parse(body);
+    const { currentWorkspaceId, newWorkspaceId, domain } = schema.parse(
+      JSON.parse(rawBody),
+    );
 
     const links = await prisma.link.findMany({
       where: { domain, projectId: currentWorkspaceId },

--- a/apps/web/app/api/cron/domains/update/route.ts
+++ b/apps/web/app/api/cron/domains/update/route.ts
@@ -20,11 +20,12 @@ const pageSize = 100;
 // POST /api/cron/domains/update
 export async function POST(req: Request) {
   try {
-    const body = await req.json();
+    const rawBody = await req.text();
+    await verifyQstashSignature({ req, rawBody });
 
-    await verifyQstashSignature({ req, body });
-
-    const { newDomain, oldDomain, workspaceId, page } = schema.parse(body);
+    const { newDomain, oldDomain, workspaceId, page } = schema.parse(
+      JSON.parse(rawBody),
+    );
 
     const newDomainRecord = await prisma.domain.findUnique({
       where: {

--- a/apps/web/app/api/cron/import/bitly/route.ts
+++ b/apps/web/app/api/cron/import/bitly/route.ts
@@ -12,8 +12,10 @@ export const dynamic = "force-dynamic";
 
 export async function POST(req: Request) {
   try {
-    const body = await req.json();
-    await verifyQstashSignature({ req, body });
+    const rawBody = await req.text();
+    await verifyQstashSignature({ req, rawBody });
+
+    const body = JSON.parse(rawBody);
     const { workspaceId, bitlyGroup, importTags } = body;
 
     try {

--- a/apps/web/app/api/cron/import/csv/route.ts
+++ b/apps/web/app/api/cron/import/csv/route.ts
@@ -45,8 +45,10 @@ type MapperResult =
 
 export async function POST(req: Request) {
   try {
-    const body = await req.json();
-    await verifyQstashSignature({ req, body });
+    const rawBody = await req.text();
+    await verifyQstashSignature({ req, rawBody });
+
+    const body = JSON.parse(rawBody);
     const { workspaceId, userId, id, url } = body;
     const mapping = linkMappingSchema.parse(body.mapping);
 

--- a/apps/web/app/api/cron/import/rebrandly/route.ts
+++ b/apps/web/app/api/cron/import/rebrandly/route.ts
@@ -10,8 +10,10 @@ export const dynamic = "force-dynamic";
 
 export async function POST(req: Request) {
   try {
-    const body = await req.json();
-    await verifyQstashSignature({ req, body });
+    const rawBody = await req.text();
+    await verifyQstashSignature({ req, rawBody });
+
+    const body = JSON.parse(rawBody);
     const { workspaceId, importTags } = body;
 
     try {

--- a/apps/web/app/api/cron/import/short/route.ts
+++ b/apps/web/app/api/cron/import/short/route.ts
@@ -10,8 +10,10 @@ export const dynamic = "force-dynamic";
 
 export async function POST(req: Request) {
   try {
-    const body = await req.json();
-    await verifyQstashSignature({ req, body });
+    const rawBody = await req.text();
+    await verifyQstashSignature({ req, rawBody });
+
+    const body = JSON.parse(rawBody);
     const {
       workspaceId,
       userId,

--- a/apps/web/app/api/cron/links/delete/route.ts
+++ b/apps/web/app/api/cron/links/delete/route.ts
@@ -11,9 +11,10 @@ export const dynamic = "force-dynamic";
 */
 export async function POST(req: Request) {
   try {
-    const body = await req.json();
-    await verifyQstashSignature({ req, body });
-    const { linkId } = body;
+    const rawBody = await req.text();
+    await verifyQstashSignature({ req, rawBody });
+
+    const { linkId } = JSON.parse(rawBody);
 
     const link = await prisma.link.findUnique({
       where: {

--- a/apps/web/app/api/cron/shopify/order-paid/route.ts
+++ b/apps/web/app/api/cron/shopify/order-paid/route.ts
@@ -14,10 +14,10 @@ const schema = z.object({
 // POST /api/cron/shopify/order-paid
 export async function POST(req: Request) {
   try {
-    const body = await req.json();
-    await verifyQstashSignature({ req, body });
+    const rawBody = await req.text();
+    await verifyQstashSignature({ req, rawBody });
 
-    const { workspaceId, checkoutToken } = schema.parse(body);
+    const { workspaceId, checkoutToken } = schema.parse(JSON.parse(rawBody));
 
     // Find Shopify order
     const event = await redis.hget(

--- a/apps/web/app/api/cron/usage/route.ts
+++ b/apps/web/app/api/cron/usage/route.ts
@@ -16,7 +16,10 @@ async function handler(req: Request) {
     if (req.method === "GET") {
       await verifyVercelSignature(req);
     } else if (req.method === "POST") {
-      await verifyQstashSignature({ req });
+      await verifyQstashSignature({
+        req,
+        rawBody: await req.text(),
+      });
     }
 
     await updateUsage();

--- a/apps/web/app/api/cron/workspaces/delete/route.ts
+++ b/apps/web/app/api/cron/workspaces/delete/route.ts
@@ -15,11 +15,10 @@ const schema = z.object({
 // POST /api/cron/workspaces/delete
 export async function POST(req: Request) {
   try {
-    const body = await req.json();
+    const rawBody = await req.text();
+    await verifyQstashSignature({ req, rawBody });
 
-    await verifyQstashSignature({ req, body });
-
-    const { workspaceId } = schema.parse(body);
+    const { workspaceId } = schema.parse(JSON.parse(rawBody));
 
     const workspace = await prisma.project.findUnique({
       where: {

--- a/apps/web/app/api/webhooks/callback/route.ts
+++ b/apps/web/app/api/webhooks/callback/route.ts
@@ -19,8 +19,7 @@ const searchParamsSchema = z.object({
 // POST /api/webhooks/callback – listen to webhooks status from QStash
 export const POST = async (req: Request) => {
   const rawBody = await req.text();
-
-  await verifyQstashSignature({ req, body: rawBody, bodyType: "text" });
+  await verifyQstashSignature({ req, rawBody });
 
   const { url, status, body, sourceBody, sourceMessageId } =
     webhookCallbackSchema.parse(JSON.parse(rawBody));

--- a/apps/web/lib/cron/verify-qstash.ts
+++ b/apps/web/lib/cron/verify-qstash.ts
@@ -1,3 +1,4 @@
+import { log } from "@dub/utils";
 import { Receiver } from "@upstash/qstash";
 import { DubApiError } from "../api/errors";
 
@@ -29,6 +30,15 @@ export const verifyQstashSignature = async ({
   });
 
   if (!isValid) {
+    const url = req.url;
+    const messageId = req.headers.get("Upstash-Message-Id");
+
+    log({
+      message: `Invalid QStash request signature: *${url}* - *${messageId}*`,
+      type: "errors",
+      mention: true,
+    });
+
     throw new DubApiError({
       code: "unauthorized",
       message: "Invalid QStash request signature.",


### PR DESCRIPTION
- Updated multiple API routes to read the raw body from requests instead of parsing JSON directly.
- Modified the `verifyQstashSignature` function to accept the raw body for signature verification.
- Ensured consistent handling of request bodies across various endpoints, improving reliability in signature validation.