### PR TITLE
Webhooks: Fix infinite loading state and add Pro badge indicator

### DIFF
--- a/apps/web/ui/modals/link-builder/webhooks-modal.tsx
+++ b/apps/web/ui/modals/link-builder/webhooks-modal.tsx
@@ -2,7 +2,15 @@ import useWebhooks from "@/lib/swr/use-webhooks";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { LinkFormData } from "@/ui/links/link-builder/link-builder-provider";
 import { useLinkBuilderKeyboardShortcut } from "@/ui/links/link-builder/use-link-builder-keyboard-shortcut";
-import { Button, Combobox, Modal, Tooltip, Webhook } from "@dub/ui";
+import { ProBadgeTooltip } from "@/ui/shared/pro-badge-tooltip";
+import {
+  Button,
+  Combobox,
+  Modal,
+  SimpleTooltipContent,
+  Tooltip,
+  Webhook,
+} from "@dub/ui";
 import { cn } from "@dub/utils";
 import { ChevronsUpDown } from "lucide-react";
 import {
@@ -72,6 +80,15 @@ function WebhooksModalInner({
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <h3 className="text-lg font-medium">Link Webhooks</h3>
+          <ProBadgeTooltip
+            content={
+              <SimpleTooltipContent
+                title="Add webhooks to receive a click event when someone clicks your link."
+                cta="Learn more."
+                href="https://dub.co/docs/concepts/webhooks/introduction"
+              />
+            }
+          />
         </div>
         <div className="max-md:hidden">
           <Tooltip
@@ -181,16 +198,15 @@ export function WebhookSelect({
         label: webhook.name,
         value: webhook.id,
         icon: <Webhook className="size-3.5" />,
-      })),
+      })) || [],
     [availableWebhooks],
   );
 
   const selectedWebhooks = useMemo(
     () =>
       webhookIds
-        .map((id) => options?.find(({ value }) => value === id)!)
+        .map((id) => options.find(({ value }) => value === id)!)
         .filter(Boolean),
-
     [webhookIds, options],
   );
 


### PR DESCRIPTION
### What's changed
- Fixed the webhook selector's infinite loading state by ensuring options array is never undefined
- Added Pro badge tooltip to indicate webhooks as a premium feature

### Why
The webhook selector would show an infinite loading state when `availableWebhooks` was undefined, leading to poor UX. Also, users weren't aware that webhooks are a Pro feature until they tried to use it.

<img width="701" alt="Screenshot 2025-04-22 at 12 21 40 PM" src="https://github.com/user-attachments/assets/9a038d65-193b-4be7-a7ff-1d9218768958" />