### PR TITLE
Fix link underline on Firefox

### DIFF
--- a/apps/web/ui/links/link-title-column.tsx
+++ b/apps/web/ui/links/link-title-column.tsx
@@ -95,7 +95,7 @@ export function LinkTitleColumn({ link }: { link: ResponseLink }) {
           )}
         </div>
       </div>
-      <div className="h-[24px] min-w-0 overflow-hidden transition-[height] group-data-[variant=loose]/card-list:h-[44px]">
+      <div className="h-[24px] min-w-0 overflow-hidden transition-[height] group-data-[variant=loose]/card-list:h-[46px]">
         <div className="flex items-center gap-2">
           <div className="min-w-0 shrink grow-0 text-gray-950">
             <div className="flex items-center gap-2">


### PR DESCRIPTION
Fixes #1868 
![Screenshot 2025-01-27 at 3 46 34 PM](https://github.com/user-attachments/assets/3388f2b8-85b0-44d8-ba6c-5dbcdba1c808)
