### PR TITLE
fix(ui): display email validation error on empty submit

### DIFF
--- a/apps/web/ui/auth/login/email-sign-in.tsx
+++ b/apps/web/ui/auth/login/email-sign-in.tsx
@@ -30,7 +30,7 @@ export const EmailSignIn = ({ next }: { next?: string }) => {
 
   const { executeAsync, isPending } = useAction(checkAccountExistsAction, {
     onError: ({ error }) => {
-      toast.error(error.serverError);
+      toast.error(error.serverError || error.validationErrors?.email?.[0]);
     },
   });
 


### PR DESCRIPTION
When submitting the email sign-in form with an empty email field, say for example when removing the 'required' attribute from the input, the error toast would appear empty.