### PR TITLE
Add support for the `partner` attribute in reward conditions

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/groups/[groupSlug]/settings/group-settings.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/groups/[groupSlug]/settings/group-settings.tsx
@@ -56,14 +56,12 @@ function GroupSettingsForm({ group }: { group: GroupProps }) {
       method: "PATCH",
       body: data,
       onSuccess: async () => {
-        toast.success("Group updated successfully!");
-
+        await mutatePrefix("/api/groups");
         // If slug changed, redirect to new URL
         if (data.slug !== group.slug) {
           router.push(`/${slug}/program/groups/${data.slug}/settings`);
         }
-
-        await mutatePrefix("/api/groups");
+        toast.success("Group updated successfully!");
       },
     });
   };

--- a/apps/web/lib/actions/partners/update-reward.ts
+++ b/apps/web/lib/actions/partners/update-reward.ts
@@ -57,18 +57,12 @@ export const updateRewardAction = authActionClient
       salePartnerGroup,
       ...rewardMetadata
     } = updatedReward;
+
     const isDefaultGroup = [
       clickPartnerGroup,
       leadPartnerGroup,
       salePartnerGroup,
     ].some((group) => group?.slug === "default");
-
-    console.log({
-      isDefaultGroup,
-      clickPartnerGroup,
-      leadPartnerGroup,
-      salePartnerGroup,
-    });
 
     waitUntil(
       Promise.allSettled([
@@ -86,6 +80,7 @@ export const updateRewardAction = authActionClient
             },
           ],
         }),
+
         // we only cache default group pages for now so we need to invalidate them
         ...(isDefaultGroup
           ? [

--- a/apps/web/lib/api/sales/construct-reward-amount.ts
+++ b/apps/web/lib/api/sales/construct-reward-amount.ts
@@ -38,9 +38,9 @@ export const constructRewardAmount = (
         );
 
         if (min !== max) {
-          return reward.type === "percentage"
-            ? `${min}% - ${max}%`
-            : `${formatCurrency(min / 100)} - ${formatCurrency(max / 100)}`;
+          return `Up to ${
+            reward.type === "percentage" ? `${max}%` : formatCurrency(max / 100)
+          }`;
         }
       }
     }

--- a/apps/web/lib/zod/schemas/rewards.ts
+++ b/apps/web/lib/zod/schemas/rewards.ts
@@ -15,13 +15,24 @@ export const COMMISSION_TYPES = [
   },
 ] as const;
 
-export const CONDITION_ENTITIES = ["customer", "sale"] as const;
+export const CONDITION_ENTITIES = ["customer", "sale", "partner"] as const;
 
 export const CONDITION_CUSTOMER_ATTRIBUTES = ["country"] as const;
+
 export const CONDITION_SALE_ATTRIBUTES = ["productId"] as const;
