### PR TITLE
Add Markdown supported hint to text block modal

### DIFF
--- a/apps/web/lib/zod/schemas/workspaces.ts
+++ b/apps/web/lib/zod/schemas/workspaces.ts
@@ -60,7 +60,9 @@ export const WorkspaceSchema = z
       ),
     payoutFee: z
       .number()
-      .describe("The payout fee Dub Partners takes for direct debit payments."),
+      .describe(
+        "The processing fee (in decimals) for partner payouts. For card payments, an additional 0.03 is added to the fee. Learn more: https://d.to/payouts",
+      ),
     domainsLimit: z.number().describe("The domains limit of the workspace."),
     tagsLimit: z.number().describe("The tags limit of the workspace."),
     foldersUsage: z.number().describe("The folders usage of the workspace."),

--- a/apps/web/ui/partners/design/modals/text-block-modal.tsx
+++ b/apps/web/ui/partners/design/modals/text-block-modal.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import { programLanderTextBlockSchema } from "@/lib/zod/schemas/program-lander";
-import { Button, Modal, useEnterSubmit, useMediaQuery } from "@dub/ui";
+import {
+  Button,
+  Markdown,
+  Modal,
+  useEnterSubmit,
+  useMediaQuery,
+} from "@dub/ui";
 import { cn } from "@dub/utils";
 import { Dispatch, SetStateAction, useId } from "react";
 import { useForm } from "react-hook-form";
@@ -91,7 +97,7 @@ function TextBlockModalInner({
                 rows={12}
                 maxLength={10000}
                 onKeyDown={handleKeyDown}
-                placeholder="Start typing (markdown supported)"
+                placeholder="Start typing..."
                 className={cn(
                   "block max-h-64 min-h-16 w-full rounded-md border-neutral-300 text-neutral-900 placeholder-neutral-400 focus:border-neutral-500 focus:outline-none focus:ring-neutral-500 sm:text-sm",
                   errors.content &&
@@ -100,6 +106,15 @@ function TextBlockModalInner({
                 {...register("content", { required: "Content is required" })}
               />
             </div>
+            <a
+              href="https://www.markdownguide.org/basic-syntax/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-content-subtle mt-1 flex items-center justify-end gap-1 text-xs"
+            >
+              <Markdown role="presentation" className="h-3 w-auto" />
+              <span className="sr-only">Markdown</span> supported
+            </a>
           </div>
 
           <div className="flex items-center justify-end gap-2">

--- a/apps/web/ui/partners/design/modals/text-block-modal.tsx
+++ b/apps/web/ui/partners/design/modals/text-block-modal.tsx
@@ -3,7 +3,7 @@
 import { programLanderTextBlockSchema } from "@/lib/zod/schemas/program-lander";
 import {
   Button,
-  Markdown,
+  MarkdownIcon,
   Modal,
   useEnterSubmit,
   useMediaQuery,
@@ -112,8 +112,8 @@ function TextBlockModalInner({
               rel="noopener noreferrer"
               className="text-content-subtle mt-1 flex items-center justify-end gap-1 text-xs"
             >
-              <Markdown role="presentation" className="h-3 w-auto" />
-              <span className="sr-only">Markdown</span> supported
+              <MarkdownIcon role="presentation" className="h-3 w-auto" />
+              <span className="sr-only">MarkdownIcon</span> supported
             </a>
           </div>
 

--- a/apps/web/ui/partners/design/modals/text-block-modal.tsx
+++ b/apps/web/ui/partners/design/modals/text-block-modal.tsx
@@ -110,7 +110,7 @@ function TextBlockModalInner({
               href="https://www.markdownguide.org/basic-syntax/"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-content-subtle mt-1 flex items-center justify-end gap-1 text-xs"
+              className="text-content-subtle mt-1 flex items-center gap-1 text-xs"
             >
               <MarkdownIcon role="presentation" className="h-3 w-auto" />
               <span className="sr-only">MarkdownIcon</span> supported

--- a/packages/prisma/schema/workspace.prisma
+++ b/packages/prisma/schema/workspace.prisma
@@ -24,7 +24,7 @@ model Project {
   linksLimit   Int   @default(25)
   payoutsUsage Int   @default(0)
   payoutsLimit Int   @default(0)
-  payoutFee    Float @default(0.05) // payout fee for direct debit payments
+  payoutFee    Float @default(0.05) // processing fee (in decimals) for partner payouts
 
   domainsLimit Int @default(3)
   tagsLimit    Int @default(5)

--- a/packages/ui/src/icons/index.tsx
+++ b/packages/ui/src/icons/index.tsx
@@ -13,6 +13,7 @@ export * from "./dub-links";
 export * from "./dub-partners";
 export { default as ExpandingArrow } from "./expanding-arrow";
 export { default as Magic } from "./magic";
+export * from "./markdown";
 export * from "./matrix-lines";
 export { default as Photo } from "./photo";
 export { default as SortOrder } from "./sort-order";

--- a/packages/ui/src/icons/index.tsx
+++ b/packages/ui/src/icons/index.tsx
@@ -13,7 +13,7 @@ export * from "./dub-links";
 export * from "./dub-partners";
 export { default as ExpandingArrow } from "./expanding-arrow";
 export { default as Magic } from "./magic";
-export * from "./markdown";
+export * from "./markdown-icon";
 export * from "./matrix-lines";
 export { default as Photo } from "./photo";
 export { default as SortOrder } from "./sort-order";

--- a/packages/ui/src/icons/markdown-icon.tsx
+++ b/packages/ui/src/icons/markdown-icon.tsx
@@ -1,6 +1,6 @@
 import { SVGProps } from "react";
 
-export function Markdown(props: SVGProps<SVGSVGElement>) {
+export function MarkdownIcon(props: SVGProps<SVGSVGElement>) {
   return (
     <svg fill="none" viewBox="0 0 22 14" {...props}>
       <path

--- a/packages/ui/src/icons/markdown.tsx
+++ b/packages/ui/src/icons/markdown.tsx
@@ -1,0 +1,14 @@
+import { SVGProps } from "react";
+
+export function Markdown(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg fill="none" viewBox="0 0 22 14" {...props}>
+      <path
+        fill="currentColor"
+        fillRule="evenodd"
+        d="M19.5 1.25h-17c-.69 0-1.25.56-1.25 1.25v9c0 .69.56 1.25 1.25 1.25h17c.69 0 1.25-.56 1.25-1.25v-9c0-.69-.56-1.25-1.25-1.25M2.5 0A2.5 2.5 0 0 0 0 2.5v9A2.5 2.5 0 0 0 2.5 14h17a2.5 2.5 0 0 0 2.5-2.5v-9A2.5 2.5 0 0 0 19.5 0zM3 3.5h1.69l.297.324L7 6.02l2.013-2.196.297-.324H11v7H9V6.798L7.737 8.176 7 8.98l-.737-.804L5 6.798V10.5H3v-7M15 7V3.5h2V7h2.5L17 9.5l-1 1-1-1L12.5 7z"
+        clipRule="evenodd"
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
<img width="514" alt="Screenshot 2025-06-24 at 5 12 23 PM" src="https://github.com/user-attachments/assets/1b97a70f-7ba4-4aa3-9235-14262fd00e54" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Markdown icon and a link to a Markdown syntax guide below the text area in the text block modal for easier access to formatting help.

- **Documentation**
  - Improved the description for the payout fee field in workspace settings to clarify processing fees and provide additional information.

- **Style**
  - Updated placeholder text in the content textarea for a cleaner appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->