### PR TITLE
 Add `mtd` and `qtd` presets

### DIFF
--- a/apps/web/lib/analytics/constants.ts
+++ b/apps/web/lib/analytics/constants.ts
@@ -5,8 +5,10 @@ export const intervals = [
   "7d",
   "30d",
   "90d",
-  "ytd",
   "1y",
+  "mtd",
+  "qtd",
+  "ytd",
   "all",
   "all_unfiltered",
 ] as const;
@@ -16,8 +18,10 @@ export const eventIntervals = [
   "7d",
   "30d",
   "90d",
-  "ytd",
   "1y",
+  "mtd",
+  "qtd",
+  "ytd",
   "all",
 ] as const;
 
@@ -35,22 +39,32 @@ export const INTERVAL_DISPLAYS = [
   {
     display: "Last 30 days",
     value: "30d",
-    shortcut: "m",
+    shortcut: "t",
   },
   {
     display: "Last 3 months",
     value: "90d",
-    shortcut: "t",
-  },
-  {
-    display: "Year to Date",
-    value: "ytd",
-    shortcut: "y",
+    shortcut: "3",
   },
   {
     display: "Last 12 months",
     value: "1y",
     shortcut: "l",
+  },
+  {
+    display: "Month to Date",
+    value: "mtd",
+    shortcut: "m",
+  },
+  {
+    display: "Quarter to Date",
+    value: "qtd",
+    shortcut: "q",
+  },
+  {
+    display: "Year to Date",
+    value: "ytd",
+    shortcut: "y",
   },
   {
     display: "All Time",
@@ -82,12 +96,24 @@ export const INTERVAL_DATA: Record<
     startDate: new Date(Date.now() - 7776000000),
     granularity: "day",
   },
-  ytd: {
-    startDate: new Date(new Date().getFullYear(), 0, 1),
-    granularity: "month",
-  },
   "1y": {
     startDate: new Date(Date.now() - 31556952000),
+    granularity: "month",
+  },
+  mtd: {
+    startDate: new Date(new Date().getFullYear(), new Date().getMonth(), 1),
+    granularity: "day",
+  },
+  qtd: {
+    startDate: new Date(
+      new Date().getFullYear(),
+      Math.floor(new Date().getMonth() / 3) * 3,
+      1,
+    ),
+    granularity: "day",
+  },
+  ytd: {
+    startDate: new Date(new Date().getFullYear(), 0, 1),
     granularity: "month",
   },
   all: {

--- a/apps/web/lib/analytics/utils/get-start-end-dates.ts
+++ b/apps/web/lib/analytics/utils/get-start-end-dates.ts
@@ -17,13 +17,8 @@ export const getStartEndDates = ({
   let granularity: "minute" | "hour" | "day" | "month" = "day";
 
   if (start || (interval === "all" && dataAvailableFrom)) {
-    startDate = start
-      ? new Date(start)
-      : dataAvailableFrom ??
-        // this should never happen since we're checking for dataAvailableFrom
-        // but typescript doesn't know that
-        new Date(Date.now());
-    endDate = end ? new Date(end) : new Date(Date.now());
+    startDate = new Date(start ?? dataAvailableFrom ?? Date.now());
+    endDate = new Date(end ?? Date.now());
 
     const daysDifference = getDaysDifference(startDate, endDate);
 
@@ -38,7 +33,7 @@ export const getStartEndDates = ({
       [startDate, endDate] = [endDate, startDate];
     }
   } else {
-    interval = interval ?? "24h";
+    interval = interval ?? "30d";
     startDate = INTERVAL_DATA[interval].startDate;
     endDate = new Date(Date.now());
     granularity = INTERVAL_DATA[interval].granularity;

--- a/apps/web/ui/analytics/analytics-area-chart.tsx
+++ b/apps/web/ui/analytics/analytics-area-chart.tsx
@@ -57,7 +57,6 @@ export default function AnalyticsAreaChart({
     !demo &&
       `${baseApiPath}?${editQueryString(queryString, {
         groupBy: "timeseries",
-        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
       })}`,
     fetcher,
     {

--- a/apps/web/ui/analytics/analytics-provider.tsx
+++ b/apps/web/ui/analytics/analytics-provider.tsx
@@ -138,7 +138,7 @@ export default function AnalyticsProvider({
     };
   }, [searchParams?.get("start"), searchParams?.get("end")]);
 
-  const defaultInterval = partnerPage ? "1y" : "24h";
+  const defaultInterval = partnerPage ? "1y" : "30d";
 
   // Only set interval if start and end are not provided
   const interval =
@@ -271,6 +271,7 @@ export default function AnalyticsProvider({
       ...(tagIds && { tagIds }),
       ...(root && { root: root.toString() }),
       event: selectedTab,
+      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
     }).toString();
   }, [workspaceId, domain, key, searchParams, start, end, tagIds, selectedTab]);
 

--- a/apps/web/ui/analytics/events/events-tabs.tsx
+++ b/apps/web/ui/analytics/events/events-tabs.tsx
@@ -42,7 +42,6 @@ export default function EventsTabs() {
       `${baseApiPath}?${editQueryString(queryString, {
         groupBy: "timeseries",
         event: "composite",
-        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
       })}`,
       fetcher,
       {

--- a/apps/web/ui/analytics/toggle.tsx
+++ b/apps/web/ui/analytics/toggle.tsx
@@ -5,6 +5,7 @@ import {
   VALID_ANALYTICS_FILTERS,
 } from "@/lib/analytics/constants";
 import { validDateRangeForPlan } from "@/lib/analytics/utils";
+import { getStartEndDates } from "@/lib/analytics/utils/get-start-end-dates";
 import useDomains from "@/lib/swr/use-domains";
 import useDomainsCount from "@/lib/swr/use-domains-count";
 import useTags from "@/lib/swr/use-tags";
@@ -701,7 +702,7 @@ export default function Toggle({
             }
           : undefined
       }
-      presetId={!start || !end ? interval ?? "24h" : undefined}
+      presetId={start && end ? undefined : interval ?? "30d"}
       onChange={(range, preset) => {
         if (preset) {
           queryParams({
@@ -740,12 +741,17 @@ export default function Toggle({
               end,
             });
 
+        const { startDate, endDate } = getStartEndDates({
+          interval: value,
+          dataAvailableFrom: createdAt,
+        });
+
         return {
           id: value,
           label: display,
           dateRange: {
-            from: start,
-            to: end,
+            from: startDate,
+            to: endDate,
           },
           requiresUpgrade,
           tooltipContent: requiresUpgrade ? (

--- a/packages/ui/src/date-picker/calendar.tsx
+++ b/packages/ui/src/date-picker/calendar.tsx
@@ -35,7 +35,7 @@ const NavigationButton = forwardRef<HTMLButtonElement, NavigationButtonProps>(
         type="button"
         disabled={disabled}
         className={cn(
-          "flex h-7 w-7 shrink-0 select-none items-center justify-center rounded border p-1 outline-none transition",
+          "flex size-7 shrink-0 select-none items-center justify-center rounded border p-1 outline-none transition",
           "border-gray-200 text-gray-600 hover:text-gray-800",
           "hover:bg-gray-50 active:bg-gray-100",
           "disabled:pointer-events-none disabled:text-gray-400",
@@ -99,7 +99,7 @@ function Calendar({
         row: "w-full",
         cell: "relative p-0 text-center focus-within:relative text-gray-900",
         day: cn(
-          "relative h-10 w-full sm:h-9 sm:w-9 rounded-md text-sm text-gray-900",
+          "relative size-10 rounded-md text-sm text-gray-900",
           "hover:bg-gray-100 active:bg-gray-200 outline outline-offset-2 outline-0 focus-visible:outline-2 outline-blue-500",
         ),
         day_today: "font-semibold",

--- a/packages/ui/src/date-picker/date-range-picker.tsx
+++ b/packages/ui/src/date-picker/date-range-picker.tsx
@@ -143,6 +143,7 @@ const DateRangePickerInner = ({
                 >
                   <div className="absolute px-3 sm:inset-0 sm:left-0 sm:p-3">
                     <Presets
+                      currentPresetId={presetId}
                       currentValue={range}
                       presets={presets}
                       onSelect={onPresetSelected}

--- a/packages/ui/src/date-picker/presets.tsx
+++ b/packages/ui/src/date-picker/presets.tsx
@@ -8,6 +8,7 @@ type PresetsProps<TPreset extends Preset, TValue> = {
   presets: TPreset[];
   onSelect: (preset: TPreset) => void;
   currentValue?: TValue;
+  currentPresetId?: string;
 };
 
 const Presets = <TPreset extends Preset, TValue>({
@@ -15,8 +16,10 @@ const Presets = <TPreset extends Preset, TValue>({
   presets,
   // Event handler when a preset is selected
   onSelect,
-  // Currently selected preset
+  // Currently selected preset range value
   currentValue,
+  // Currently selected preset id
+  currentPresetId,
 }: PresetsProps<TPreset, TValue>) => {
   const isDateRangePresets = (preset: any): preset is DateRangePreset =>
     "dateRange" in preset;
@@ -55,6 +58,10 @@ const Presets = <TPreset extends Preset, TValue>({
   };
 
   const matchesCurrent = (preset: TPreset) => {
+    if (currentPresetId) {
+      return currentPresetId === preset.id;
+    }
+
     if (isDateRangePresets(preset)) {
       const value = currentValue as DateRange | undefined;
 


### PR DESCRIPTION
A few other changes:

- Keyboard shortcut for "Last 30 days" and "Last 3 months" have been changed to `t` and `3` respectively
- Default Analytics date range is now `30d` instead of `24h` (on the API side the default is still `24h` though)