### PR TITLE
Add temporary handling for webhook requests with version=latest

### DIFF
--- a/apps/web/app/(ee)/api/stripe/integration/webhook/route.ts
+++ b/apps/web/app/(ee)/api/stripe/integration/webhook/route.ts
@@ -19,6 +19,14 @@ const relevantEvents = new Set([
 
 // POST /api/stripe/integration/webhook – listen to Stripe webhooks (for Stripe Integration)
 export const POST = withAxiom(async (req: Request) => {
+  // Skip the request with query params version=latest
+  // We'll remove this once we're ready to go live
+  if (req.url.includes("version=latest")) {
+    return new Response(
+      "Ignore the request from the new webhook with ?version=latest",
+    );
+  }
+
   const buf = await req.text();
   const { livemode } = JSON.parse(buf);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Requests to the Stripe webhook route with the query parameter "version=latest" are now immediately acknowledged with a 200 OK response and ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->