### PR TITLE
Allow updating partner email

### DIFF
--- a/apps/web/app/(ee)/partners.dub.co/(dashboard)/profile/page-client.tsx
+++ b/apps/web/app/(ee)/partners.dub.co/(dashboard)/profile/page-client.tsx
@@ -203,7 +203,6 @@ function ProfileForm({
     <form
       ref={formRef}
       onSubmit={handleSubmit(async (data) => {
-        console.log({ data });
         const imageChanged = data.image !== partner.image;
 
         await executeAsync({

--- a/apps/web/app/(ee)/partners.dub.co/(dashboard)/profile/page-client.tsx
+++ b/apps/web/app/(ee)/partners.dub.co/(dashboard)/profile/page-client.tsx
@@ -285,7 +285,7 @@ function ProfileForm({
                 type="email"
                 className={cn(
                   "block w-full rounded-md focus:outline-none sm:text-sm",
-                  errors.name
+                  errors.email
                     ? "border-red-300 pr-10 text-red-900 placeholder-red-300 focus:border-red-500 focus:ring-red-500"
                     : "border-neutral-300 text-neutral-900 placeholder-neutral-400 focus:border-neutral-500 focus:ring-neutral-500",
                   completedPayoutsCount > 0 &&

--- a/apps/web/lib/actions/partners/update-partner-profile.ts
+++ b/apps/web/lib/actions/partners/update-partner-profile.ts
@@ -75,10 +75,11 @@ export const updatePartnerProfileAction = authPartnerActionClient
         countryChanged ||
         profileTypeChanged ||
         companyNameChanged) &&
-      partner.stripeConnectId
+      partner.stripeConnectId &&
+      partner.payoutsEnabledAt
     ) {
-      // Partner is only able to update their country, profile type, or company name
-      // as long as they don't have any completed payouts
+      // Partner is not able to update their country, profile type, or company name
+      // if they have a verified Stripe Express account + any completed payouts
       const completedPayoutsCount = await prisma.payout.count({
         where: {
           partnerId: partner.id,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to edit the partner's email address in the profile form, with conditional restrictions based on payout status.
  * Enhanced user warnings and confirmation dialogs when changing sensitive fields (email, country, or profile type) that may impact Stripe payouts.
  * Unified disabling logic and tooltips for email, country, and profile type fields when payouts have been completed.

* **Bug Fixes**
  * Improved error messages and validation when attempting to update restricted profile fields after payouts have been received.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->