### PR TITLE
Fix tooltips within dialogs

### DIFF
--- a/packages/ui/src/tooltip.tsx
+++ b/packages/ui/src/tooltip.tsx
@@ -59,7 +59,7 @@ export function Tooltip({
         <TooltipPrimitive.Content
           sideOffset={8}
           side={side}
-          className="animate-slide-up-fade z-[99] items-center overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm"
+          className="animate-slide-up-fade pointer-events-auto z-[99] items-center overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm"
           collisionPadding={0}
           {...rest}
         >


### PR DESCRIPTION
Adds `pointer-events-auto` to make sure tooltips are interactable when dialogs are opened and `body` receives a `pointer-events: none`