### PR TITLE
Update OpenAPI definitions

### DIFF
--- a/apps/web/guides/manual-track-sale.md
+++ b/apps/web/guides/manual-track-sale.md
@@ -13,10 +13,10 @@ const dub = new Dub({
 await dub.track.sale({
   externalId: "cus_oFUYbZYqHFR0knk0MjsMC6b0",
   amount: 3000, // sale amount in cents
+  currency: "usd",
   paymentProcessor: "stripe",
   eventName: "Invoice paid",
   invoiceId: "INV_1234567890",
-  currency: "usd",
 });
 ```
 

--- a/apps/web/lib/actions/partners/onboard-partner.ts
+++ b/apps/web/lib/actions/partners/onboard-partner.ts
@@ -37,7 +37,7 @@ export const onboardPartnerAction = authUserActionClient
 
     // country, profileType, and companyName cannot be changed once set
     const payload: Prisma.PartnerCreateInput = {
-      name,
+      name: name || user.email,
       email: user.email,
       // you can only update these fields if the partner doesn't already have a stripeConnectId
       ...(existingPartner?.stripeConnectId

--- a/apps/web/lib/api/partners/create-and-enroll-partner.ts
+++ b/apps/web/lib/api/partners/create-and-enroll-partner.ts
@@ -138,7 +138,7 @@ export const createAndEnrollPartner = async ({
     create: {
       ...payload,
       id: createId({ prefix: "pn_" }),
-      name: partner.name,
+      name: partner.name || partner.email,
       email: partner.email,
       image: partner.image && !isStored(partner.image) ? null : partner.image,
       country: partner.country,

--- a/apps/web/lib/zod/schemas/analytics-response.ts
+++ b/apps/web/lib/zod/schemas/analytics-response.ts
@@ -1,6 +1,6 @@
 import { TRIGGER_TYPES } from "@/lib/analytics/constants";
 import z from "@/lib/zod";
-import { CONTINENT_CODES, COUNTRY_CODES } from "@dub/utils";
+import { CONTINENT_CODES } from "@dub/utils";
 
 const analyticsTriggersResponse = z
   .object({
@@ -89,9 +89,9 @@ export const analyticsResponse = {
   countries: z
     .object({
       country: z
-        .enum(COUNTRY_CODES)
+        .string()
         .describe(
-          "The 2-letter ISO 3166-1 country code for the country associated with the location of the user. Learn more: https://d.to/geo",
+          "The 2-letter ISO 3166-1 country code of the country. Learn more: https://d.to/geo",
         ),
       region: z.literal("*").default("*"),
       city: z.literal("*").default("*"),
@@ -117,13 +117,13 @@ export const analyticsResponse = {
   regions: z
     .object({
       country: z
-        .enum(COUNTRY_CODES)
-        .describe("The 2-letter country code of the region: https://d.to/geo"),
-      region: z
         .string()
         .describe(
-          "The 2-letter ISO 3166-2 region code representing the region associated with the location of the user.",
+          "The 2-letter ISO 3166-1 country code of the country. Learn more: https://d.to/geo",
         ),
+      region: z
+        .string()
+        .describe("The 2-letter ISO 3166-2 region code of the region."),
       city: z.literal("*").default("*"),
       clicks: z
         .number()
@@ -147,8 +147,10 @@ export const analyticsResponse = {
   cities: z
     .object({
       country: z
-        .enum(COUNTRY_CODES)
-        .describe("The 2-letter country code of the city: https://d.to/geo"),
+        .string()
+        .describe(
+          "The 2-letter ISO 3166-1 country code of the country where this city is located. Learn more: https://d.to/geo",
+        ),
       region: z
         .string()
         .describe(

--- a/apps/web/lib/zod/schemas/analytics.ts
+++ b/apps/web/lib/zod/schemas/analytics.ts
@@ -140,7 +140,9 @@ export const analyticsQuerySchema = z
     country: z
       .enum(COUNTRY_CODES)
       .optional()
-      .describe("The country to retrieve analytics for.")
+      .describe(
+        "The country to retrieve analytics for. Must be passed as a 2-letter ISO 3166-1 country code. Learn more: https://d.to/geo",
+      )
       .openapi({ ref: "countryCode" }),
     city: z
       .string()

--- a/apps/web/lib/zod/schemas/leads.ts
+++ b/apps/web/lib/zod/schemas/leads.ts
@@ -21,12 +21,6 @@ export const trackLeadRequestSchema = z.object({
       "The name of the lead event to track. Can also be used as a unique identifier to associate a given lead event for a customer for a subsequent sale event (via the `leadEventName` prop in `/track/sale`).",
     )
     .openapi({ example: "Sign up" }),
-  eventQuantity: z
-    .number()
-    .nullish()
-    .describe(
-      "The numerical value associated with this lead event (e.g., number of provisioned seats in a free trial). If defined as N, the lead event will be tracked N times.",
-    ),
   externalId: z
     .string()
     .trim()
@@ -54,6 +48,12 @@ export const trackLeadRequestSchema = z.object({
     .nullish()
     .default(null)
     .describe("The avatar URL of the customer."),
+  eventQuantity: z
+    .number()
+    .nullish()
+    .describe(
+      "The numerical value associated with this lead event (e.g., number of provisioned seats in a free trial). If defined as N, the lead event will be tracked N times.",
+    ),
   mode: z
     .enum(["async", "wait"])
     .default("async")

--- a/apps/web/lib/zod/schemas/partners.ts
+++ b/apps/web/lib/zod/schemas/partners.ts
@@ -397,6 +397,7 @@ export const onboardPartnerSchema = createPartnerSchema
   })
   .merge(
     z.object({
+      name: z.string(),
       image: z.string(),
       country: z.enum(COUNTRY_CODES),
       profileType: z.enum(["individual", "company"]).default("individual"),

--- a/apps/web/lib/zod/schemas/partners.ts
+++ b/apps/web/lib/zod/schemas/partners.ts
@@ -325,7 +325,7 @@ export const createPartnerSchema = z.object({
     .max(100)
     .nullish()
     .describe(
-      "The partner's full legal name. If undefined, the partner's name will be generated from the email address (e.g. `john@acme.com` -> `John`).",
+      "The partner's full name. If undefined, the partner's email will be used in lieu of their name (e.g. `john@acme.com`)",
     ),
   email: z
     .string()
@@ -334,7 +334,7 @@ export const createPartnerSchema = z.object({
     .max(190)
     .email()
     .describe(
-      "The partner's email address in your system. Partners will be able to claim their profile by signing up at partners.dub.co with this email.",
+      "The partner's email address. Partners will be able to claim their profile by signing up at `partners.dub.co` with this email.",
     ),
   username: z
     .string()
@@ -349,6 +349,12 @@ export const createPartnerSchema = z.object({
     .describe(
       "The partner's avatar image. If not provided, a default avatar will be used.",
     ),
+  tenantId: z
+    .string()
+    .optional()
+    .describe(
+      "The partner's unique ID in your system. Useful for retrieving the partner's links and stats later on. If not provided, the partner will be created as a standalone partner.",
+    ),
   country: z
     .enum(COUNTRY_CODES)
     .nullish()
@@ -361,12 +367,6 @@ export const createPartnerSchema = z.object({
     .nullish()
     .describe(
       "A brief description of the partner and their background. Max 5,000 characters.",
-    ),
-  tenantId: z
-    .string()
-    .optional()
-    .describe(
-      "The partner's unique ID in your system. Useful for retrieving the partner's links and stats later on. If not provided, the partner will be created as a standalone partner.",
     ),
   linkProps: createLinkBodySchema
     .omit({

--- a/apps/web/lib/zod/schemas/partners.ts
+++ b/apps/web/lib/zod/schemas/partners.ts
@@ -322,9 +322,11 @@ export const createPartnerSchema = z.object({
   name: z
     .string()
     .trim()
-    .min(1)
     .max(100)
-    .describe("Full legal name of the partner."),
+    .nullish()
+    .describe(
+      "The partner's full legal name. If undefined, the partner's name will be generated from the email address (e.g. `john@acme.com` -> `John`).",
+    ),
   email: z
     .string()
     .trim()
@@ -332,34 +334,40 @@ export const createPartnerSchema = z.object({
     .max(190)
     .email()
     .describe(
-      "Email for the partner in your system. Partners will be able to claim their profile by signing up to Dub Partners with this email.",
+      "The partner's email address in your system. Partners will be able to claim their profile by signing up at partners.dub.co with this email.",
     ),
   username: z
     .string()
     .max(100)
     .nullish()
     .describe(
-      "A unique username for the partner in your system (max 100 characters). This will be used to create a short link for the partner using your program's default domain. If not provided, Dub will try to generate a username from the partner's name or email.",
+      "The partner's unique username in your system (max 100 characters). This will be used to create a short link for the partner using your program's default domain. If not provided, Dub will try to generate a username from the partner's name or email.",
     ),
   image: z
     .string()
     .nullish()
     .describe(
-      "Avatar image for the partner – if not provided, a default avatar will be used.",
+      "The partner's avatar image. If not provided, a default avatar will be used.",
     ),
   country: z
     .enum(COUNTRY_CODES)
     .nullish()
-    .describe("Country where the partner is based."),
+    .describe(
+      "The partner's country of residence. Must be passed as a 2-letter ISO 3166-1 country code. Learn more: https://d.to/geo",
+    ),
   description: z
     .string()
     .max(5000)
     .nullish()
-    .describe("A brief description of the partner and their background."),
+    .describe(
+      "A brief description of the partner and their background. Max 5,000 characters.",
+    ),
   tenantId: z
     .string()
     .optional()
-    .describe("The ID of the partner in your system."),
+    .describe(
+      "The partner's unique ID in your system. Useful for retrieving the partner's links and stats later on. If not provided, the partner will be created as a standalone partner.",
+    ),
   linkProps: createLinkBodySchema
     .omit({
       url: true,

--- a/apps/web/lib/zod/schemas/sales.ts
+++ b/apps/web/lib/zod/schemas/sales.ts
@@ -16,17 +16,28 @@ export const trackSaleRequestSchema = z.object({
     .number({ required_error: "amount is required" })
     .int()
     .min(0, "amount cannot be negative")
-    .describe("The amount of the sale in cents."),
-  paymentProcessor: z
-    .enum(["stripe", "shopify", "polar", "paddle", "custom"])
-    .describe("The payment processor via which the sale was made."),
+    .describe(
+      "The amount of the sale in cents (for all two-decimal currencies). If the sale is in a zero-decimal currency, pass the full integer value (e.g. `1437` JPY). Learn more: https://d.to/currency",
+    ),
+  currency: z
+    .string()
+    .default("usd")
+    .transform((val) => val.toLowerCase())
+    .describe(
+      "The currency of the sale. Accepts ISO 4217 currency codes. Sales will be automatically converted and stored as USD at the latest exchange rates. Learn more: https://d.to/currency",
+    ),
   eventName: z
     .string()
     .max(255)
     .optional()
     .default("Purchase")
-    .describe("The name of the sale event.")
+    .describe(
+      "The name of the sale event. Recommended format: `Invoice paid` or `Subscription created`.",
+    )
     .openapi({ example: "Invoice paid" }),
+  paymentProcessor: z
+    .enum(["stripe", "shopify", "polar", "paddle", "custom"])
+    .describe("The payment processor via which the sale was made."),
   invoiceId: z
     .string()
     .nullish()
@@ -34,17 +45,12 @@ export const trackSaleRequestSchema = z.object({
     .describe(
       "The invoice ID of the sale. Can be used as a idempotency key – only one sale event can be recorded for a given invoice ID.",
     ),
-  currency: z
-    .string()
-    .default("usd")
-    .transform((val) => val.toLowerCase())
-    .describe("The currency of the sale. Accepts ISO 4217 currency codes."),
   leadEventName: z
     .string()
     .nullish()
     .default(null)
     .describe(
-      "The name of the lead event that occurred before the sale (case-sensitive). This is used to associate the sale event with a particular lead event (instead of the latest lead event, which is the default behavior).",
+      "The name of the lead event that occurred before the sale (case-sensitive). This is used to associate the sale event with a particular lead event (instead of the latest lead event for a link-customer combination, which is the default behavior).",
     )
     .openapi({ example: "Cloned template 1481267" }),
   metadata: z
@@ -55,7 +61,7 @@ export const trackSaleRequestSchema = z.object({
       message: "Metadata must be less than 10,000 characters when stringified",
     })
     .describe(
-      "Additional metadata to be stored with the sale event. Max 10,000 characters.",
+      "Additional metadata to be stored with the sale event. Max 10,000 characters when stringified.",
     ),
 });
 

--- a/apps/web/tests/utils/resource.ts
+++ b/apps/web/tests/utils/resource.ts
@@ -57,7 +57,7 @@ export const E2E_DISCOUNT = {
 export const E2E_PROGRAM = {
   id: "prog_CYCu7IMAapjkRpTnr8F1azjN",
   domain: "getacme.link",
-  url: "https://acme.com",
+  url: "https://acme.dub.sh",
 };
 
 export const E2E_PARTNER = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying currency in sales tracking, with automatic conversion to lowercase and a default of "usd".
  * Made several fields in the partner creation process optional or nullable, allowing greater flexibility when submitting partner details.

* **Improvements**
  * Enhanced and clarified descriptions for country, region, and city fields across analytics and partner schemas, including reference links and ISO code format explanations.
  * Improved descriptions for event and metadata fields in sales and partner schemas for better guidance.
  * Reordered fields in lead and sales tracking forms for improved usability.
  * Partner creation now defaults the name to the partner's email if no name is provided.
  * Updated example code for sale event tracking to improve property ordering.
  * Updated test resource URL to a new domain.

* **Bug Fixes**
  * Relaxed validation for country fields, now accepting any 2-letter ISO code string instead of a fixed set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->