### PR TITLE
Overview logo alignment and date range picker fix

### DIFF
--- a/apps/web/app/(ee)/partners.dub.co/(dashboard)/programs/[programSlug]/(enrolled)/page-client.tsx
+++ b/apps/web/app/(ee)/partners.dub.co/(dashboard)/programs/[programSlug]/(enrolled)/page-client.tsx
@@ -279,7 +279,7 @@ function EarningsChart() {
             href={`/programs/${programSlug}/earnings${getQueryString()}`}
           />
           <SimpleDateRangePicker
-            className="h-7 w-full px-2.5 text-xs font-medium md:w-fit"
+            className="h-7 min-w-0 flex-1 px-2.5 text-xs font-medium md:w-fit md:flex-none"
             align="end"
           />
         </div>

--- a/apps/web/ui/partners/hero-background.tsx
+++ b/apps/web/ui/partners/hero-background.tsx
@@ -326,7 +326,7 @@ export function HeroBackground({
 
       <div
         className={cn(
-          "absolute right-4 top-4 block size-6 min-[300px]:size-8",
+          "absolute right-4 top-3 block size-6 min-[300px]:size-8",
 
           // Position based on cqh to adjust for container height
           "",


### PR DESCRIPTION
Fixed the alignment of the overview logo.
<img width="2074" height="616" alt="CleanShot 2025-07-17 at 08 10 00@2x" src="https://github.com/user-attachments/assets/6e0c0aab-6650-4174-86b9-2037de53dd20" />


Fixed the date range on small screens to not overlap the view more button on small screens.
<img width="1998" height="1578" alt="CleanShot 2025-07-17 at 08 41 40@2x" src="https://github.com/user-attachments/assets/20d262dd-0a17-46fe-a014-452e7f76aa36" />
