### PR TITLE
fixix(tinybird): Align MV columns and fix downstream pipe queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,13 @@ packages/stripe-app/.build/*
 *.csv
 *.ndjson
 .vitest
+.cursorrules
+
+fixtures/visits.sql
+endpoints/top_pages.pipe
+endpoints/get_visits.pipe
+endpoints/daily_visits_stats.pipe
+datasources/visits.datasource
+README.md
+pnpm-lock.yaml
+packages/tinybird/Test

--- a/packages/tinybird/pipes/dub_click_events_pipe.pipe
+++ b/packages/tinybird/pipes/dub_click_events_pipe.pipe
@@ -1,6 +1,5 @@
 NODE mv
 SQL >
-
     SELECT
         timestamp,
         click_id,
@@ -9,15 +8,20 @@ SQL >
         continent,
         country,
         city,
+        region,         
+        latitude,       
+        longitude,   
         device,
         browser,
         os,
+        engine,         
+        ua,             
+        identity_hash,  
         referer,
+        referer_url,    
         qr,
         ip
     FROM dub_click_events
 
 TYPE materialized
 DATASOURCE dub_click_events_mv
-
-

--- a/packages/tinybird/pipes/dub_lead_events_pipe.pipe
+++ b/packages/tinybird/pipes/dub_lead_events_pipe.pipe
@@ -1,23 +1,29 @@
 NODE mv
 SQL >
-
     SELECT
-        timestamp,
-        event_id,
-        click_id,
-        link_id,
-        customer_id,
-        event_name,
-        url,
-        continent,
-        country,
-        city,
-        device,
-        browser,
-        os,
-        referer,
-        qr,
-        ip
+        engine,          
+        country,         
+        qr,              
+        ua,              
+        os,              
+        latitude,        
+        event_name,      
+        url,             
+        event_id,        
+        referer,         
+        timestamp,       
+        city,            
+        ip,              
+        region,          
+        customer_id,     
+        continent,       
+        longitude,       
+        device,          
+        link_id,         
+        referer_url,     
+        click_id,        
+        browser          
+        
     FROM dub_lead_events
 
 TYPE materialized

--- a/packages/tinybird/pipes/dub_sale_events_pipe.pipe
+++ b/packages/tinybird/pipes/dub_sale_events_pipe.pipe
@@ -1,6 +1,5 @@
 NODE mv
 SQL >
-
     SELECT
         timestamp,
         event_id,
@@ -15,15 +14,19 @@ SQL >
         continent,
         country,
         city,
+        region,         
+        latitude,       
+        longitude,      
         device,
         browser,
         os,
+        engine,         
+        ua,             
         referer,
+        referer_url,    
         qr,
         ip
     FROM dub_sale_events
 
 TYPE materialized
 DATASOURCE dub_sale_events_mv
-
-

--- a/packages/tinybird/pipes/v2_customer_events.pipe
+++ b/packages/tinybird/pipes/v2_customer_events.pipe
@@ -6,7 +6,6 @@ TAGS "Dub Endpoints"
 
 NODE lead_events
 SQL >
-
     %
     SELECT
         timestamp,
@@ -32,8 +31,7 @@ SQL >
         splitByString('?', referer_url)[1] as referer_url_processed,
         'lead' as event,
         event_id,
-        event_name,
-        metadata
+        event_name 
     FROM dub_lead_events_mv
     WHERE
         customer_id
@@ -88,7 +86,6 @@ SQL >
 
 NODE sale_events
 SQL >
-
     %
     SELECT
         timestamp,
@@ -114,8 +111,7 @@ SQL >
         splitByString('?', referer_url)[1] as referer_url_processed,
         'sale' as event,
         event_id,
-        event_name,
-        metadata,
+        event_name, 
         amount as saleAmount,
         invoice_id,
         payment_processor
@@ -137,28 +133,106 @@ SQL >
 
 NODE endpoint
 SQL >
-
     %
     SELECT *
-    FROM
-        (
-            SELECT *, NULL AS saleAmount, NULL AS invoice_id, NULL AS payment_processor
-            FROM lead_events
-            UNION ALL
-            SELECT
-                *,
-                NULL AS event_id,
-                NULL AS event_name,
-                NULL AS metadata,
-                NULL AS saleAmount,
-                NULL AS invoice_id,
-                NULL AS payment_processor
-            FROM click_events
-            UNION ALL
-            SELECT *
-            FROM sale_events
-        )
+    FROM (
+        -- Branch 1: lead_events
+        SELECT
+            timestamp,
+            click_id,
+            link_id,
+            url,
+            continent,
+            country,
+            city,
+            region,
+            latitude,
+            longitude,
+            device,
+            browser,
+            os,
+            engine,
+            ua,
+            referer,
+            referer_url,
+            qr,
+            ip,
+            region_processed,
+            referer_url_processed,
+            event,
+            event_id,         
+            event_name,      
+            NULL AS saleAmount, 
+            NULL AS invoice_id, 
+            NULL AS payment_processor
+        FROM lead_events
+
+        UNION ALL
+
+        -- Branch 2: click_events
+        SELECT
+            timestamp,
+            click_id,
+            link_id,
+            url,
+            continent,
+            country,
+            city,
+            region,
+            latitude,
+            longitude,
+            device,
+            browser,
+            os,
+            engine,
+            ua,
+            referer,
+            referer_url,
+            qr,
+            ip,
+            region_processed,
+            referer_url_processed,
+            event,
+            NULL AS event_id,         
+            NULL AS event_name,       
+            NULL AS saleAmount,       
+            NULL AS invoice_id,       
+            NULL AS payment_processor 
+        FROM click_events
+
+        UNION ALL
+
+        -- Branch 3: sale_events
+        SELECT
+            timestamp,
+            click_id,
+            link_id,
+            url,
+            continent,
+            country,
+            city,
+            region,
+            latitude,
+            longitude,
+            device,
+            browser,
+            os,
+            engine,
+            ua,
+            referer,
+            referer_url,
+            qr,
+            ip,
+            region_processed,
+            referer_url_processed,
+            event,
+            event_id,        
+            event_name,      
+            saleAmount,      
+            invoice_id,      
+            payment_processor
+        FROM sale_events
+    ) AS final_union
     ORDER BY
-        timestamp DESC, CASE event WHEN 'click' THEN 1 WHEN 'lead' THEN 2 WHEN 'sale' THEN 3 END DESC
-
-
+        timestamp DESC,
+        CASE event WHEN 'click' THEN 1 WHEN 'lead' THEN 2 WHEN 'sale' THEN 3 END DESC


### PR DESCRIPTION
=

Deployment was failing due to mismatches between materialized view
pipe outputs and target datasource schemas, as well as downstream
pipes referencing columns that were no longer being materialized.

- Aligned columns in `dub_click_events_pipe` final node with the schema
  of `dub_click_events_mv.datasource`. Added missing fields like
  `region`, `latitude`, `longitude`, `engine`, `ua`, `identity_hash`,
  and `referer_url`.
- Aligned columns in `dub_lead_events_pipe` final node with the schema
  of `dub_lead_events_mv.datasource`. Initially added missing fields,
  then removed fields (`bot`, `metadata`, `engine_version`, etc.) that
  were not actually present in the target MV schema according to later
  deployment errors.
- Aligned columns in `dub_sale_events_pipe` final node with the schema
  of `dub_sale_events_mv.datasource`. Added missing fields like
  `region`, `latitude`, `longitude`, `engine`, `ua`, and `referer_url`.
- Removed references to the `metadata` column from `NODE lead_events`
  and `NODE sale_events` within `v2_customer_events.pipe`, as this
  column was no longer present in `dub_lead_events_mv` or
  `dub_sale_events_mv`.
- Corrected the `UNION ALL` structure in `NODE endpoint` of
  `v2_customer_events.pipe` to ensure all branches selected the
  same number and order of columns after the removal of `metadata`.