### PR TITLE
Fix `usePayoutsCount` hook

### DIFF
--- a/apps/web/lib/swr/use-payouts-count.ts
+++ b/apps/web/lib/swr/use-payouts-count.ts
@@ -6,21 +6,20 @@ import { PayoutsCount } from "../types";
 import { payoutsCountQuerySchema } from "../zod/schemas/payouts";
 import useWorkspace from "./use-workspace";
 
-export default function usePayoutsCount<T>(
-  opts: z.input<typeof payoutsCountQuerySchema> & { enabled?: boolean } = {
-    enabled: true,
-  },
-) {
+export default function usePayoutsCount<T>({
+  enabled = true,
+  ...query
+}: z.input<typeof payoutsCountQuerySchema> & { enabled?: boolean } = {}) {
   const { id: workspaceId, defaultProgramId } = useWorkspace();
   const { getQueryString } = useRouterStuff();
 
   const { data: payoutsCount, error } = useSWR<PayoutsCount[]>(
     workspaceId &&
       defaultProgramId &&
-      opts.enabled &&
+      enabled &&
       `/api/programs/${defaultProgramId}/payouts/count${getQueryString(
         {
-          ...opts,
+          ...query,
           workspaceId,
         },
         {


### PR DESCRIPTION
Ensures the `enabled` option defaults to true, even if other options / query values are passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing changes in this release.
- Refactor
  - Streamlined configuration for retrieving payout counts, improving clarity and consistency while preserving existing behavior.
- Chores
  - Internal alignment of options handling for payout count requests to simplify future maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->