### PR TITLE
Partner account settings updates

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/account/settings/page-client.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/account/settings/page-client.tsx
@@ -8,16 +8,22 @@ import UserId from "@/ui/account/user-id";
 import { Form } from "@dub/ui";
 import { APP_NAME } from "@dub/utils";
 import { useSession } from "next-auth/react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 
 export default function SettingsPageClient() {
   const { data: session, update, status } = useSession();
+  const [isPartnerPage, setIsPartnerPage] = useState(false);
+
+  useEffect(() => {
+    setIsPartnerPage(window.location.hostname.startsWith("partners."));
+  }, []);
 
   return (
     <>
       <Form
         title="Your Name"
-        description={`This will be your display name on ${APP_NAME}.`}
+        description={`This is the display name on your  ${APP_NAME} account.`}
         inputAttrs={{
           name: "name",
           defaultValue:
@@ -75,7 +81,7 @@ export default function SettingsPageClient() {
       />
       <UploadAvatar />
       <UserId />
-      <UpdateDefaultWorkspace />
+      {!isPartnerPage && <UpdateDefaultWorkspace />}
       <DeleteAccountSection />
     </>
   );

--- a/apps/web/ui/account/upload-avatar.tsx
+++ b/apps/web/ui/account/upload-avatar.tsx
@@ -43,7 +43,7 @@ export default function UploadAvatar() {
       <div className="flex flex-col space-y-3 p-5 sm:p-10">
         <h2 className="text-xl font-medium">Your Avatar</h2>
         <p className="text-sm text-neutral-500">
-          This is your avatar image on {process.env.NEXT_PUBLIC_APP_NAME}.
+          This is your avatar image on your {process.env.NEXT_PUBLIC_APP_NAME} account.
         </p>
         <div className="mt-1">
           <FileUpload

--- a/apps/web/ui/layout/sidebar/user-dropdown.tsx
+++ b/apps/web/ui/layout/sidebar/user-dropdown.tsx
@@ -50,7 +50,7 @@ export default function UserDropdown() {
           )}
           <UserOption
             as={Link}
-            label="Account"
+            label="Account settings"
             icon={User}
             href="/account/settings"
             onClick={() => setOpenPopover(false)}


### PR DESCRIPTION
- Changed the account drop-down to say "account settings".
<img width="686" height="558" alt="CleanShot 2025-07-25 at 15 45 55@2x" src="https://github.com/user-attachments/assets/017c4f2c-9dde-4f41-8c7e-f2691d665f52" />

- Changed some of the language on the display name and your logo to differentiate slightly from the partner profile.
<img width="1352" height="602" alt="CleanShot 2025-07-25 at 15 46 19@2x" src="https://github.com/user-attachments/assets/a595cd49-bb88-4706-9092-d310006bd3b8" />
<img width="1206" height="656" alt="CleanShot 2025-07-25 at 15 46 44@2x" src="https://github.com/user-attachments/assets/d93fd99d-247c-4db0-8891-7259f8b49bd9" />

- Hiding the default workspace when you're logged in as a partner to avoid confusion for just partners.