### PR TITLE
Improve folders linkCount

### DIFF
--- a/apps/web/app/(ee)/api/admin/ban/route.ts
+++ b/apps/web/app/(ee)/api/admin/ban/route.ts
@@ -12,7 +12,7 @@ import { NextResponse } from "next/server";
 export const POST = withAdmin(async ({ req }) => {
   const { email } = await req.json();
 
-  const user = await prisma.user.findUnique({
+  const user = await prisma.user.findUniqueOrThrow({
     where: {
       email,
     },
@@ -38,29 +38,32 @@ export const POST = withAdmin(async ({ req }) => {
     },
   });
 
-  if (!user?.email) {
-    return new Response("No user found", { status: 404 });
-  }
+  console.log(
+    `Found user ${user.email} with ${user.projects.length} workspaces`,
+  );
 
   waitUntil(
-    Promise.allSettled([
-      ...user.projects.map(({ project }) => deleteWorkspaceAdmin(project)),
-      // delete user
-      prisma.user.delete({
-        where: {
-          id: user.id,
-        },
-      }),
-      // if the user has a custom avatar, delete it
-      user.image &&
-        isStored(user.image) &&
-        storage.delete(user.image.replace(`${R2_URL}/`, "")),
-      unsubscribe({ email }),
-      updateConfig({
-        key: "emails",
-        value: email,
-      }),
-    ]),
+    Promise.allSettled(
+      user.projects.map(({ project }) => deleteWorkspaceAdmin(project)),
+    ).then(async () => {
+      await Promise.allSettled([
+        // delete user
+        prisma.user.delete({
+          where: {
+            id: user.id,
+          },
+        }),
+        // if the user has a custom avatar, delete it
+        user.image &&
+          isStored(user.image) &&
+          storage.delete(user.image.replace(`${R2_URL}/`, "")),
+        unsubscribe({ email }),
+        updateConfig({
+          key: "emails",
+          value: email,
+        }),
+      ]);
+    }),
   );
 
   return NextResponse.json({ success: true });

--- a/apps/web/app/api/folders/route.ts
+++ b/apps/web/app/api/folders/route.ts
@@ -16,7 +16,7 @@ import { NextResponse } from "next/server";
 // GET /api/folders - get all folders for a workspace
 export const GET = withWorkspace(
   async ({ workspace, headers, session, searchParams }) => {
-    const { search, includeLinkCount, pageSize, page } =
+    const { search, pageSize, page } =
       listFoldersQuerySchema.parse(searchParams);
 
     const folders = await getFolders({
@@ -25,7 +25,6 @@ export const GET = withWorkspace(
       search,
       pageSize,
       page,
-      includeLinkCount,
     });
 
     return NextResponse.json(FolderSchema.array().parse(folders), {

--- a/apps/web/app/api/folders/route.ts
+++ b/apps/web/app/api/folders/route.ts
@@ -19,6 +19,8 @@ export const GET = withWorkspace(
     const { search, pageSize, page } =
       listFoldersQuerySchema.parse(searchParams);
 
+    console.log({ search, pageSize, page });
+
     const folders = await getFolders({
       workspaceId: workspace.id,
       userId: session.user.id,

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/settings/library/folders/[folderId]/members/page-client.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/settings/library/folders/[folderId]/members/page-client.tsx
@@ -6,6 +6,7 @@ import {
   FOLDER_WORKSPACE_ACCESS,
 } from "@/lib/folder/constants";
 import { getPlanCapabilities } from "@/lib/plan-capabilities";
+import { useFolderLinkCount } from "@/lib/swr/use-folder-link-count";
 import {
   useCheckFolderPermission,
   useFolderPermissions,
@@ -16,7 +17,7 @@ import { FolderIcon } from "@/ui/folders/folder-icon";
 import { RequestFolderEditAccessButton } from "@/ui/folders/request-edit-button";
 import { FolderUserRole } from "@dub/prisma/client";
 import { Avatar, BlurImage, Globe } from "@dub/ui";
-import { cn, fetcher, nFormatter, OG_AVATAR_URL } from "@dub/utils";
+import { cn, fetcher, nFormatter, OG_AVATAR_URL, pluralize } from "@dub/utils";
 import { ChevronLeft } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { useAction } from "next-safe-action/hooks";
@@ -48,6 +49,8 @@ export const FolderUsersPageClient = ({ folderId }: { folderId: string }) => {
     `/api/folders/${folderId}?workspaceId=${workspace.id}`,
     fetcher,
   );
+
+  const { folderLinkCount } = useFolderLinkCount({ folderId });
 
   const {
     data: users,
@@ -120,8 +123,8 @@ export const FolderUsersPageClient = ({ folderId }: { folderId: string }) => {
                   <div className="flex items-center gap-1">
                     <Globe className="size-3.5 text-neutral-500" />
                     <span className="text-[13px] font-normal leading-[14.30px] text-neutral-500">
-                      {nFormatter(folder.linkCount)} link
-                      {folder.linkCount !== 1 && "s"}
+                      {nFormatter(folderLinkCount, { full: true })}
+                      {pluralize("link", folderLinkCount)}
                     </span>
                   </div>
                 </div>

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/settings/library/folders/page-client.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/settings/library/folders/page-client.tsx
@@ -27,9 +27,6 @@ export const FoldersPageClient = () => {
 
   const { folders, loading, isValidating } = useFolders({
     includeParams: ["search", "page"],
-    query: {
-      includeLinkCount: true,
-    },
   });
 
   const { data: foldersCount } = useFoldersCount({
@@ -51,7 +48,7 @@ export const FoldersPageClient = () => {
               loading={isValidating}
               onChangeDebounced={(t) => {
                 if (t) {
-                  queryParams({ set: { search: t } });
+                  queryParams({ set: { search: t }, del: "page" });
                 } else {
                   queryParams({ del: "search" });
                 }

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/settings/library/folders/page-client.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/settings/library/folders/page-client.tsx
@@ -25,11 +25,15 @@ export const FoldersPageClient = () => {
 
   const { AddFolderButton, AddFolderModal } = useAddFolderModal();
 
-  const { data: foldersCount } = useFoldersCount({
-    includeParams: true,
-  });
   const { folders, loading, isValidating } = useFolders({
-    includeParams: true,
+    includeParams: ["search", "page"],
+    query: {
+      includeLinkCount: true,
+    },
+  });
+
+  const { data: foldersCount } = useFoldersCount({
+    includeParams: ["search", "page"],
   });
 
   const showAllLinkFolder =

--- a/apps/web/lib/analytics/get-folder-ids-to-filter.ts
+++ b/apps/web/lib/analytics/get-folder-ids-to-filter.ts
@@ -24,7 +24,7 @@ export const getFolderIdsToFilter = async ({
     const folders = await getFolders({
       workspaceId: workspace.id,
       userId,
-      excludeBulkFolders: true,
+      type: "default",
       pageSize: 1000, // TODO: might need to handle this if folks have > 1000 folders in the future
     });
 

--- a/apps/web/lib/api/workspaces.ts
+++ b/apps/web/lib/api/workspaces.ts
@@ -64,44 +64,56 @@ export async function deleteWorkspace(
 export async function deleteWorkspaceAdmin(
   workspace: Pick<WorkspaceProps, "id" | "slug" | "logo" | "stripeId">,
 ) {
-  const [defaultDomainLinks, customDomains] = await Promise.all([
-    prisma.link.findMany({
+  while (true) {
+    const defaultDomainLinks = await prisma.link.findMany({
       where: {
+        projectId: workspace.id,
         domain: {
           in: DUB_DOMAINS_ARRAY,
         },
-        projectId: workspace.id,
       },
       select: {
         id: true,
         domain: true,
         key: true,
       },
-    }),
-    prisma.domain.findMany({
-      where: {
-        projectId: workspace.id,
-      },
-      select: {
-        slug: true,
-      },
-    }),
-  ]);
+      take: 100,
+    });
 
-  const [redisRes, prismaRes] = await Promise.allSettled([
-    linkCache.expireMany(defaultDomainLinks),
-    prisma.link.updateMany({
-      where: {
-        id: {
-          in: defaultDomainLinks.map((link) => link.id),
+    if (defaultDomainLinks.length === 0) {
+      break;
+    }
+
+    const [redisRes, prismaRes] = await Promise.allSettled([
+      linkCache.expireMany(defaultDomainLinks),
+      prisma.link.updateMany({
+        where: {
+          id: {
+            in: defaultDomainLinks.map((link) => link.id),
+          },
         },
-      },
-      data: {
-        projectId: LEGAL_WORKSPACE_ID,
-        userId: LEGAL_USER_ID,
-      },
-    }),
-  ]);
+        data: {
+          projectId: LEGAL_WORKSPACE_ID,
+          userId: LEGAL_USER_ID,
+        },
+      }),
+    ]);
+
+    console.log(
+      `Banned ${defaultDomainLinks.length} default domain links for ${workspace.slug}`,
+      redisRes,
+      prismaRes,
+    );
+  }
+
+  const customDomains = await prisma.domain.findMany({
+    where: {
+      projectId: workspace.id,
+    },
+    select: {
+      slug: true,
+    },
+  });
 
   // delete all domains, links, and uploaded images associated with the workspace
   const deleteDomainsLinksResponse = await Promise.allSettled(
@@ -111,6 +123,11 @@ export async function deleteWorkspaceAdmin(
         workspaceId: workspace.id,
       }),
     ),
+  );
+
+  console.log(
+    `Deleted ${customDomains.length} custom domains for ${workspace.slug}`,
+    deleteDomainsLinksResponse,
   );
 
   const deleteWorkspaceResponse = await Promise.allSettled([
@@ -128,9 +145,9 @@ export async function deleteWorkspaceAdmin(
     }),
   ]);
 
+  console.log(`Deleted workspace ${workspace.slug}`, deleteWorkspaceResponse);
+
   return {
-    redisRes,
-    prismaRes,
     deleteDomainsLinksResponse,
     deleteWorkspaceResponse,
   };

--- a/apps/web/lib/folder/constants.ts
+++ b/apps/web/lib/folder/constants.ts
@@ -45,5 +45,4 @@ export const unsortedLinks: FolderSummary = {
   id: "unsorted",
   name: "Links",
   accessLevel: "write",
-  linkCount: -1,
 };

--- a/apps/web/lib/folder/get-folders.ts
+++ b/apps/web/lib/folder/get-folders.ts
@@ -1,16 +1,19 @@
 import { prisma } from "@dub/prisma";
+import { FolderType } from "@prisma/client";
 import { FOLDERS_MAX_PAGE_SIZE } from "../zod/schemas/folders";
 
 export const getFolders = async ({
   workspaceId,
   userId,
   search,
+  type,
   pageSize = FOLDERS_MAX_PAGE_SIZE,
   page = 1,
 }: {
   workspaceId: string;
   userId: string;
   search?: string;
+  type?: FolderType;
   pageSize?: number;
   page?: number;
 }) => {
@@ -45,6 +48,7 @@ export const getFolders = async ({
           contains: search,
         },
       }),
+      type,
     },
     select: {
       id: true,

--- a/apps/web/lib/folder/get-folders.ts
+++ b/apps/web/lib/folder/get-folders.ts
@@ -5,20 +5,16 @@ export const getFolders = async ({
   workspaceId,
   userId,
   search,
-  includeLinkCount = false,
-  excludeBulkFolders = false,
   pageSize = FOLDERS_MAX_PAGE_SIZE,
   page = 1,
 }: {
   workspaceId: string;
   userId: string;
-  includeLinkCount?: boolean;
-  excludeBulkFolders?: boolean;
   search?: string;
   pageSize?: number;
   page?: number;
 }) => {
-  const folders = await prisma.folder.findMany({
+  return await prisma.folder.findMany({
     where: {
       projectId: workspaceId,
       OR: [
@@ -49,11 +45,6 @@ export const getFolders = async ({
           contains: search,
         },
       }),
-      ...(excludeBulkFolders && {
-        type: {
-          not: "mega",
-        },
-      }),
     },
     select: {
       id: true,
@@ -62,13 +53,6 @@ export const getFolders = async ({
       accessLevel: true,
       createdAt: true,
       updatedAt: true,
-      ...(includeLinkCount && {
-        _count: {
-          select: {
-            links: true,
-          },
-        },
-      }),
     },
     orderBy: {
       createdAt: "asc",
@@ -76,11 +60,4 @@ export const getFolders = async ({
     take: pageSize,
     skip: (page - 1) * pageSize,
   });
-
-  return folders.map((folder) => ({
-    ...folder,
-    ...(includeLinkCount && {
-      linkCount: folder._count.links,
-    }),
-  }));
 };

--- a/apps/web/lib/swr/use-folder-link-count.ts
+++ b/apps/web/lib/swr/use-folder-link-count.ts
@@ -7,7 +7,7 @@ export function useFolderLinkCount({ folderId }: { folderId: string | null }) {
       folderId: string;
       _count: number;
     }[]
-  >({ query: { groupBy: "folderId" } });
+  >({ query: { groupBy: "folderId" }, ignoreParams: true });
 
   const folderLinkCount = useMemo(() => {
     return (

--- a/apps/web/lib/swr/use-folder-link-count.ts
+++ b/apps/web/lib/swr/use-folder-link-count.ts
@@ -1,0 +1,22 @@
+import { useMemo } from "react";
+import useLinksCount from "./use-links-count";
+
+export function useFolderLinkCount({ folderId }: { folderId: string | null }) {
+  const { data: folderLinksCount, loading } = useLinksCount<
+    {
+      folderId: string;
+      _count: number;
+    }[]
+  >({ query: { groupBy: "folderId" } });
+
+  const folderLinkCount = useMemo(() => {
+    return (
+      folderLinksCount?.find(
+        ({ folderId: id }) =>
+          id === folderId || (id === null && folderId === "unsorted"),
+      )?._count || 0
+    );
+  }, [folderLinksCount, folderId]);
+
+  return { folderLinkCount, loading };
+}

--- a/apps/web/lib/swr/use-folders-count.ts
+++ b/apps/web/lib/swr/use-folders-count.ts
@@ -4,10 +4,10 @@ import useSWR from "swr";
 import useWorkspace from "./use-workspace";
 
 export default function useFoldersCount({
-  includeParams = false,
+  includeParams = [],
   query,
 }: {
-  includeParams?: boolean;
+  includeParams?: string[];
   query?: Record<string, any>;
 } = {}) {
   const { id: workspaceId, plan } = useWorkspace();
@@ -16,7 +16,7 @@ export default function useFoldersCount({
 
   const qs = getQueryString(
     { workspaceId, ...query },
-    { include: includeParams ? ["search"] : [] },
+    { include: includeParams },
   );
 
   const { data, error } = useSWR<number>(

--- a/apps/web/lib/swr/use-folders.ts
+++ b/apps/web/lib/swr/use-folders.ts
@@ -5,23 +5,16 @@ import useSWR, { SWRConfiguration } from "swr";
 import useWorkspace from "./use-workspace";
 
 export default function useFolders({
-  includeParams = false,
-  includeLinkCount = false,
+  includeParams = [],
   query,
   options,
 }: {
-  includeParams?: boolean;
-  includeLinkCount?: boolean;
+  includeParams?: string[];
   query?: Record<string, any>;
   options?: SWRConfiguration;
 } = {}) {
   const { id: workspaceId, plan } = useWorkspace();
   const { getQueryString } = useRouterStuff();
-
-  const qs = getQueryString(
-    { workspaceId, ...query },
-    { include: includeParams ? undefined : [] },
-  );
 
   const {
     data: folders,
@@ -29,7 +22,10 @@ export default function useFolders({
     isLoading,
   } = useSWR<Folder[]>(
     workspaceId && plan !== "free"
-      ? `/api/folders${qs}${includeLinkCount ? "&includeLinkCount=true" : ""}`
+      ? `/api/folders${getQueryString(
+          { workspaceId, ...query },
+          { include: includeParams },
+        )}`
       : null,
     fetcher,
     {

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -464,7 +464,7 @@ export type FolderWithPermissions = {
 
 export type FolderSummary = Pick<
   Folder,
-  "id" | "name" | "accessLevel" | "linkCount"
+  "id" | "name" | "accessLevel" | "type"
 >;
 
 // Rewards

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -462,10 +462,7 @@ export type FolderWithPermissions = {
   permissions: FolderPermission[];
 };
 
-export type FolderSummary = Pick<
-  Folder,
-  "id" | "name" | "accessLevel" | "type"
->;
+export type FolderSummary = Pick<Folder, "id" | "name" | "accessLevel">;
 
 // Rewards
 

--- a/apps/web/lib/zod/schemas/folders.ts
+++ b/apps/web/lib/zod/schemas/folders.ts
@@ -5,7 +5,7 @@ import {
 import { FolderAccessLevel } from "@/lib/types";
 import z from "@/lib/zod";
 import { FolderType, FolderUserRole } from "@dub/prisma/client";
-import { booleanQuerySchema, getPaginationQuerySchema } from "./misc";
+import { getPaginationQuerySchema } from "./misc";
 
 const workspaceFolderAccess = z
   .enum(
@@ -27,10 +27,6 @@ export const FolderSchema = z.object({
   name: z.string().describe("The name of the folder."),
   type: z.enum(Object.keys(FolderType) as [FolderType, ...FolderType[]]),
   accessLevel: workspaceFolderAccess,
-  linkCount: z
-    .number()
-    .describe("The number of links in the folder.")
-    .default(0),
   createdAt: z.date().describe("The date the folder was created."),
   updatedAt: z.date().describe("The date the folder was updated."),
 });
@@ -48,9 +44,6 @@ export const listFoldersQuerySchema = z
       .string()
       .optional()
       .describe("The search term to filter the folders by."),
-    includeLinkCount: booleanQuerySchema
-      .optional()
-      .describe("Whether to include the link count in the response."),
   })
   .merge(getPaginationQuerySchema({ pageSize: FOLDERS_MAX_PAGE_SIZE }));
 

--- a/apps/web/tests/folders/index.test.ts
+++ b/apps/web/tests/folders/index.test.ts
@@ -9,7 +9,6 @@ type FolderRecord = z.infer<typeof FolderSchema>;
 const expectedFolder = {
   id: expect.any(String),
   type: "default",
-  linkCount: expect.any(Number),
   createdAt: expect.any(String),
   updatedAt: expect.any(String),
 };

--- a/apps/web/ui/folders/folder-card.tsx
+++ b/apps/web/ui/folders/folder-card.tsx
@@ -1,16 +1,15 @@
 "use client";
 
+import { useFolderLinkCount } from "@/lib/swr/use-folder-link-count";
 import {
   useCheckFolderPermission,
   useFolderPermissions,
 } from "@/lib/swr/use-folder-permissions";
-import useLinksCount from "@/lib/swr/use-links-count";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { Folder } from "@/lib/types";
 import { Globe } from "@dub/ui/icons";
 import { cn, nFormatter, pluralize } from "@dub/utils";
 import Link from "next/link";
-import { useMemo } from "react";
 import { FolderActions } from "./folder-actions";
 import { FolderIcon } from "./folder-icon";
 import { RequestFolderEditAccessButton } from "./request-edit-button";
@@ -80,24 +79,9 @@ export const FolderCard = ({ folder }: { folder: Folder }) => {
 };
 
 function FolderLinksCount({ folder }: { folder: Folder }) {
-  const { data: folderLinksCount, loading } = useLinksCount<
-    {
-      folderId: string;
-      _count: number;
-    }[]
-  >({ query: { groupBy: "folderId" } });
-
-  const folderLinkCount = useMemo(() => {
-    return (
-      folderLinksCount?.find(
-        ({ folderId }) =>
-          folderId === folder.id ||
-          (folder.id === "unsorted" && folderId === null),
-      )?._count || 0
-    );
-  }, [folderLinksCount, folder.id]);
-
-  console.log({ folderLinkCount });
+  const { folderLinkCount, loading } = useFolderLinkCount({
+    folderId: folder.id,
+  });
 
   return (
     <div className="mt-1.5 flex items-center gap-1 text-neutral-500">

--- a/apps/web/ui/folders/folder-card.tsx
+++ b/apps/web/ui/folders/folder-card.tsx
@@ -8,7 +8,7 @@ import {
 import useWorkspace from "@/lib/swr/use-workspace";
 import { Folder } from "@/lib/types";
 import { Globe } from "@dub/ui/icons";
-import { cn, nFormatter, pluralize } from "@dub/utils";
+import { nFormatter, pluralize } from "@dub/utils";
 import Link from "next/link";
 import { FolderActions } from "./folder-actions";
 import { FolderIcon } from "./folder-icon";
@@ -32,12 +32,7 @@ export const FolderCard = ({ folder }: { folder: Folder }) => {
   const isDefault = isDefaultFolder({ folder, defaultFolderId });
 
   return (
-    <div
-      className={cn(
-        "hover:drop-shadow-card-hover relative flex flex-col justify-between rounded-xl border border-neutral-200 bg-white px-5 py-4 transition-all duration-200 sm:h-36",
-        folder.type === "mega" && "sm:h-32",
-      )}
-    >
+    <div className="hover:drop-shadow-card-hover relative flex flex-col justify-between rounded-xl border border-neutral-200 bg-white px-5 py-4 transition-all duration-200 sm:h-36">
       <Link
         href={`/${workspaceSlug}${unsortedLinks ? "" : `?folderId=${folder.id}`}`}
         className="absolute inset-0 h-full w-full"
@@ -92,7 +87,7 @@ function FolderLinksCount({ folder }: { folder: Folder }) {
       ) : (
         <span className="text-sm font-normal">
           {folder.type === "mega"
-            ? "1,000+ links"
+            ? "10,000+ links"
             : `${nFormatter(folderLinkCount, { full: true })} ${pluralize(
                 "link",
                 folderLinkCount,

--- a/apps/web/ui/folders/folder-dropdown.tsx
+++ b/apps/web/ui/folders/folder-dropdown.tsx
@@ -2,11 +2,12 @@ import { unsortedLinks } from "@/lib/folder/constants";
 import { getPlanCapabilities } from "@/lib/plan-capabilities";
 import useFolder from "@/lib/swr/use-folder";
 import useFolders from "@/lib/swr/use-folders";
+import useLinksCount from "@/lib/swr/use-links-count";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { FolderSummary } from "@/lib/types";
 import { FOLDERS_MAX_PAGE_SIZE } from "@/lib/zod/schemas/folders";
 import { Button, Combobox, TooltipContent, useRouterStuff } from "@dub/ui";
-import { cn } from "@dub/utils";
+import { cn, nFormatter } from "@dub/utils";
 import { ChevronsUpDown } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -62,6 +63,13 @@ export const FolderDropdown = ({
     if (folders && !useAsync && folders.length >= FOLDERS_MAX_PAGE_SIZE)
       setUseAsync(true);
   }, [folders, useAsync]);
+
+  const { data: folderLinksCount } = useLinksCount<
+    {
+      folderId: string;
+      _count: number;
+    }[]
+  >({ query: { groupBy: "folderId" }, ignoreParams: true });
 
   const [openPopover, setOpenPopover] = useState(false);
 
@@ -122,7 +130,15 @@ export const FolderDropdown = ({
         value: folder.id,
         label: folder.name,
         icon: <FolderIcon className="mr-1" folder={folder} shape="square" />,
-        meta: folder,
+        meta: {
+          ...folder,
+          linksCount:
+            folderLinksCount?.find(
+              ({ folderId }) =>
+                folderId === folder.id ||
+                (folder.id === "unsorted" && folderId === null),
+            )?._count || 0,
+        },
         first: folder.id === "unsorted",
       })),
       {
@@ -210,10 +226,10 @@ export const FolderDropdown = ({
           ) : undefined
         }
         optionRight={(option) =>
-          option.value === "unsorted" ? (
-            <div className="rounded bg-neutral-100 p-1">
-              <div className="text-xs font-normal text-black">Unsorted</div>
-            </div>
+          option.meta && "linksCount" in option.meta ? (
+            <span className="text-xs text-neutral-500">
+              {nFormatter(option.meta.linksCount, { full: true })}
+            </span>
           ) : undefined
         }
         caret={

--- a/apps/web/ui/folders/folder-dropdown.tsx
+++ b/apps/web/ui/folders/folder-dropdown.tsx
@@ -228,7 +228,9 @@ export const FolderDropdown = ({
         optionRight={(option) =>
           option.meta && "linksCount" in option.meta ? (
             <span className="text-xs text-neutral-500">
-              {nFormatter(option.meta.linksCount, { full: true })}
+              {option.meta.type === "mega"
+                ? "10,000+"
+                : nFormatter(option.meta.linksCount, { full: true })}
             </span>
           ) : undefined
         }

--- a/apps/web/ui/folders/folder-permissions-panel.tsx
+++ b/apps/web/ui/folders/folder-permissions-panel.tsx
@@ -365,7 +365,7 @@ const FolderUserPlaceholder = () => (
 );
 
 export function useFolderPermissionsPanel(
-  folder: Pick<Folder, "id" | "name" | "accessLevel" | "type">,
+  folder: Pick<Folder, "id" | "name" | "accessLevel">,
 ) {
   const [showFolderPermissionsPanel, setShowFolderPermissionsPanel] =
     useState(false);

--- a/apps/web/ui/folders/folder-permissions-panel.tsx
+++ b/apps/web/ui/folders/folder-permissions-panel.tsx
@@ -4,11 +4,11 @@ import {
   FOLDER_WORKSPACE_ACCESS,
 } from "@/lib/folder/constants";
 import { getPlanCapabilities } from "@/lib/plan-capabilities";
+import { useFolderLinkCount } from "@/lib/swr/use-folder-link-count";
 import {
   useCheckFolderPermission,
   useFolderPermissions,
 } from "@/lib/swr/use-folder-permissions";
-import useLinksCount from "@/lib/swr/use-links-count";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { Folder, FolderUser } from "@/lib/types";
 import { FolderUserRole } from "@dub/prisma/client";
@@ -17,7 +17,7 @@ import { Globe, UserCheck } from "@dub/ui/icons";
 import { cn, fetcher, nFormatter, OG_AVATAR_URL, pluralize } from "@dub/utils";
 import { useSession } from "next-auth/react";
 import { useAction } from "next-safe-action/hooks";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { toast } from "sonner";
 import useSWR, { mutate } from "swr";
 import { Drawer } from "vaul";
@@ -69,22 +69,7 @@ const FolderPermissionsPanel = ({
       keepPreviousData: true,
     },
   );
-  const { data: folderLinksCount, loading } = useLinksCount<
-    {
-      folderId: string;
-      _count: number;
-    }[]
-  >({ query: { groupBy: "folderId" } });
-
-  const folderLinkCount = useMemo(() => {
-    return (
-      folderLinksCount?.find(
-        ({ folderId }) =>
-          folderId === folder.id ||
-          (folder.id === "unsorted" && folderId === null),
-      )?._count || 0
-    );
-  }, [folderLinksCount, folder.id]);
+  const { folderLinkCount } = useFolderLinkCount({ folderId: folder.id });
 
   const updateWorkspaceAccessLevel = async (accessLevel: string) => {
     setIsUpdating(true);

--- a/apps/web/ui/links/use-folder-filter-options.ts
+++ b/apps/web/ui/links/use-folder-filter-options.ts
@@ -1,0 +1,42 @@
+import useFolders from "@/lib/swr/use-folders";
+import useFoldersCount from "@/lib/swr/use-folders-count";
+import useLinksCount from "@/lib/swr/use-links-count";
+import { FOLDERS_MAX_PAGE_SIZE } from "@/lib/zod/schemas/folders";
+import { useMemo } from "react";
+
+export function useFolderFilterOptions({ search }: { search: string }) {
+  const { data: foldersCount } = useFoldersCount();
+  const foldersAsync = Boolean(
+    foldersCount && foldersCount > FOLDERS_MAX_PAGE_SIZE,
+  );
+  const { folders, loading: loadingFolders } = useFolders({
+    query: { search: foldersAsync ? search : "" },
+  });
+
+  const { data: folderLinksCount } = useLinksCount<
+    {
+      folderId: string;
+      _count: number;
+    }[]
+  >({ query: { groupBy: "folderId" } });
+
+  const foldersResult = useMemo(() => {
+    return (
+      (loadingFolders ||
+        [...(folders ?? [])]
+          .map((folder) => ({
+            ...folder,
+            count:
+              folderLinksCount?.find(
+                ({ folderId }) =>
+                  folderId === folder.id ||
+                  (folder.id === "unsorted" && folderId === null),
+              )?._count || 0,
+          }))
+          .sort((a, b) => b.count - a.count)) ??
+      null
+    );
+  }, [loadingFolders, folders, folderLinksCount]);
+
+  return { folders: foldersResult, foldersAsync };
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new hook to provide folder filtering options with link counts, enabling enhanced folder filtering and sorting.
	- Introduced a hook to fetch and display dynamic link counts for individual folders.
- **Improvements**
	- Folder link counts are now dynamically fetched and displayed in folder cards, dropdowns, permissions panels, and user pages for more accurate and up-to-date information.
	- Folder-related components now show a fixed "10,000+ links" label for certain folder types and improved pluralization of link labels.
- **Refactor**
	- Simplified folder data structures and API parameters by removing direct link count properties and related query options.
	- Updated folder-related hooks and types to use more precise parameter handling and data fetching strategies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->