### PR TITLE
Add opacity border to workspace images and profile avatars in the nav…

### DIFF
--- a/apps/web/ui/layout/sidebar/partner-program-dropdown.tsx
+++ b/apps/web/ui/layout/sidebar/partner-program-dropdown.tsx
@@ -104,7 +104,7 @@ export function PartnerProgramDropdown() {
                   width={40}
                   height={40}
                   alt={partner.name}
-                  className="size-5 shrink-0 overflow-hidden rounded-full border border-black/10"
+                  className="size-5 shrink-0 overflow-hidden rounded-full border border-neutral-900/10"
                 />
                 <span className="block min-w-0 truncate text-sm leading-5 text-neutral-800">
                   {partner.name}
@@ -153,7 +153,7 @@ export function PartnerProgramDropdown() {
               width={28}
               height={28}
               alt={selectedProgram?.name || partner.name}
-              className="size-7 flex-none shrink-0 overflow-hidden rounded-full"
+              className="size-7 flex-none shrink-0 overflow-hidden rounded-full border border-neutral-900/10"
             />
             <div className="min-w-0">
               <div className="truncate text-sm font-medium leading-5 text-neutral-900">
@@ -284,7 +284,7 @@ function ProgramList({
                           width={40}
                           height={40}
                           alt={name}
-                          className="size-5 shrink-0 overflow-hidden rounded-full border border-black/10"
+                          className="size-5 shrink-0 overflow-hidden rounded-full border border-neutral-900/10"
                         />
                         <span className="block min-w-0 grow truncate text-sm leading-5 text-neutral-800">
                           {name}

--- a/apps/web/ui/layout/sidebar/workspace-dropdown.tsx
+++ b/apps/web/ui/layout/sidebar/workspace-dropdown.tsx
@@ -101,7 +101,7 @@ export function WorkspaceDropdown() {
               width={28}
               height={28}
               alt={selected.id || selected.name}
-              className="h-7 w-7 flex-none shrink-0 overflow-hidden rounded-full"
+              className="h-7 w-7 flex-none shrink-0 overflow-hidden rounded-full border border-neutral-900/10"
             />
             <div className={cn(key ? "hidden" : "block", "min-w-0 sm:block")}>
               <div className="truncate text-sm font-medium leading-5 text-neutral-900">
@@ -245,7 +245,7 @@ function WorkspaceList({
                     width={28}
                     height={28}
                     alt={id}
-                    className="size-7 shrink-0 overflow-hidden rounded-full"
+                    className="size-7 shrink-0 overflow-hidden rounded-full border border-neutral-900/10"
                   />
                   <div>
                     <span className="block truncate text-sm leading-5 text-neutral-900 sm:max-w-[140px]">

--- a/packages/ui/src/avatar.tsx
+++ b/packages/ui/src/avatar.tsx
@@ -48,7 +48,7 @@ export function Avatar({
       referrerPolicy="no-referrer"
       src={url}
       className={cn(
-        "h-10 w-10 rounded-full border border-neutral-300",
+        "h-10 w-10 rounded-full border border-neutral-900/10",
         className,
       )}
       draggable={false}


### PR DESCRIPTION
To make lighter images easier to see their bounding box, a neutral-900/10 border has been added that also blends into darker images.