### PR TITLE
Fix `PATCH /links/bulk` bug

### DIFF
--- a/apps/web/lib/api/links/bulk-update-links.ts
+++ b/apps/web/lib/api/links/bulk-update-links.ts
@@ -47,15 +47,15 @@ export async function bulkUpdateLinks(
           ...rest,
           url,
           proxy,
-          title: truncate(title, 120),
-          description: truncate(description, 240),
+          title: title ? truncate(title, 120) : title,
+          description: description ? truncate(description, 240) : description,
           image:
             proxy && image && isNotHostedImage(image)
               ? `${R2_URL}/images/${linkIds[0]}_${imageUrlNonce}`
               : image,
-          expiresAt: expiresAt ? new Date(expiresAt) : null,
-          geo: geo || Prisma.JsonNull,
-          testVariants: testVariants || Prisma.JsonNull,
+          expiresAt: expiresAt ? new Date(expiresAt) : expiresAt,
+          geo: geo === null ? Prisma.JsonNull : geo,
+          testVariants: testVariants === null ? Prisma.JsonNull : testVariants,
 
           ...(url && getParamsFromURL(url)),
           // Associate tags by tagNames


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of optional and nullable fields during bulk link updates to prevent unintended overwrites or truncations. Fields like title, description, expiresAt, geo, and testVariants now retain their original values more accurately when not provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->