### PR TITLE
Refactor payout processing to use invoiceId only

### DIFF
--- a/apps/web/app/(ee)/api/cron/payouts/charge-succeeded/route.ts
+++ b/apps/web/app/(ee)/api/cron/payouts/charge-succeeded/route.ts
@@ -2,11 +2,15 @@ import { handleAndReturnErrorResponse } from "@/lib/api/errors";
 import { verifyQstashSignature } from "@/lib/cron/verify-qstash";
 import { prisma } from "@dub/prisma";
 import { log } from "@dub/utils";
+import { z } from "zod";
 import { sendPaypalPayouts } from "./send-paypal-payouts";
 import { sendStripePayouts } from "./send-stripe-payouts";
-import { payloadSchema } from "./utils";
 
 export const dynamic = "force-dynamic";
+
+const payloadSchema = z.object({
+  invoiceId: z.string(),
+});
 
 // POST /api/cron/payouts/charge-succeeded
 // This route is used to process the charge-succeeded event from Stripe
@@ -17,8 +21,7 @@ export async function POST(req: Request) {
     const rawBody = await req.text();
     await verifyQstashSignature({ req, rawBody });
 
-    const body = payloadSchema.parse(JSON.parse(rawBody));
-    const { invoiceId } = body;
+    const { invoiceId } = payloadSchema.parse(JSON.parse(rawBody));
 
     const invoice = await prisma.invoice.findUnique({
       where: {
@@ -53,11 +56,11 @@ export async function POST(req: Request) {
 
     await Promise.allSettled([
       sendStripePayouts({
-        payload: body,
+        invoiceId,
       }),
 
       sendPaypalPayouts({
-        payload: body,
+        invoiceId,
       }),
     ]);
 

--- a/apps/web/app/(ee)/api/cron/payouts/charge-succeeded/send-paypal-payouts.ts
+++ b/apps/web/app/(ee)/api/cron/payouts/charge-succeeded/send-paypal-payouts.ts
@@ -3,11 +3,8 @@ import { resend } from "@dub/email/resend";
 import { VARIANT_TO_FROM_MAP } from "@dub/email/resend/constants";
 import PartnerPayoutProcessed from "@dub/email/templates/partner-payout-processed";
 import { prisma } from "@dub/prisma";
-import { Payload } from "./utils";
 
-export async function sendPaypalPayouts({ payload }: { payload: Payload }) {
-  const { invoiceId } = payload;
-
+export async function sendPaypalPayouts({ invoiceId }: { invoiceId: string }) {
   const payouts = await prisma.payout.findMany({
     where: {
       invoiceId,

--- a/apps/web/app/(ee)/api/cron/payouts/charge-succeeded/send-stripe-payouts.ts
+++ b/apps/web/app/(ee)/api/cron/payouts/charge-succeeded/send-stripe-payouts.ts
@@ -8,11 +8,8 @@ import PartnerPayoutProcessed from "@dub/email/templates/partner-payout-processe
 import { prisma } from "@dub/prisma";
 import { currencyFormatter, pluralize } from "@dub/utils";
 import { Prisma } from "@prisma/client";
-import { Payload } from "./utils";
 
-export async function sendStripePayouts({ payload }: { payload: Payload }) {
-  const { invoiceId } = payload;
-
+export async function sendStripePayouts({ invoiceId }: { invoiceId: string }) {
   const commonInclude = Prisma.validator<Prisma.PayoutInclude>()({
     partner: {
       select: {

--- a/apps/web/app/(ee)/api/cron/payouts/charge-succeeded/utils.ts
+++ b/apps/web/app/(ee)/api/cron/payouts/charge-succeeded/utils.ts
@@ -1,9 +1,0 @@
-import { z } from "zod";
-
-export const payloadSchema = z.object({
-  chargeId: z.string(),
-  invoiceId: z.string(),
-  achCreditTransfer: z.boolean(),
-});
-
-export type Payload = z.infer<typeof payloadSchema>;

--- a/apps/web/app/(ee)/api/stripe/webhook/charge-succeeded.ts
+++ b/apps/web/app/(ee)/api/stripe/webhook/charge-succeeded.ts
@@ -64,11 +64,7 @@ export async function chargeSucceeded(event: Stripe.Event) {
   const qstashResponse = await qstash.publishJSON({
     url: `${APP_DOMAIN_WITH_NGROK}/api/cron/payouts/charge-succeeded`,
     body: {
-      chargeId,
       invoiceId: invoice.id,
-      achCreditTransfer: Boolean(
-        charge.payment_method_details?.ach_credit_transfer,
-      ),
     },
   });
 


### PR DESCRIPTION
Simplifies the payload for payout processing by removing unused fields and the shared utils file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the handling of payout processing by updating function parameters to accept only the invoice ID, removing unnecessary nested objects.
  * Streamlined schema validation and removed unused schema and types related to charge and ACH transfer details.

* **Chores**
  * Removed obsolete code and cleaned up imports for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->