### PR TITLE
Update rate limit window to once every minute

### DIFF
--- a/apps/web/lib/auth/workspace.ts
+++ b/apps/web/lib/auth/workspace.ts
@@ -232,10 +232,10 @@ export const withWorkspace = (
           }
 
           waitUntil(
-            // update last used time for the token (only once every 15 minutes)
+            // update last used time for the token (only once every minute)
             (async () => {
               try {
-                const { success } = await ratelimit(1, "15 m").limit(
+                const { success } = await ratelimit(1, "1 m").limit(
                   `last-used-${hashedKey}`,
                 );
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the update process for token usage timestamps with enhanced rate limiting and error handling, ensuring updates occur at most once per minute.
  * Increased the frequency of token usage timestamp updates from once every 15 minutes to once every 1 minute for better tracking accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->