### PR TITLE
Refactor webhook failure handling and notifications

### DIFF
--- a/apps/web/app/api/webhooks/[webhookId]/route.ts
+++ b/apps/web/app/api/webhooks/[webhookId]/route.ts
@@ -137,6 +137,7 @@ export const PATCH = withWorkspace(
             })),
           },
         }),
+        disabledAt: null,
       },
       select: {
         id: true,

--- a/apps/web/emails/webhook-failed.tsx
+++ b/apps/web/emails/webhook-failed.tsx
@@ -1,4 +1,3 @@
-import { WEBHOOK_FAILURE_DISABLE_THRESHOLD } from "@/lib/webhook/constants";
 import { DUB_WORDMARK } from "@dub/utils";
 import {
   Body,
@@ -15,7 +14,7 @@ import {
 } from "@react-email/components";
 import Footer from "./components/footer";
 
-export default function WebhookDisabled({
+export default function WebhookFailed({
   email = "panic@thedis.co",
   workspace = {
     name: "Acme, Inc",
@@ -39,7 +38,7 @@ export default function WebhookDisabled({
   return (
     <Html>
       <Head />
-      <Preview>Webhook has been disabled</Preview>
+      <Preview>Webhook is failing to deliver</Preview>
       <Tailwind>
         <Body className="mx-auto my-auto bg-white font-sans">
           <Container className="mx-auto my-10 max-w-[500px] rounded border border-solid border-gray-200 px-10 py-5">
@@ -52,12 +51,11 @@ export default function WebhookDisabled({
               />
             </Section>
             <Heading className="mx-0 my-7 p-0 text-center text-xl font-semibold text-black">
-              Webhook has been disabled
+              Webhook is failing to deliver
             </Heading>
             <Text className="text-sm leading-6 text-black">
-              Your webhook <strong>{webhook.url}</strong> has failed to deliver
-              successfully {WEBHOOK_FAILURE_DISABLE_THRESHOLD} times in a row
-              and has been deactivated to prevent further issues.
+              Your webhook <strong>{webhook.url}</strong> is encountering
+              delivery failures and will be disabled if it continues to fail.
             </Text>
             <Text className="text-sm leading-6 text-black">
               Please review the webhook details and update the URL if necessary

--- a/apps/web/lib/actions/enable-disable-webhook.ts
+++ b/apps/web/lib/actions/enable-disable-webhook.ts
@@ -19,9 +19,7 @@ export const enableOrDisableWebhook = authActionClient
     const { workspace } = ctx;
     const { webhookId } = parsedInput;
 
-    const canAccessWebhook = !["free", "pro"].includes(workspace.plan);
-
-    if (!canAccessWebhook) {
+    if (["free", "pro"].includes(workspace.plan)) {
       throw new Error("You must upgrade your plan to enable webhooks.");
     }
 

--- a/apps/web/lib/webhook/constants.ts
+++ b/apps/web/lib/webhook/constants.ts
@@ -32,4 +32,5 @@ export const WEBHOOK_TRIGGER_DESCRIPTIONS = {
   "sale.created": "Sale created",
 } as const;
 
-export const WEBHOOK_FAILURE_NOTIFY_THRESHOLD = 20;
+export const WEBHOOK_FAILURE_NOTIFY_THRESHOLDS = [5, 10, 15] as const;
+export const WEBHOOK_FAILURE_DISABLE_THRESHOLD = 20 as const;


### PR DESCRIPTION
- Introduced a new email template for notifying users when a webhook is failing to deliver.
- Updated the webhook failure threshold constants to support multiple notification thresholds.
- Modified the logic for handling webhook failures to send notifications based on the new thresholds.
- Added a new function to notify users when a webhook is disabled due to consecutive failures.
- Updated existing email templates to reflect the new failure threshold terminology.