### PR TITLE
Partner link control

### DIFF
--- a/apps/web/app/(ee)/app.dub.co/embed/referrals/add-edit-link.tsx
+++ b/apps/web/app/(ee)/app.dub.co/embed/referrals/add-edit-link.tsx
@@ -140,55 +140,6 @@ export function ReferralsEmbedCreateUpdateLink({
 
         <div className="space-y-6 p-6">
           <div>
-            <div className="flex items-center gap-2">
-              <label
-                htmlFor="url"
-                className="text-content-default block text-sm font-medium"
-              >
-                Destination URL
-              </label>
-              <InfoTooltip
-                content={
-                  <SimpleTooltipContent
-                    title="The URL your users will get redirected to when they visit your referral link."
-                    cta="Learn more."
-                    href="https://dub.co/help/article/how-to-create-link"
-                  />
-                }
-              />
-            </div>
-            <div className="mt-2 flex rounded-md">
-              <span className="inline-flex items-center rounded-l-md border border-r-0 border-neutral-300 bg-neutral-50 px-3 text-neutral-500 sm:text-sm dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-400">
-                {destinationDomain}
-              </span>
-              <input
-                type="text"
-                placeholder="about"
-                className="border-border-default text-content-default bg-bg-default block w-full rounded-r-md placeholder-neutral-400 focus:border-neutral-500 focus:outline-none focus:ring-neutral-500 sm:text-sm dark:placeholder-neutral-500 dark:focus:border-neutral-400 dark:focus:ring-neutral-400"
-                {...register("url", { required: false })}
-                autoFocus={!isMobile}
-                onPaste={(e: React.ClipboardEvent<HTMLInputElement>) => {
-                  e.preventDefault();
-
-                  // if pasting in a URL, extract the pathname
-                  const text = e.clipboardData.getData("text/plain");
-
-                  try {
-                    const url = new URL(text);
-                    e.currentTarget.value = url.pathname.slice(1);
-                  } catch (err) {
-                    e.currentTarget.value = text;
-                  }
-
-                  setValue("url", e.currentTarget.value, {
-                    shouldDirty: true,
-                  });
-                }}
-              />
-            </div>
-          </div>
-
-          <div>
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2">
                 <label
@@ -229,6 +180,7 @@ export function ReferralsEmbedCreateUpdateLink({
               <input
                 type="text"
                 placeholder="another-link"
+                autoFocus={!isMobile}
                 className={cn(
                   "border-border-default text-content-default bg-bg-default block w-full rounded-r-md placeholder-neutral-400 focus:border-neutral-500 focus:outline-none focus:ring-neutral-500 sm:text-sm dark:placeholder-neutral-500 dark:focus:border-neutral-400 dark:focus:ring-neutral-400",
                   {
@@ -248,6 +200,54 @@ export function ReferralsEmbedCreateUpdateLink({
                 </span>
               </div>
             )}
+          </div>
+
+          <div>
+            <div className="flex items-center gap-2">
+              <label
+                htmlFor="url"
+                className="text-content-default block text-sm font-medium"
+              >
+                Destination URL
+              </label>
+              <InfoTooltip
+                content={
+                  <SimpleTooltipContent
+                    title="The URL your users will get redirected to when they visit your referral link."
+                    cta="Learn more."
+                    href="https://dub.co/help/article/how-to-create-link"
+                  />
+                }
+              />
+            </div>
+            <div className="mt-2 flex rounded-md">
+              <span className="inline-flex items-center rounded-l-md border border-r-0 border-neutral-300 bg-neutral-50 px-3 text-neutral-500 sm:text-sm dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-400">
+                {destinationDomain}
+              </span>
+              <input
+                type="text"
+                placeholder="about"
+                className="border-border-default text-content-default bg-bg-default block w-full rounded-r-md placeholder-neutral-400 focus:border-neutral-500 focus:outline-none focus:ring-neutral-500 sm:text-sm dark:placeholder-neutral-500 dark:focus:border-neutral-400 dark:focus:ring-neutral-400"
+                {...register("url", { required: false })}
+                onPaste={(e: React.ClipboardEvent<HTMLInputElement>) => {
+                  e.preventDefault();
+
+                  // if pasting in a URL, extract the pathname
+                  const text = e.clipboardData.getData("text/plain");
+
+                  try {
+                    const url = new URL(text);
+                    e.currentTarget.value = url.pathname.slice(1);
+                  } catch (err) {
+                    e.currentTarget.value = text;
+                  }
+
+                  setValue("url", e.currentTarget.value, {
+                    shouldDirty: true,
+                  });
+                }}
+              />
+            </div>
           </div>
         </div>
       </form>

--- a/apps/web/ui/links/link-builder/constants.ts
+++ b/apps/web/ui/links/link-builder/constants.ts
@@ -10,10 +10,9 @@ import {
   Icon,
   Incognito,
   InputPassword,
-  Webhook,
   WindowSearch,
 } from "@dub/ui/icons";
-import { Settings } from "lucide-react";
+import { Settings, User2 } from "lucide-react";
 
 type MoreItem = {
   key: string;
@@ -50,13 +49,15 @@ export const MORE_ITEMS: MoreItem[] = [
     type: "boolean",
   },
   {
-    key: "webhookIds",
-    icon: Webhook,
-    label: "Webhooks",
-    shortcutKey: "w",
-    enabled: (data) => Boolean(data.webhookIds?.length),
+    key: "partnerId",
+    icon: User2,
+    label: "Assign to Partner",
+    shortcutKey: "b",
     type: "modal",
+    enabled: (data) => Boolean(data.partnerId),
     add: false,
+    description: "Assign this link to a partner.",
+    learnMoreUrl: "https://dub.co/help/article/dub-partners",
   },
   {
     key: "advanced",

--- a/apps/web/ui/links/link-builder/link-builder-provider.tsx
+++ b/apps/web/ui/links/link-builder/link-builder-provider.tsx
@@ -21,7 +21,7 @@ export type LinkBuilderProps = {
     plan?: string;
     nextPlan?: (typeof PLANS)[number];
     conversionEnabled?: boolean;
-    defaultProgramId?: string;
+    defaultProgramId?: string | null;
   };
   modal: boolean;
 };

--- a/apps/web/ui/links/link-builder/link-builder-provider.tsx
+++ b/apps/web/ui/links/link-builder/link-builder-provider.tsx
@@ -21,6 +21,7 @@ export type LinkBuilderProps = {
     plan?: string;
     nextPlan?: (typeof PLANS)[number];
     conversionEnabled?: boolean;
+    defaultProgramId?: string;
   };
   modal: boolean;
 };

--- a/apps/web/ui/links/link-builder/more-dropdown.tsx
+++ b/apps/web/ui/links/link-builder/more-dropdown.tsx
@@ -2,9 +2,9 @@ import useWorkspace from "@/lib/swr/use-workspace";
 import { useABTestingModal } from "@/ui/modals/link-builder/ab-testing-modal";
 import { useAdvancedModal } from "@/ui/modals/link-builder/advanced-modal";
 import { useExpirationModal } from "@/ui/modals/link-builder/expiration-modal";
+import { usePartnersModal } from "@/ui/modals/link-builder/partners-modal";
 import { usePasswordModal } from "@/ui/modals/link-builder/password-modal";
 import { useTargetingModal } from "@/ui/modals/link-builder/targeting-modal";
-import { useWebhooksModal } from "@/ui/modals/link-builder/webhooks-modal";
 import { ProBadgeTooltip } from "@/ui/shared/pro-badge-tooltip";
 import { Button, Popover, SimpleTooltipContent, useMediaQuery } from "@dub/ui";
 import { Dots } from "@dub/ui/icons";
@@ -16,34 +16,37 @@ import { LinkFormData } from "./link-builder-provider";
 import { useLinkBuilderKeyboardShortcut } from "./use-link-builder-keyboard-shortcut";
 
 export function MoreDropdown() {
-  const { flags } = useWorkspace();
+  const { flags, defaultProgramId } = useWorkspace();
   const { isMobile } = useMediaQuery();
-
-  const { watch, setValue } = useFormContext<LinkFormData>();
-  const data = watch();
-
   const [openPopover, setOpenPopover] = useState(false);
+  const { watch, setValue } = useFormContext<LinkFormData>();
+
+  const data = watch();
 
   const options = useMemo(() => {
     return [...(isMobile ? MOBILE_MORE_ITEMS : []), ...MORE_ITEMS].filter(
-      (option) => (option.key === "testVariants" ? flags?.abTesting : true),
+      (option) => {
+        if (option.key === "testVariants") return flags?.abTesting;
+        if (option.key === "partnerId") return Boolean(defaultProgramId);
+        return true;
+      }
     );
-  }, [data, isMobile, flags]);
+  }, [data, isMobile, flags, defaultProgramId]);
 
   const { ABTestingModal, setShowABTestingModal } = useABTestingModal();
   const { PasswordModal, setShowPasswordModal } = usePasswordModal();
   const { TargetingModal, setShowTargetingModal } = useTargetingModal();
   const { ExpirationModal, setShowExpirationModal } = useExpirationModal();
-  const { WebhooksModal, setShowWebhooksModal } = useWebhooksModal();
   const { AdvancedModal, setShowAdvancedModal } = useAdvancedModal();
+  const { PartnersModal, setShowPartnerModal } = usePartnersModal();
 
   const modalCallbacks = {
     testVariants: setShowABTestingModal,
     password: setShowPasswordModal,
     targeting: setShowTargetingModal,
     expiresAt: setShowExpirationModal,
-    webhookIds: setShowWebhooksModal,
     advanced: setShowAdvancedModal,
+    partnerId: setShowPartnerModal,
   };
 
   useLinkBuilderKeyboardShortcut(
@@ -66,8 +69,8 @@ export function MoreDropdown() {
       <PasswordModal />
       <TargetingModal />
       <ExpirationModal />
-      <WebhooksModal />
       <AdvancedModal />
+      <PartnersModal />
       <Popover
         align="start"
         content={

--- a/apps/web/ui/links/link-builder/use-link-builder-submit.tsx
+++ b/apps/web/ui/links/link-builder/use-link-builder-submit.tsx
@@ -17,13 +17,12 @@ export function useLinkBuilderSubmit({
   const router = useRouter();
   const { workspace, props } = useLinkBuilderContext();
   const { getValues, setError } = useFormContext<LinkFormData>();
-
   const [, copyToClipboard] = useCopyToClipboard();
 
   return useCallback(
     async (data: LinkFormData) => {
       // @ts-ignore – exclude extra attributes from `data` object before sending to API
-      const { user, tags, tagId, folderId, ...rest } = data;
+      const { user, tags, tagId, folderId, partnerId, ...rest } = data;
       const bodyData = {
         ...rest,
 
@@ -37,6 +36,11 @@ export function useLinkBuilderSubmit({
         expiredUrl: rest.expiredUrl || null,
         ios: rest.ios || null,
         android: rest.android || null,
+
+        // Create partner links
+        ...(partnerId
+          ? { programId: workspace.defaultProgramId, partnerId }
+          : {}),
       };
 
       const endpoint = props?.id

--- a/apps/web/ui/links/links-toolbar.tsx
+++ b/apps/web/ui/links/links-toolbar.tsx
@@ -52,7 +52,6 @@ export const LinksToolbar = memo(
     const { slug, plan } = useWorkspace();
 
     const { isMegaFolder } = useIsMegaFolder();
-    console.log({ isMegaFolder });
 
     const { canManageFolderPermissions } = getPlanCapabilities(plan);
     const { folders } = useFolderPermissions();

--- a/apps/web/ui/modals/link-builder/partners-modal.tsx
+++ b/apps/web/ui/modals/link-builder/partners-modal.tsx
@@ -1,0 +1,162 @@
+import { LinkFormData } from "@/ui/links/link-builder/link-builder-provider";
+import { PartnerSelector } from "@/ui/partners/partner-selector";
+import { Button, Modal, Tooltip } from "@dub/ui";
+import {
+  Dispatch,
+  SetStateAction,
+  useCallback,
+  useMemo,
+  useState,
+} from "react";
+import { useForm, useFormContext } from "react-hook-form";
+
+function PartnersModal({
+  showPartnerModal,
+  setShowPartnerModal,
+}: {
+  showPartnerModal: boolean;
+  setShowPartnerModal: Dispatch<SetStateAction<boolean>>;
+}) {
+  return (
+    <Modal
+      showModal={showPartnerModal}
+      setShowModal={setShowPartnerModal}
+      className="sm:max-w-md"
+    >
+      <PartnerModalInner setShowPartnerModal={setShowPartnerModal} />
+    </Modal>
+  );
+}
+
+function PartnerModalInner({
+  setShowPartnerModal,
+}: {
+  setShowPartnerModal: Dispatch<SetStateAction<boolean>>;
+}) {
+  const {
+    watch: watchParent,
+    getValues: getValuesParent,
+    setValue: setValueParent,
+  } = useFormContext<LinkFormData>();
+
+  const {
+    watch,
+    setValue,
+    reset,
+    formState: { isDirty },
+    handleSubmit,
+  } = useForm<Pick<LinkFormData, "partnerId">>({
+    values: {
+      partnerId: getValuesParent("partnerId"),
+    },
+  });
+
+  const parentPartnerId = watchParent("partnerId");
+  const partnerId = watch("partnerId");
+
+  return (
+    <form
+      className="px-5 py-4"
+      onSubmit={(e) => {
+        e.stopPropagation();
+        handleSubmit((data) => {
+          setValueParent("partnerId", data.partnerId, { shouldDirty: true });
+          setShowPartnerModal(false);
+        })(e);
+      }}
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <h3 className="text-lg font-medium">Assign to partner</h3>
+        </div>
+        <div className="max-md:hidden">
+          <Tooltip
+            content={
+              <div className="px-2 py-1 text-xs text-neutral-700">
+                Press{" "}
+                <strong className="font-medium text-neutral-950">B</strong> to
+                open this quickly
+              </div>
+            }
+            side="right"
+          >
+            <kbd className="flex size-6 cursor-default items-center justify-center rounded-md border border-neutral-200 font-sans text-xs text-neutral-950">
+              B
+            </kbd>
+          </Tooltip>
+        </div>
+      </div>
+
+      <div className="mt-6 flex flex-col gap-2">
+        <span className="block text-sm font-medium text-neutral-900">
+          Partner
+        </span>
+
+        <PartnerSelector
+          selectedPartnerId={partnerId || null}
+          setSelectedPartnerId={(id: string | null) =>
+            setValue("partnerId", id, { shouldDirty: true })
+          }
+        />
+      </div>
+
+      <div className="mt-6 flex items-center justify-between">
+        <div>
+          {Boolean(parentPartnerId) && (
+            <button
+              type="button"
+              className="text-xs font-medium text-neutral-700 transition-colors hover:text-neutral-950"
+              onClick={() => {
+                setValueParent("partnerId", null, { shouldDirty: true });
+                setShowPartnerModal(false);
+              }}
+            >
+              Remove partner
+            </button>
+          )}
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            variant="secondary"
+            text="Cancel"
+            className="h-9 w-fit"
+            onClick={() => {
+              reset();
+              setShowPartnerModal(false);
+            }}
+          />
+          <Button
+            type="submit"
+            variant="primary"
+            text="Save"
+            className="h-9 w-fit"
+            disabled={!isDirty}
+          />
+        </div>
+      </div>
+    </form>
+  );
+}
+
+export function usePartnersModal() {
+  const [showPartnerModal, setShowPartnerModal] = useState(false);
+
+  const PartnersModalCallback = useCallback(() => {
+    return (
+      <PartnersModal
+        showPartnerModal={showPartnerModal}
+        setShowPartnerModal={setShowPartnerModal}
+      />
+    );
+  }, [showPartnerModal, setShowPartnerModal]);
+
+  return useMemo(
+    () => ({
+      setShowPartnerModal,
+      PartnersModal: PartnersModalCallback,
+    }),
+    [setShowPartnerModal, PartnersModalCallback],
+  );
+}

--- a/apps/web/ui/modals/partner-link-modal.tsx
+++ b/apps/web/ui/modals/partner-link-modal.tsx
@@ -3,7 +3,7 @@
 import { mutateSuffix } from "@/lib/swr/mutate";
 import useProgramEnrollment from "@/lib/swr/use-program-enrollment";
 import { PartnerProfileLinkProps } from "@/lib/types";
-import { Lock, X } from "@/ui/shared/icons";
+import { X } from "@/ui/shared/icons";
 import { QRCode } from "@/ui/shared/qr-code";
 import {
   Button,
@@ -17,7 +17,12 @@ import {
   useLocalStorage,
   useMediaQuery,
 } from "@dub/ui";
-import { ArrowTurnLeft, Pen2, QRCode as QRCodeIcon } from "@dub/ui/icons";
+import {
+  ArrowTurnLeft,
+  Pen2,
+  PenWriting,
+  QRCode as QRCodeIcon,
+} from "@dub/ui/icons";
 import {
   cn,
   getDomainWithoutWWW,
@@ -318,7 +323,7 @@ function PartnerLinkModalContent({
                     ) && setLockKey(false);
                   }}
                 >
-                  <Lock className="h-3 w-3" />
+                  <PenWriting className="size-3.5" />
                 </button>
               )}
             </div>

--- a/apps/web/ui/modals/partner-link-modal.tsx
+++ b/apps/web/ui/modals/partner-link-modal.tsx
@@ -290,58 +290,6 @@ function PartnerLinkModalContent({
 
         <div className="flex w-full flex-col gap-6">
           <div>
-            <div className="flex items-center gap-2">
-              <label
-                htmlFor="url"
-                className="block text-sm font-medium text-neutral-700"
-              >
-                Destination URL
-              </label>
-              <InfoTooltip
-                content={
-                  <SimpleTooltipContent
-                    title="The URL your users will get redirected to when they visit your short link."
-                    cta="Learn more."
-                    href="https://dub.co/help/article/how-to-create-link"
-                  />
-                }
-              />
-            </div>
-            {isDefaultLink ? (
-              <Tooltip content="You cannot edit the default link destination">
-                <div className="mt-2 block w-full rounded-md border border-neutral-300 bg-neutral-50 px-3 py-2 text-neutral-500 sm:text-sm">
-                  {getPrettyUrl(link?.url)}
-                </div>
-              </Tooltip>
-            ) : (
-              <div className="mt-2 flex rounded-md">
-                <span className="inline-flex items-center rounded-l-md border border-r-0 border-neutral-300 bg-neutral-50 px-3 text-neutral-500 sm:text-sm">
-                  {destinationDomain}
-                </span>
-                <input
-                  {...register("url", { required: false })}
-                  type="text"
-                  id="url"
-                  placeholder="(optional)"
-                  autoFocus={!isMobile}
-                  onPaste={(e: React.ClipboardEvent<HTMLInputElement>) => {
-                    e.preventDefault();
-                    // if pasting in a URL, extract the pathname
-                    const text = e.clipboardData.getData("text/plain");
-                    try {
-                      const url = new URL(text);
-                      e.currentTarget.value = url.pathname.slice(1);
-                    } catch (err) {
-                      e.currentTarget.value = text;
-                    }
-                  }}
-                  className="block w-full rounded-r-md border-neutral-300 text-neutral-900 placeholder-neutral-400 focus:border-neutral-500 focus:outline-none focus:ring-neutral-500 sm:text-sm"
-                />
-              </div>
-            )}
-          </div>
-
-          <div>
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2">
                 <label
@@ -382,6 +330,7 @@ function PartnerLinkModalContent({
                 {...register("key", { required: true })}
                 type="text"
                 id="key"
+                autoFocus={!isMobile}
                 disabled={lockKey}
                 className={cn(
                   "block w-full rounded-r-md border-neutral-300 text-neutral-900 placeholder-neutral-400 focus:border-neutral-500 focus:outline-none focus:ring-neutral-500 sm:text-sm",
@@ -393,6 +342,57 @@ function PartnerLinkModalContent({
                 placeholder="short-link"
               />
             </div>
+          </div>
+
+          <div>
+            <div className="flex items-center gap-2">
+              <label
+                htmlFor="url"
+                className="block text-sm font-medium text-neutral-700"
+              >
+                Destination URL
+              </label>
+              <InfoTooltip
+                content={
+                  <SimpleTooltipContent
+                    title="The URL your users will get redirected to when they visit your short link."
+                    cta="Learn more."
+                    href="https://dub.co/help/article/how-to-create-link"
+                  />
+                }
+              />
+            </div>
+            {isDefaultLink ? (
+              <Tooltip content="You cannot edit the default link destination">
+                <div className="mt-2 block w-full rounded-md border border-neutral-300 bg-neutral-50 px-3 py-2 text-neutral-500 sm:text-sm">
+                  {getPrettyUrl(link?.url)}
+                </div>
+              </Tooltip>
+            ) : (
+              <div className="mt-2 flex rounded-md">
+                <span className="inline-flex items-center rounded-l-md border border-r-0 border-neutral-300 bg-neutral-50 px-3 text-neutral-500 sm:text-sm">
+                  {destinationDomain}
+                </span>
+                <input
+                  {...register("url", { required: false })}
+                  type="text"
+                  id="url"
+                  placeholder="(optional)"
+                  onPaste={(e: React.ClipboardEvent<HTMLInputElement>) => {
+                    e.preventDefault();
+                    // if pasting in a URL, extract the pathname
+                    const text = e.clipboardData.getData("text/plain");
+                    try {
+                      const url = new URL(text);
+                      e.currentTarget.value = url.pathname.slice(1);
+                    } catch (err) {
+                      e.currentTarget.value = text;
+                    }
+                  }}
+                  className="block w-full rounded-r-md border-neutral-300 text-neutral-900 placeholder-neutral-400 focus:border-neutral-500 focus:outline-none focus:ring-neutral-500 sm:text-sm"
+                />
+              </div>
+            )}
           </div>
 
           <div>

--- a/apps/web/ui/partners/add-partner-link-modal.tsx
+++ b/apps/web/ui/partners/add-partner-link-modal.tsx
@@ -87,7 +87,9 @@ const AddPartnerLinkModal = ({
       setShowModal(false);
       copyToClipboard(data.shortLink);
     } catch (error) {
-      setErrorMessage(error.message || "Failed to create link.");
+      setErrorMessage(
+        error instanceof Error ? error.message : "Failed to create link.",
+      );
     } finally {
       setIsSubmitting(false);
     }

--- a/apps/web/ui/partners/add-partner-link-modal.tsx
+++ b/apps/web/ui/partners/add-partner-link-modal.tsx
@@ -68,10 +68,13 @@ const AddPartnerLinkModal = ({
           ...formData,
           partnerId: partner.id,
           programId: program.id,
+          domain: program.domain,
           url: linkConstructor({
             domain: destinationDomain,
             key: formData.url,
           }),
+          trackConversion: true,
+          folderId: program.defaultFolderId,
         }),
       });
 
@@ -139,7 +142,7 @@ const AddPartnerLinkModal = ({
 
               <div className="flex">
                 <span className="inline-flex items-center rounded-l-md border border-r-0 border-neutral-300 bg-neutral-50 px-3 text-neutral-500 sm:text-sm">
-                  {getDomainWithoutWWW(program?.domain || "")}
+                  {program?.domain}
                 </span>
 
                 <input

--- a/apps/web/ui/partners/add-partner-link-modal.tsx
+++ b/apps/web/ui/partners/add-partner-link-modal.tsx
@@ -1,0 +1,259 @@
+import useProgram from "@/lib/swr/use-program";
+import useWorkspace from "@/lib/swr/use-workspace";
+import { LinkProps, PartnerProps } from "@/lib/types";
+import {
+  ArrowTurnLeft,
+  Button,
+  InfoTooltip,
+  Modal,
+  SimpleTooltipContent,
+  useCopyToClipboard,
+  useMediaQuery,
+} from "@dub/ui";
+import { getDomainWithoutWWW, linkConstructor } from "@dub/utils";
+import { useCallback, useMemo, useRef, useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { mutate } from "swr";
+import { X } from "../shared/icons";
+
+interface AddPartnerLinkModalProps {
+  showModal: boolean;
+  setShowModal: (showModal: boolean) => void;
+  onSuccess?: (link: LinkProps) => void;
+  partner: Pick<PartnerProps, "id" | "email">;
+}
+
+type FormData = Pick<LinkProps, "url" | "key">;
+
+const AddPartnerLinkModal = ({
+  showModal,
+  setShowModal,
+  onSuccess,
+  partner,
+}: AddPartnerLinkModalProps) => {
+  const { program } = useProgram();
+  const { isMobile } = useMediaQuery();
+  const { id: workspaceId } = useWorkspace();
+  const [, copyToClipboard] = useCopyToClipboard();
+  const formRef = useRef<HTMLFormElement>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const { register, handleSubmit, watch } = useForm<FormData>({
+    defaultValues: {
+      url: "",
+      key: "",
+    },
+  });
+
+  const key = watch("key");
+  const destinationDomain = getDomainWithoutWWW(program?.url || "");
+
+  const onSubmit = async (formData: FormData) => {
+    if (!destinationDomain || !program?.id || !partner.id) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    setErrorMessage(null);
+
+    try {
+      const response = await fetch(`/api/links?workspaceId=${workspaceId}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          ...formData,
+          partnerId: partner.id,
+          programId: program.id,
+          url: linkConstructor({
+            domain: destinationDomain,
+            key: formData.url,
+          }),
+        }),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.error.message);
+      }
+
+      await mutate(`/api/partners?workspaceId=${workspaceId}`);
+      toast.success("Link created successfully!");
+      onSuccess?.(data);
+      setShowModal(false);
+      copyToClipboard(data.shortLink);
+    } catch (error) {
+      setErrorMessage(error.message || "Failed to create link.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal
+      showModal={showModal}
+      setShowModal={setShowModal}
+      className="max-w-lg"
+    >
+      <form ref={formRef} onSubmit={handleSubmit(onSubmit)}>
+        <div className="flex flex-col items-start justify-between gap-4 px-6 py-4">
+          <div className="flex w-full items-center justify-between">
+            <h3 className="text-lg font-medium">New partner link</h3>
+            <button
+              type="button"
+              onClick={() => setShowModal(false)}
+              className="group rounded-full p-2 text-neutral-500 transition-all duration-75 hover:bg-neutral-100 focus:outline-none active:bg-neutral-200"
+            >
+              <X className="h-5 w-5" />
+            </button>
+          </div>
+
+          <div className="flex w-full flex-col gap-6">
+            <div className="flex flex-col gap-2">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <label
+                    htmlFor="key"
+                    className="block text-sm font-medium text-neutral-700"
+                  >
+                    Short Link
+                  </label>
+
+                  <InfoTooltip
+                    content={
+                      <SimpleTooltipContent
+                        title="This is the short link that will redirect to your destination URL."
+                        cta="Learn more."
+                        href="https://dub.co/help/article/how-to-create-link"
+                      />
+                    }
+                  />
+                </div>
+              </div>
+
+              <div className="flex">
+                <span className="inline-flex items-center rounded-l-md border border-r-0 border-neutral-300 bg-neutral-50 px-3 text-neutral-500 sm:text-sm">
+                  {getDomainWithoutWWW(program?.domain || "")}
+                </span>
+
+                <input
+                  {...register("key", { required: true })}
+                  type="text"
+                  id="key"
+                  autoFocus={!isMobile}
+                  className={
+                    "block w-full rounded-r-md border-neutral-300 text-neutral-900 placeholder-neutral-400 focus:border-neutral-500 focus:outline-none focus:ring-neutral-500 sm:text-sm"
+                  }
+                  placeholder={partner.email?.split("@")[0] || "short-link"}
+                />
+              </div>
+
+              {errorMessage && (
+                <span className="text-sm text-red-600 dark:text-red-400">
+                  {errorMessage}
+                </span>
+              )}
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <div className="flex items-center gap-2">
+                <label
+                  htmlFor="url"
+                  className="block text-sm font-medium text-neutral-700"
+                >
+                  Destination URL
+                </label>
+
+                <InfoTooltip
+                  content={
+                    <SimpleTooltipContent
+                      title="The URL your users will get redirected to when they visit your short link."
+                      cta="Learn more."
+                      href="https://dub.co/help/article/how-to-create-link"
+                    />
+                  }
+                />
+              </div>
+
+              <div className="flex">
+                <span className="inline-flex items-center rounded-l-md border border-r-0 border-neutral-300 bg-neutral-50 px-3 text-neutral-500 sm:text-sm">
+                  {destinationDomain}
+                </span>
+
+                <input
+                  {...register("url", { required: false })}
+                  type="text"
+                  id="url"
+                  placeholder="(optional)"
+                  className="block w-full rounded-r-md border-neutral-300 text-neutral-900 placeholder-neutral-400 focus:border-neutral-500 focus:outline-none focus:ring-neutral-500 sm:text-sm"
+                  onPaste={(e: React.ClipboardEvent<HTMLInputElement>) => {
+                    e.preventDefault();
+
+                    const text = e.clipboardData.getData("text/plain");
+
+                    try {
+                      const url = new URL(text);
+                      e.currentTarget.value = url.pathname.slice(1);
+                    } catch (err) {
+                      e.currentTarget.value = text;
+                    }
+                  }}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-end border-t border-neutral-200 bg-neutral-50 p-4">
+          <Button
+            type="submit"
+            text={
+              <span className="flex items-center gap-2">
+                Create link
+                <div className="rounded border border-white/20 p-1">
+                  <ArrowTurnLeft className="size-3.5" />
+                </div>
+              </span>
+            }
+            className="h-8 w-fit pl-2.5 pr-1.5"
+            loading={isSubmitting}
+            disabled={!key}
+          />
+        </div>
+      </form>
+    </Modal>
+  );
+};
+
+export function useAddPartnerLinkModal({
+  onSuccess,
+  partner,
+}: {
+  onSuccess?: (link: LinkProps) => void;
+  partner: Pick<PartnerProps, "id" | "email">;
+}) {
+  const [showAddPartnerLinkModal, setShowAddPartnerLinkModal] = useState(false);
+
+  const AddPartnerLinkModalCallback = useCallback(() => {
+    return (
+      <AddPartnerLinkModal
+        showModal={showAddPartnerLinkModal}
+        setShowModal={setShowAddPartnerLinkModal}
+        onSuccess={onSuccess}
+        partner={partner}
+      />
+    );
+  }, [showAddPartnerLinkModal, setShowAddPartnerLinkModal, partner]);
+
+  return useMemo(
+    () => ({
+      setShowAddPartnerLinkModal,
+      AddPartnerLinkModal: AddPartnerLinkModalCallback,
+    }),
+    [setShowAddPartnerLinkModal, AddPartnerLinkModalCallback],
+  );
+}

--- a/apps/web/ui/partners/partner-details-sheet.tsx
+++ b/apps/web/ui/partners/partner-details-sheet.tsx
@@ -23,6 +23,7 @@ import { LockOpen } from "lucide-react";
 import Link from "next/link";
 import { Dispatch, SetStateAction, useState } from "react";
 import { AnimatedEmptyState } from "../shared/animated-empty-state";
+import { useAddPartnerLinkModal } from "./add-partner-link-modal";
 import { useBanPartnerModal } from "./ban-partner-modal";
 import { usePartnerApplicationSheet } from "./partner-application-sheet";
 import { PartnerInfoSection } from "./partner-info-section";
@@ -38,7 +39,7 @@ type PartnerDetailsSheetProps = {
 type Tab = "payouts" | "links";
 
 function PartnerDetailsSheetContent({ partner }: PartnerDetailsSheetProps) {
-  const { slug, defaultProgramId } = useWorkspace();
+  const { slug } = useWorkspace();
   const [tab, setTab] = useState<Tab>("links");
 
   const { createCommissionSheet, setIsOpen: setCreateCommissionSheetOpen } =
@@ -309,6 +310,11 @@ function PartnerPayouts({ partner }: { partner: EnrolledPartnerProps }) {
 const PartnerLinks = ({ partner }: { partner: EnrolledPartnerProps }) => {
   const { slug } = useWorkspace();
 
+  const { AddPartnerLinkModal, setShowAddPartnerLinkModal } =
+    useAddPartnerLinkModal({
+      partner,
+    });
+
   const table = useTable({
     data: partner.links || [],
     columns: [
@@ -399,15 +405,18 @@ const PartnerLinks = ({ partner }: { partner: EnrolledPartnerProps }) => {
   } as any);
 
   return (
-    <div className="flex flex-col gap-4">
-      <Button
-        variant="secondary"
-        text="Create link"
-        className="h-8 w-fit rounded-lg px-3 py-2 font-medium"
-        onClick={() => {}}
-      />
-      <Table {...table} />
-    </div>
+    <>
+      <AddPartnerLinkModal />
+      <div className="flex flex-col gap-4">
+        <Button
+          variant="secondary"
+          text="Create link"
+          className="h-8 w-fit rounded-lg px-3 py-2 font-medium"
+          onClick={() => setShowAddPartnerLinkModal(true)}
+        />
+        <Table {...table} />
+      </div>
+    </>
   );
 };
 

--- a/apps/web/ui/partners/partner-details-sheet.tsx
+++ b/apps/web/ui/partners/partner-details-sheet.tsx
@@ -398,7 +398,17 @@ const PartnerLinks = ({ partner }: { partner: EnrolledPartnerProps }) => {
     scrollWrapperClassName: "min-h-[40px]",
   } as any);
 
-  return <Table {...table} />;
+  return (
+    <div className="flex flex-col gap-4">
+      <Button
+        variant="secondary"
+        text="Create link"
+        className="h-8 w-fit rounded-lg px-3 py-2 font-medium"
+        onClick={() => {}}
+      />
+      <Table {...table} />
+    </div>
+  );
 };
 
 function Menu({ partner }: { partner: EnrolledPartnerProps }) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a modal dialog for creating new partner links, accessible from the partner details section.
	- Users can now add a short link and optional destination URL for partners, with tooltips and improved UX.
	- Added a modal for assigning or removing partners within the link-building interface.
- **Refactor**
	- Rearranged the order of input fields in link creation forms, placing the "Destination URL" input after the "Short Link" input.
	- Updated autofocus behavior to focus on the "Short Link" input by default.
- **Enhancements**
	- Updated link builder options to include partner assignment with new icons, labels, and help links.
	- Extended link creation payloads to support partner and program associations.
	- Replaced webhook-related modals with partner-related modals in the link builder UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->