### PR TITLE
Fix error handling for program application form

### DIFF
--- a/apps/web/ui/partners/lander/program-application-form.tsx
+++ b/apps/web/ui/partners/lander/program-application-form.tsx
@@ -77,10 +77,6 @@ export function ProgramApplicationForm({
       },
       onError({ error }) {
         toast.error(error.serverError);
-
-        setError("root.serverError", {
-          message: error.serverError,
-        });
       },
     },
   );
@@ -90,10 +86,16 @@ export function ProgramApplicationForm({
   return (
     <form
       onSubmit={handleSubmit(async (data) => {
-        await executeAsync({
+        const result = await executeAsync({
           ...data,
           programId: program.id,
         });
+
+        if (!result || result.serverError || result.validationErrors) {
+          setError("root.serverError", {
+            message: "Error submitting application.",
+          });
+        }
       })}
       className="flex flex-col gap-6"
     >


### PR DESCRIPTION
Just a quick fix to do error checking async instead of in the `onError` callback, to make sure `isSubmitSuccessful` doesn't become `true` when there's an error.

In the future we may want to look into using [@next-safe-action/adapter-react-hook-form](https://github.com/next-safe-action/adapter-react-hook-form) for forms+actions and see if that would make things nicer.