### PR TITLE
Cancel existing PayPal payout after retrying

### DIFF
--- a/apps/web/lib/paypal/cancel-paypal-payout.ts
+++ b/apps/web/lib/paypal/cancel-paypal-payout.ts
@@ -1,0 +1,18 @@
+import { createPaypalToken } from "@/lib/paypal/create-paypal-token";
+import { paypalEnv } from "@/lib/paypal/env";
+
+export const cancelPaypalPayout = async (paypalTransferId: string) => {
+  const paypalAccessToken = await createPaypalToken();
+
+  const response = await fetch(
+    `${paypalEnv.PAYPAL_API_HOST}/v1/payments/payouts-item/${paypalTransferId}/cancel`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${paypalAccessToken}`,
+      },
+    },
+  ).then((r) => r.json());
+
+  return response;
+};

--- a/apps/web/lib/paypal/cancel-paypal-payout.ts
+++ b/apps/web/lib/paypal/cancel-paypal-payout.ts
@@ -4,15 +4,26 @@ import { paypalEnv } from "@/lib/paypal/env";
 export const cancelPaypalPayout = async (paypalTransferId: string) => {
   const paypalAccessToken = await createPaypalToken();
 
-  const response = await fetch(
+  const res = await fetch(
     `${paypalEnv.PAYPAL_API_HOST}/v1/payments/payouts-item/${paypalTransferId}/cancel`,
     {
       method: "POST",
       headers: {
         Authorization: `Bearer ${paypalAccessToken}`,
+        "Content-Type": "application/json",
       },
     },
-  ).then((r) => r.json());
+  );
+
+  const body = await res.json();
+
+  if (!res.ok) {
+    console.error("[PayPal] Failed to cancel payout.", body);
+    throw new Error("Failed to cancel PayPal payout.");
+  }
+
+  return body;
+};
 
   return response;
 };

--- a/apps/web/lib/paypal/cancel-paypal-payout.ts
+++ b/apps/web/lib/paypal/cancel-paypal-payout.ts
@@ -15,15 +15,12 @@ export const cancelPaypalPayout = async (paypalTransferId: string) => {
     },
   );
 
-  const body = await res.json();
+  const data = await res.json();
 
   if (!res.ok) {
-    console.error("[PayPal] Failed to cancel payout.", body);
+    console.error("[PayPal] Failed to cancel payout.", data);
     throw new Error("Failed to cancel PayPal payout.");
   }
 
-  return body;
-};
-
-  return response;
+  return data;
 };

--- a/apps/web/lib/paypal/create-batch-payout.ts
+++ b/apps/web/lib/paypal/create-batch-payout.ts
@@ -55,4 +55,6 @@ export async function createPayPalBatchPayout({
   }
 
   console.log("[PayPal] Batch payout created", data);
+
+  return data;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added the ability to cancel previous PayPal payouts when retrying failed payouts, ensuring smoother payout management and reducing duplicate transfers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->