### PR TITLE
Add back retry paypal payout

### DIFF
--- a/apps/web/app/(ee)/api/cron/payouts/charge-succeeded/send-paypal-payouts.ts
+++ b/apps/web/app/(ee)/api/cron/payouts/charge-succeeded/send-paypal-payouts.ts
@@ -17,6 +17,6 @@ export async function sendPaypalPayouts({
 
   await createPayPalBatchPayout({
     payouts,
-    senderBatchId: invoiceId,
+    invoiceId,
   });
 }

--- a/apps/web/lib/actions/partners/retry-failed-paypal-payouts.ts
+++ b/apps/web/lib/actions/partners/retry-failed-paypal-payouts.ts
@@ -77,7 +77,7 @@ export const retryFailedPaypalPayoutsAction = authPartnerActionClient
 
     try {
       await createPayPalBatchPayout({
-        senderBatchId: `${payout.id}_${nanoid(7)}`,
+        invoiceId: `${payout.invoiceId}-${nanoid(7)}`,
         payouts: [
           {
             id: payout.id,

--- a/apps/web/lib/paypal/create-batch-payout.ts
+++ b/apps/web/lib/paypal/create-batch-payout.ts
@@ -7,19 +7,19 @@ interface CreatePayPalBatchPayout {
     partner: Pick<Partner, "paypalEmail">;
     program: Pick<Program, "name">;
   })[];
-  senderBatchId: string;
+  invoiceId: string;
 }
 
 // Create a batch payout for an array of payouts for a program
 export async function createPayPalBatchPayout({
   payouts,
-  senderBatchId,
+  invoiceId,
 }: CreatePayPalBatchPayout) {
   const paypalAccessToken = await createPaypalToken();
 
   const body = {
     sender_batch_header: {
-      sender_batch_id: senderBatchId,
+      sender_batch_id: invoiceId,
     },
     items: payouts.map((payout) => ({
       recipient_type: "EMAIL",
@@ -50,7 +50,7 @@ export async function createPayPalBatchPayout({
   if (!response.ok) {
     console.error("[PayPal] Batch payout creation failed", data);
     throw new Error(
-      `[PayPal] Batch payout creation failed. Sender batch ID: ${senderBatchId}. Error: ${JSON.stringify(data)}`,
+      `[PayPal] Batch payout creation failed. Invoice ID: ${invoiceId}. Error: ${JSON.stringify(data)}`,
     );
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Re-enabled the menu column in the payouts table, allowing users to access additional payout options for each row.

- **Bug Fixes**
  - Improved handling of PayPal payout statuses to prevent failure notification emails from being sent for payouts still in processing.
  - Enhanced error messaging when attempting to retry PayPal payouts that are not in a failed state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->