### PR TITLE
Make company name optional in the payout settings modal

### DIFF
--- a/apps/web/app/(ee)/partners.dub.co/(dashboard)/payouts/payout-settings-modal.tsx
+++ b/apps/web/app/(ee)/partners.dub.co/(dashboard)/payouts/payout-settings-modal.tsx
@@ -85,10 +85,6 @@ function PayoutSettingsModalInner({
     await executeAsync(data);
   };
 
-  const shouldDisableSubmit = useMemo(() => {
-    return !watch("companyName") || !isDirty;
-  }, [watch, isDirty]);
-
   const minWithdrawalAmount = watch("minWithdrawalAmount");
 
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -182,10 +178,9 @@ function PayoutSettingsModalInner({
               </label>
               <div className="relative mt-1.5 rounded-md shadow-sm">
                 <input
-                  required
                   autoFocus
                   className="block w-full rounded-md border-neutral-300 text-neutral-900 placeholder-neutral-400 focus:border-neutral-500 focus:outline-none focus:ring-neutral-500 sm:text-sm"
-                  {...register("companyName", { required: true })}
+                  {...register("companyName")}
                 />
               </div>
             </div>
@@ -233,7 +228,7 @@ function PayoutSettingsModalInner({
           text="Save"
           className="h-8 w-fit px-3"
           loading={isPending}
-          disabled={shouldDisableSubmit}
+          disabled={!isDirty}
           type="submit"
         />
       </div>

--- a/apps/web/lib/zod/schemas/partners.ts
+++ b/apps/web/lib/zod/schemas/partners.ts
@@ -581,7 +581,7 @@ export const archivePartnerSchema = z.object({
 });
 
 export const partnerPayoutSettingsSchema = z.object({
-  companyName: z.string().max(190).trim().min(1, "Business name is required."),
+  companyName: z.string().max(190).trim().nullish(),
   address: z.string().max(500).trim().nullish(),
   taxId: z.string().max(100).trim().nullish(),
   minWithdrawalAmount: z.coerce


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The "companyName" field in payout settings is now optional instead of required.

* **Refactor**
  * The submit button in the payout settings modal is now enabled based solely on whether the form has been modified, regardless of the "companyName" field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->