### PR TITLE
Remove `highdpi` screen from `tailwind.config.ts`

### DIFF
--- a/apps/web/ui/partners/design/previews/embed-preview.tsx
+++ b/apps/web/ui/partners/design/previews/embed-preview.tsx
@@ -64,7 +64,7 @@ export function EmbedPreview({
               {/* Inner shadow on top of studs */}
               <div className="absolute inset-0 overflow-hidden rounded-xl shadow-[0_12px_20px_0_#00000026_inset,0_2px_5px_0_#00000026_inset,0_2px_13px_2px_#FFFFFF59]" />
 
-              <div className="highdpi:@[800px]:-translate-y-10 highdpi:@[800px]:translate-x-10 highdpi:@[800px]:rotate-[2.4deg] relative overflow-hidden rounded-xl border border-black/10 bg-white drop-shadow-lg">
+              <div className="@[800px]:-translate-y-10 @[800px]:translate-x-10 @[800px]:rotate-[2.4deg] relative overflow-hidden rounded-xl border border-black/10 bg-white drop-shadow-lg">
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
                   xmlnsXlink="http://www.w3.org/1999/xlink"

--- a/packages/tailwind-config/tailwind.config.ts
+++ b/packages/tailwind-config/tailwind.config.ts
@@ -15,9 +15,6 @@ const config: Config = {
     extend: {
       screens: {
         xs: "420px",
-        highdpi: {
-          raw: "only screen and (min-resolution: 2dppx)",
-        },
       },
       typography: {
         DEFAULT: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated responsive styling for certain elements, removing high-DPI specific adjustments to ensure consistent appearance across devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->