### PR TITLE
Fix reward schema to match discount (description > name)

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/invite-partner-sheet.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/invite-partner-sheet.tsx
@@ -274,8 +274,7 @@ function InvitePartnerSheetContent({ setIsOpen }: InvitePartnerSheetProps) {
                           <option value="">Select a reward</option>
                           {rewards?.map((reward) => (
                             <option value={reward.id} key={reward.id}>
-                              {reward.name ||
-                                formatRewardDescription({ reward })}{" "}
+                              {formatRewardDescription({ reward })}{" "}
                               {reward.default && "(Default)"}
                             </option>
                           ))}

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/use-partner-filters.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/use-partner-filters.tsx
@@ -138,7 +138,7 @@ export function usePartnerFilters(extraSearchParams: Record<string, string>) {
                 saleRewardsCount?.map((reward) => {
                   return {
                     value: reward.id,
-                    label: reward.name || formatRewardDescription({ reward }),
+                    label: formatRewardDescription({ reward }),
                     icon: <InvoiceDollar className="size-4 bg-transparent" />,
                     right: nFormatter(reward.partnersCount, { full: true }),
                   };
@@ -157,7 +157,7 @@ export function usePartnerFilters(extraSearchParams: Record<string, string>) {
                 leadRewardsCount?.map((reward) => {
                   return {
                     value: reward.id,
-                    label: reward.name || formatRewardDescription({ reward }),
+                    label: formatRewardDescription({ reward }),
                     icon: <UserPlus className="size-4 bg-transparent" />,
                     right: nFormatter(reward.partnersCount, { full: true }),
                   };
@@ -176,7 +176,7 @@ export function usePartnerFilters(extraSearchParams: Record<string, string>) {
                 clickRewardsCount?.map((reward) => {
                   return {
                     value: reward.id,
-                    label: reward.name || formatRewardDescription({ reward }),
+                    label: formatRewardDescription({ reward }),
                     icon: <CursorRays className="size-4 bg-transparent" />,
                     right: nFormatter(reward.partnersCount, { full: true }),
                   };

--- a/apps/web/lib/zod/schemas/rewards.ts
+++ b/apps/web/lib/zod/schemas/rewards.ts
@@ -18,7 +18,6 @@ export const COMMISSION_TYPES = [
 export const RewardSchema = z.object({
   id: z.string(),
   event: z.nativeEnum(EventType),
-  name: z.string().nullish(),
   description: z.string().nullish(),
   type: z.nativeEnum(RewardStructure),
   amount: z.number(),

--- a/apps/web/ui/partners/design/modals/edit-rewards-modal.tsx
+++ b/apps/web/ui/partners/design/modals/edit-rewards-modal.tsx
@@ -189,8 +189,7 @@ function EditRewardsModalInner({
                               <option value="none">None</option>
                               {eventRewards?.map((reward) => (
                                 <option value={reward.id} key={reward.id}>
-                                  {reward.name ||
-                                    formatRewardDescription({ reward })}{" "}
+                                  {formatRewardDescription({ reward })}{" "}
                                   {reward.default && "(Default)"}
                                 </option>
                               ))}

--- a/apps/web/ui/partners/format-reward-description.ts
+++ b/apps/web/ui/partners/format-reward-description.ts
@@ -4,8 +4,15 @@ import { RewardProps } from "@/lib/types";
 export function formatRewardDescription({
   reward,
 }: {
-  reward: Pick<RewardProps, "amount" | "type" | "event" | "maxDuration">;
+  reward: Pick<
+    RewardProps,
+    "description" | "amount" | "type" | "event" | "maxDuration"
+  >;
 }): string {
+  if (reward.description) {
+    return reward.description;
+  }
+
   const rewardAmount = constructRewardAmount(reward);
   const parts: string[] = [];
 

--- a/packages/prisma/schema/reward.prisma
+++ b/packages/prisma/schema/reward.prisma
@@ -12,7 +12,6 @@ enum RewardStructure {
 model Reward {
   id          String          @id @default(cuid())
   programId   String
-  name        String?
   description String?
   event       EventType
   type        RewardStructure @default(percentage)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reward descriptions now consistently display a formatted description, prioritizing any custom description provided.

* **Refactor**
  * Simplified reward option labels in dropdowns and filters to always use the formatted reward description.
  * Updated logic to prioritize custom reward descriptions over generated text.

* **Chores**
  * Removed the unused "name" field from rewards across the application and database schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->