### PR TITLE
Applications link/prefetching fix

### DIFF
--- a/apps/web/ui/partners/partner-social-column.tsx
+++ b/apps/web/ui/partners/partner-social-column.tsx
@@ -1,6 +1,6 @@
 import { BadgeCheck2Fill, Tooltip } from "@dub/ui";
-import { getUrlFromString } from "@dub/utils";
-import Link from "next/link";
+import { getUrlFromString, isValidUrl } from "@dub/utils";
+import { PropsWithChildren } from "react";
 
 export function PartnerSocialColumn({
   at,
@@ -14,10 +14,8 @@ export function PartnerSocialColumn({
   href: string;
 }) {
   return value && href ? (
-    <Link
+    <LinkIfValid
       href={getUrlFromString(href)}
-      target="_blank"
-      rel="noopener noreferrer"
       className="flex items-center gap-2 hover:underline"
     >
       <span className="min-w-0 truncate">
@@ -31,8 +29,27 @@ export function PartnerSocialColumn({
           </div>
         </Tooltip>
       )}
-    </Link>
+    </LinkIfValid>
   ) : (
     "-"
   );
 }
+
+const LinkIfValid = ({
+  href,
+  className,
+  children,
+}: PropsWithChildren<{ href: string; className?: string }>) => {
+  return isValidUrl(href) ? (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={className}
+    >
+      {children}
+    </a>
+  ) : (
+    <span className={className}>{children}</span>
+  );
+};

--- a/apps/web/ui/partners/partner-social-column.tsx
+++ b/apps/web/ui/partners/partner-social-column.tsx
@@ -14,10 +14,7 @@ export function PartnerSocialColumn({
   href: string;
 }) {
   return value && href ? (
-    <LinkIfValid
-      href={getUrlFromString(href)}
-      className="flex items-center gap-2 hover:underline"
-    >
+    <LinkIfValid href={getUrlFromString(href)}>
       <span className="min-w-0 truncate">
         {at && "@"}
         {value}
@@ -37,19 +34,18 @@ export function PartnerSocialColumn({
 
 const LinkIfValid = ({
   href,
-  className,
   children,
-}: PropsWithChildren<{ href: string; className?: string }>) => {
+}: PropsWithChildren<{ href: string }>) => {
   return isValidUrl(href) ? (
     <a
       href={href}
       target="_blank"
       rel="noopener noreferrer"
-      className={className}
+      className="flex items-center gap-2 hover:underline"
     >
       {children}
     </a>
   ) : (
-    <span className={className}>{children}</span>
+    <span className="flex items-center gap-2">{children}</span>
   );
 };


### PR DESCRIPTION
* Switches from `Link` to `a` for social links since we don't need Next.js trying to prefetch anything
* Only renders as a link if the URL is valid

Should fix the following error:
<img width="905" alt="Screenshot 2025-06-30 at 10 29 19 AM" src="https://github.com/user-attachments/assets/c1f398e0-1564-4c64-a32d-81086c88cec4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of partner social links to ensure only valid URLs are rendered as clickable links, while invalid URLs are displayed as plain text with consistent styling. This enhances the reliability and appearance of social link displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->