### PR TITLE
Add `syncTotalCommissions` call in server actions 

### DIFF
--- a/apps/web/lib/actions/partners/mark-commission-duplicate.ts
+++ b/apps/web/lib/actions/partners/mark-commission-duplicate.ts
@@ -1,8 +1,10 @@
 "use server";
 
 import { DubApiError } from "@/lib/api/errors";
+import { syncTotalCommissions } from "@/lib/api/partners/sync-total-commissions";
 import { getDefaultProgramIdOrThrow } from "@/lib/api/programs/get-default-program-id-or-throw";
 import { prisma } from "@dub/prisma";
+import { waitUntil } from "@vercel/functions";
 import { z } from "zod";
 import { authActionClient } from "../safe-action";
 
@@ -65,6 +67,13 @@ export const markCommissionDuplicateAction = authActionClient
         payoutId: null,
       },
     });
+
+    waitUntil(
+      syncTotalCommissions({
+        partnerId: commission.partnerId,
+        programId,
+      }),
+    );
 
     // TODO: We might want to store the history of the sale status changes
     // TODO: Send email to the partner informing them about the sale status change

--- a/apps/web/lib/actions/partners/mark-commission-fraud-or-canceled.ts
+++ b/apps/web/lib/actions/partners/mark-commission-fraud-or-canceled.ts
@@ -1,7 +1,9 @@
 "use server";
 
+import { syncTotalCommissions } from "@/lib/api/partners/sync-total-commissions";
 import { getDefaultProgramIdOrThrow } from "@/lib/api/programs/get-default-program-id-or-throw";
 import { prisma } from "@dub/prisma";
+import { waitUntil } from "@vercel/functions";
 import { z } from "zod";
 import { authActionClient } from "../safe-action";
 
@@ -102,4 +104,11 @@ export const markCommissionFraudOrCanceledAction = authActionClient
         payoutId: null,
       },
     });
+
+    waitUntil(
+      syncTotalCommissions({
+        partnerId: commission.partnerId,
+        programId,
+      }),
+    );
   });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved responsiveness by updating total commission data asynchronously after marking commissions as duplicate, fraud, or canceled. This ensures commission totals are kept up to date without impacting user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->