+
+export const CONDITION_PARTNER_ATTRIBUTES = [
+  "totalClicks",
+  "totalLeads",
+  "totalConversions",
+  "totalSaleAmount",
+  "totalCommissions",
+] as const;
+
 export const CONDITION_ATTRIBUTES = [
   ...CONDITION_CUSTOMER_ATTRIBUTES,
   ...CONDITION_SALE_ATTRIBUTES,
+  ...CONDITION_PARTNER_ATTRIBUTES,
 ] as const;
 
 export const CONDITION_OPERATORS = [
@@ -31,11 +42,20 @@ export const CONDITION_OPERATORS = [
   "ends_with",
   "in",
   "not_in",
+  "greater_than",
+  "greater_than_or_equal",
+  "less_than",
+  "less_than_or_equal",
 ] as const;
 
 export const ATTRIBUTE_LABELS = {
-  country: "country",
-  productId: "product",
+  country: "Country",
+  productId: "Product ID",
+  totalClicks: "Total Clicks",
+  totalLeads: "Total Leads",
+  totalConversions: "Total Conversions",
+  totalSaleAmount: "Total Sale Amount",
+  totalCommissions: "Total Commissions",
 } as const;
 
 export const CONDITION_OPERATOR_LABELS = {
@@ -45,6 +65,10 @@ export const CONDITION_OPERATOR_LABELS = {
   ends_with: "ends with",
   in: "is one of",
   not_in: "is not one of",
+  greater_than: "is greater than",
+  greater_than_or_equal: "is greater than or equal to",
+  less_than: "is less than",
+  less_than_or_equal: "is less than or equal to",
 } as const;
 
 export const rewardConditionSchema = z.object({
@@ -142,6 +166,16 @@ export const rewardContextSchema = z.object({
   sale: z
     .object({
       productId: z.string().nullish(),
+    })
+    .optional(),
+
+  partner: z
+    .object({
+      totalClicks: z.number().nullish(),
+      totalLeads: z.number().nullish(),
+      totalConversions: z.number().nullish(),
+      totalSaleAmount: z.number().nullish(),
+      totalCommissions: z.number().nullish(),
     })
     .optional(),
 });

--- a/apps/web/lib/zod/schemas/rewards.ts
+++ b/apps/web/lib/zod/schemas/rewards.ts
@@ -35,6 +35,26 @@ export const CONDITION_ATTRIBUTES = [
   ...CONDITION_PARTNER_ATTRIBUTES,
 ] as const;
 
+export const ENTITY_ATTRIBUTE_TYPES: Partial<
+  Record<
+    (typeof CONDITION_ENTITIES)[number],
+    Partial<
+      Record<
+        (typeof CONDITION_ATTRIBUTES)[number],
+        "string" | "number" | "currency"
+      >
+    >
+  >
+> = {
+  partner: {
+    totalClicks: "number",
+    totalLeads: "number",
+    totalConversions: "number",
+    totalSaleAmount: "currency",
+    totalCommissions: "currency",
+  },
+};
+
 export const CONDITION_OPERATORS = [
   "equals_to",
   "not_equals",
@@ -47,6 +67,19 @@ export const CONDITION_OPERATORS = [
   "less_than",
   "less_than_or_equal",
 ] as const;
+
+export const STRING_CONDITION_OPERATORS: (typeof CONDITION_OPERATORS)[number][] =
+  ["equals_to", "not_equals", "starts_with", "ends_with", "in", "not_in"];
+
+export const NUMBER_CONDITION_OPERATORS: (typeof CONDITION_OPERATORS)[number][] =
+  [
+    "equals_to",
+    "not_equals",
+    "greater_than",
+    "greater_than_or_equal",
+    "less_than",
+    "less_than_or_equal",
+  ];
 
 export const ATTRIBUTE_LABELS = {
   country: "Country",

--- a/apps/web/lib/zod/schemas/rewards.ts
+++ b/apps/web/lib/zod/schemas/rewards.ts
@@ -84,11 +84,11 @@ export const NUMBER_CONDITION_OPERATORS: (typeof CONDITION_OPERATORS)[number][] 
 export const ATTRIBUTE_LABELS = {
   country: "Country",
   productId: "Product ID",
-  totalClicks: "Total Clicks",
-  totalLeads: "Total Leads",
-  totalConversions: "Total Conversions",
-  totalSaleAmount: "Total Sale Amount",
-  totalCommissions: "Total Commissions",
+  totalClicks: "Total clicks",
+  totalLeads: "Total leads",
+  totalConversions: "Total conversions",
+  totalSaleAmount: "Total revenue",
+  totalCommissions: "Total commissions",
 } as const;
 
 export const CONDITION_OPERATOR_LABELS = {

--- a/apps/web/tests/rewards/reward-conditions.test.ts
+++ b/apps/web/tests/rewards/reward-conditions.test.ts
@@ -711,6 +711,374 @@ describe("evaluateRewardConditions", () => {
         expect(result).toBe(null);
       });
     });
+
+    describe("greater_than", () => {
+      test("should match when numeric value is greater than condition value", () => {
+        const conditions = [
+          {
+            operator: "AND" as const,
+            amount: 5000,
+            conditions: [
+              {
+                entity: "partner" as const,
+                attribute: "totalClicks" as const,
+                operator: "greater_than" as const,
+                value: 100,
+              },
+            ],
+          },
+        ];
+
+        const context: RewardContext = {
+          partner: {
+            totalClicks: 150,
+          },
+        };
+
+        const result = evaluateRewardConditions({
+          conditions,
+          context,
+        });
+
+        expect(result).toEqual(conditions[0]);
+      });
+
+      test("should not match when numeric value is equal to condition value", () => {
+        const conditions = [
+          {
+            operator: "AND" as const,
+            amount: 5000,
+            conditions: [
+              {
+                entity: "partner" as const,
+                attribute: "totalClicks" as const,
+                operator: "greater_than" as const,
+                value: 100,
+              },
+            ],
+          },
+        ];
+
+        const context: RewardContext = {
+          partner: {
+            totalClicks: 100,
+          },
+        };
+
+        const result = evaluateRewardConditions({
+          conditions,
+          context,
+        });
+
+        expect(result).toBe(null);
+      });
+
+      test("should not match when numeric value is less than condition value", () => {
+        const conditions = [
+          {
+            operator: "AND" as const,
+            amount: 5000,
+            conditions: [
+              {
+                entity: "partner" as const,
+                attribute: "totalClicks" as const,
+                operator: "greater_than" as const,
+                value: 100,
+              },
+            ],
+          },
+        ];
+
+        const context: RewardContext = {
+          partner: {
+            totalClicks: 50,
+          },
+        };
+
+        const result = evaluateRewardConditions({
+          conditions,
+          context,
+        });
+
+        expect(result).toBe(null);
+      });
+    });
+
+    describe("greater_than_or_equal", () => {
+      test("should match when numeric value is greater than condition value", () => {
+        const conditions = [
+          {
+            operator: "AND" as const,
+            amount: 5000,
+            conditions: [
+              {
+                entity: "partner" as const,
+                attribute: "totalLeads" as const,
+                operator: "greater_than_or_equal" as const,
+                value: 50,
+              },
+            ],
+          },
+        ];
+
+        const context: RewardContext = {
+          partner: {
+            totalLeads: 75,
+          },
+        };
+
+        const result = evaluateRewardConditions({
+          conditions,
+          context,
+        });
+
+        expect(result).toEqual(conditions[0]);
+      });
+
+      test("should match when numeric value is equal to condition value", () => {
+        const conditions = [
+          {
+            operator: "AND" as const,
+            amount: 5000,
+            conditions: [
+              {
+                entity: "partner" as const,
+                attribute: "totalLeads" as const,
+                operator: "greater_than_or_equal" as const,
+                value: 50,
+              },
+            ],
+          },
+        ];
+
+        const context: RewardContext = {
+          partner: {
+            totalLeads: 50,
+          },
+        };
+
+        const result = evaluateRewardConditions({
+          conditions,
+          context,
+        });
+
+        expect(result).toEqual(conditions[0]);
+      });
+
+      test("should not match when numeric value is less than condition value", () => {
+        const conditions = [
+          {
+            operator: "AND" as const,
+            amount: 5000,
+            conditions: [
+              {
+                entity: "partner" as const,
+                attribute: "totalLeads" as const,
+                operator: "greater_than_or_equal" as const,
+                value: 50,
+              },
+            ],
+          },
+        ];
+
+        const context: RewardContext = {
+          partner: {
+            totalLeads: 25,
+          },
+        };
+
+        const result = evaluateRewardConditions({
+          conditions,
+          context,
+        });
+
+        expect(result).toBe(null);
+      });
+    });
+
+    describe("less_than", () => {
+      test("should match when numeric value is less than condition value", () => {
+        const conditions = [
+          {
+            operator: "AND" as const,
+            amount: 5000,
+            conditions: [
+              {
+                entity: "partner" as const,
+                attribute: "totalConversions" as const,
+                operator: "less_than" as const,
+                value: 10,
+              },
+            ],
+          },
+        ];
+
+        const context: RewardContext = {
+          partner: {
+            totalConversions: 5,
+          },
+        };
+
+        const result = evaluateRewardConditions({
+          conditions,
+          context,
+        });
+
+        expect(result).toEqual(conditions[0]);
+      });
+
+      test("should not match when numeric value is equal to condition value", () => {
+        const conditions = [
+          {
+            operator: "AND" as const,
+            amount: 5000,
+            conditions: [
+              {
+                entity: "partner" as const,
+                attribute: "totalConversions" as const,
+                operator: "less_than" as const,
+                value: 10,
+              },
+            ],
+          },
+        ];
+
+        const context: RewardContext = {
+          partner: {
+            totalConversions: 10,
+          },
+        };
+
+        const result = evaluateRewardConditions({
+          conditions,
+          context,
+        });
+
+        expect(result).toBe(null);
+      });
+
+      test("should not match when numeric value is greater than condition value", () => {
+        const conditions = [
+          {
+            operator: "AND" as const,
+            amount: 5000,
+            conditions: [
+              {
+                entity: "partner" as const,
+                attribute: "totalConversions" as const,
+                operator: "less_than" as const,
+                value: 10,
+              },
+            ],
+          },
+        ];
+
+        const context: RewardContext = {
+          partner: {
+            totalConversions: 15,
+          },
+        };
+
+        const result = evaluateRewardConditions({
+          conditions,
+          context,
+        });
+
+        expect(result).toBe(null);
+      });
+    });
+
+    describe("less_than_or_equal", () => {
+      test("should match when numeric value is less than condition value", () => {
+        const conditions = [
+          {
+            operator: "AND" as const,
+            amount: 5000,
+            conditions: [
+              {
+                entity: "partner" as const,
+                attribute: "totalSaleAmount" as const,
+                operator: "less_than_or_equal" as const,
+                value: 1000,
+              },
+            ],
+          },
+        ];
+
+        const context: RewardContext = {
+          partner: {
+            totalSaleAmount: 750,
+          },
+        };
+
+        const result = evaluateRewardConditions({
+          conditions,
+          context,
+        });
+
+        expect(result).toEqual(conditions[0]);
+      });
+
+      test("should match when numeric value is equal to condition value", () => {
+        const conditions = [
+          {
+            operator: "AND" as const,
+            amount: 5000,
+            conditions: [
+              {
+                entity: "partner" as const,
+                attribute: "totalSaleAmount" as const,
+                operator: "less_than_or_equal" as const,
+                value: 1000,
+              },
+            ],
+          },
+        ];
+
+        const context: RewardContext = {
+          partner: {
+            totalSaleAmount: 1000,
+          },
+        };
+
+        const result = evaluateRewardConditions({
+          conditions,
+          context,
+        });
+
+        expect(result).toEqual(conditions[0]);
+      });
+
+      test("should not match when numeric value is greater than condition value", () => {
+        const conditions = [
+          {
+            operator: "AND" as const,
+            amount: 5000,
+            conditions: [
+              {
+                entity: "partner" as const,
+                attribute: "totalSaleAmount" as const,
+                operator: "less_than_or_equal" as const,
+                value: 1000,
+              },
+            ],
+          },
+        ];
+
+        const context: RewardContext = {
+          partner: {
+            totalSaleAmount: 1250,
+          },
+        };
+
+        const result = evaluateRewardConditions({
+          conditions,
+          context,
+        });
+
+        expect(result).toBe(null);
+      });
+    });
   });
 
   describe("edge cases", () => {
@@ -783,6 +1151,350 @@ describe("evaluateRewardConditions", () => {
       });
 
       expect(result).toBe(null);
+    });
+
+    test("should handle numeric operators with string values (type coercion)", () => {
+      const conditions = [
+        {
+          operator: "AND" as const,
+          amount: 5000,
+          conditions: [
+            {
+              entity: "partner" as const,
+              attribute: "totalClicks" as const,
+              operator: "greater_than" as const,
+              value: "100", // String value that should be coerced to number
+            },
+          ],
+        },
+      ];
+
+      const context: RewardContext = {
+        partner: {
+          totalClicks: 150,
+        },
+      };
+
+      const result = evaluateRewardConditions({
+        conditions,
+        context,
+      });
+
+      expect(result).toEqual(conditions[0]);
+    });
+
+    test("should handle string field values with numeric operators (type coercion)", () => {
+      const conditions = [
+        {
+          operator: "AND" as const,
+          amount: 5000,
+          conditions: [
+            {
+              entity: "partner" as const,
+              attribute: "totalCommissions" as const,
+              operator: "less_than_or_equal" as const,
+              value: 500,
+            },
+          ],
+        },
+      ];
+
+      const context: RewardContext = {
+        partner: {
+          totalCommissions: 300, // Should work with Number() conversion
+        },
+      };
+
+      const result = evaluateRewardConditions({
+        conditions,
+        context,
+      });
+
+      expect(result).toEqual(conditions[0]);
+    });
+
+    test("should handle decimal numbers with numeric operators", () => {
+      const conditions = [
+        {
+          operator: "AND" as const,
+          amount: 5000,
+          conditions: [
+            {
+              entity: "partner" as const,
+              attribute: "totalSaleAmount" as const,
+              operator: "greater_than_or_equal" as const,
+              value: 999.99,
+            },
+          ],
+        },
+      ];
+
+      const context: RewardContext = {
+        partner: {
+          totalSaleAmount: 1000.0,
+        },
+      };
+
+      const result = evaluateRewardConditions({
+        conditions,
+        context,
+      });
+
+      expect(result).toEqual(conditions[0]);
+    });
+
+    test("should handle zero values with numeric operators", () => {
+      const conditions = [
+        {
+          operator: "AND" as const,
+          amount: 5000,
+          conditions: [
+            {
+              entity: "partner" as const,
+              attribute: "totalClicks" as const,
+              operator: "greater_than" as const,
+              value: 0,
+            },
+          ],
+        },
+      ];
+
+      const context: RewardContext = {
+        partner: {
+          totalClicks: 0,
+        },
+      };
+
+      const result = evaluateRewardConditions({
+        conditions,
+        context,
+      });
+
+      expect(result).toBe(null); // 0 is not greater than 0
+    });
+
+    test("should handle negative numbers with numeric operators", () => {
+      const conditions = [
+        {
+          operator: "AND" as const,
+          amount: 5000,
+          conditions: [
+            {
+              entity: "partner" as const,
+              attribute: "totalCommissions" as const,
+              operator: "greater_than" as const,
+              value: -100,
+            },
+          ],
+        },
+      ];
+
+      const context: RewardContext = {
+        partner: {
+          totalCommissions: 50,
+        },
+      };
+
+      const result = evaluateRewardConditions({
+        conditions,
+        context,
+      });
+
+      expect(result).toEqual(conditions[0]);
+    });
+  });
+
+  describe("mixed condition scenarios", () => {
+    test("should handle mixed string and numeric operators in AND condition", () => {
+      const conditions = [
+        {
+          operator: "AND" as const,
+          amount: 5000,
+          conditions: [
+            {
+              entity: "customer" as const,
+              attribute: "country" as const,
+              operator: "equals_to" as const,
+              value: "US",
+            },
+            {
+              entity: "partner" as const,
+              attribute: "totalClicks" as const,
+              operator: "greater_than" as const,
+              value: 100,
+            },
+            {
+              entity: "partner" as const,
+              attribute: "totalSaleAmount" as const,
+              operator: "less_than_or_equal" as const,
+              value: 10000,
+            },
+          ],
+        },
+      ];
+
+      const context: RewardContext = {
+        customer: {
+          country: "US",
+        },
+        partner: {
+          totalClicks: 150,
+          totalSaleAmount: 8500,
+        },
+      };
+
+      const result = evaluateRewardConditions({
+        conditions,
+        context,
+      });
+
+      expect(result).toEqual(conditions[0]);
+    });
+
+    test("should fail when one numeric condition in AND group fails", () => {
+      const conditions = [
+        {
+          operator: "AND" as const,
+          amount: 5000,
+          conditions: [
+            {
+              entity: "customer" as const,
+              attribute: "country" as const,
+              operator: "equals_to" as const,
+              value: "US",
+            },
+            {
+              entity: "partner" as const,
+              attribute: "totalClicks" as const,
+              operator: "greater_than" as const,
+              value: 100,
+            },
+            {
+              entity: "partner" as const,
+              attribute: "totalSaleAmount" as const,
+              operator: "less_than" as const,
+              value: 5000, // This will fail
+            },
+          ],
+        },
+      ];
+
+      const context: RewardContext = {
+        customer: {
+          country: "US",
+        },
+        partner: {
+          totalClicks: 150,
+          totalSaleAmount: 8500, // Greater than 5000
+        },
+      };
+
+      const result = evaluateRewardConditions({
+        conditions,
+        context,
+      });
+
+      expect(result).toBe(null);
+    });
+
+    test("should succeed when one numeric condition in OR group succeeds", () => {
+      const conditions = [
+        {
+          operator: "OR" as const,
+          amount: 5000,
+          conditions: [
+            {
+              entity: "partner" as const,
+              attribute: "totalClicks" as const,
+              operator: "greater_than" as const,
+              value: 1000, // This will fail
+            },
+            {
+              entity: "partner" as const,
+              attribute: "totalLeads" as const,
+              operator: "greater_than_or_equal" as const,
+              value: 50, // This will succeed
+            },
+            {
+              entity: "partner" as const,
+              attribute: "totalSaleAmount" as const,
+              operator: "less_than" as const,
+              value: 1000, // This will fail
+            },
+          ],
+        },
+      ];
+
+      const context: RewardContext = {
+        partner: {
+          totalClicks: 100, // Less than 1000
+          totalLeads: 75, // Greater than or equal to 50
+          totalSaleAmount: 5000, // Greater than 1000
+        },
+      };
+
+      const result = evaluateRewardConditions({
+        conditions,
+        context,
+      });
+
+      expect(result).toEqual(conditions[0]);
+    });
+
+    test("should return highest amount when multiple condition groups with numeric operators match", () => {
+      const conditions = [
+        {
+          operator: "AND" as const,
+          amount: 1000,
+          conditions: [
+            {
+              entity: "partner" as const,
+              attribute: "totalClicks" as const,
+              operator: "greater_than" as const,
+              value: 10,
+            },
+          ],
+        },
+        {
+          operator: "AND" as const,
+          amount: 3000, // Highest amount
+          conditions: [
+            {
+              entity: "partner" as const,
+              attribute: "totalLeads" as const,
+              operator: "greater_than_or_equal" as const,
+              value: 5,
+            },
+          ],
+        },
+        {
+          operator: "AND" as const,
+          amount: 2000,
+          conditions: [
+            {
+              entity: "partner" as const,
+              attribute: "totalConversions" as const,
+              operator: "less_than_or_equal" as const,
+              value: 100,
+            },
+          ],
+        },
+      ];
+
+      const context: RewardContext = {
+        partner: {
+          totalClicks: 50, // > 10
+          totalLeads: 20, // >= 5
+          totalConversions: 25, // <= 100
+        },
+      };
+
+      const result = evaluateRewardConditions({
+        conditions,
+        context,
+      });
+
+      expect(result).toEqual(conditions[1]); // Should return the highest amount (3000)
     });
   });
 });

