### PR TITLE
fix: improve partner sale alert email for zero holding periods

### DIFF
--- a/packages/email/src/templates/new-sale-alert-partner.tsx
+++ b/packages/email/src/templates/new-sale-alert-partner.tsx
@@ -23,7 +23,7 @@ export default function NewSaleAlertPartner({
     name: "Acme",
     slug: "acme",
     logo: DUB_WORDMARK,
-    holdingPeriodDays: 0,
+    holdingPeriodDays: 30,
   },
   sale = {
     amount: 4900,

--- a/packages/email/src/templates/new-sale-alert-partner.tsx
+++ b/packages/email/src/templates/new-sale-alert-partner.tsx
@@ -23,7 +23,7 @@ export default function NewSaleAlertPartner({
     name: "Acme",
     slug: "acme",
     logo: DUB_WORDMARK,
-    holdingPeriodDays: 30,
+    holdingPeriodDays: 0,
   },
   sale = {
     amount: 4900,
@@ -96,18 +96,28 @@ export default function NewSaleAlertPartner({
             <Text className="text-sm leading-6 text-neutral-600">
               You received{" "}
               <strong className="text-black">{earningsInDollars}</strong> in
-              commission for this sale and it will be eligible for payout after
-              the program's {program.holdingPeriodDays}-day holding period (
-              <strong>
-                {new Date(
-                  Date.now() + program.holdingPeriodDays * 24 * 60 * 60 * 1000,
-                ).toLocaleDateString("en-US", {
-                  month: "long",
-                  day: "numeric",
-                  year: "numeric",
-                })}
-              </strong>
-              ).
+              commission for this sale
+              {program.holdingPeriodDays > 0 ? (
+                <>
+                  {" "}
+                  and it will be eligible for payout after the program's{" "}
+                  {program.holdingPeriodDays}-day holding period (
+                  <strong>
+                    {new Date(
+                      Date.now() +
+                        program.holdingPeriodDays * 24 * 60 * 60 * 1000,
+                    ).toLocaleDateString("en-US", {
+                      month: "long",
+                      day: "numeric",
+                      year: "numeric",
+                    })}
+                  </strong>
+                  )
+                </>
+              ) : (
+                " and it will be included in your next payout"
+              )}
+              .
             </Text>
 
             <Section className="mb-12 mt-8">


### PR DESCRIPTION
- Hide holding period clause when program has 0-day holding period
- Improve text formatting and readability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated commission payout messaging in sale alert emails to reflect whether a holding period applies. If there is no holding period, the message now states the commission will be included in the next payout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->