### PR TITLE
Safari select fix

### DIFF
--- a/packages/ui/src/table/table.tsx
+++ b/packages/ui/src/table/table.tsx
@@ -325,6 +325,14 @@ export function Table<T>({
             scrollWrapperClassName,
           )}
         >
+          {/* Selection Toolbar Overlay */}
+          {selectionEnabled && (
+            <SelectionToolbar
+              table={table}
+              controls={selectionControls}
+              className="top-0 left-0 right-0"
+            />
+          )}
           <table
             className={cn(
               [
@@ -425,9 +433,7 @@ export function Table<T>({
                   })}
                 </tr>
               ))}
-              {selectionEnabled && (
-                <SelectionToolbar table={table} controls={selectionControls} />
-              )}
+              {/* SelectionToolbar row removed from here */}
             </thead>
             <tbody>
               {table.getRowModel().rows.map((row) => {


### PR DESCRIPTION
Moved SelectionToolbar from inside the table header to an absolute overlay above the table, to make it look the same across all browsers, but mostly to fix the weird safari location.

**Before**
![CleanShot 2025-07-08 at 12 57 13@2x](https://github.com/user-attachments/assets/6c4c2b10-50ba-40ee-9626-1a3012724ac6)

**After**
![CleanShot 2025-07-08 at 14 30 13@2x](https://github.com/user-attachments/assets/b969d8a7-6144-4196-9596-d5ae731ef42b)
