### PR TITLE
chore: Update outdated URL references in plan-compare.tsx

### DIFF
--- a/packages/utils/src/constants/plan-compare.tsx
+++ b/packages/utils/src/constants/plan-compare.tsx
@@ -25,7 +25,7 @@ export const PLAN_COMPARE_FEATURES: {
 }[] = [
   {
     category: "Links",
-    href: "https://dub.co/home", // TODO: update to https://dub.co/links
+    href: "https://dub.co/links",
     features: [
       {
         text: () => (
@@ -447,7 +447,7 @@ export const PLAN_COMPARE_FEATURES: {
   },
   {
     category: "Support",
-    href: "https://dub.co/help", // TODO: update to https://dub.co/contact/support
+    href: "https://dub.co/contact/support",
     features: [
       {
         text: ({ id }) => (


### PR DESCRIPTION
# URL Reference Update in `plan-compare.tsx`

## Overview

This pull request updates two outdated URL references in the `plan-compare.tsx` file to ensure users are directed to the most accurate and current pages for documentation and support.

---

## Changes Made

- ✅ Updated URL in the **Links** section:  
  From: `https://dub.co/home`  
  To: `https://dub.co/links`

- ✅ Updated URL in the **Support** section:  
  From: `https://dub.co/help`  
  To: `https://dub.co/contact/support`

- ✅ Removed obsolete `TODO` comments related to the above links

---

## Motivation

- Ensure all URLs point to the correct and most relevant destinations
- Improve user experience and navigation
- Clean up unnecessary inline comments for better code maintainability

---

## Type of Change

- 🔧 **Chore:** Maintenance update to project URLs

---

## Checklist

- [x] Updated outdated URL references
- [x] Removed associated `TODO` comments
- [x] Verified correctness of new links

---

## Fixes

- Resolves outdated URL references in the project's **plan comparison constants**
