### PR TITLE
Update webhook receiver identification for Zapier

### DIFF
--- a/apps/web/lib/webhook/utils.ts
+++ b/apps/web/lib/webhook/utils.ts
@@ -2,6 +2,7 @@ import { Webhook, WebhookReceiver } from "@dub/prisma/client";
 import { LINK_LEVEL_WEBHOOK_TRIGGERS } from "./constants";
 
 const webhookReceivers: Record<string, WebhookReceiver> = {
+  "zapier.com": "zapier",
   "hooks.zapier.com": "zapier",
   "make.com": "make",
   "hooks.slack.com": "slack",
@@ -22,8 +23,7 @@ export const isLinkLevelWebhook = (webhook: Pick<Webhook, "triggers">) => {
 };
 
 export const identifyWebhookReceiver = (url: string): WebhookReceiver => {
-  const urlObject = new URL(url);
-  const domain = urlObject.hostname;
+  const { hostname } = new URL(url);
 
-  return webhookReceivers[domain] || "user";
+  return webhookReceivers[hostname] || "user";
 };


### PR DESCRIPTION
This pull request includes changes to the `apps/web/lib/webhook/utils.ts` file to improve the identification of webhook receivers and simplify the code. The most important changes include adding a new entry to the `webhookReceivers` object and refactoring the `identifyWebhookReceiver` function to use destructuring for better readability.

Improvements to webhook receiver identification:

* [`apps/web/lib/webhook/utils.ts`](diffhunk://#diff-cb0a4cc386a034a28c0cd9286f9aea6327abb4ffca80c49cd704b2a9c70076b6R5): Added a new entry `"zapier.com": "zapier"` to the `webhookReceivers` object to ensure proper identification of Zapier webhooks.

Code simplification:

* [`apps/web/lib/webhook/utils.ts`](diffhunk://#diff-cb0a4cc386a034a28c0cd9286f9aea6327abb4ffca80c49cd704b2a9c70076b6L25-R28): Refactored the `identifyWebhookReceiver` function to use destructuring for extracting the `hostname` from the URL object, improving code readability and maintainability.