--- a/apps/web/ui/partners/program-reward-description.tsx
+++ b/apps/web/ui/partners/program-reward-description.tsx
@@ -25,7 +25,9 @@ export function ProgramRewardDescription({
         ? reward.description || (
             <>
               Earn{" "}
-              <strong className={cn("font-semibold", amountClassName)}>
+              <strong
+                className={cn("font-semibold lowercase", amountClassName)}
+              >
                 {constructRewardAmount(reward)}{" "}
               </strong>
               {reward.event === "sale" && reward.maxDuration === 0 ? (

--- a/apps/web/ui/partners/program-reward-modifiers-tooltip.tsx
+++ b/apps/web/ui/partners/program-reward-modifiers-tooltip.tsx
@@ -6,7 +6,7 @@ import {
   rewardConditionsArraySchema,
 } from "@/lib/zod/schemas/rewards";
 import { InfoTooltip } from "@dub/ui";
-import { pluralize } from "@dub/utils";
+import { currencyFormatter, pluralize } from "@dub/utils";
 import { z } from "zod";
 
 export function ProgramRewardModifiersTooltip({
@@ -94,22 +94,30 @@ const RewardItem = ({
 
       {conditions && conditions.length > 0 && (
         <ul className="ml-1 text-xs font-medium text-neutral-600">
-          {conditions.map((condition, idx) => (
-            <li key={idx} className="flex items-start gap-1">
-              <span className="shrink-0 text-lg leading-none">&bull;</span>
-              <span className="min-w-0 truncate">
-                {idx === 0 ? "If" : "Or"} {condition.entity}{" "}
-                {ATTRIBUTE_LABELS[condition.attribute]}{" "}
-                {CONDITION_OPERATOR_LABELS[condition.operator]}{" "}
-                {condition.value &&
-                  (Array.isArray(condition.value)
-                    ? condition.value.join(", ")
-                    : condition.attribute === "productId" && condition.label
-                      ? condition.label
-                      : condition.value.toString())}
-              </span>
-            </li>
-          ))}
+          {conditions.map((condition, idx) => {
+            return (
+              <li key={idx} className="flex items-start gap-1">
+                <span className="shrink-0 text-lg leading-none">&bull;</span>
+                <span className="min-w-0">
+                  {idx === 0 ? "If" : "Or"} {condition.entity}{" "}
+                  {ATTRIBUTE_LABELS[condition.attribute].toLowerCase()}{" "}
+                  {CONDITION_OPERATOR_LABELS[condition.operator]}{" "}
+                  {condition.value &&
+                    (Array.isArray(condition.value)
+                      ? condition.value.join(", ")
+                      : condition.attribute === "productId" && condition.label
+                        ? condition.label
+                        : condition.attribute === "totalCommissions" ||
+                            condition.attribute === "totalSaleAmount"
+                          ? currencyFormatter(Number(condition.value) / 100, {
+                              minimumFractionDigits: 2,
+                              maximumFractionDigits: 2,
+                            })
+                          : condition.value.toString())}
+                </span>
+              </li>
+            );
+          })}
         </ul>
       )}
     </div>

--- a/apps/web/ui/partners/program-reward-modifiers-tooltip.tsx
+++ b/apps/web/ui/partners/program-reward-modifiers-tooltip.tsx
@@ -1,6 +1,7 @@
 import { constructRewardAmount } from "@/lib/api/sales/construct-reward-amount";
 import { RewardProps } from "@/lib/types";
 import {
+  ATTRIBUTE_LABELS,
   CONDITION_OPERATOR_LABELS,
   ENTITY_ATTRIBUTE_TYPES,
   rewardConditionsArraySchema,
@@ -15,15 +16,10 @@ import {
 } from "@dub/utils";
 import { z } from "zod";
 
-export const ATTRIBUTE_LABELS = {
-  country: "Country",
+const REWARD_MODIFIER_LABELS = {
+  ...ATTRIBUTE_LABELS,
   productId: "Product",
-  totalClicks: "Total Clicks",
-  totalLeads: "Total Leads",
-  totalConversions: "Total Conversions",
-  totalSaleAmount: "Total Sale Amount",
-  totalCommissions: "Total Commissions",
-} as const;
+};
 
 export function ProgramRewardModifiersTooltip({
   reward,
@@ -124,7 +120,7 @@ const RewardItem = ({
                 <span className="min-w-0">
                   {idx === 0 ? "If" : capitalize(operator.toLowerCase())}{" "}
                   {condition.entity}{" "}
-                  {ATTRIBUTE_LABELS[condition.attribute].toLowerCase()}{" "}
+                  {REWARD_MODIFIER_LABELS[condition.attribute].toLowerCase()}{" "}
                   {CONDITION_OPERATOR_LABELS[condition.operator]}{" "}
                   {condition.value &&
                     (condition.attribute === "country"

--- a/apps/web/ui/partners/program-reward-modifiers-tooltip.tsx
+++ b/apps/web/ui/partners/program-reward-modifiers-tooltip.tsx
@@ -1,13 +1,22 @@
 import { constructRewardAmount } from "@/lib/api/sales/construct-reward-amount";
 import { RewardProps } from "@/lib/types";
 import {
-  ATTRIBUTE_LABELS,
   CONDITION_OPERATOR_LABELS,
   rewardConditionsArraySchema,
 } from "@/lib/zod/schemas/rewards";
 import { InfoTooltip } from "@dub/ui";
 import { currencyFormatter, pluralize } from "@dub/utils";
 import { z } from "zod";
+
+export const ATTRIBUTE_LABELS = {
+  country: "Country",
+  productId: "Product",
+  totalClicks: "Total Clicks",
+  totalLeads: "Total Leads",
+  totalConversions: "Total Conversions",
+  totalSaleAmount: "Total Sale Amount",
+  totalCommissions: "Total Commissions",
+} as const;
 
 export function ProgramRewardModifiersTooltip({
   reward,

--- a/apps/web/ui/partners/rewards/add-edit-reward-sheet.tsx
+++ b/apps/web/ui/partners/rewards/add-edit-reward-sheet.tsx
@@ -13,6 +13,7 @@ import { RewardConditionsArray, RewardProps } from "@/lib/types";
 import { RECURRING_MAX_DURATIONS } from "@/lib/zod/schemas/misc";
 import {
   createOrUpdateRewardSchema,
+  ENTITY_ATTRIBUTE_TYPES,
   rewardConditionsArraySchema,
   rewardConditionSchema,
   rewardConditionsSchema,
@@ -111,6 +112,13 @@ function RewardSheetContent({
 
         return {
           ...m,
+          conditions: m.conditions.map((c) => ({
+            ...c,
+            value:
+              ENTITY_ATTRIBUTE_TYPES[c.entity]?.[c.attribute] === "currency"
+                ? Number(c.value) / 100
+                : c.value,
+          })),
           amount: type === "flat" ? m.amount / 100 : m.amount,
           maxDuration: m.maxDuration === null ? Infinity : maxDuration,
         };
@@ -201,6 +209,15 @@ function RewardSheetContent({
 
             return {
               ...m,
+              conditions: m.conditions.map((c) => ({
+                ...c,
+                value:
+                  c.entity &&
+                  c.attribute &&
+                  ENTITY_ATTRIBUTE_TYPES[c.entity]?.[c.attribute] === "currency"
+                    ? Number(c.value) * 100
+                    : c.value,
+              })),
               amount: type === "flat" ? m.amount * 100 : m.amount,
               maxDuration: maxDuration === Infinity ? null : maxDuration,
             };

--- a/apps/web/ui/partners/rewards/add-edit-reward-sheet.tsx
+++ b/apps/web/ui/partners/rewards/add-edit-reward-sheet.tsx
@@ -115,7 +115,10 @@ function RewardSheetContent({
           conditions: m.conditions.map((c) => ({
             ...c,
             value:
-              ENTITY_ATTRIBUTE_TYPES[c.entity]?.[c.attribute] === "currency"
+              ENTITY_ATTRIBUTE_TYPES[c.entity]?.[c.attribute] === "currency" &&
+              c.value !== "" &&
+              c.value != null &&
+              !Number.isNaN(Number(c.value))
                 ? Number(c.value) / 100
                 : c.value,
           })),
@@ -215,15 +218,20 @@ function RewardSheetContent({
                   c.entity &&
                   c.attribute &&
                   ENTITY_ATTRIBUTE_TYPES[c.entity]?.[c.attribute] === "currency"
-                    ? Number(c.value) * 100
+                    ? c.value === "" ||
+                      c.value == null ||
+                      Number.isNaN(Number(c.value))
+                      ? c.value
+                      : Math.round(Number(c.value) * 100)
                     : c.value,
               })),
-              amount: type === "flat" ? m.amount * 100 : m.amount,
+              amount: type === "flat" ? Math.round(m.amount * 100) : m.amount,
               maxDuration: maxDuration === Infinity ? null : maxDuration,
             };
           }),
         );
       } catch (error) {
+        console.log("parse error", error);
         setError("root.logic", { message: "Invalid reward condition" });
         toast.error(
           "Invalid reward condition. Please fix the errors and try again.",
@@ -235,7 +243,7 @@ function RewardSheetContent({
     const payload = {
       ...data,
       workspaceId,
-      amount: type === "flat" ? data.amount * 100 : data.amount,
+      amount: type === "flat" ? Math.round(data.amount * 100) : data.amount,
       maxDuration:
         Infinity === Number(data.maxDuration) ? null : data.maxDuration,
       modifiers,

--- a/apps/web/ui/partners/rewards/inline-badge-popover.tsx
+++ b/apps/web/ui/partners/rewards/inline-badge-popover.tsx
@@ -135,7 +135,7 @@ export function InlineBadgePopoverMenu<T extends any>({
       <AnimatedSizeContainer height>
         <div className="relative">
           <Command.List
-            className="scrollbar-hide flex max-h-64 max-w-48 flex-col gap-1 overflow-y-auto transition-all"
+            className="scrollbar-hide flex max-h-64 max-w-52 flex-col gap-1 overflow-y-auto transition-all"
             ref={scrollRef}
             onScroll={updateScrollProgress}
           >

--- a/apps/web/ui/partners/rewards/rewards-logic.tsx
+++ b/apps/web/ui/partners/rewards/rewards-logic.tsx
@@ -735,8 +735,7 @@ function ResultAmountInput({
 }: {
   modifierKey: `modifiers.${number}`;
 }) {
-  const { watch, register, setValue } = useAddEditRewardForm();
-  const { setIsOpen } = useContext(InlineBadgePopoverContext);
+  const { watch, setValue } = useAddEditRewardForm();
 
   const type = watch(`${modifierKey}.type`);
   const parentType = watch("type");

--- a/apps/web/ui/partners/rewards/rewards-logic.tsx
+++ b/apps/web/ui/partners/rewards/rewards-logic.tsx
@@ -314,7 +314,13 @@ function ConditionLogic({
                 onSelect={(value) =>
                   setValue(
                     conditionKey,
-                    { entity: value as keyof typeof ENTITIES },
+                    {
+                      entity: value as keyof typeof ENTITIES,
+                      // Clear dependent fields when entity changes
+                      attribute: undefined,
+                      operator: undefined,
+                      value: undefined,
+                    },
                     {
                       shouldDirty: true,
                     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add "partner" as a condition entity with partner metrics and productId for sales; pick highest‑amount matching group; new numeric comparison operators.

* **UI**
  * Numeric-aware inputs/formatting, currency scaling on load/save, updated labels/icons, improved modifier tooltip and inline badge, slightly wider dropdown, lowercase reward amount styling.

* **Chores**
  * Invalidate default partner-group pages after reward updates; adjust post-submit refresh/notification flow for group settings.

* **Behavior**
  * Reward summaries now display "Up to …" using the maximum value.

* **Tests**
  * Expanded tests for numeric operators, edge cases, and multi-group selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->