### PR TITLE
Restrict payout confirmation to workspace owners

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/payouts/payout-stats.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/payouts/payout-stats.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { clientAccessCheck } from "@/lib/api/tokens/permissions";
 import usePayoutsCount from "@/lib/swr/use-payouts-count";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { PayoutsCount } from "@/lib/types";
@@ -52,12 +51,6 @@ export function PayoutStats() {
   const totalPaid =
     (completedPayouts?.amount || 0) + (processingPayouts?.amount || 0);
 
-  const { error: permissionsError } = clientAccessCheck({
-    role,
-    action: "payouts.write",
-    customPermissionDescription: "confirm payouts.",
-  });
-
   return (
     <>
       <PayoutInvoiceSheet />
@@ -78,15 +71,11 @@ export function PayoutStats() {
                   scroll: false,
                 });
               }}
-              disabled={
-                eligiblePayoutsLoading ||
-                confirmButtonDisabled ||
-                permissionsError !== false
-              }
+              disabled={eligiblePayoutsLoading || confirmButtonDisabled}
               disabledTooltip={
                 confirmButtonDisabled
                   ? "You have no pending payouts that match the minimum payout requirement for partners that have payouts enabled."
-                  : permissionsError || undefined
+                  : undefined
               }
             />
           </div>

--- a/apps/web/lib/actions/partners/confirm-payouts.ts
+++ b/apps/web/lib/actions/partners/confirm-payouts.ts
@@ -22,6 +22,10 @@ export const confirmPayoutsAction = authActionClient
     const { workspace, user } = ctx;
     const { paymentMethodId, cutoffPeriod } = parsedInput;
 
+    if (workspace.role !== "owner") {
+      throw new Error("Only workspace owners can confirm payouts.");
+    }
+
     if (!workspace.stripeId) {
       throw new Error("Workspace does not have a valid Stripe ID.");
     }

--- a/apps/web/lib/actions/safe-action.ts
+++ b/apps/web/lib/actions/safe-action.ts
@@ -68,14 +68,12 @@ export const authActionClient = actionClient.use(
       throw new Error("Workspace not found.");
     }
 
-    const { role } = workspace.users[0];
-
     return next({
       ctx: {
         user: session.user,
         workspace: {
           ...workspace,
-          role,
+          role: workspace.users[0].role,
           plan: workspace.plan as PlanProps,
         },
       },

--- a/apps/web/lib/actions/safe-action.ts
+++ b/apps/web/lib/actions/safe-action.ts
@@ -68,11 +68,14 @@ export const authActionClient = actionClient.use(
       throw new Error("Workspace not found.");
     }
 
+    const { role } = workspace.users[0];
+
     return next({
       ctx: {
         user: session.user,
         workspace: {
           ...workspace,
+          role,
           plan: workspace.plan as PlanProps,
         },
       },

--- a/apps/web/lib/api/rbac/permissions.ts
+++ b/apps/web/lib/api/rbac/permissions.ts
@@ -20,6 +20,7 @@ export const PERMISSION_ACTIONS = [
   "webhooks.write",
   "folders.read",
   "folders.write",
+  "payouts.write",
 ] as const;
 
 export type PermissionAction = (typeof PERMISSION_ACTIONS)[number];
@@ -123,6 +124,11 @@ export const ROLE_PERMISSIONS: {
     action: "folders.write",
     description: "create, update, or delete folders",
     roles: ["owner", "member"],
+  },
+  {
+    action: "payouts.write",
+    description: "confirm payouts",
+    roles: ["owner"],
   },
 ];
 

--- a/apps/web/ui/partners/payout-invoice-sheet.tsx
+++ b/apps/web/ui/partners/payout-invoice-sheet.tsx
@@ -1,5 +1,6 @@
 import { confirmPayoutsAction } from "@/lib/actions/partners/confirm-payouts";
 import { exceededLimitError } from "@/lib/api/errors";
+import { clientAccessCheck } from "@/lib/api/tokens/permissions";
 import { DIRECT_DEBIT_PAYMENT_METHOD_TYPES } from "@/lib/partners/constants";
 import {
   CUTOFF_PERIOD,
@@ -85,6 +86,7 @@ function PayoutInvoiceSheetContent() {
     id: workspaceId,
     slug,
     plan,
+    role,
     defaultProgramId,
     payoutsUsage,
     payoutsLimit,
@@ -355,6 +357,12 @@ function PayoutInvoiceSheetContent() {
     }
   }, [eligiblePayouts]);
 
+  const { error: permissionsError } = clientAccessCheck({
+    role,
+    action: "payouts.write",
+    customPermissionDescription: "confirm payouts",
+  });
+
   return (
     <div className="flex h-full flex-col">
       <div className="flex items-start justify-between border-b border-neutral-200 p-6">
@@ -441,7 +449,7 @@ function PayoutInvoiceSheetContent() {
             payoutsUsage &&
             payoutsLimit &&
             amount &&
-            payoutsUsage + amount > payoutsLimit && (
+            payoutsUsage + amount > payoutsLimit ? (
               <TooltipContent
                 title={exceededLimitError({
                   plan: plan as PlanProps,
@@ -451,6 +459,8 @@ function PayoutInvoiceSheetContent() {
                 cta="Upgrade"
                 href={`/${slug}/settings/billing/upgrade`}
               />
+            ) : (
+              permissionsError || undefined
             )
           }
         />


### PR DESCRIPTION
limit the confirm payouts to workspace owners only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added role-based permissions for confirming payouts, restricting this action to workspace owners only.
  * The "Confirm payouts" button now shows permission-related feedback in its tooltip when disabled for unauthorized users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->