### PR TITLE
Add support for manual commissions

### DIFF
--- a/apps/web/app/(ee)/api/partner-profile/programs/[programId]/earnings/count/route.ts
+++ b/apps/web/app/(ee)/api/partner-profile/programs/[programId]/earnings/count/route.ts
@@ -66,7 +66,9 @@ export const GET = withPartnerProfile(
         const links = await prisma.link.findMany({
           where: {
             id: {
-              in: counts.map(({ linkId }) => linkId),
+              in: counts
+                .map(({ linkId }) => linkId)
+                .filter((id): id is string => id !== null),
             },
           },
         });

--- a/apps/web/app/(ee)/app.dub.co/(new-program)/[slug]/program/new/overview/page-client.tsx
+++ b/apps/web/app/(ee)/app.dub.co/(new-program)/[slug]/program/new/overview/page-client.tsx
@@ -5,7 +5,7 @@ import { getLinkStructureOptions } from "@/lib/partners/get-link-structure-optio
 import useWorkspace from "@/lib/swr/use-workspace";
 import { ProgramData } from "@/lib/types";
 import { ProgramRewardDescription } from "@/ui/partners/program-reward-description";
-import { CommissionType, EventType } from "@dub/prisma/client";
+import { EventType, RewardStructure } from "@dub/prisma/client";
 import { Button } from "@dub/ui";
 import { Pencil } from "lucide-react";
 import { useAction } from "next-safe-action/hooks";
@@ -73,7 +73,7 @@ export function PageClient() {
         event: "sale" as EventType,
       }
     : {
-        type: (data.type ?? "flat") as CommissionType,
+        type: (data.type ?? "flat") as RewardStructure,
         amount: data.amount ?? 0,
         maxDuration: data.maxDuration ?? 0,
         event: data.defaultRewardType,

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/commissions/use-commission-filters.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/commissions/use-commission-filters.tsx
@@ -76,7 +76,7 @@ export function useCommissionFilters() {
         key: "type",
         icon: Sliders,
         label: "Type",
-        options: ["click", "lead", "sale"].map((slug) => ({
+        options: ["click", "lead", "sale", "custom"].map((slug) => ({
           value: slug,
           label: capitalize(slug) as string,
           icon: <CommissionTypeIcon type={slug} />,

--- a/apps/web/lib/actions/partners/mark-commission-duplicate.ts
+++ b/apps/web/lib/actions/partners/mark-commission-duplicate.ts
@@ -42,6 +42,10 @@ export const markCommissionDuplicateAction = authActionClient
       throw new Error("You cannot mark a paid commission as duplicate.");
     }
 
+    if (commission.type === "custom") {
+      throw new Error("You cannot mark a custom commission as duplicate.");
+    }
+
     // there is a payout associated with this sale
     // we need to update the payout amount if the sale is being marked as duplicate
     if (commission.payout) {

--- a/apps/web/lib/actions/partners/mark-commission-fraud-or-canceled.ts
+++ b/apps/web/lib/actions/partners/mark-commission-fraud-or-canceled.ts
@@ -32,6 +32,12 @@ export const markCommissionFraudOrCanceledAction = authActionClient
       throw new Error("Commission not found.");
     }
 
+    if (commission.type === "custom") {
+      throw new Error(
+        "You cannot mark a custom commission as fraud or canceled.",
+      );
+    }
+
     const { partnerId, customerId } = commission;
 
     // Find all historical commissions for this customer

--- a/apps/web/lib/api/sales/construct-reward-amount.ts
+++ b/apps/web/lib/api/sales/construct-reward-amount.ts
@@ -1,4 +1,4 @@
-import { CommissionType } from "@dub/prisma/client";
+import { RewardStructure } from "@dub/prisma/client";
 import { currencyFormatter } from "@dub/utils";
 
 export const constructRewardAmount = ({
@@ -6,7 +6,7 @@ export const constructRewardAmount = ({
   type,
 }: {
   amount: number;
-  type: CommissionType;
+  type: RewardStructure;
 }) => {
   return type === "percentage"
     ? `${amount}%`

--- a/apps/web/lib/rewardful/import-campaign.ts
+++ b/apps/web/lib/rewardful/import-campaign.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@dub/prisma";
-import { CommissionType, EventType } from "@dub/prisma/client";
+import { EventType, RewardStructure } from "@dub/prisma/client";
 import { createId } from "../api/create-id";
 import { DUB_MIN_PAYOUT_AMOUNT_CENTS } from "../partners/constants";
 import { RewardfulApi } from "./api";
@@ -35,8 +35,8 @@ export async function importCampaign({ programId }: { programId: string }) {
     maxDuration: max_commission_period_months,
     type:
       reward_type === "amount"
-        ? CommissionType.flat
-        : CommissionType.percentage,
+        ? RewardStructure.flat
+        : RewardStructure.percentage,
     amount:
       reward_type === "amount" ? commission_amount_cents : commission_percent,
   };

--- a/apps/web/lib/zod/schemas/commissions.ts
+++ b/apps/web/lib/zod/schemas/commissions.ts
@@ -6,11 +6,13 @@ import { getPaginationQuerySchema } from "./misc";
 import { PartnerSchema } from "./partners";
 import { parseDateSchema } from "./utils";
 
+const CommissionType = z.enum(["click", "lead", "sale", "custom"]);
+
 export const CommissionSchema = z.object({
   id: z.string().describe("The commission's unique ID on Dub.").openapi({
     example: "cm_1JVR7XRCSR0EDBAF39FZ4PMYE",
   }),
-  type: z.enum(["click", "lead", "sale"]).optional(),
+  type: CommissionType.optional(),
   amount: z.number(),
   earnings: z.number(),
   currency: z.string(),
@@ -30,7 +32,7 @@ export const CommissionResponseSchema = CommissionSchema.merge(
 
 export const getCommissionsQuerySchema = z
   .object({
-    type: z.enum(["click", "lead", "sale"]).optional(),
+    type: CommissionType.optional(),
     customerId: z
       .string()
       .optional()

--- a/apps/web/lib/zod/schemas/commissions.ts
+++ b/apps/web/lib/zod/schemas/commissions.ts
@@ -1,18 +1,16 @@
 import { DATE_RANGE_INTERVAL_PRESETS } from "@/lib/analytics/constants";
-import { CommissionStatus } from "@dub/prisma/client";
+import { CommissionStatus, CommissionType } from "@dub/prisma/client";
 import { z } from "zod";
 import { CustomerSchema } from "./customers";
 import { getPaginationQuerySchema } from "./misc";
 import { PartnerSchema } from "./partners";
 import { parseDateSchema } from "./utils";
 
-const CommissionType = z.enum(["click", "lead", "sale", "custom"]);
-
 export const CommissionSchema = z.object({
   id: z.string().describe("The commission's unique ID on Dub.").openapi({
     example: "cm_1JVR7XRCSR0EDBAF39FZ4PMYE",
   }),
-  type: CommissionType.optional(),
+  type: z.nativeEnum(CommissionType).optional(),
   amount: z.number(),
   earnings: z.number(),
   currency: z.string(),
@@ -32,7 +30,7 @@ export const CommissionResponseSchema = CommissionSchema.merge(
 
 export const getCommissionsQuerySchema = z
   .object({
-    type: CommissionType.optional(),
+    type: z.nativeEnum(CommissionType).optional(),
     customerId: z
       .string()
       .optional()

--- a/apps/web/lib/zod/schemas/discount.ts
+++ b/apps/web/lib/zod/schemas/discount.ts
@@ -1,11 +1,11 @@
-import { CommissionType } from "@dub/prisma/client";
+import { RewardStructure } from "@dub/prisma/client";
 import { z } from "zod";
 import { getPaginationQuerySchema, maxDurationSchema } from "./misc";
 
 export const DiscountSchema = z.object({
   id: z.string(),
   amount: z.number(),
-  type: z.nativeEnum(CommissionType),
+  type: z.nativeEnum(RewardStructure),
   maxDuration: z.number().nullable(),
   description: z.string().nullish(),
   couponId: z.string().nullable(),
@@ -25,7 +25,7 @@ export const createDiscountSchema = z.object({
   workspaceId: z.string(),
   partnerIds: z.array(z.string()).nullish(),
   amount: z.number().min(0),
-  type: z.nativeEnum(CommissionType).default("flat"),
+  type: z.nativeEnum(RewardStructure).default("flat"),
   maxDuration: maxDurationSchema,
   couponId: z.string(),
   couponTestId: z.string().nullish(),

--- a/apps/web/lib/zod/schemas/program-onboarding.ts
+++ b/apps/web/lib/zod/schemas/program-onboarding.ts
@@ -1,4 +1,4 @@
-import { CommissionType, LinkStructure } from "@dub/prisma/client";
+import { LinkStructure, RewardStructure } from "@dub/prisma/client";
 import { z } from "zod";
 import { maxDurationSchema } from "./misc";
 import { updateProgramSchema } from "./programs";
@@ -33,7 +33,7 @@ export const programRewardSchema = z
   .merge(
     z.object({
       defaultRewardType: z.enum(["lead", "sale"]).default("lead"),
-      type: z.nativeEnum(CommissionType).nullish(),
+      type: z.nativeEnum(RewardStructure).nullish(),
       amount: z.number().min(0).nullish(),
       maxDuration: maxDurationSchema,
     }),

--- a/apps/web/lib/zod/schemas/rewards.ts
+++ b/apps/web/lib/zod/schemas/rewards.ts
@@ -1,4 +1,4 @@
-import { CommissionType, EventType } from "@dub/prisma/client";
+import { EventType, RewardStructure } from "@dub/prisma/client";
 import { z } from "zod";
 import { getPaginationQuerySchema, maxDurationSchema } from "./misc";
 
@@ -20,7 +20,7 @@ export const RewardSchema = z.object({
   event: z.nativeEnum(EventType),
   name: z.string().nullish(),
   description: z.string().nullish(),
-  type: z.nativeEnum(CommissionType),
+  type: z.nativeEnum(RewardStructure),
   amount: z.number(),
   maxDuration: z.number().nullish(),
   maxAmount: z.number().nullish(),
@@ -30,7 +30,7 @@ export const RewardSchema = z.object({
 export const createOrUpdateRewardSchema = z.object({
   workspaceId: z.string(),
   event: z.nativeEnum(EventType),
-  type: z.nativeEnum(CommissionType).default("flat"),
+  type: z.nativeEnum(RewardStructure).default("flat"),
   amount: z.number().min(0),
   maxDuration: maxDurationSchema,
   maxAmount: z.number().nullish(),

--- a/apps/web/lib/zod/schemas/rewards.ts
+++ b/apps/web/lib/zod/schemas/rewards.ts
@@ -30,7 +30,7 @@ export const RewardSchema = z.object({
 export const createOrUpdateRewardSchema = z.object({
   workspaceId: z.string(),
   event: z.nativeEnum(EventType),
-  type: z.nativeEnum(RewardStructure).default("flat"),
+  type: z.nativeEnum(RewardStructure).default(RewardStructure.flat),
   amount: z.number().min(0),
   maxDuration: maxDurationSchema,
   maxAmount: z.number().nullish(),

--- a/apps/web/scripts/convert-manual-commissions.ts
+++ b/apps/web/scripts/convert-manual-commissions.ts
@@ -1,0 +1,74 @@
+import { createId } from "@/lib/api/create-id";
+import { prisma } from "@dub/prisma";
+import { CommissionStatus, CommissionType } from "@prisma/client";
+import "dotenv-flow/config";
+
+async function main() {
+  const programId = "prog_";
+
+  const manualPayouts = await prisma.payout.findMany({
+    where: {
+      programId,
+      status: "pending",
+      periodStart: null,
+      periodEnd: null,
+    },
+    include: {
+      partner: true,
+    },
+  });
+
+  let groupedPayouts: {
+    partnerId: string;
+    partnerName: string;
+    programId: string;
+    amount: number;
+  }[] = [];
+
+  for (const payout of manualPayouts) {
+    const existingPayout = groupedPayouts.find(
+      (group) => group.partnerId === payout.partnerId,
+    );
+
+    if (!existingPayout) {
+      groupedPayouts.push({
+        partnerName: payout.partner.name,
+        partnerId: payout.partnerId,
+        programId: payout.programId,
+        amount: payout.amount,
+      });
+    } else {
+      existingPayout.amount += payout.amount;
+    }
+  }
+
+  if (groupedPayouts.length === 0) {
+    console.log("No manual payouts found.");
+    return;
+  }
+
+  console.table(groupedPayouts);
+
+  const manualCommissions = groupedPayouts.map((payout) => {
+    return {
+      id: createId({ prefix: "cm_" }),
+      programId: payout.programId,
+      partnerId: payout.partnerId,
+      type: CommissionType.custom,
+      amount: 0,
+      quantity: 1,
+      earnings: payout.amount,
+      status: CommissionStatus.pending,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+  });
+
+  console.table(manualCommissions);
+
+  await prisma.commission.createMany({
+    data: manualCommissions,
+  });
+}
+
+main();

--- a/apps/web/scripts/convert-manual-commissions.ts
+++ b/apps/web/scripts/convert-manual-commissions.ts
@@ -68,6 +68,7 @@ async function main() {
 
   await prisma.commission.createMany({
     data: manualCommissions,
+    skipDuplicates: true,
   });
 }
 

--- a/apps/web/scripts/convert-manual-commissions.ts
+++ b/apps/web/scripts/convert-manual-commissions.ts
@@ -66,9 +66,18 @@ async function main() {
 
   console.table(manualCommissions);
 
+  // Add manual commissions to the database
   await prisma.commission.createMany({
     data: manualCommissions,
     skipDuplicates: true,
+  });
+
+  // Cancel the manual payouts
+  await prisma.payout.updateMany({
+    where: {
+      id: { in: manualPayouts.map((payout) => payout.id) },
+    },
+    data: { status: "canceled" },
   });
 }
 

--- a/apps/web/scripts/tella/update-commissions.ts
+++ b/apps/web/scripts/tella/update-commissions.ts
@@ -1,7 +1,7 @@
 import { calculateSaleEarnings } from "@/lib/api/sales/calculate-sale-earnings";
 import { determinePartnerReward } from "@/lib/partners/determine-partner-reward";
 import { prisma } from "@dub/prisma";
-import { Prisma } from "@dub/prisma/client";
+import { EventType, Prisma } from "@dub/prisma/client";
 import "dotenv-flow/config";
 
 // update commissions for a program
@@ -20,7 +20,7 @@ async function main() {
   const updatedCommissions = await Promise.all(
     commissions.map(async (commission) => {
       const reward = await determinePartnerReward({
-        event: commission.type,
+        event: commission.type as EventType,
         partnerId: commission.partnerId,
         programId: commission.programId,
       });

--- a/apps/web/ui/partners/add-edit-reward-sheet.tsx
+++ b/apps/web/ui/partners/add-edit-reward-sheet.tsx
@@ -599,7 +599,7 @@ function RewardSheetContent({
 
             <ProgramSheetAccordionItem value="payout-amount">
               <ProgramSheetAccordionTrigger>
-                Payout Amount
+                Reward Details
               </ProgramSheetAccordionTrigger>
               <ProgramSheetAccordionContent>
                 <div className="space-y-4">
@@ -613,7 +613,7 @@ function RewardSheetContent({
                         htmlFor="type"
                         className="text-sm font-medium text-neutral-800"
                       >
-                        Payout model
+                        Reward structure
                       </label>
                       <div className="relative mt-2 rounded-md shadow-sm">
                         <select
@@ -632,7 +632,7 @@ function RewardSheetContent({
                       htmlFor="amount"
                       className="text-sm font-medium text-neutral-800"
                     >
-                      Amount{" "}
+                      Reward amount{" "}
                       {selectedEvent !== "sale" ? `per ${selectedEvent}` : ""}
                     </label>
                     <div className="relative mt-2 rounded-md shadow-sm">

--- a/apps/web/ui/partners/comission-type-icon.tsx
+++ b/apps/web/ui/partners/comission-type-icon.tsx
@@ -1,5 +1,10 @@
 import { PartnerEarningsSchema } from "@/lib/zod/schemas/partner-profile";
-import { CursorRays, InvoiceDollar, UserCheck } from "@dub/ui/icons";
+import {
+  CursorRays,
+  InvoiceDollar,
+  MoneyBills2,
+  UserCheck,
+} from "@dub/ui/icons";
 import { cn } from "@dub/utils";
 import { z } from "zod";
 
@@ -7,6 +12,7 @@ const iconsMap = {
   click: { icon: CursorRays, className: "text-blue-500" },
   lead: { icon: UserCheck, className: "text-purple-500" },
   sale: { icon: InvoiceDollar, className: "text-teal-500" },
+  custom: { icon: MoneyBills2, className: "text-gray-500" },
 };
 
 export const CommissionTypeIcon = ({

--- a/apps/web/ui/partners/comission-type-icon.tsx
+++ b/apps/web/ui/partners/comission-type-icon.tsx
@@ -8,7 +8,7 @@ import {
 import { cn } from "@dub/utils";
 import { z } from "zod";
 
-const iconsMap = {
+const ICONS_MAP = {
   click: { icon: CursorRays, className: "text-blue-500" },
   lead: { icon: UserCheck, className: "text-purple-500" },
   sale: { icon: InvoiceDollar, className: "text-teal-500" },
@@ -22,7 +22,7 @@ export const CommissionTypeIcon = ({
   type: z.infer<typeof PartnerEarningsSchema>["type"];
   className?: string;
 }) => {
-  const { icon: Icon, className: iconClassName } = iconsMap[type];
+  const { icon: Icon, className: iconClassName } = ICONS_MAP[type];
 
   return <Icon className={cn("size-4", iconClassName, className)} />;
 };

--- a/apps/web/ui/partners/commission-row-menu.tsx
+++ b/apps/web/ui/partners/commission-row-menu.tsx
@@ -45,6 +45,10 @@ export function CommissionRowMenu({ row }: { row: Row<CommissionResponse> }) {
     return null;
   }
 
+  if (row.original.type === "custom") {
+    return null;
+  }
+
   return (
     <>
       <MarkCommissionDuplicateModal />

--- a/packages/prisma/client.ts
+++ b/packages/prisma/client.ts
@@ -2,7 +2,6 @@ export * from "@prisma/client";
 
 export {
   CommissionStatus,
-  CommissionType,
   EventType,
   FolderType,
   FolderUserRole,
@@ -15,6 +14,7 @@ export {
   PayoutStatus,
   Prisma,
   ProgramEnrollmentStatus,
+  RewardStructure,
   Role,
   WebhookReceiver,
 } from "@prisma/client";

--- a/packages/prisma/schema/commission.prisma
+++ b/packages/prisma/schema/commission.prisma
@@ -8,7 +8,7 @@ enum CommissionStatus {
   canceled
 }
 
-enum CommissionType {
+enum EventType {
   click
   lead
   sale
@@ -25,7 +25,7 @@ model Commission {
   customerId String? // only for leads and sales
   eventId    String? @unique // only for leads and sales
 
-  type     CommissionType
+  type     EventType
   amount   Int // only for sales (amount of the sale event)
   quantity Int // only for clicks/leads (quantity of the event)
   earnings Int              @default(0) // amount earned by the partner

--- a/packages/prisma/schema/commission.prisma
+++ b/packages/prisma/schema/commission.prisma
@@ -19,7 +19,7 @@ model Commission {
   id         String  @id @default(cuid())
   programId  String
   partnerId  String
-  linkId     String
+  linkId     String?
   payoutId   String?
   invoiceId  String? // only for sales (idempotency key, each sale event is associated with a unique invoice)
   customerId String? // only for leads and sales
@@ -38,7 +38,7 @@ model Commission {
   program  Program   @relation(fields: [programId], references: [id])
   partner  Partner   @relation(fields: [partnerId], references: [id])
   payout   Payout?   @relation(fields: [payoutId], references: [id])
-  link     Link      @relation(fields: [linkId], references: [id])
+  link     Link?     @relation(fields: [linkId], references: [id])
   customer Customer? @relation(fields: [customerId], references: [id])
 
   @@unique([programId, invoiceId])

--- a/packages/prisma/schema/commission.prisma
+++ b/packages/prisma/schema/commission.prisma
@@ -8,7 +8,7 @@ enum CommissionStatus {
   canceled
 }
 
-enum EventType {
+enum CommissionType {
   click
   lead
   sale
@@ -25,7 +25,7 @@ model Commission {
   customerId String? // only for leads and sales
   eventId    String? @unique // only for leads and sales
 
-  type     EventType
+  type     CommissionType
   amount   Int // only for sales (amount of the sale event)
   quantity Int // only for clicks/leads (quantity of the event)
   earnings Int              @default(0) // amount earned by the partner

--- a/packages/prisma/schema/commission.prisma
+++ b/packages/prisma/schema/commission.prisma
@@ -8,10 +8,11 @@ enum CommissionStatus {
   canceled
 }
 
-enum EventType {
+enum CommissionType {
   click
   lead
   sale
+  custom
 }
 
 model Commission {
@@ -24,7 +25,7 @@ model Commission {
   customerId String? // only for leads and sales
   eventId    String? @unique // only for leads and sales
 
-  type     EventType
+  type     CommissionType
   amount   Int // only for sales (amount of the sale event)
   quantity Int // only for clicks/leads (quantity of the event)
   earnings Int              @default(0) // amount earned by the partner

--- a/packages/prisma/schema/discount.prisma
+++ b/packages/prisma/schema/discount.prisma
@@ -2,7 +2,7 @@ model Discount {
   id String @id @default(cuid())
 
   amount      Int            @default(0)
-  type        CommissionType @default(percentage)
+  type        RewardStructure @default(percentage)
   maxDuration Int? // in months (0 -> not recurring, null -> lifetime)
   description String?
 

--- a/packages/prisma/schema/program.prisma
+++ b/packages/prisma/schema/program.prisma
@@ -1,8 +1,3 @@
-enum CommissionType {
-  percentage
-  flat
-}
-
 enum ProgramEnrollmentStatus {
   pending // pending applications that need approval
   approved // partner who has been approved/actively enrolled

--- a/packages/prisma/schema/reward.prisma
+++ b/packages/prisma/schema/reward.prisma
@@ -1,3 +1,10 @@
+
+enum EventType {
+  click
+  lead
+  sale
+}
+
 model Reward {
   id        String @id @default(cuid())
   programId String

--- a/packages/prisma/schema/reward.prisma
+++ b/packages/prisma/schema/reward.prisma
@@ -1,10 +1,3 @@
-
-enum EventType {
-  click
-  lead
-  sale
-}
-
 model Reward {
   id        String @id @default(cuid())
   programId String

--- a/packages/prisma/schema/reward.prisma
+++ b/packages/prisma/schema/reward.prisma
@@ -1,3 +1,14 @@
+enum EventType {
+  click
+  lead
+  sale
+}
+
+enum RewardStructure {
+  percentage
+  flat
+}
+
 model Reward {
   id        String @id @default(cuid())
   programId String
@@ -5,7 +16,7 @@ model Reward {
   name        String?
   description String?
   event       EventType
-  type        CommissionType @default(percentage)
+  type        RewardStructure @default(percentage)
   amount      Int            @default(0)
   maxDuration Int? // in months (0 -> not recurring, null -> infinite)
   maxAmount   Int? // how much a partner can receive payouts (in cents)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for a new "custom" commission type, including filter options and icon representation in the UI.

- **Bug Fixes**
  - Prevented marking "custom" commissions as duplicates, fraud, or canceled to maintain data integrity.

- **Style**
  - Updated UI labels to use "Reward Details," "Reward structure," and "Reward amount" for improved clarity.

- **Refactor**
  - Standardized and renamed enums related to commission and reward types for consistency across models and schemas.
  - Centralized commission type definitions and updated validation schemas accordingly.
  - Updated icon mappings and menu rendering logic to accommodate the new "custom" commission type.

- **Chores**
  - Updated database schema and internal references to reflect new enum structures and naming conventions.
  - Added a script to convert manual payout records into commission entries for better data management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->