### PR TITLE
configureVercelNameservers for .link domains

### DIFF
--- a/apps/web/lib/api/domains/claim-dot-link-domain.ts
+++ b/apps/web/lib/api/domains/claim-dot-link-domain.ts
@@ -9,6 +9,7 @@ import { DEFAULT_LINK_PROPS } from "@dub/utils";
 import { get } from "@vercel/edge-config";
 import { waitUntil } from "@vercel/functions";
 import { addDomainToVercel } from "./add-domain-vercel";
+import { configureVercelNameservers } from "./configure-vercel-nameservers";
 import { markDomainAsDeleted } from "./mark-domain-deleted";
 
 export async function claimDotLinkDomain({
@@ -87,7 +88,7 @@ export async function claimDotLinkDomain({
   // if the domain was added to a different workspace but is not verified
   // we should remove it to free up the domain for the current workspace
   if (matchingUnverifiedDomain) {
-    const { projectId, slug } = matchingUnverifiedDomain;
+    const { slug } = matchingUnverifiedDomain;
 
     await markDomainAsDeleted({
       domain: slug,
@@ -127,8 +128,8 @@ export async function claimDotLinkDomain({
 
   waitUntil(
     Promise.all([
-      // add domain to Vercel
-      addDomainToVercel(domain),
+      // add domain to Vercel + configure it to use Vercel nameservers
+      addDomainToVercel(domain).then(() => configureVercelNameservers(domain)),
 
       // send email to workspace owners
       !skipWorkspaceChecks

--- a/apps/web/lib/api/domains/configure-vercel-nameservers.ts
+++ b/apps/web/lib/api/domains/configure-vercel-nameservers.ts
@@ -1,0 +1,19 @@
+import { CustomResponse } from "./utils";
+
+export const configureVercelNameservers = async (
+  domain: string,
+): Promise<CustomResponse> => {
+  return await fetch(
+    `https://api.vercel.com/v3/domains/${domain}?teamId=${process.env.TEAM_ID_VERCEL}`,
+    {
+      method: "PATCH",
+      headers: {
+        Authorization: `Bearer ${process.env.AUTH_BEARER_TOKEN}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        zone: true,
+      }),
+    },
+  ).then((res) => res.json());
+};

--- a/apps/web/lib/api/domains/configure-vercel-nameservers.ts
+++ b/apps/web/lib/api/domains/configure-vercel-nameservers.ts
@@ -12,6 +12,7 @@ export const configureVercelNameservers = async (
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
+        op: "update",
         zone: true,
       }),
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved domain setup process by automatically configuring Vercel nameservers after adding a domain. This streamlines the experience when claiming a domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->