### PR TITLE
AB testing date picker fix

### DIFF
--- a/apps/web/ui/modals/link-builder/ab-testing-modal.tsx
+++ b/apps/web/ui/modals/link-builder/ab-testing-modal.tsx
@@ -54,6 +54,7 @@ function ABTestingModal({
   setShowABTestingModal: Dispatch<SetStateAction<boolean>>;
 }) {
   const id = useId();
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const {
     watch: watchParent,
@@ -400,6 +401,7 @@ function ABTestingModal({
           </div>
           <div className="mt-2 flex w-full items-center justify-between rounded-md border border-neutral-300 bg-white shadow-sm transition-all focus-within:border-neutral-800 focus-within:outline-none focus-within:ring-1 focus-within:ring-neutral-500">
             <input
+              ref={inputRef}
               id={`${id}-testCompletedAt`}
               type="text"
               placeholder='E.g. "in 2 weeks" or "next month"'
@@ -433,6 +435,9 @@ function ABTestingModal({
                 setValue("testCompletedAt", completeDate, {
                   shouldDirty: true,
                 });
+                if (inputRef.current) {
+                  inputRef.current.value = formatDateTime(completeDate);
+                }
               }}
               className="w-[40px] border-none bg-transparent text-neutral-500 focus:outline-none focus:ring-0 sm:text-sm"
             />

--- a/apps/web/ui/modals/link-builder/ab-testing/ab-testing-modal.tsx
+++ b/apps/web/ui/modals/link-builder/ab-testing/ab-testing-modal.tsx
@@ -34,6 +34,7 @@ import {
   useCallback,
   useId,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { useForm, useFormContext } from "react-hook-form";
@@ -91,6 +92,7 @@ function ABTestingEdit({
   setShowABTestingModal: Dispatch<SetStateAction<boolean>>;
 }) {
   const id = useId();
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const {
     watch: watchParent,
@@ -442,6 +444,7 @@ function ABTestingEdit({
           </div>
           <div className="mt-2 flex w-full items-center justify-between rounded-md border border-neutral-300 bg-white shadow-sm transition-all focus-within:border-neutral-800 focus-within:outline-none focus-within:ring-1 focus-within:ring-neutral-500">
             <input
+              ref={inputRef}
               id={`${id}-testCompletedAt`}
               type="text"
               placeholder='E.g. "in 2 weeks" or "next month"'
@@ -475,6 +478,9 @@ function ABTestingEdit({
                 setValue("testCompletedAt", completeDate, {
                   shouldDirty: true,
                 });
+                if (inputRef.current) {
+                  inputRef.current.value = formatDateTime(completeDate);
+                }
               }}
               className="w-[40px] border-none bg-transparent text-neutral-500 focus:outline-none focus:ring-0 sm:text-sm"
             />


### PR DESCRIPTION
When clicking the date picker, the field wasn't updating, but the input actually was.

Now the date picker behaves the same way as the expiration date.

Tested by creating an AB test and the date completed as scheduled.

**Update**
![CleanShot 2025-07-17 at 20 40 09](https://github.com/user-attachments/assets/2f15fab3-02b2-4994-a876-18373fd5b391)



**Current**
![CleanShot 2025-07-17 at 20 40 34](https://github.com/user-attachments/assets/9403f1a5-420f-486b-bbf2-b4cce8621d66)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization between the date picker and the human-readable date field in the A/B Testing modal, ensuring both fields display consistent values when the completion date is changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->