### PR TITLE
Workspace onboarding improvements

### DIFF
--- a/apps/web/app/app.dub.co/(onboarding)/layout.tsx
+++ b/apps/web/app/app.dub.co/(onboarding)/layout.tsx
@@ -1,45 +1,13 @@
-"use client";
-
 import Toolbar from "@/ui/layout/toolbar/toolbar";
-import { PropsWithChildren, useState } from "react";
-import { usePathname } from "next/navigation";
-import { signOut, useSession } from "next-auth/react";
-import { Button } from "@dub/ui";
+import { PropsWithChildren } from "react";
+import { SignedInHint } from "./signed-in-hint";
 
 export default function Layout({ children }: PropsWithChildren) {
-  const pathname = usePathname();
-  const isWorkspacePage = pathname === "/onboarding/workspace";
-  const { data: session } = useSession();
-  const [isLoading, setIsLoading] = useState(false);
-
   return (
     <>
       {children}
       <Toolbar show={["help"]} />
-      {isWorkspacePage && (
-        <div className="fixed bottom-0 left-0 z-40 m-5 flex flex-col gap-2">
-          <div className="flex items-center gap-1 text-neutral-600 text-xs">
-            You're signed in as{" "}
-            {session ? (
-              <b className="text-neutral-800">{session.user?.email}</b>
-            ) : (
-              <span className="h-3 w-32 rounded-md border border-neutral-300 bg-neutral-200" />
-            )}
-          </div>
-          <Button
-            variant="secondary"
-            text="Sign in as a different user"
-            onClick={() => {
-              setIsLoading(true);
-              signOut({
-                callbackUrl: "/login",
-              });
-            }}
-            loading={isLoading}
-            className="h-8 text-xs rounded-lg px-3 shadow-sm w-fit"
-          />
-        </div>
-      )}
+      <SignedInHint />
     </>
   );
 }

--- a/apps/web/app/app.dub.co/(onboarding)/layout.tsx
+++ b/apps/web/app/app.dub.co/(onboarding)/layout.tsx
@@ -1,34 +1,43 @@
 "use client";
 
 import Toolbar from "@/ui/layout/toolbar/toolbar";
-import { PropsWithChildren } from "react";
+import { PropsWithChildren, useState } from "react";
 import { usePathname } from "next/navigation";
-import { signOut } from "next-auth/react";
+import { signOut, useSession } from "next-auth/react";
 import { Button } from "@dub/ui";
 
 export default function Layout({ children }: PropsWithChildren) {
   const pathname = usePathname();
   const isWorkspacePage = pathname === "/onboarding/workspace";
+  const { data: session } = useSession();
+  const [isLoading, setIsLoading] = useState(false);
 
   return (
     <>
       {children}
       <Toolbar show={["help"]} />
       {isWorkspacePage && (
-        <div className="fixed bottom-0 left-0 z-40 m-5">
+        <div className="fixed bottom-0 left-0 z-40 m-5 flex flex-col gap-2">
+          <div className="flex items-center gap-1 text-neutral-600 text-xs">
+            You're signed in as{" "}
+            {session ? (
+              <b className="text-neutral-800">{session.user?.email}</b>
+            ) : (
+              <span className="h-3 w-32 rounded-md border border-neutral-300 bg-neutral-200" />
+            )}
+          </div>
           <Button
             variant="secondary"
-            text="Back to sign in"
-            size="sm"
-            onClick={() =>
+            text="Sign in as a different user"
+            onClick={() => {
+              setIsLoading(true);
               signOut({
                 callbackUrl: "/login",
-              })
-            }
-            className="h-8 text-xs rounded-lg px-3 shadow-sm"
-          >
-            Back to sign in
-          </Button>
+              });
+            }}
+            loading={isLoading}
+            className="h-8 text-xs rounded-lg px-3 shadow-sm w-fit"
+          />
         </div>
       )}
     </>

--- a/apps/web/app/app.dub.co/(onboarding)/layout.tsx
+++ b/apps/web/app/app.dub.co/(onboarding)/layout.tsx
@@ -1,11 +1,36 @@
+"use client";
+
 import Toolbar from "@/ui/layout/toolbar/toolbar";
 import { PropsWithChildren } from "react";
+import { usePathname } from "next/navigation";
+import { signOut } from "next-auth/react";
+import { Button } from "@dub/ui";
 
 export default function Layout({ children }: PropsWithChildren) {
+  const pathname = usePathname();
+  const isWorkspacePage = pathname === "/onboarding/workspace";
+
   return (
     <>
       {children}
       <Toolbar show={["help"]} />
+      {isWorkspacePage && (
+        <div className="fixed bottom-0 left-0 z-40 m-5">
+          <Button
+            variant="secondary"
+            text="Back to sign in"
+            size="sm"
+            onClick={() =>
+              signOut({
+                callbackUrl: "/login",
+              })
+            }
+            className="h-8 text-xs rounded-lg px-3 shadow-sm"
+          >
+            Back to sign in
+          </Button>
+        </div>
+      )}
     </>
   );
 }

