### PR TITLE
Adding a response message for cases with no pending sales

### DIFF
--- a/apps/web/app/api/cron/process-payouts/route.ts
+++ b/apps/web/app/api/cron/process-payouts/route.ts
@@ -25,7 +25,9 @@ export async function GET(req: Request) {
     });
 
     if (!pendingSales.length) {
-      return;
+      return NextResponse.json({
+        message: "No pending sales found. Skipping...",
+      });
     }
 
     // TODO: Find a batter way to handle this recursively (e.g. /api/cron/usage)


### PR DESCRIPTION
Fix the error

```
Ensure you return a `Response` or a `NextResponse` in all branches of your handler.
```