### PR TITLE
Scalable daily click aggregation using batch processing

### DIFF
--- a/apps/web/app/api/cron/aggregate-clicks/route.ts
+++ b/apps/web/app/api/cron/aggregate-clicks/route.ts
@@ -1,135 +1,44 @@
-import { getAnalytics } from "@/lib/analytics/get-analytics";
 import { handleAndReturnErrorResponse } from "@/lib/api/errors";
+import { verifyQstashSignature } from "@/lib/cron/verify-qstash";
 import { verifyVercelSignature } from "@/lib/cron/verify-vercel";
-import { createPartnerCommission } from "@/lib/partners/create-partner-commission";
-import { prisma } from "@dub/prisma";
+import { log } from "@dub/utils";
 import { NextResponse } from "next/server";
+import { updateAggregateClicks } from "./utils";
 
 export const dynamic = "force-dynamic";
 
-/**
- * TODO: Use a cron job (similar to how we do it for usage cron) to account for the future where we have a lot of links to process
- */
-
-// This route is used aggregate clicks events on daily basis for Program links and add to the Commission table
-// Runs every day at 00:00 (0 0 * * *)
-// GET /api/cron/aggregate-clicks
-export async function GET(req: Request) {
+/*
+    This route aggregates click events in daily batches for Program links and add to the Commission table.
+    Runs every day at 00:00 (0 0 * * *)
+    GET /api/cron/aggregate-clicks   -- initial trigger (Vercel)
+    POST /api/cron/aggregate-clicks  -- batch continuation (QStash)
+*/
+async function handler(req: Request) {
   try {
-    await verifyVercelSignature(req);
+    if (req.method === "GET") {
+      await verifyVercelSignature(req);
+      await updateAggregateClicks();
+    } else if (req.method === "POST") {
+      await verifyQstashSignature({
+        req,
+        rawBody: await req.text(),
+      });
 
-    const now = new Date();
+      const { cursor } = JSON.parse(await req.text()) as { cursor?: string };
+      await updateAggregateClicks({ cursor });
+    }
 
-    // set 'start' to the beginning of the previous day (00:00:00)
-    const start = new Date(now);
-    start.setDate(start.getDate() - 1);
-    start.setHours(0, 0, 0, 0);
-
-    // set 'end' to the end of the previous day (23:59:59)
-    const end = new Date(now);
-    end.setDate(end.getDate() - 1);
-    end.setHours(23, 59, 59, 999);
-
-    const rewards = await prisma.reward.findMany({
-      where: {
-        event: "click",
-      },
-      // click rewards are always partner-specific for now
-      // but in the future we need to account for program-wide click rewards
-      include: {
-        partners: {
-          select: {
-            programEnrollment: {
-              select: {
-                partnerId: true,
-              },
-            },
-          },
-        },
-      },
+    return NextResponse.json({
+      response: "success",
+    });
+  } catch (error) {
+    await log({
+      message: `Error updating aggregate clicks: ${error.message}`,
+      type: "cron",
     });
 
-    if (!rewards.length) {
-      return NextResponse.json({
-        message: "No programs with click rewards found. Skipping...",
-      });
-    }
-
-    for (const reward of rewards) {
-      const partnerIds = reward.partners.map(
-        ({ programEnrollment }) => programEnrollment.partnerId,
-      );
-
-      const links = await prisma.link.findMany({
-        where: {
-          programId: reward.programId,
-          partnerId: {
-            in: partnerIds,
-          },
-          clicks: {
-            gt: 0,
-          },
-          lastClicked: {
-            gte: start, // links that were clicked on after the start date
-          },
-        },
-        select: {
-          id: true,
-          programId: true,
-          partnerId: true,
-        },
-      });
-
-      if (!links.length) {
-        return NextResponse.json({
-          message: "No links found. Skipping...",
-        });
-      }
-
-      for (const { id: linkId, programId, partnerId } of links) {
-        if (!linkId || !programId || !partnerId) {
-          console.log("Invalid link", { linkId, programId, partnerId });
-          continue;
-        }
-
-        const { clicks: quantity } = await getAnalytics({
-          linkId,
-          start,
-          end,
-          groupBy: "count",
-          event: "clicks",
-        });
-
-        if (!quantity || quantity === 0) {
-          console.log("No clicks found for link", {
-            linkId,
-            programId,
-            partnerId,
-          });
-          continue;
-        }
-
-        console.log("Creating commission", {
-          reward,
-          event: "click",
-          programId,
-          partnerId,
-          linkId,
-          quantity,
-        });
-        await createPartnerCommission({
-          reward,
-          event: "click",
-          programId,
-          partnerId,
-          linkId,
-          quantity,
-        });
-      }
-    }
-
-    return NextResponse.json("OK");
-  } catch (error) {
     return handleAndReturnErrorResponse(error);
   }
 }
+
+export { handler as GET, handler as POST };

--- a/apps/web/app/api/cron/aggregate-clicks/utils.ts
+++ b/apps/web/app/api/cron/aggregate-clicks/utils.ts
@@ -1,0 +1,132 @@
+import { getAnalytics } from "@/lib/analytics/get-analytics";
+import { qstash } from "@/lib/cron";
+import { createPartnerCommission } from "@/lib/partners/create-partner-commission";
+import { prisma } from "@dub/prisma";
+import { APP_DOMAIN_WITH_NGROK } from "@dub/utils";
+
+interface Options {
+  cursor?: string;
+}
+
+const batchSize = 100;
+
+export const updateAggregateClicks = async ({ cursor }: Options = {}) => {
+  const now = new Date();
+
+  // define the 24h window for "yesterday"
+  const start = new Date(now);
+  start.setDate(start.getDate() - 1);
+  start.setHours(0, 0, 0, 0);
+
+  const end = new Date(now);
+  end.setDate(end.getDate() - 1);
+  end.setHours(23, 59, 59, 999);
+
+  const rewards = await prisma.reward.findMany({
+    where: {
+      event: "click",
+    },
+    // click rewards are always partner-specific for now
+    // but in the future we need to account for program-wide click rewards
+    include: {
+      partners: {
+        select: {
+          programEnrollment: {
+            select: {
+              partnerId: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  if (!rewards.length) {
+    console.log("No programs with click rewards found. Skipping...");
+    return;
+  }
+
+  // build OR-filters by programId & partnerId
+  const filters = rewards.flatMap((r) => {
+    const partnerIds = r.partners.map((p) => p.programEnrollment.partnerId);
+    return partnerIds.length
+      ? { programId: r.programId, partnerId: { in: partnerIds } }
+      : [];
+  });
+
+  // page through links matching click rewards
+  const links = await prisma.link.findMany({
+    where: {
+      clicks: { gt: 0 },
+      lastClicked: { gte: start },
+      OR: filters,
+    },
+    select: { id: true, programId: true, partnerId: true },
+    orderBy: { id: "asc" },
+    take: batchSize,
+    ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+  });
+
+  if (links.length === 0) {
+    console.log("All link click aggregations complete.");
+    return;
+  }
+
+  for (const { id: linkId, programId, partnerId } of links) {
+    if (!programId || !partnerId) {
+      console.warn("Invalid link", { linkId, programId, partnerId });
+      continue;
+    }
+    const { clicks: quantity } = await getAnalytics({
+      linkId,
+      start,
+      end,
+      groupBy: "count",
+      event: "clicks",
+    });
+    if (!quantity || quantity === 0) {
+      console.log("No clicks found for link", {
+        linkId,
+        programId,
+        partnerId,
+      });
+      continue;
+    }
+
+    // pick the matching reward
+    const reward = rewards.find((r) => r.programId === programId);
+    if (!reward) {
+      console.warn("No matching reward found for link", {
+        linkId,
+        programId,
+        partnerId,
+      });
+      continue;
+    }
+
+    console.log("Creating commission", {
+      reward,
+      event: "click",
+      programId,
+      partnerId,
+      linkId,
+      quantity,
+    });
+    await createPartnerCommission({
+      reward,
+      event: "click",
+      programId,
+      partnerId,
+      linkId,
+      quantity,
+    });
+  }
+
+  // schedule the next page
+  const lastLinkId = links[links.length - 1].id;
+  await qstash.publishJSON({
+    url: `${APP_DOMAIN_WITH_NGROK}/api/cron/aggregate-clicks`,
+    method: "POST",
+    body: { cursor: lastLinkId },
+  });
+};


### PR DESCRIPTION
This PR adds batch processing to the daily click aggregation to handle larger datasets more efficiently, addressing the TODO comment in the old code about using a cron job for scalability. Previously, processing all links at once could lead to performance issues. Now, we're using QStash to process links in batches of 100, with the GET handler initiating the first batch and the POST handler managing subsequent batches via cursor-based pagination. This approach improves scalability and reliability, reducing the risk of timeouts or resource exhaustion