### PR TITLE
Add invitations count to sidebar

### DIFF
--- a/apps/web/app/(ee)/api/partner-profile/programs/count/route.ts
+++ b/apps/web/app/(ee)/api/partner-profile/programs/count/route.ts
@@ -1,0 +1,18 @@
+import { withPartnerProfile } from "@/lib/auth/partner";
+import { partnerProfileProgramsCountQuerySchema } from "@/lib/zod/schemas/partner-profile";
+import { prisma } from "@dub/prisma";
+import { NextResponse } from "next/server";
+
+// GET /api/partner-profile/programs/count - count program enrollments for a given partnerId
+export const GET = withPartnerProfile(async ({ partner, searchParams }) => {
+  const { status } = partnerProfileProgramsCountQuerySchema.parse(searchParams);
+
+  const count = await prisma.programEnrollment.count({
+    where: {
+      partnerId: partner.id,
+      ...(status && { status }),
+    },
+  });
+
+  return NextResponse.json(count);
+});

--- a/apps/web/lib/swr/use-program-enrollments-count.ts
+++ b/apps/web/lib/swr/use-program-enrollments-count.ts
@@ -1,0 +1,30 @@
+import { fetcher } from "@dub/utils";
+import { useSession } from "next-auth/react";
+import useSWR from "swr";
+import { z } from "zod";
+import { partnerProfileProgramsCountQuerySchema } from "../zod/schemas/partner-profile";
+
+export default function useProgramEnrollmentsCount(
+  query: z.infer<typeof partnerProfileProgramsCountQuerySchema> = {},
+) {
+  const { data: session } = useSession();
+  const partnerId = session?.user?.["defaultPartnerId"];
+
+  const { data: count, isLoading } = useSWR<number>(
+    partnerId &&
+      `/api/partner-profile/programs/count?${new URLSearchParams(
+        Object.fromEntries(
+          Object.entries(query).map(([key, value]) => [key, value.toString()]),
+        ),
+      )}`,
+    fetcher,
+    {
+      dedupingInterval: 60000,
+    },
+  );
+
+  return {
+    count,
+    isLoading,
+  };
+}

--- a/apps/web/lib/swr/use-program-enrollments-count.ts
+++ b/apps/web/lib/swr/use-program-enrollments-count.ts
@@ -12,11 +12,7 @@ export default function useProgramEnrollmentsCount(
 
   const { data: count, isLoading } = useSWR<number>(
     partnerId &&
-      `/api/partner-profile/programs/count?${new URLSearchParams(
-        Object.fromEntries(
-          Object.entries(query).map(([key, value]) => [key, value.toString()]),
-        ),
-      )}`,
+      `/api/partner-profile/programs/count?${new URLSearchParams(query)}`,
     fetcher,
     {
       dedupingInterval: 60000,

--- a/apps/web/lib/zod/schemas/partner-profile.ts
+++ b/apps/web/lib/zod/schemas/partner-profile.ts
@@ -122,3 +122,6 @@ export const partnerProfileProgramsQuerySchema = z.object({
   includeRewardsDiscounts: z.coerce.boolean().optional(),
   status: z.nativeEnum(ProgramEnrollmentStatus).optional(),
 });
+
+export const partnerProfileProgramsCountQuerySchema =
+  partnerProfileProgramsQuerySchema.pick({ status: true });

--- a/apps/web/ui/layout/sidebar/partners-sidebar-nav.tsx
+++ b/apps/web/ui/layout/sidebar/partners-sidebar-nav.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import useProgramEnrollment from "@/lib/swr/use-program-enrollment";
+import useProgramEnrollmentsCount from "@/lib/swr/use-program-enrollments-count";
 import { useRouterStuff } from "@dub/ui";
 import {
   CircleDollar,
@@ -30,6 +31,7 @@ type SidebarNavData = {
   queryString?: string;
   programSlug?: string;
   isUnapproved: boolean;
+  invitationsCount?: number;
 };
 
 const NAV_GROUPS: SidebarNavGroups<SidebarNavData> = ({ pathname }) => [
@@ -61,7 +63,7 @@ const NAV_GROUPS: SidebarNavGroups<SidebarNavData> = ({ pathname }) => [
 
 const NAV_AREAS: SidebarNavAreas<SidebarNavData> = {
   // Top-level
-  programs: () => ({
+  programs: ({ invitationsCount }) => ({
     title: (
       <div className="mb-3">
         <PartnerProgramDropdown />
@@ -84,6 +86,7 @@ const NAV_AREAS: SidebarNavAreas<SidebarNavData> = {
             name: "Invitations",
             icon: UserCheck,
             href: "/programs/invitations",
+            badge: invitationsCount || undefined,
           },
         ],
       },
@@ -239,6 +242,10 @@ export function PartnersSidebarNav({
             : "programs";
   }, [pathname, programSlug, isEnrolledProgramPage]);
 
+  const { count: invitationsCount } = useProgramEnrollmentsCount({
+    status: "invited",
+  });
+
   return (
     <SidebarNav
       groups={NAV_GROUPS}
@@ -250,6 +257,7 @@ export function PartnersSidebarNav({
         programSlug: programSlug || "",
         isUnapproved:
           !!programEnrollment && programEnrollment.status !== "approved",
+        invitationsCount,
       }}
       toolContent={toolContent}
       newsContent={newsContent}


### PR DESCRIPTION
<img width="274" alt="Screenshot 2025-07-03 at 5 10 46 PM" src="https://github.com/user-attachments/assets/ad406d62-f237-4b5c-a66d-fe638fd6b688" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a badge to the "Invitations" menu item in the sidebar showing the count of pending program invitations.
  * Introduced a new API endpoint to fetch the count of program enrollments for partners.
  * Added a React hook to retrieve and display program enrollment counts with optional status filtering.

* **Enhancements**
  * Sidebar navigation dynamically updates the invitations count badge based on live data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->