### PR TITLE
Fix click tracking bug by filtering HEAD requests

### DIFF
--- a/apps/web/lib/tinybird/record-click.ts
+++ b/apps/web/lib/tinybird/record-click.ts
@@ -63,6 +63,10 @@ export async function recordClick({
     return null;
   }
 
+  if (req.method === "HEAD") {
+    return null;
+  }
+
   const isBot = detectBot(req);
 
   // don't record clicks from bots

--- a/apps/web/lib/tinybird/record-click.ts
+++ b/apps/web/lib/tinybird/record-click.ts
@@ -63,6 +63,7 @@ export async function recordClick({
     return null;
   }
 
+  // don't track HEAD requests to avoid non-user traffic from inflating click count
   if (req.method === "HEAD") {
     return null;
   }


### PR DESCRIPTION
Addresses issue #2309 (and #1860) by ensuring only user-initiated requests are counted, preventing inflation from HEAD requests.