### PR TITLE
Fix bulk actions for users w/o access to folders

### DIFF
--- a/apps/web/ui/links/links-toolbar.tsx
+++ b/apps/web/ui/links/links-toolbar.tsx
@@ -66,6 +66,9 @@ export const LinksToolbar = memo(
     );
 
     const hasAllFolderPermissions = useMemo(() => {
+      // `folders` is undefined for users without access, so just check if all links are not in a folder first
+      if (selectedLinks.every((link) => !link.folderId)) return true;
+
       if (!folders || !Array.isArray(folders)) return false;
 
       return selectedLinks.every(


### PR DESCRIPTION
Users/workspaces without folder access (e.g. free/pro users) couldn't perform bulk actions because `folders` is `undefined`. This adds special handling for when no selected links are in folders to avoid the `folders` check.