### PR TITLE
Add retrieve partner to OpenAPI spec

### DIFF
--- a/apps/web/app/(ee)/api/partners/[partnerId]/route.ts
+++ b/apps/web/app/(ee)/api/partners/[partnerId]/route.ts
@@ -5,6 +5,9 @@ import { withWorkspace } from "@/lib/auth";
 import { EnrolledPartnerSchema } from "@/lib/zod/schemas/partners";
 import { NextResponse } from "next/server";
 
+// TODO:
+// Fetch the partner by their tenantId
+
 // GET /api/partners/:id – Get a partner by ID
 export const GET = withWorkspace(
   async ({ workspace, params }) => {
@@ -16,11 +19,12 @@ export const GET = withWorkspace(
       partnerId,
     });
 
-    if (!partner)
+    if (!partner) {
       throw new DubApiError({
         code: "not_found",
-        message: "Partner not found.",
+        message: `Partner ${partnerId} not found.`,
       });
+    }
 
     return NextResponse.json(EnrolledPartnerSchema.parse(partner));
   },

--- a/apps/web/lib/openapi/partners/index.ts
+++ b/apps/web/lib/openapi/partners/index.ts
@@ -2,12 +2,16 @@ import { ZodOpenApiPathsObject } from "zod-openapi";
 import { createPartner } from "./create-partner";
 import { createPartnerLink } from "./create-partner-link";
 import { retrievePartnerAnalytics } from "./retrieve-analytics";
+import { retrievePartner } from "./retrieve-partner";
 import { retrievePartnerLinks } from "./retrieve-partner-links";
 import { upsertPartnerLink } from "./upsert-partner-link";
 
 export const partnersPaths: ZodOpenApiPathsObject = {
   "/partners": {
     post: createPartner,
+  },
+  "/partners/{partnerId}": {
+    get: retrievePartner,
   },
   "/partners/links": {
     post: createPartnerLink,

--- a/apps/web/lib/openapi/partners/retrieve-partner.ts
+++ b/apps/web/lib/openapi/partners/retrieve-partner.ts
@@ -1,0 +1,29 @@
+import { openApiErrorResponses } from "@/lib/openapi/responses";
+import { EnrolledPartnerSchema } from "@/lib/zod/schemas/partners";
+import { z } from "zod";
+import { ZodOpenApiOperationObject } from "zod-openapi";
+
+export const retrievePartner: ZodOpenApiOperationObject = {
+  operationId: "retrievePartner",
+  "x-speakeasy-name-override": "retrievePartner",
+  summary: "Retrieve a partner.",
+  description: "Retrieve a partner by their partner ID or tenant ID.",
+  requestParams: {
+    path: z.object({
+      partnerId: z.string().min(1).describe("The partner's unique ID on Dub."),
+    }),
+  },
+  responses: {
+    "200": {
+      description: "The retrieved partner.",
+      content: {
+        "application/json": {
+          schema: EnrolledPartnerSchema,
+        },
+      },
+    },
+    ...openApiErrorResponses,
+  },
+  tags: ["Partners"],
+  security: [{ token: [] }],
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new API endpoint to retrieve partner details by partner ID, with comprehensive OpenAPI documentation and error handling.
* **Improvements**
  * Enhanced error messages for missing partners to include the partner ID for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->