--- a/apps/web/app/app.dub.co/(onboarding)/onboarding/(steps)/workspace/page.tsx
+++ b/apps/web/app/app.dub.co/(onboarding)/onboarding/(steps)/workspace/page.tsx
@@ -7,7 +7,7 @@ export default function Workspace() {
       title="Create your workspace"
       description={
         <>
-          Set up a common space to manage your links with your team.{" "}
+          Set up a shared space to manage your links with your team.{" "}
           <a
             href="https://dub.co/help/article/what-is-a-workspace"
             target="_blank"

--- a/apps/web/app/app.dub.co/(onboarding)/signed-in-hint.tsx
+++ b/apps/web/app/app.dub.co/(onboarding)/signed-in-hint.tsx
@@ -15,7 +15,7 @@ export function SignedInHint() {
         {session ? (
           <b className="text-neutral-800">{session.user?.email}</b>
         ) : (
-          <span className="h-3 w-32 rounded-md border border-neutral-300 bg-neutral-200" />
+          <span className="h-3 w-32 animate-pulse rounded-md border border-neutral-300 bg-neutral-200" />
         )}
       </div>
       <Button

--- a/apps/web/app/app.dub.co/(onboarding)/signed-in-hint.tsx
+++ b/apps/web/app/app.dub.co/(onboarding)/signed-in-hint.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { Button } from "@dub/ui";
+import { signOut, useSession } from "next-auth/react";
+import { useState } from "react";
+
+export function SignedInHint() {
+  const { data: session } = useSession();
+  const [isLoading, setIsLoading] = useState(false);
+
+  return (
+    <div className="fixed bottom-0 left-0 z-40 m-5 flex flex-col gap-2">
+      <div className="flex items-center gap-1 text-xs text-neutral-600">
+        You're signed in as{" "}
+        {session ? (
+          <b className="text-neutral-800">{session.user?.email}</b>
+        ) : (
+          <span className="h-3 w-32 rounded-md border border-neutral-300 bg-neutral-200" />
+        )}
+      </div>
+      <Button
+        variant="secondary"
+        text="Sign in as a different user"
+        onClick={() => {
+          setIsLoading(true);
+          signOut({
+            callbackUrl: "/login",
+          });
+        }}
+        loading={isLoading}
+        className="h-8 w-fit rounded-lg px-3 text-xs shadow-sm"
+      />
+    </div>
+  );
+}

--- a/apps/web/ui/workspaces/create-workspace-form.tsx
+++ b/apps/web/ui/workspaces/create-workspace-form.tsx
@@ -138,7 +138,7 @@ export function CreateWorkspaceForm({
       <div>
         <label htmlFor="slug" className="flex items-center space-x-2">
           <p className="block text-sm font-medium text-neutral-700">
-            Workspace Slug
+            Slug
           </p>
         </label>
         <div className="relative mt-2 flex rounded-md shadow-sm">
@@ -204,7 +204,7 @@ export function CreateWorkspaceForm({
       <div>
         <label>
           <p className="block text-sm font-medium text-neutral-700">
-            Workspace Logo
+            Logo
           </p>
           <div className="mt-1.5 flex items-center gap-5">
             <Controller

--- a/apps/web/ui/workspaces/create-workspace-form.tsx
+++ b/apps/web/ui/workspaces/create-workspace-form.tsx
@@ -116,7 +116,7 @@ export function CreateWorkspaceForm({
       <div>
         <label htmlFor="name" className="flex items-center space-x-2">
           <p className="block text-sm font-medium text-neutral-700">
-            Workspace Name
+            Workspace name
           </p>
         </label>
         <div className="mt-2 flex rounded-md shadow-sm">
@@ -138,7 +138,7 @@ export function CreateWorkspaceForm({
       <div>
         <label htmlFor="slug" className="flex items-center space-x-2">
           <p className="block text-sm font-medium text-neutral-700">
-            Slug
+            Workspace slug
           </p>
         </label>
         <div className="relative mt-2 flex rounded-md shadow-sm">
@@ -204,7 +204,7 @@ export function CreateWorkspaceForm({
       <div>
         <label>
           <p className="block text-sm font-medium text-neutral-700">
-            Logo
+            Workspace logo
           </p>
           <div className="mt-1.5 flex items-center gap-5">
             <Controller


### PR DESCRIPTION

- Added the back to sign in button to show only on the onboarding/workspace page

<img width="3516" height="2052" alt="CleanShot 2025-07-23 at 15 16 40@2x" src="https://github.com/user-attachments/assets/750947ad-c610-4a3b-94cf-e10778219b61" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Sign in as a different user" button on the onboarding workspace page, enabling easy sign-out and return to the login screen.

* **Style**
  * Updated descriptive text in the onboarding workspace step for improved clarity.
  * Changed workspace creation form labels to lowercase for a more consistent interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->