### PR TITLE
Improve AI filter date handling

### DIFF
--- a/apps/web/lib/ai/generate-filters.ts
+++ b/apps/web/lib/ai/generate-filters.ts
@@ -3,41 +3,30 @@
 import { VALID_ANALYTICS_FILTERS } from "@/lib/analytics/constants";
 import { analyticsQuerySchema } from "@/lib/zod/schemas/analytics";
 import { anthropic } from "@ai-sdk/anthropic";
-import { parseDateTime } from "@dub/utils";
 import { streamObject } from "ai";
 import { createStreamableValue } from "ai/rsc";
 
 export async function generateFilters(prompt: string) {
   const stream = createStreamableValue();
 
+  const schema = analyticsQuerySchema.pick({
+    ...(VALID_ANALYTICS_FILTERS.reduce((acc, filter) => {
+      acc[filter] = true;
+      return acc;
+    }, {}) as any),
+  });
+
   (async () => {
     const { partialObjectStream } = await streamObject({
       model: anthropic("claude-3-5-sonnet-latest"),
-      schema: analyticsQuerySchema.pick({
-        ...(VALID_ANALYTICS_FILTERS.reduce((acc, filter) => {
-          acc[filter] = true;
-          return acc;
-        }, {}) as any),
-      }),
+      schema,
       prompt,
       temperature: 0.4,
     });
 
     for await (const partialObject of partialObjectStream) {
-      stream.update(
-        Object.fromEntries(
-          Object.entries(partialObject).map(([key, value]) => {
-            if (!["start", "end"].includes(key) || value === null)
-              return [key, value];
-
-            // Convert start and end dates to standard format
-            return [
-              key,
-              value ? parseDateTime(value.toString())?.toISOString() : value,
-            ];
-          }),
-        ),
-      );
+      const parsed = schema.safeParse(partialObject);
+      if (parsed.success) stream.update(parsed.data);
     }
 
     stream.done();

--- a/apps/web/ui/analytics/toggle.tsx
+++ b/apps/web/ui/analytics/toggle.tsx
@@ -598,9 +598,13 @@ export default function Toggle({
           for await (const partialObject of readStreamableValue(object)) {
             if (partialObject) {
               queryParams({
-                set: {
-                  ...partialObject,
-                },
+                set: Object.fromEntries(
+                  Object.entries(partialObject).map(([key, value]) => [
+                    key,
+                    // Convert Dates to ISO strings
+                    value instanceof Date ? value.toISOString() : String(value),
+                  ]),
+                ),
               });
             }
           }


### PR DESCRIPTION
Passes the parsed filter object to the client instead of the original to persist any schema transformations (such as parsed dates). Adds special date handling to the client so things are stringified nicely.