### PR TITLE
Fix folder switching

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/settings/library/tags/tag-card.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/settings/library/tags/tag-card.tsx
@@ -98,7 +98,7 @@ export function TagCard({
         <div className="flex items-center gap-5 sm:gap-8 md:gap-12">
           {linksCount !== undefined && (
             <Link
-              href={`/${slug}?tagIds=${tag.id}`}
+              href={`/${slug}/links?tagIds=${tag.id}`}
               className="whitespace-nowrap rounded-md border border-neutral-200 bg-neutral-50 px-2 py-0.5 text-sm text-neutral-800 transition-colors hover:bg-neutral-100"
             >
               {nFormatter(linksCount || 0)} {pluralize("link", linksCount || 0)}

--- a/apps/web/lib/middleware/app.ts
+++ b/apps/web/lib/middleware/app.ts
@@ -10,7 +10,7 @@ import { isTopLevelSettingsRedirect } from "./utils/is-top-level-settings-redire
 import WorkspacesMiddleware from "./workspaces";
 
 export default async function AppMiddleware(req: NextRequest) {
-  const { path, fullPath } = parse(req);
+  const { path, fullPath, searchParamsString } = parse(req);
 
   if (path.startsWith("/embed")) {
     return EmbedMiddleware(req);
@@ -95,8 +95,10 @@ export default async function AppMiddleware(req: NextRequest) {
       isTopLevelSettingsRedirect(path)
     ) {
       return WorkspacesMiddleware(req, user);
-    } else if (appRedirect(path)) {
-      return NextResponse.redirect(new URL(appRedirect(path), req.url));
+    } else if (appRedirect(path, searchParamsString)) {
+      return NextResponse.redirect(
+        new URL(appRedirect(path, searchParamsString), req.url),
+      );
     }
   }
 

--- a/apps/web/lib/middleware/utils/app-redirect.ts
+++ b/apps/web/lib/middleware/utils/app-redirect.ts
@@ -4,14 +4,15 @@ const APP_REDIRECTS = {
   "/welcome": "/onboarding",
 };
 
-export const appRedirect = (path: string) => {
+export const appRedirect = (path: string, searchParamsString: string) => {
   if (APP_REDIRECTS[path]) {
     return APP_REDIRECTS[path];
   }
 
   // Redirect "/[slug]" to "/[slug]/links"
   const rootRegex = /^\/([^\/]+)$/;
-  if (rootRegex.test(path)) return path.replace(rootRegex, "/$1/links");
+  if (rootRegex.test(path))
+    return path.replace(rootRegex, "/$1/links") + searchParamsString;
 
   // Redirect "programs/[programId]/settings" to "programs/[programId]/settings/rewards" (first tab)
   const programSettingsRegex = /\/programs\/([^\/]+)\/settings$/;

--- a/apps/web/ui/folders/folder-dropdown.tsx
+++ b/apps/web/ui/folders/folder-dropdown.tsx
@@ -80,7 +80,7 @@ export const FolderDropdown = ({
 
       if (!disableAutoRedirect) {
         if (folder.id !== "unsorted") {
-          router.push(`/${slug}?folderId=${folder.id}`);
+          router.push(`/${slug}/links?folderId=${folder.id}`);
         } else {
           router.push(`/${slug}`);
         }
@@ -173,7 +173,7 @@ export const FolderDropdown = ({
             setSelectedFolder(folder);
             onFolderSelect
               ? onFolderSelect(folder)
-              : router.push(`/${slug}?folderId=${folder.id}`);
+              : router.push(`/${slug}/links?folderId=${folder.id}`);
           }
         }}
         inputRight={

--- a/apps/web/ui/links/link-card.tsx
+++ b/apps/web/ui/links/link-card.tsx
@@ -53,7 +53,7 @@ export function LinkCard({ link }: { link: ResponseLink }) {
           ) && {
             banner: (
               <Link
-                href={`/${slug}?folderId=${folder?.id}`}
+                href={`/${slug}/links?folderId=${folder?.id}`}
                 className="group flex items-center justify-between gap-2 rounded-t-xl border-b border-neutral-100 bg-neutral-50 px-5 py-2 text-xs"
               >
                 <div className="flex items-center gap-1.5">

--- a/apps/web/ui/links/link-title-column.tsx
+++ b/apps/web/ui/links/link-title-column.tsx
@@ -87,7 +87,7 @@ export function LinkTitleColumn({ link }: { link: ResponseLink }) {
         ![defaultFolderId, searchParams.get("folderId")].includes(
           link.folderId,
         ) && (
-          <Link href={`/${slug}?folderId=${link.folderId}`}>
+          <Link href={`/${slug}/links?folderId=${link.folderId}`}>
             {folder ? (
               <FolderIcon
                 folder={folder}


### PR DESCRIPTION
* Updates middleware redirect from `/[slug]` to `/[slug]/links` to persist search params
* Updates `/[slug]` to `/[slug]/links` in several places so they don't need to pass through the redirect anyways