### PR TITLE
Fix partner link URL parsing

### DIFF
--- a/apps/web/ui/modals/partner-link-modal.tsx
+++ b/apps/web/ui/modals/partner-link-modal.tsx
@@ -23,6 +23,7 @@ import {
   getDomainWithoutWWW,
   getPrettyUrl,
   linkConstructor,
+  regexEscape,
 } from "@dub/utils";
 import { AnimatePresence, motion } from "framer-motion";
 import {
@@ -179,7 +180,10 @@ function PartnerLinkModalContent({
   const form = useForm<PartnerLinkFormData>({
     defaultValues: link
       ? {
-          url: link.url.replace(`https://${destinationDomain}/`, ""),
+          url: link.url.replace(
+            new RegExp(`^https?:\/\/${regexEscape(destinationDomain)}\/?`),
+            "",
+          ),
           key: link.key,
           comments: link.comments ?? "",
         }

--- a/packages/utils/src/functions/index.ts
+++ b/packages/utils/src/functions/index.ts
@@ -24,6 +24,7 @@ export * from "./normalize-string";
 export * from "./pluralize";
 export * from "./punycode";
 export * from "./random-value";
+export * from "./regex-escape";
 export * from "./resize-image";
 export * from "./smart-truncate";
 export * from "./stable-sort";

--- a/packages/utils/src/functions/regex-escape.ts
+++ b/packages/utils/src/functions/regex-escape.ts
@@ -1,0 +1,7 @@
+/**
+ * Escapes a string for use in a regular expression.
+ * https://stackoverflow.com/a/6969486
+ */
+export function regexEscape(str: string) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}


### PR DESCRIPTION
Partner links pointing to a destination URL w/o any path (e.g. `dub.co`) are currently parsed incorrectly because the `replace` is expecting a slash after the domain