### PR TITLE
Fixed nav item height

### DIFF
--- a/apps/web/ui/layout/sidebar/sidebar-nav.tsx
+++ b/apps/web/ui/layout/sidebar/sidebar-nav.tsx
@@ -331,7 +331,7 @@ function NavItem({ item }: { item: NavItemType | NavSubItemType }) {
         onPointerEnter={() => setHovered(true)}
         onPointerLeave={() => setHovered(false)}
         className={cn(
-          "text-content-default group flex items-center justify-between rounded-lg p-2 text-sm leading-none transition-[background-color,color,font-weight] duration-75",
+          "text-content-default group flex items-center justify-between rounded-lg h-8 p-2 text-sm leading-none transition-[background-color,color,font-weight] duration-75",
           "outline-none focus-visible:ring-2 focus-visible:ring-black/50",
           isActive && !items
             ? "bg-blue-100/50 font-medium text-blue-600 hover:bg-blue-100/80 active:bg-blue-100"


### PR DESCRIPTION
Added a set height to the navigation page items, so that when there's a tag, it doesn't impact the height, creating differences between all the items.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated navigation items in the sidebar to have a consistent height for improved layout alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->