### PR TITLE
Update webhook failure notification template

### DIFF
--- a/apps/web/app/api/webhooks/[webhookId]/route.ts
+++ b/apps/web/app/api/webhooks/[webhookId]/route.ts
@@ -138,6 +138,7 @@ export const PATCH = withWorkspace(
           },
         }),
         disabledAt: null,
+        consecutiveFailures: 0,
       },
       select: {
         id: true,

--- a/apps/web/emails/webhook-failed.tsx
+++ b/apps/web/emails/webhook-failed.tsx
@@ -1,3 +1,4 @@
+import { WEBHOOK_FAILURE_DISABLE_THRESHOLD } from "@/lib/webhook/constants";
 import { DUB_WORDMARK } from "@dub/utils";
 import {
   Body,
@@ -23,6 +24,7 @@ export default function WebhookFailed({
   webhook = {
     id: "wh_tYedrqsWgNJxUwQOaAnupcUJ1",
     url: "https://example.com/webhook",
+    consecutiveFailures: 15,
   },
 }: {
   email: string;
@@ -33,6 +35,7 @@ export default function WebhookFailed({
   webhook: {
     id: string;
     url: string;
+    consecutiveFailures: number;
   };
 }) {
   return (
@@ -54,8 +57,9 @@ export default function WebhookFailed({
               Webhook is failing to deliver
             </Heading>
             <Text className="text-sm leading-6 text-black">
-              Your webhook <strong>{webhook.url}</strong> is encountering
-              delivery failures and will be disabled if it continues to fail.
+              Your webhook <strong>{webhook.url}</strong> has failed to deliver{" "}
+              {webhook.consecutiveFailures} times and will be disabled after{" "}
+              {WEBHOOK_FAILURE_DISABLE_THRESHOLD} consecutive failures.
             </Text>
             <Text className="text-sm leading-6 text-black">
               Please review the webhook details and update the URL if necessary

--- a/apps/web/lib/webhook/failure.ts
+++ b/apps/web/lib/webhook/failure.ts
@@ -80,7 +80,7 @@ export const resetWebhookFailureCount = async (webhookId: string) => {
 
 // Send email to workspace owners when the webhook is failing to deliver
 const notifyWebhookFailure = async (
-  webhook: Pick<Webhook, "id" | "url" | "projectId">,
+  webhook: Pick<Webhook, "id" | "url" | "projectId" | "consecutiveFailures">,
 ) => {
   const workspaceOwners = await prisma.projectUsers.findFirst({
     where: { projectId: webhook.projectId, role: "owner" },
@@ -118,6 +118,7 @@ const notifyWebhookFailure = async (
       webhook: {
         id: webhook.id,
         url: webhook.url,
+        consecutiveFailures: webhook.consecutiveFailures,
       },
     }),
   });

--- a/apps/web/tests/tags/list-tags.test.ts
+++ b/apps/web/tests/tags/list-tags.test.ts
@@ -18,7 +18,7 @@ test("GET /tags", async (ctx) => {
   });
 
   const { status, data: tags } = await http.get<Tag[]>({
-    path: "/tags",
+    path: "/tags?sortBy=createdAt&sortOrder=desc",
   });
 
   expect(status).toEqual(200);


### PR DESCRIPTION
This pull request introduces changes to track and handle consecutive webhook failures. The most important changes include adding a new `consecutiveFailures` field to various parts of the codebase and updating the email notification content to reflect this new field.

Tracking consecutive failures:

* `apps/web/app/api/webhooks/[webhookId]/route.ts`: Added `consecutiveFailures` field to the webhook object. ([apps/web/app/api/webhooks/[webhookId]/route.tsR141](diffhunk://#diff-32500fa9d9575c404d91dd97dc6cb017f9ea98f0724e628551d28a5b5912ae55R141))
* [`apps/web/lib/webhook/failure.ts`](diffhunk://#diff-b16b78cb32159950effadeea3841e558ec846b773a07ab63acde98c84f7b2b76L83-R83): Updated the `notifyWebhookFailure` function to include the `consecutiveFailures` field when notifying workspace owners. [[1]](diffhunk://#diff-b16b78cb32159950effadeea3841e558ec846b773a07ab63acde98c84f7b2b76L83-R83) [[2]](diffhunk://#diff-b16b78cb32159950effadeea3841e558ec846b773a07ab63acde98c84f7b2b76R121)

Email notification updates:

* [`apps/web/emails/webhook-failed.tsx`](diffhunk://#diff-1df26f7a656d4d0998782d428d37686b5bdf038342bb8eaa573786cd6a6d5fbeR1): Imported `WEBHOOK_FAILURE_DISABLE_THRESHOLD` constant and added `consecutiveFailures` field to the webhook object. Updated the email content to include the number of consecutive failures and the threshold for disabling the webhook. [[1]](diffhunk://#diff-1df26f7a656d4d0998782d428d37686b5bdf038342bb8eaa573786cd6a6d5fbeR1) [[2]](diffhunk://#diff-1df26f7a656d4d0998782d428d37686b5bdf038342bb8eaa573786cd6a6d5fbeR27) [[3]](diffhunk://#diff-1df26f7a656d4d0998782d428d37686b5bdf038342bb8eaa573786cd6a6d5fbeR38) [[4]](diffhunk://#diff-1df26f7a656d4d0998782d428d37686b5bdf038342bb8eaa573786cd6a6d5fbeL57-R62)