### PR TITLE
Make paymentProcessor optional and fallback to "custom"

### DIFF
--- a/apps/web/lib/zod/schemas/sales.ts
+++ b/apps/web/lib/zod/schemas/sales.ts
@@ -37,6 +37,7 @@ export const trackSaleRequestSchema = z.object({
     .openapi({ example: "Invoice paid" }),
   paymentProcessor: z
     .enum(["stripe", "shopify", "polar", "paddle", "revenuecat", "custom"])
+    .default("custom")
     .describe("The payment processor via which the sale was made."),
   invoiceId: z
     .string()
@@ -95,7 +96,7 @@ export const saleEventSchemaTB = clickEventSchemaTB
       event_id: z.string(),
       event_name: z.string().default("Purchase"),
       customer_id: z.string(),
-      payment_processor: z.string(),
+      payment_processor: z.string().default("custom"),
       amount: z.number(),
       invoice_id: z.string().default(""),
       currency: z


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Forms and API requests no longer fail when the payment processor field is omitted; it now defaults to “custom.”

* **New Features**
  * Introduced default handling for payment processor fields, automatically setting them to “custom” when not provided.

* **Documentation**
  * Clarified behavior that payment processor fields default to “custom” if unspecified.

* **Chores**
  * Minor validation updates to improve robustness and reduce friction in sale tracking flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->