### PR TITLE
Partner notification settings

### DIFF
--- a/apps/web/app/(ee)/api/partner-profile/notification-preferences/route.ts
+++ b/apps/web/app/(ee)/api/partner-profile/notification-preferences/route.ts
@@ -1,0 +1,23 @@
+import { withPartnerProfile } from "@/lib/auth/partner";
+import { prisma } from "@dub/prisma";
+import { NextResponse } from "next/server";
+
+// GET /api/partner-profile/notification-preferences – get notification preferences for the current partner+user
+export const GET = withPartnerProfile(async ({ partner, session }) => {
+  const response = await prisma.partnerNotificationPreferences.findFirstOrThrow(
+    {
+      select: {
+        sale: true,
+        applicationApproved: true,
+      },
+      where: {
+        partnerUser: {
+          partnerId: partner.id,
+          userId: session.user.id,
+        },
+      },
+    },
+  );
+
+  return NextResponse.json(response);
+});

--- a/apps/web/app/(ee)/api/partner-profile/notification-preferences/route.ts
+++ b/apps/web/app/(ee)/api/partner-profile/notification-preferences/route.ts
@@ -7,7 +7,7 @@ export const GET = withPartnerProfile(async ({ partner, session }) => {
   const response = await prisma.partnerNotificationPreferences.findFirstOrThrow(
     {
       select: {
-        sale: true,
+        newCommission: true,
         applicationApproved: true,
       },
       where: {

--- a/apps/web/app/(ee)/api/partner-profile/notification-preferences/route.ts
+++ b/apps/web/app/(ee)/api/partner-profile/notification-preferences/route.ts
@@ -6,15 +6,15 @@ import { NextResponse } from "next/server";
 export const GET = withPartnerProfile(async ({ partner, session }) => {
   const response = await prisma.partnerNotificationPreferences.findFirstOrThrow(
     {
-      select: {
-        newCommission: true,
-        applicationApproved: true,
-      },
       where: {
         partnerUser: {
           partnerId: partner.id,
           userId: session.user.id,
         },
+      },
+      select: {
+        commissionCreated: true,
+        applicationApproved: true,
       },
     },
   );

--- a/apps/web/app/(ee)/partners.dub.co/(dashboard)/settings/notifications/page-client.tsx
+++ b/apps/web/app/(ee)/partners.dub.co/(dashboard)/settings/notifications/page-client.tsx
@@ -35,7 +35,7 @@ export function PartnerSettingsNotificationsPageClient() {
     isLoading,
     update,
   } = useOptimisticUpdate<Preferences>(
-    `/api/partner-profile/notification-preferences`,
+    "/api/partner-profile/notification-preferences",
     {
       loading: "Updating notification preference...",
       success: "Notification preference updated.",

--- a/apps/web/app/(ee)/partners.dub.co/(dashboard)/settings/notifications/page-client.tsx
+++ b/apps/web/app/(ee)/partners.dub.co/(dashboard)/settings/notifications/page-client.tsx
@@ -16,10 +16,10 @@ type Preferences = Record<PreferenceType, boolean>;
 
 const notifications = [
   {
-    type: "sale",
+    type: "commissionCreated",
     icon: InvoiceDollar,
-    title: "New sale",
-    description: "Alert when a new sale is made.",
+    title: "New commission event",
+    description: "Alert when a new commission event is created.",
   },
   {
     type: "applicationApproved",

--- a/apps/web/app/(ee)/partners.dub.co/(dashboard)/settings/notifications/page-client.tsx
+++ b/apps/web/app/(ee)/partners.dub.co/(dashboard)/settings/notifications/page-client.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { updatePartnerNotificationPreference } from "@/lib/actions/partners/update-partner-notification-preference";
+import { partnerNotificationTypes } from "@/lib/zod/schemas/partner-profile";
+import {
+  CircleCheck,
+  InvoiceDollar,
+  Switch,
+  useOptimisticUpdate,
+} from "@dub/ui";
+import { useAction } from "next-safe-action/hooks";
+import { z } from "zod";
+
+type PreferenceType = z.infer<typeof partnerNotificationTypes>;
+type Preferences = Record<PreferenceType, boolean>;
+
+const notifications = [
+  {
+    type: "sale",
+    icon: InvoiceDollar,
+    title: "New sale",
+    description: "Alert when a new sale is made.",
+  },
+  {
+    type: "applicationApproved",
+    icon: CircleCheck,
+    title: "Application approval",
+    description: "Alert when an application to a program is approved.",
+  },
+];
+
+export function PartnerSettingsNotificationsPageClient() {
+  const {
+    data: preferences,
+    isLoading,
+    update,
+  } = useOptimisticUpdate<Preferences>(
+    `/api/partner-profile/notification-preferences`,
+    {
+      loading: "Updating notification preference...",
+      success: "Notification preference updated.",
+      error: "Failed to update notification preference.",
+    },
+  );
+
+  const { executeAsync } = useAction(updatePartnerNotificationPreference);
+
+  const handleUpdate = async ({
+    type,
+    value,
+    currentPreferences,
+  }: {
+    type: string;
+    value: boolean;
+    currentPreferences: Preferences;
+  }) => {
+    await executeAsync({
+      type: type as PreferenceType,
+      value,
+    });
+
+    return {
+      ...currentPreferences,
+      [type]: value,
+    };
+  };
+
+  return (
+    <div className="mt-2 grid grid-cols-1 gap-3">
+      {notifications.map(({ type, icon: Icon, title, description }) => (
+        <div
+          key={type}
+          className="flex items-center justify-between gap-4 rounded-xl border border-neutral-200 bg-white p-5"
+        >
+          <div className="flex min-w-0 items-center gap-4">
+            <div className="hidden rounded-full border border-neutral-200 sm:block">
+              <div className="rounded-full border border-white bg-gradient-to-t from-neutral-100 p-1 md:p-3">
+                <Icon className="size-5" />
+              </div>
+            </div>
+            <div className="overflow-hidden">
+              <div className="flex items-center gap-1.5 sm:gap-2.5">
+                <div className="truncate text-sm font-medium">{title}</div>
+              </div>
+              <div className="mt-1 flex items-center gap-1 text-xs">
+                <span className="whitespace-pre-wrap text-neutral-500">
+                  {description}
+                </span>
+              </div>
+            </div>
+          </div>
+          <Switch
+            checked={preferences?.[type] ?? false}
+            disabled={isLoading}
+            fn={(checked: boolean) => {
+              if (!preferences) return;
+
+              update(
+                () =>
+                  handleUpdate({
+                    type,
+                    value: checked,
+                    currentPreferences: preferences,
+                  }),
+                {
+                  ...preferences,
+                  [type]: checked,
+                },
+              );
+            }}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/app/(ee)/partners.dub.co/(dashboard)/settings/notifications/page-client.tsx
+++ b/apps/web/app/(ee)/partners.dub.co/(dashboard)/settings/notifications/page-client.tsx
@@ -27,7 +27,7 @@ const notifications = [
     title: "Application approval",
     description: "Alert when an application to a program is approved.",
   },
-];
+] as const;
 
 export function PartnerSettingsNotificationsPageClient() {
   const {
@@ -50,12 +50,12 @@ export function PartnerSettingsNotificationsPageClient() {
     value,
     currentPreferences,
   }: {
-    type: string;
+    type: PreferenceType;
     value: boolean;
     currentPreferences: Preferences;
   }) => {
     await executeAsync({
-      type: type as PreferenceType,
+      type,
       value,
     });
 

--- a/apps/web/app/(ee)/partners.dub.co/(dashboard)/settings/notifications/page.tsx
+++ b/apps/web/app/(ee)/partners.dub.co/(dashboard)/settings/notifications/page.tsx
@@ -1,0 +1,19 @@
+import { PageContent } from "@/ui/layout/page-content";
+import { PageWidthWrapper } from "@/ui/layout/page-width-wrapper";
+import { PartnerSettingsNotificationsPageClient } from "./page-client";
+
+export default function PartnerSettingsNotificationsPage() {
+  return (
+    <PageContent
+      title="Notifications"
+      titleInfo={{
+        title:
+          "Adjust your personal notification preferences and choose which updates you want to receive. These settings will only be applied to your personal account.",
+      }}
+    >
+      <PageWidthWrapper>
+        <PartnerSettingsNotificationsPageClient />
+      </PageWidthWrapper>
+    </PageContent>
+  );
+}

--- a/apps/web/lib/actions/partners/bulk-approve-partners.ts
+++ b/apps/web/lib/actions/partners/bulk-approve-partners.ts
@@ -37,7 +37,7 @@ export const bulkApprovePartnersAction = authActionClient
               include: {
                 users: {
                   where: {
-                    notificationPreference: {
+                    notificationPreferences: {
                       applicationApproved: true,
                     },
                   },

--- a/apps/web/lib/actions/partners/bulk-approve-partners.ts
+++ b/apps/web/lib/actions/partners/bulk-approve-partners.ts
@@ -33,7 +33,20 @@ export const bulkApprovePartnersAction = authActionClient
             },
           },
           include: {
-            partner: true,
+            partner: {
+              include: {
+                users: {
+                  where: {
+                    notificationPreference: {
+                      applicationApproved: true,
+                    },
+                  },
+                  include: {
+                    user: true,
+                  },
+                },
+              },
+            },
           },
         },
       },

--- a/apps/web/lib/actions/partners/onboard-partner.ts
+++ b/apps/web/lib/actions/partners/onboard-partner.ts
@@ -60,7 +60,7 @@ export const onboardPartnerAction = authUserActionClient
           create: {
             userId: user.id,
             role: "owner",
-            notificationPreference: {
+            notificationPreferences: {
               create: {},
             },
           },

--- a/apps/web/lib/actions/partners/onboard-partner.ts
+++ b/apps/web/lib/actions/partners/onboard-partner.ts
@@ -60,6 +60,7 @@ export const onboardPartnerAction = authUserActionClient
           create: {
             userId: user.id,
             role: "owner",
+            notificationPreference: {},
           },
         },
       },

--- a/apps/web/lib/actions/partners/onboard-partner.ts
+++ b/apps/web/lib/actions/partners/onboard-partner.ts
@@ -60,7 +60,9 @@ export const onboardPartnerAction = authUserActionClient
           create: {
             userId: user.id,
             role: "owner",
-            notificationPreference: {},
+            notificationPreference: {
+              create: {},
+            },
           },
         },
       },

--- a/apps/web/lib/actions/partners/update-partner-notification-preference.ts
+++ b/apps/web/lib/actions/partners/update-partner-notification-preference.ts
@@ -1,0 +1,37 @@
+"use server";
+
+import { partnerNotificationTypes } from "@/lib/zod/schemas/partner-profile";
+import { prisma } from "@dub/prisma";
+import z from "../../zod";
+import { authPartnerActionClient } from "../safe-action";
+
+const schema = z.object({
+  type: partnerNotificationTypes,
+  value: z.boolean(),
+});
+
+// Update the notification preference for a partner+user
+export const updatePartnerNotificationPreference = authPartnerActionClient
+  .schema(schema)
+  .action(async ({ ctx, parsedInput }) => {
+    const { user, partner } = ctx;
+    const { type, value } = parsedInput;
+
+    await prisma.partnerUser.update({
+      where: {
+        userId_partnerId: {
+          userId: user.id,
+          partnerId: partner.id,
+        },
+      },
+      data: {
+        notificationPreference: {
+          update: {
+            [type]: value,
+          },
+        },
+      },
+    });
+
+    return { ok: true };
+  });

--- a/apps/web/lib/actions/partners/update-partner-notification-preference.ts
+++ b/apps/web/lib/actions/partners/update-partner-notification-preference.ts
@@ -25,7 +25,7 @@ export const updatePartnerNotificationPreference = authPartnerActionClient
         },
       },
       data: {
-        notificationPreference: {
+        notificationPreferences: {
           update: {
             [type]: value,
           },

--- a/apps/web/lib/api/partners/notify-partner-application.ts
+++ b/apps/web/lib/api/partners/notify-partner-application.ts
@@ -1,8 +1,9 @@
-import { limiter } from "@/lib/cron/limiter";
-import { sendEmail } from "@dub/email";
+import { resend } from "@dub/email/resend";
+import { VARIANT_TO_FROM_MAP } from "@dub/email/resend/constants";
 import PartnerApplicationReceived from "@dub/email/templates/partner-application-received";
 import { prisma } from "@dub/prisma";
 import { Partner, Program, ProgramApplication } from "@dub/prisma/client";
+import { chunk } from "@dub/utils";
 
 export async function notifyPartnerApplication({
   partner,
@@ -39,36 +40,38 @@ export async function notifyPartnerApplication({
     },
   });
 
+  // Create all emails first, then chunk them into batches of 100
+  const allEmails = workspaceUsers.map(({ user, project }) => ({
+    subject: `New partner application for ${program.name}`,
+    from: VARIANT_TO_FROM_MAP.notifications,
+    to: user.email!,
+    react: PartnerApplicationReceived({
+      email: user.email!,
+      partner: {
+        id: partner.id,
+        name: partner.name,
+        email: partner.email!,
+        image: partner.image,
+        country: partner.country,
+        proposal: application.proposal,
+        comments: application.comments,
+      },
+      program: {
+        name: program.name,
+        autoApprovePartners: program.autoApprovePartnersEnabledAt
+          ? true
+          : false,
+      },
+      workspace: {
+        slug: project.slug,
+      },
+    }),
+  }));
+
+  const emailChunks = chunk(allEmails, 100);
+
+  // Send all emails in batches
   await Promise.all(
-    workspaceUsers.map(({ user, project }) =>
-      limiter.schedule(() =>
-        sendEmail({
-          subject: `New partner application for ${program.name}`,
-          email: user.email!,
-          react: PartnerApplicationReceived({
-            email: user.email!,
-            partner: {
-              id: partner.id,
-              name: partner.name,
-              email: partner.email!,
-              image: partner.image,
-              country: partner.country,
-              proposal: application.proposal,
-              comments: application.comments,
-            },
-            program: {
-              name: program.name,
-              autoApprovePartners: program.autoApprovePartnersEnabledAt
-                ? true
-                : false,
-            },
-            workspace: {
-              slug: project.slug,
-            },
-          }),
-          variant: "notifications",
-        }),
-      ),
-    ),
+    emailChunks.map((emailChunk) => resend?.batch.send(emailChunk)),
   );
 }

--- a/apps/web/lib/api/partners/notify-partner-sale.ts
+++ b/apps/web/lib/api/partners/notify-partner-sale.ts
@@ -49,8 +49,8 @@ export async function notifyPartnerSale({
         email: true,
         users: {
           where: {
-            notificationPreference: {
-              sale: true,
+            notificationPreferences: {
+              newCommission: true,
             },
           },
           select: {

--- a/apps/web/lib/api/partners/notify-partner-sale.ts
+++ b/apps/web/lib/api/partners/notify-partner-sale.ts
@@ -51,7 +51,7 @@ export async function notifyPartnerSale({
         users: {
           where: {
             notificationPreferences: {
-              newCommission: true,
+              commissionCreated: true,
             },
           },
           select: {

--- a/apps/web/lib/partners/approve-partner-enrollment.ts
+++ b/apps/web/lib/partners/approve-partner-enrollment.ts
@@ -163,29 +163,33 @@ export async function approvePartnerEnrollment({
       await Promise.allSettled([
         updatedLink ? recordLink(updatedLink) : Promise.resolve(null),
 
-        resend?.batch.send(
-          partnerEmailsToNotify.map((email) => ({
-            subject: `Your application to join ${program.name} partner program has been approved!`,
-            from: VARIANT_TO_FROM_MAP.notifications,
-            to: email,
-            react: PartnerApplicationApproved({
-              program: {
-                name: program.name,
-                logo: program.logo,
-                slug: program.slug,
-                supportEmail: program.supportEmail,
-              },
-              partner: {
-                name: partner.name,
-                email,
-                payoutsEnabled: Boolean(partner.payoutsEnabledAt),
-              },
-              rewardDescription: ProgramRewardDescription({
-                reward: rewards.find((r) => r.event === "sale"),
-              }),
-            }),
-          })),
-        ),
+        ...(partnerEmailsToNotify.length
+          ? [
+              resend?.batch.send(
+                partnerEmailsToNotify.map((email) => ({
+                  subject: `Your application to join ${program.name} partner program has been approved!`,
+                  from: VARIANT_TO_FROM_MAP.notifications,
+                  to: email,
+                  react: PartnerApplicationApproved({
+                    program: {
+                      name: program.name,
+                      logo: program.logo,
+                      slug: program.slug,
+                      supportEmail: program.supportEmail,
+                    },
+                    partner: {
+                      name: partner.name,
+                      email,
+                      payoutsEnabled: Boolean(partner.payoutsEnabledAt),
+                    },
+                    rewardDescription: ProgramRewardDescription({
+                      reward: rewards.find((r) => r.event === "sale"),
+                    }),
+                  }),
+                })),
+              ),
+            ]
+          : []),
 
         sendWorkspaceWebhook({
           workspace,

--- a/apps/web/lib/partners/approve-partner-enrollment.ts
+++ b/apps/web/lib/partners/approve-partner-enrollment.ts
@@ -84,7 +84,7 @@ export async function approvePartnerEnrollment({
           include: {
             users: {
               where: {
-                notificationPreference: {
+                notificationPreferences: {
                   applicationApproved: true,
                 },
               },

--- a/apps/web/lib/zod/schemas/partner-profile.ts
+++ b/apps/web/lib/zod/schemas/partner-profile.ts
@@ -127,4 +127,7 @@ export const partnerProfileProgramsQuerySchema = z.object({
 export const partnerProfileProgramsCountQuerySchema =
   partnerProfileProgramsQuerySchema.pick({ status: true });
 
-export const partnerNotificationTypes = z.enum(["sale", "applicationApproved"]);
+export const partnerNotificationTypes = z.enum([
+  "commissionCreated",
+  "applicationApproved",
+]);

--- a/apps/web/lib/zod/schemas/partner-profile.ts
+++ b/apps/web/lib/zod/schemas/partner-profile.ts
@@ -126,3 +126,5 @@ export const partnerProfileProgramsQuerySchema = z.object({
 
 export const partnerProfileProgramsCountQuerySchema =
   partnerProfileProgramsQuerySchema.pick({ status: true });
+
+export const partnerNotificationTypes = z.enum(["sale", "applicationApproved"]);

--- a/apps/web/scripts/backfill-notification-preferences.ts
+++ b/apps/web/scripts/backfill-notification-preferences.ts
@@ -1,0 +1,33 @@
+import { prisma } from "@dub/prisma";
+import "dotenv-flow/config";
+
+async function main() {
+  const partnerUsers = await prisma.partnerUser.findMany({
+    where: {
+      notificationPreferences: null,
+    },
+    select: {
+      id: true,
+    },
+    take: 100,
+  });
+
+  if (partnerUsers.length === 0) {
+    console.log("No partner users found without notification preferences");
+    return;
+  }
+
+  const result = await prisma.partnerNotificationPreferences.createMany({
+    data: partnerUsers.map((partnerUser) => ({
+      partnerUserId: partnerUser.id,
+    })),
+  });
+
+  console.log(
+    "Created notification preferences for",
+    result.count,
+    "partner users",
+  );
+}
+
+main();

--- a/apps/web/ui/layout/page-content/index.tsx
+++ b/apps/web/ui/layout/page-content/index.tsx
@@ -18,7 +18,7 @@ export function PageContent({
   children,
 }: PropsWithChildren<{
   title?: ReactNode;
-  titleInfo?: ReactNode | { title: string; href: string };
+  titleInfo?: ReactNode | { title: string; href?: string };
   titleBackHref?: string;
   controls?: ReactNode;
   className?: string;
@@ -26,10 +26,7 @@ export function PageContent({
 }>) {
   // Generate titleInfo from object if provided
   const finalTitleInfo =
-    titleInfo &&
-    typeof titleInfo === "object" &&
-    "title" in titleInfo &&
-    "href" in titleInfo ? (
+    titleInfo && typeof titleInfo === "object" && "title" in titleInfo ? (
       <InfoTooltip
         content={
           <SimpleTooltipContent

--- a/apps/web/ui/layout/sidebar/partners-sidebar-nav.tsx
+++ b/apps/web/ui/layout/sidebar/partners-sidebar-nav.tsx
@@ -202,6 +202,7 @@ const NAV_AREAS: SidebarNavAreas<SidebarNavData> = {
     direction: "left",
     content: [
       {
+        name: "Account",
         items: [
           {
             name: "Notifications",

--- a/apps/web/ui/layout/sidebar/partners-sidebar-nav.tsx
+++ b/apps/web/ui/layout/sidebar/partners-sidebar-nav.tsx
@@ -5,9 +5,11 @@ import useProgramEnrollmentsCount from "@/lib/swr/use-program-enrollments-count"
 import { useRouterStuff } from "@dub/ui";
 import {
   CircleDollar,
+  CircleInfo,
   CircleUser,
   ColorPalette2,
   Gauge6,
+  Gear,
   Gear2,
   Globe,
   GridIcon,
@@ -58,6 +60,13 @@ const NAV_GROUPS: SidebarNavGroups<SidebarNavData> = ({ pathname }) => [
     icon: SquareUserSparkle2,
     href: "/profile",
     active: pathname.startsWith("/profile"),
+  },
+  {
+    name: "Settings",
+    description: "Manage preferences for your partner account.",
+    icon: Gear,
+    href: "/settings/notifications",
+    active: pathname.startsWith("/settings"),
   },
 ];
 
@@ -187,6 +196,24 @@ const NAV_AREAS: SidebarNavAreas<SidebarNavData> = {
     ],
   }),
 
+  // Partner settings
+  partnerSettings: () => ({
+    title: "Settings",
+    direction: "left",
+    content: [
+      {
+        items: [
+          {
+            name: "Notifications",
+            icon: CircleInfo,
+            href: "/settings/notifications",
+            exact: true,
+          },
+        ],
+      },
+    ],
+  }),
+
   // User settings
   userSettings: () => ({
     title: "Settings",
@@ -233,13 +260,15 @@ export function PartnersSidebarNav({
   const currentArea = useMemo(() => {
     return pathname.startsWith("/account/settings")
       ? "userSettings"
-      : pathname.startsWith("/profile")
-        ? "profile"
-        : pathname.startsWith("/payouts")
-          ? null
-          : isEnrolledProgramPage
-            ? "program"
-            : "programs";
+      : pathname.startsWith("/settings")
+        ? "partnerSettings"
+        : pathname.startsWith("/profile")
+          ? "profile"
+          : pathname.startsWith("/payouts")
+            ? null
+            : isEnrolledProgramPage
+              ? "program"
+              : "programs";
   }, [pathname, programSlug, isEnrolledProgramPage]);
 
   const { count: invitationsCount } = useProgramEnrollmentsCount({

--- a/packages/email/src/templates/new-sale-alert-partner.tsx
+++ b/packages/email/src/templates/new-sale-alert-partner.tsx
@@ -128,7 +128,10 @@ export default function NewSaleAlertPartner({
                 View earnings
               </Link>
             </Section>
-            <Footer email={email} />
+            <Footer
+              email={email}
+              notificationSettingsUrl="https://partners.dub.co/settings/notifications"
+            />
           </Container>
         </Body>
       </Tailwind>

--- a/packages/email/src/templates/partner-application-approved.tsx
+++ b/packages/email/src/templates/partner-application-approved.tsx
@@ -169,7 +169,10 @@ export default function PartnerApplicationApproved({
               success!
             </Text>
 
-            <Footer email={partner.email} />
+            <Footer
+              email={partner.email}
+              notificationSettingsUrl="https://partners.dub.co/settings/notifications"
+            />
           </Container>
         </Body>
       </Tailwind>

--- a/packages/prisma/schema/partner.prisma
+++ b/packages/prisma/schema/partner.prisma
@@ -68,8 +68,20 @@ model PartnerUser {
   user    User    @relation(fields: [userId], references: [id], onDelete: Cascade)
   partner Partner @relation(fields: [partnerId], references: [id], onDelete: Cascade)
 
+  notificationPreference PartnerNotificationPreferences?
+
   @@unique([userId, partnerId])
   @@index([partnerId])
+}
+
+model PartnerNotificationPreferences {
+  id                         String  @id @default(cuid())
+  partnerUserId              String  @unique
+
+  sale                       Boolean @default(true)
+  applicationApproved        Boolean @default(true)
+
+  partnerUser PartnerUser @relation(fields: [partnerUserId], references: [id], onDelete: Cascade)
 }
 
 model PartnerInvite {

--- a/packages/prisma/schema/partner.prisma
+++ b/packages/prisma/schema/partner.prisma
@@ -80,7 +80,7 @@ model PartnerUser {
   user    User    @relation(fields: [userId], references: [id], onDelete: Cascade)
   partner Partner @relation(fields: [partnerId], references: [id], onDelete: Cascade)
 
-  notificationPreference PartnerNotificationPreferences?
+  notificationPreferences PartnerNotificationPreferences?
 
   @@unique([userId, partnerId])
   @@index([partnerId])

--- a/packages/prisma/schema/partner.prisma
+++ b/packages/prisma/schema/partner.prisma
@@ -89,7 +89,7 @@ model PartnerNotificationPreferences {
   id                         String  @id @default(cuid())
   partnerUserId              String  @unique
 
-  newCommission              Boolean @default(true)
+  commissionCreated              Boolean @default(true)
   applicationApproved        Boolean @default(true)
 
   partnerUser PartnerUser @relation(fields: [partnerUserId], references: [id], onDelete: Cascade)

--- a/packages/prisma/schema/partner.prisma
+++ b/packages/prisma/schema/partner.prisma
@@ -56,6 +56,18 @@ model Partner {
   payouts     Payout[]
   commissions Commission[]
 }
+model PartnerInvite {
+  email     String
+  expires   DateTime
+  partnerId String
+  role      PartnerRole @default(member)
+  createdAt DateTime    @default(now())
+
+  partner Partner @relation(fields: [partnerId], references: [id], onDelete: Cascade)
+
+  @@unique([email, partnerId])
+  @@index([partnerId])
+}
 
 model PartnerUser {
   id        String      @id @default(cuid())
@@ -73,26 +85,12 @@ model PartnerUser {
   @@unique([userId, partnerId])
   @@index([partnerId])
 }
-
 model PartnerNotificationPreferences {
   id                         String  @id @default(cuid())
   partnerUserId              String  @unique
 
-  sale                       Boolean @default(true)
+  newCommission              Boolean @default(true)
   applicationApproved        Boolean @default(true)
 
   partnerUser PartnerUser @relation(fields: [partnerUserId], references: [id], onDelete: Cascade)
-}
-
-model PartnerInvite {
-  email     String
-  expires   DateTime
-  partnerId String
-  role      PartnerRole @default(member)
-  createdAt DateTime    @default(now())
-
-  partner Partner @relation(fields: [partnerId], references: [id], onDelete: Cascade)
-
-  @@unique([email, partnerId])
-  @@index([partnerId])
 }


### PR DESCRIPTION
<img width="1311" height="752" alt="Screenshot 2025-07-22 at 3 13 13 PM" src="https://github.com/user-attachments/assets/ffac3065-c49e-4db6-b00e-db76cec11729" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a notification preferences page for partner users with toggles for commission and application approval notifications.
  * Notification emails for sales and application approvals are now sent individually to partner users who opted in, rather than only to the main partner email.
  * Added API endpoints and actions to retrieve and update partner notification preferences.
  * Added a new model for partner invites and extended partner user profiles with notification preferences.

* **Improvements**
  * Added a new "Settings" section in the sidebar navigation for easy access to notification preferences.
  * Notification emails now include a direct link to manage notification settings.

* **Bug Fixes**
  * Initialized notification preferences for new partner users during onboarding.
  * Backfilled missing notification preferences for existing partner users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->