### PR TITLE
Fix `allowedHostnames` implementation

### DIFF
--- a/apps/web/lib/api/links/process-link.ts
+++ b/apps/web/lib/api/links/process-link.ts
@@ -192,11 +192,13 @@ export async function processLink<T extends Record<string, any>>({
   } else if (isDubDomain(domain)) {
     // coerce type with ! cause we already checked if it exists
     const { allowedHostnames } = DUB_DOMAINS.find((d) => d.slug === domain)!;
-    const urlDomain = getApexDomain(url) || "";
+    const urlDomain = getDomainWithoutWWW(url) || "";
+    const apexDomain = getApexDomain(url);
     if (
       key !== "_root" &&
       allowedHostnames &&
-      !allowedHostnames.includes(urlDomain)
+      !allowedHostnames.includes(urlDomain) &&
+      !allowedHostnames.includes(apexDomain)
     ) {
       return {
         link: payload,

--- a/apps/web/ui/links/short-link-input.tsx
+++ b/apps/web/ui/links/short-link-input.tsx
@@ -20,6 +20,7 @@ import {
   cn,
   DUB_DOMAINS,
   getApexDomain,
+  getDomainWithoutWWW,
   linkConstructor,
   nanoid,
   punycode,
@@ -395,10 +396,17 @@ function DefaultDomainPrompt({
 }) {
   if (!url || !domain) return null;
 
+  const urlDomain = getDomainWithoutWWW(url);
   const apexDomain = getApexDomain(url);
-  const hostnameFor = DUB_DOMAINS.find((domain) =>
-    domain?.allowedHostnames?.includes(apexDomain),
-  );
+  const hostnameFor = DUB_DOMAINS.find((domain) => {
+    if (domain?.allowedHostnames) {
+      return (
+        (urlDomain && domain.allowedHostnames.includes(urlDomain)) ||
+        domain.allowedHostnames.includes(apexDomain)
+      );
+    }
+    return false;
+  });
   const domainSlug = hostnameFor?.slug;
 
   if (!domainSlug || domain === domainSlug) return null;


### PR DESCRIPTION
Improve `allowedHostnames` implementation by updating the logic to check both the apex domain and the domain without the "www" prefix.