### PR TITLE
Add cmd+/aux click to open group in new tab

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/groups/groups-table.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/groups/groups-table.tsx
@@ -29,6 +29,14 @@ import { useParams, useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
 
+const getGroupUrl = ({
+  workspaceSlug,
+  groupSlug,
+}: {
+  workspaceSlug: string;
+  groupSlug: string;
+}) => `/${workspaceSlug}/program/groups/${groupSlug}/rewards`;
+
 export function GroupsTable() {
   const router = useRouter();
   const { slug } = useWorkspace();
@@ -56,7 +64,9 @@ export function GroupsTable() {
     data: groups
       ? groups.map((group) => {
           // prefetch the group page
-          router.prefetch(`/${slug}/program/groups/${group.slug}/rewards`);
+          router.prefetch(
+            getGroupUrl({ workspaceSlug: slug!, groupSlug: group.slug }),
+          );
           return group;
         })
       : [],
@@ -135,9 +145,20 @@ export function GroupsTable() {
         cell: ({ row }) => <RowMenuButton row={row} />,
       },
     ],
-    onRowClick: (row) => {
-      router.push(`/${slug}/program/groups/${row.original.slug}/rewards`);
+    onRowClick: (row, e) => {
+      const url = getGroupUrl({
+        workspaceSlug: slug!,
+        groupSlug: row.original.slug,
+      });
+
+      if (e.metaKey || e.ctrlKey) window.open(url, "_blank");
+      else router.push(url);
     },
+    onRowAuxClick: (row) =>
+      window.open(
+        getGroupUrl({ workspaceSlug: slug!, groupSlug: row.original.slug }),
+        "_blank",
+      ),
     pagination,
     onPaginationChange: setPagination,
     sortableColumns: [

--- a/packages/ui/src/table/table.tsx
+++ b/packages/ui/src/table/table.tsx
@@ -243,13 +243,17 @@ type ResizableTableRowProps<T> = {
   row: Row<T>;
   rowProps?: HTMLAttributes<HTMLTableRowElement>;
   table: TableType<T>;
-} & Pick<TableProps<T>, "cellRight" | "tdClassName" | "onRowClick">;
+} & Pick<
+  TableProps<T>,
+  "cellRight" | "tdClassName" | "onRowClick" | "onRowAuxClick"
+>;
 
 // Memoized row component to prevent re-renders during column resizing
 const ResizableTableRow = memo(
   function ResizableTableRow<T>({
     row,
     onRowClick,
+    onRowAuxClick,
     rowProps,
     cellRight,
     tdClassName,
@@ -275,6 +279,15 @@ const ResizableTableRow = memo(
                 // Ignore if click is on an interactive child
                 if (isClickOnInteractiveChild(e)) return;
                 onRowClick(row, e);
+              }
+            : undefined
+        }
+        onAuxClick={
+          onRowAuxClick
+            ? (e) => {
+                // Ignore if click is on an interactive child
+                if (isClickOnInteractiveChild(e)) return;
+                onRowAuxClick(row, e);
               }
             : undefined
         }
@@ -342,6 +355,7 @@ export function Table<T>({
   pagination,
   resourceName,
   onRowClick,
+  onRowAuxClick,
   onRowSelectionChange,
   selectionControls,
   rowProps,
@@ -497,6 +511,7 @@ export function Table<T>({
                         .join(",")}`}
                       row={row}
                       onRowClick={onRowClick}
+                      onRowAuxClick={onRowAuxClick}
                       rowProps={props}
                       cellRight={cellRight}
                       tdClassName={tdClassName}
@@ -518,6 +533,14 @@ export function Table<T>({
                           ? (e) => {
                               if (isClickOnInteractiveChild(e)) return;
                               onRowClick(row, e);
+                            }
+                          : undefined
+                      }
+                      onAuxClick={
+                        onRowAuxClick
+                          ? (e) => {
+                              if (isClickOnInteractiveChild(e)) return;
+                              onRowAuxClick(row, e);
                             }
                           : undefined
                       }

--- a/packages/ui/src/table/types.ts
+++ b/packages/ui/src/table/types.ts
@@ -55,6 +55,7 @@ type BaseTableProps<T> = {
 
   // Misc. row props
   onRowClick?: (row: Row<T>, e: MouseEvent) => void;
+  onRowAuxClick?: (row: Row<T>, e: MouseEvent) => void;
   rowProps?:
     | HTMLAttributes<HTMLTableRowElement>
     | ((row: Row<T>) => HTMLAttributes<HTMLTableRowElement>);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Table rows now support auxiliary clicks: middle-click opens items in a new tab without disrupting in-page controls.
  - In Groups, clicking a row with Ctrl/Cmd opens the group’s rewards page in a new tab; standard click navigates in the same tab.
  - Prefetching and navigation use consistent URLs for group rewards links, improving reliability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->