### PR TITLE
Remove old externalId prop from OpenAPI (but keep backwards compatibi…

### DIFF
--- a/apps/web/lib/zod/schemas/leads.ts
+++ b/apps/web/lib/zod/schemas/leads.ts
@@ -70,13 +70,6 @@ export const trackLeadRequestSchema = z.object({
     .describe(
       "Additional metadata to be stored with the lead event. Max 10,000 characters.",
     ),
-  externalId: z
-    .string()
-    .trim()
-    .max(100)
-    .nullish()
-    .describe("Deprecated. Use `customerExternalId` instead.")
-    .openapi({ deprecated: true }),
 });
 
 export const trackLeadResponseSchema = z.object({

--- a/apps/web/lib/zod/schemas/sales.ts
+++ b/apps/web/lib/zod/schemas/sales.ts
@@ -63,13 +63,6 @@ export const trackSaleRequestSchema = z.object({
     .describe(
       "Additional metadata to be stored with the sale event. Max 10,000 characters when stringified.",
     ),
-  externalId: z
-    .string()
-    .trim()
-    .max(100)
-    .nullish()
-    .describe("Deprecated. Use `customerExternalId` instead.")
-    .openapi({ deprecated: true }),
 });
 
 export const trackSaleResponseSchema = z.object({


### PR DESCRIPTION
…lity)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated request validation to remove the deprecated "externalId" field from lead and sale tracking forms. Users should now use "customerExternalId" instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->