### PR TITLE
fix: add quotes around port mappings in `docker-compose.yml`

### DIFF
--- a/apps/web/docker-compose.yml
+++ b/apps/web/docker-compose.yml
@@ -15,7 +15,7 @@ services:
         "--default-authentication-plugin=mysql_native_password",
       ]
     ports:
-      - 3306:3306
+      - "3306:3306"
     volumes:
       - ps-mysql:/var/lib/mysql
 
@@ -31,7 +31,7 @@ services:
     depends_on:
       - ps-mysql
     ports:
-      - 3900:3900
+      - "3900:3900"
     links:
       - ps-mysql
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated formatting of port mappings in configuration files to improve compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->