### PR TITLE
Fix + add Library create keyboard shortcuts

### DIFF
--- a/apps/web/ui/modals/add-edit-tag-modal.tsx
+++ b/apps/web/ui/modals/add-edit-tag-modal.tsx
@@ -11,6 +11,7 @@ import {
   RadioGroup,
   RadioGroupItem,
   TooltipContent,
+  useKeyboardShortcut,
   useMediaQuery,
 } from "@dub/ui";
 import { capitalize, cn, pluralize } from "@dub/utils";
@@ -213,11 +214,16 @@ function AddTagButton({
   const { tags } = useTags();
   const exceededTags = tags && tagsLimit && tags.length >= tagsLimit;
 
+  useKeyboardShortcut("c", () => setShowAddEditTagModal(true), {
+    enabled: !exceededTags,
+  });
+
   return (
     <div>
       <Button
         variant="primary"
         text="Create tag"
+        shortcut="C"
         className="h-9 rounded-lg"
         disabledTooltip={
           exceededTags ? (

--- a/apps/web/ui/modals/add-edit-utm-template.modal.tsx
+++ b/apps/web/ui/modals/add-edit-utm-template.modal.tsx
@@ -1,6 +1,12 @@
 import useWorkspace from "@/lib/swr/use-workspace";
 import { UtmTemplateProps } from "@/lib/types";
-import { Button, Modal, useMediaQuery, UTMBuilder } from "@dub/ui";
+import {
+  Button,
+  Modal,
+  useKeyboardShortcut,
+  useMediaQuery,
+  UTMBuilder,
+} from "@dub/ui";
 import posthog from "posthog-js";
 import {
   Dispatch,
@@ -160,11 +166,14 @@ function AddUtmTemplateButton({
 }: {
   setShowAddEditUtmTemplateModal: Dispatch<SetStateAction<boolean>>;
 }) {
+  useKeyboardShortcut("c", () => setShowAddEditUtmTemplateModal(true));
+
   return (
     <div>
       <Button
         variant="primary"
         text="Create template"
+        shortcut="C"
         className="h-9 rounded-lg"
         onClick={() => setShowAddEditUtmTemplateModal(true)}
       />

--- a/apps/web/ui/modals/add-folder-modal.tsx
+++ b/apps/web/ui/modals/add-folder-modal.tsx
@@ -1,11 +1,10 @@
 import useWorkspace from "@/lib/swr/use-workspace";
 import { FolderSummary } from "@/lib/types";
-import { Button, Modal, TooltipContent } from "@dub/ui";
+import { Button, Modal, TooltipContent, useKeyboardShortcut } from "@dub/ui";
 import {
   Dispatch,
   SetStateAction,
   useCallback,
-  useEffect,
   useMemo,
   useState,
 } from "react";
@@ -42,21 +41,9 @@ function AddFolderButton({
 }) {
   const { slug, plan } = useWorkspace();
 
-  const onKeyDown = useCallback((e: KeyboardEvent) => {
-    const existingModalBackdrop = document.getElementById("modal-backdrop");
-
-    if (e.key.toLowerCase() === "c" && !existingModalBackdrop) {
-      e.preventDefault();
-      setShowAddFolderModal(true);
-    }
-  }, []);
-
-  useEffect(() => {
-    document.addEventListener("keydown", onKeyDown);
-    return () => {
-      document.removeEventListener("keydown", onKeyDown);
-    };
-  }, [onKeyDown]);
+  useKeyboardShortcut("c", () => setShowAddFolderModal(true), {
+    enabled: plan !== "free",
+  });
 
   return (
     <Button


### PR DESCRIPTION
* Fixes the "Create folder" keyboard shortcut by using `useKeyboardShortcut`
* Adds keyboard shortcut for "Create tag" and "Create template"