### PR TITLE
Set amount to zero for custom commissions

### DIFF
--- a/apps/web/lib/partners/create-partner-commission.ts
+++ b/apps/web/lib/partners/create-partner-commission.ts
@@ -47,6 +47,7 @@ export const createPartnerCommission = async ({
 
   if (event === "custom") {
     earnings = amount;
+    amount = 0;
   } else {
     if (!reward) {
       reward = await determinePartnerReward({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected calculation for "custom" event commissions to ensure the amount is set to zero, preventing incorrect commission amounts from being processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->