### PR TITLE
Safari modal corner issue

### DIFF
--- a/apps/web/ui/shared/modal-hero.tsx
+++ b/apps/web/ui/shared/modal-hero.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 
 export function ModalHero() {
   return (
-    <div className="relative h-48 w-full overflow-hidden bg-white">
+    <div className="relative h-48 w-full overflow-hidden bg-white rounded-t-2xl">
       <BackgroundGradient className="opacity-15" />
       <Image
         src="https://assets.dub.co/misc/welcome-modal-background.svg"


### PR DESCRIPTION
On the welcome modal (on Safari only) the corners of the top visual were always clipped improperly. So now they are not.

**Before**
<img width="763" height="608" alt="CleanShot 2025-08-22 at 09 50 11@2x" src="https://github.com/user-attachments/assets/5af87d3d-e5ef-48f9-a708-3da4a9daf104" />


**After**
<img width="654" height="593" alt="CleanShot 2025-08-22 at 09 49 52@2x" src="https://github.com/user-attachments/assets/84070c78-9b9c-47c6-aba7-d9901931c862" />
