### PR TITLE
Deactivate ProgramApplicationReminder if ProgramEnrollment exists

### DIFF
--- a/apps/web/app/(ee)/api/cron/program-application-reminder/route.ts
+++ b/apps/web/app/(ee)/api/cron/program-application-reminder/route.ts
@@ -35,10 +35,23 @@ export async function POST(req: Request) {
       },
     });
 
-    if (!application)
+    if (!application) {
       return new Response(
         `Application ${applicationId} without partner not found. Skipping...`,
       );
+    }
+
+    const programEnrollment = await prisma.programEnrollment.findFirst({
+      where: {
+        applicationId: application.id,
+      },
+    });
+
+    if (programEnrollment) {
+      return new Response(
+        `Partner with applicationId ${application.id} has already been enrolled in program ${application.program.name}. Skipping...`,
+      );
+    }
 
     await sendEmail({
       subject: `Complete your application for ${application.program.name}`,

--- a/apps/web/scripts/wispr-flow/update-links.ts
+++ b/apps/web/scripts/wispr-flow/update-links.ts
@@ -1,0 +1,41 @@
+import { prisma } from "@dub/prisma";
+import "dotenv-flow/config";
+import { linkCache } from "../../lib/api/links/cache";
+
+// update links
+async function main() {
+  const url = undefined;
+  if (!url) {
+    console.log("No url provided");
+    return;
+  }
+
+  const links = await prisma.link.findMany({
+    where: {
+      folderId: "fold_mslj7fMwqZPIFJqPQIoenL8H",
+      ios: {
+        not: url,
+      },
+    },
+    take: 100,
+  });
+
+  const updatedLinks = await prisma.link.updateMany({
+    where: {
+      id: {
+        in: links.map((link) => link.id),
+      },
+    },
+    data: {
+      ios: url,
+    },
+  });
+
+  console.log(updatedLinks);
+
+  const res = await linkCache.expireMany(links);
+
+  console.log(res);
+}
+
+main();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented reminder emails from being sent for applications that already have an associated program enrollment.

- **Chores**
  - Added a script to batch update iOS link URLs and refresh related cache entries for multiple records in the database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->