### PR TITLE
Include totalSaleAmount in commission webhook

### DIFF
--- a/apps/web/lib/webhook/sample-events/commission-created.json
+++ b/apps/web/lib/webhook/sample-events/commission-created.json
@@ -22,6 +22,7 @@
     "totalLeads": 15,
     "totalConversions": 10,
     "totalSales": 10,
+    "totalSaleAmount": 100000,
     "totalCommissions": 50000
   },
   "customer": {

--- a/apps/web/lib/zod/schemas/commissions.ts
+++ b/apps/web/lib/zod/schemas/commissions.ts
@@ -57,6 +57,7 @@ export const CommissionWebhookSchema = CommissionSchema.merge(
         totalLeads: z.number(),
         totalConversions: z.number(),
         totalSales: z.number(),
+        totalSaleAmount: z.number(),
         totalCommissions: z.number(),
       }),
     ),

--- a/apps/web/ui/customers/customer-partner-earnings-table.tsx
+++ b/apps/web/ui/customers/customer-partner-earnings-table.tsx
@@ -1,6 +1,6 @@
 import { CommissionResponse } from "@/lib/types";
 import { StatusBadge } from "@dub/ui";
-import { currencyFormatter, formatDateTimeSmart } from "@dub/utils";
+import { currencyFormatter, formatDateTimeSmart, nFormatter } from "@dub/utils";
 import {
   flexRender,
   getCoreRowModel,
@@ -124,7 +124,9 @@ export function CustomerPartnerEarningsTable({
               href={viewAllHref ?? "#"}
               className="flex items-center gap-1.5 font-medium text-neutral-700 hover:text-neutral-900"
             >
-              {totalCommissions ?? (
+              {totalCommissions ? (
+                nFormatter(totalCommissions, { full: true })
+              ) : (
                 <div className="size-3 animate-pulse rounded-md bg-neutral-100" />
               )}{" "}
               results

--- a/apps/web/ui/customers/customer-sales-table.tsx
+++ b/apps/web/ui/customers/customer-sales-table.tsx
@@ -1,6 +1,6 @@
 import { CommissionResponse, SaleEvent } from "@/lib/types";
 import { StatusBadge } from "@dub/ui";
-import { currencyFormatter, formatDateTimeSmart } from "@dub/utils";
+import { currencyFormatter, formatDateTimeSmart, nFormatter } from "@dub/utils";
 import {
   flexRender,
   getCoreRowModel,
@@ -143,7 +143,9 @@ export function CustomerSalesTable({
               href={viewAllHref ?? "#"}
               className="flex items-center gap-1.5 font-medium text-neutral-700 hover:text-neutral-900"
             >
-              {totalSales ?? (
+              {totalSales ? (
+                nFormatter(totalSales, { full: true })
+              ) : (
                 <div className="size-3 animate-pulse rounded-md bg-neutral-100" />
               )}{" "}
               results


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a “Total Sale Amount” metric in commission data to enable richer aggregates across partner and sales views.

* **Refactor**
  * Improved totals display in customer sales and partner earnings tables: non-zero values now use human-readable number formatting; zero/undefined values show a loading placeholder for a cleaner experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->