### PR TITLE
Updated the link settings display

### DIFF
--- a/apps/web/lib/partners/get-link-structure-options.ts
+++ b/apps/web/lib/partners/get-link-structure-options.ts
@@ -23,19 +23,19 @@ export const getLinkStructureOptions = ({
     {
       id: LinkStructure.short,
       label: "Short link",
-      example: `${shortDomain}/${username}`,
+      example: `${shortDomain}/{partnerName}`,
       comingSoon: false,
     },
     {
       id: LinkStructure.query,
       label: "Query parameter",
-      example: `${websiteDomain}?via=${username}`,
+      example: `${websiteDomain}?via={partnerName}`,
       comingSoon: false,
     },
     {
       id: LinkStructure.path,
       label: "Dynamic path",
-      example: `${websiteDomain}/refer/${username}`,
+      example: `${websiteDomain}/refer/{partnerName}`,
       comingSoon: true,
     },
   ];


### PR DESCRIPTION
Instead of showing the current username at the end of the link, changed to a placeholder of {partnerName} to help communicate that's the link structure.

![CleanShot 2025-06-19 at 08 42 50@2x](https://github.com/user-attachments/assets/9eee21e3-cbe0-425e-ab27-0c3185d76717)
