### PR TITLE
notifyPartnerCommission

### DIFF
--- a/apps/web/app/(ee)/api/stripe/integration/webhook/checkout-session-completed.ts
+++ b/apps/web/app/(ee)/api/stripe/integration/webhook/checkout-session-completed.ts
@@ -2,7 +2,6 @@ import { convertCurrency } from "@/lib/analytics/convert-currency";
 import { isFirstConversion } from "@/lib/analytics/is-first-conversion";
 import { createId } from "@/lib/api/create-id";
 import { includeTags } from "@/lib/api/links/include-tags";
-import { notifyPartnerSale } from "@/lib/api/partners/notify-partner-sale";
 import { executeWorkflows } from "@/lib/api/workflows/execute-workflows";
 import { createPartnerCommission } from "@/lib/partners/create-partner-commission";
 import {
@@ -365,18 +364,11 @@ export async function checkoutSessionCompleted(event: Stripe.Event) {
 
     if (commission) {
       waitUntil(
-        Promise.allSettled([
-          notifyPartnerSale({
-            link,
-            commission,
-          }),
-
-          executeWorkflows({
-            trigger: WorkflowTrigger.saleRecorded,
-            programId: link.programId,
-            partnerId: link.partnerId,
-          }),
-        ]),
+        executeWorkflows({
+          trigger: WorkflowTrigger.saleRecorded,
+          programId: link.programId,
+          partnerId: link.partnerId,
+        }),
       );
     }
   }

--- a/apps/web/app/(ee)/api/stripe/integration/webhook/invoice-paid.ts
+++ b/apps/web/app/(ee)/api/stripe/integration/webhook/invoice-paid.ts
@@ -1,7 +1,6 @@
 import { convertCurrency } from "@/lib/analytics/convert-currency";
 import { isFirstConversion } from "@/lib/analytics/is-first-conversion";
 import { includeTags } from "@/lib/api/links/include-tags";
-import { notifyPartnerSale } from "@/lib/api/partners/notify-partner-sale";
 import { executeWorkflows } from "@/lib/api/workflows/execute-workflows";
 import { createPartnerCommission } from "@/lib/partners/create-partner-commission";
 import { getLeadEvent, recordSale } from "@/lib/tinybird";
@@ -212,18 +211,11 @@ export async function invoicePaid(event: Stripe.Event) {
 
     if (commission) {
       waitUntil(
-        Promise.allSettled([
-          notifyPartnerSale({
-            link,
-            commission,
-          }),
-
-          executeWorkflows({
-            trigger: WorkflowTrigger.saleRecorded,
-            programId: link.programId,
-            partnerId: link.partnerId,
-          }),
-        ]),
+        executeWorkflows({
+          trigger: WorkflowTrigger.saleRecorded,
+          programId: link.programId,
+          partnerId: link.partnerId,
+        }),
       );
     }
   }

--- a/apps/web/lib/api/conversions/track-sale.ts
+++ b/apps/web/lib/api/conversions/track-sale.ts
@@ -2,7 +2,6 @@ import { convertCurrency } from "@/lib/analytics/convert-currency";
 import { isFirstConversion } from "@/lib/analytics/is-first-conversion";
 import { DubApiError } from "@/lib/api/errors";
 import { includeTags } from "@/lib/api/links/include-tags";
-import { notifyPartnerSale } from "@/lib/api/partners/notify-partner-sale";
 import { createPartnerCommission } from "@/lib/partners/create-partner-commission";
 import { getLeadEvent, recordSale } from "@/lib/tinybird";
 import { logConversionEvent } from "@/lib/tinybird/log-conversion-events";
@@ -219,7 +218,7 @@ export const trackSale = async ({
 
       // for program links
       if (link.programId && link.partnerId) {
-        const commission = await createPartnerCommission({
+        await createPartnerCommission({
           event: "sale",
           programId: link.programId,
           partnerId: link.partnerId,
@@ -239,13 +238,6 @@ export const trackSale = async ({
             },
           },
         });
-
-        if (commission) {
-          await notifyPartnerSale({
-            link,
-            commission,
-          });
-        }
 
         await executeWorkflows({
           trigger: WorkflowTrigger.saleRecorded,

--- a/apps/web/lib/integrations/shopify/create-sale.ts
+++ b/apps/web/lib/integrations/shopify/create-sale.ts
@@ -1,6 +1,5 @@
 import { isFirstConversion } from "@/lib/analytics/is-first-conversion";
 import { includeTags } from "@/lib/api/links/include-tags";
-import { notifyPartnerSale } from "@/lib/api/partners/notify-partner-sale";
 import { createPartnerCommission } from "@/lib/partners/create-partner-commission";
 import { recordSale } from "@/lib/tinybird";
 import { LeadEventTB } from "@/lib/types";
@@ -138,7 +137,7 @@ export async function createShopifySale({
 
   // for program links
   if (link.programId && link.partnerId) {
-    const commission = await createPartnerCommission({
+    await createPartnerCommission({
       event: "sale",
       programId: link.programId,
       partnerId: link.partnerId,
@@ -155,14 +154,5 @@ export async function createShopifySale({
         },
       },
     });
-
-    if (commission) {
-      waitUntil(
-        notifyPartnerSale({
-          link,
-          commission,
-        }),
-      );
-    }
   }
 }

--- a/apps/web/lib/partners/create-partner-commission.ts
+++ b/apps/web/lib/partners/create-partner-commission.ts
@@ -286,11 +286,12 @@ export const createPartnerCommission = async ({
             }),
           }),
 
-          notifyPartnerCommission({
-            program,
-            workspace,
-            commission,
-          }),
+          !isClawback &&
+            notifyPartnerCommission({
+              program,
+              workspace,
+              commission,
+            }),
 
           // We only capture audit logs for manual commissions
           user &&

--- a/apps/web/lib/partners/create-partner-commission.ts
+++ b/apps/web/lib/partners/create-partner-commission.ts
@@ -10,6 +10,7 @@ import { waitUntil } from "@vercel/functions";
 import { differenceInMonths } from "date-fns";
 import { recordAuditLog } from "../api/audit-logs/record-audit-log";
 import { createId } from "../api/create-id";
+import { notifyPartnerCommission } from "../api/partners/notify-partner-commission";
 import { syncTotalCommissions } from "../api/partners/sync-total-commissions";
 import { getProgramEnrollmentOrThrow } from "../api/programs/get-program-enrollment-or-throw";
 import { calculateSaleEarnings } from "../api/sales/calculate-sale-earnings";
@@ -239,19 +240,28 @@ export const createPartnerCommission = async ({
 
     waitUntil(
       (async () => {
-        const { workspace } = await prisma.program.findUniqueOrThrow({
+        const program = await prisma.program.findUniqueOrThrow({
           where: {
             id: programId,
           },
           select: {
+            id: true,
+            name: true,
+            slug: true,
+            logo: true,
+            holdingPeriodDays: true,
             workspace: {
               select: {
                 id: true,
+                slug: true,
+                name: true,
                 webhookEnabled: true,
               },
             },
           },
         });
+
+        const { workspace } = program;
 
         const isClawback = earnings < 0;
         const shouldTriggerWorkflow = !isClawback && !skipWorkflow;
@@ -274,6 +284,12 @@ export const createPartnerCommission = async ({
                 totalCommissions,
               },
             }),
+          }),
+
+          notifyPartnerCommission({
+            program,
+            workspace,
+            commission,
           }),
 
           // We only capture audit logs for manual commissions

--- a/packages/email/src/templates/new-commission-alert-partner.tsx
+++ b/packages/email/src/templates/new-commission-alert-partner.tsx
@@ -14,49 +14,46 @@ import {
 } from "@react-email/components";
 import { Footer } from "../components/footer";
 
-export default function NewSaleAlertPartner({
+export default function NewCommissionAlertPartner({
   email = "panic@thedis.co",
-  partner = {
-    referralLink: "https://refer.dub.co/steven",
-  },
   program = {
     name: "Acme",
     slug: "acme",
     logo: DUB_WORDMARK,
     holdingPeriodDays: 30,
   },
-  sale = {
-    amount: 4900,
-    earnings: 490,
+  commission = {
+    type: "sale",
+    amount: 25000,
+    earnings: 6900,
   },
+  shortLink = "https://refer.dub.co/steven",
 }: {
   email: string;
-  partner: {
-    referralLink: string;
-  };
   program: {
     name: string;
     slug: string;
     logo: string | null;
     holdingPeriodDays: number;
   };
-  sale: {
+  commission: {
+    type: "click" | "lead" | "sale" | "custom";
     amount: number;
     earnings: number;
   };
+  shortLink?: string | null;
 }) {
+  const earningsInDollars = currencyFormatter(commission.earnings / 100);
   const linkToEarnings = `https://partners.dub.co/programs/${program.slug}/earnings`;
-
-  const earningsInDollars = currencyFormatter(sale.earnings / 100);
-
-  const saleAmountInDollars = currencyFormatter(sale.amount / 100);
 
   return (
     <Html>
       <Head />
       <Preview>
-        You just made a {earningsInDollars} sale via your referral link{" "}
-        {getPrettyUrl(partner.referralLink)}
+        You just earned {earningsInDollars} in commissions via $
+        {shortLink
+          ? `your referral link ${getPrettyUrl(shortLink)}`
+          : "Dub Partners"}
       </Preview>
       <Tailwind>
         <Body className="mx-auto my-auto bg-white font-sans">
@@ -70,27 +67,61 @@ export default function NewSaleAlertPartner({
             </Section>
 
             <Heading className="mx-0 my-7 p-0 text-lg font-medium text-black">
-              You just made a {earningsInDollars} referral commission!
+              You just earned {earningsInDollars} in commissions!
             </Heading>
 
-            <Text className="text-sm leading-6 text-neutral-600">
-              Congratulations! Someone made a{" "}
-              <strong className="text-black">{saleAmountInDollars}</strong>{" "}
-              purchase on <strong className="text-black">{program.name}</strong>{" "}
-              using your referral link (
-              <a
-                href={partner.referralLink}
-                className="text-semibold font-medium text-black underline"
-              >
-                {getPrettyUrl(partner.referralLink)}
-              </a>
-              ).
-            </Text>
+            {!["custom", "click"].includes(commission.type) && (
+              <Text className="text-sm leading-6 text-neutral-600">
+                Congratulations! Someone{" "}
+                {commission.type === "lead" ? (
+                  "signed up"
+                ) : (
+                  <>
+                    made a{" "}
+                    <strong className="text-black">
+                      {currencyFormatter(commission.amount / 100)}
+                    </strong>{" "}
+                    purchase
+                  </>
+                )}{" "}
+                on <strong className="text-black">{program.name}</strong>
+                {shortLink ? (
+                  <>
+                    {" "}
+                    using your referral link (
+                    <a
+                      href={shortLink}
+                      className="text-semibold font-medium text-black underline"
+                    >
+                      {getPrettyUrl(shortLink)}
+                    </a>
+                    )
+                  </>
+                ) : (
+                  ""
+                )}
+                .
+              </Text>
+            )}
 
             <Text className="text-sm leading-6 text-neutral-600">
+              {["custom", "click"].includes(commission.type)
+                ? "Congratulations! "
+                : ""}
               You received{" "}
               <strong className="text-black">{earningsInDollars}</strong> in
-              commission for this sale
+              commission
+              {commission.type === "custom" ? (
+                ""
+              ) : commission.type === "click" ? (
+                <>
+                  {" "}
+                  for your clicks to{" "}
+                  <strong className="text-black">{program.name}</strong>
+                </>
+              ) : (
+                ` for this ${commission.type}`
+              )}
               {program.holdingPeriodDays > 0 ? (
                 <>
                   {" "}

--- a/packages/email/src/templates/new-commission-alert-partner.tsx
+++ b/packages/email/src/templates/new-commission-alert-partner.tsx
@@ -50,7 +50,7 @@ export default function NewCommissionAlertPartner({
     <Html>
       <Head />
       <Preview>
-        You just earned {earningsInDollars} in commissions via $
+        You just earned {earningsInDollars} in commissions via{" "}
         {shortLink
           ? `your referral link ${getPrettyUrl(shortLink)}`
           : "Dub Partners"}

--- a/packages/email/src/templates/new-sale-alert-program-owner.tsx
+++ b/packages/email/src/templates/new-sale-alert-program-owner.tsx
@@ -35,7 +35,7 @@ export default function NewSaleAlertProgramOwner({
     name: "Steven",
     email: "steven@dub.co",
   },
-  sale = {
+  commission = {
     amount: 1330,
     earnings: 399,
   },
@@ -58,7 +58,7 @@ export default function NewSaleAlertProgramOwner({
     name: string | null;
     email: string | null;
   };
-  sale: {
+  commission: {
     amount: number;
     earnings: number;
   };
@@ -66,12 +66,12 @@ export default function NewSaleAlertProgramOwner({
   const salesLink = `https://app.dub.co/${workspace.slug}/program/commissions?partnerId=${partner.id}`;
   const notificationPreferencesLink = `https://app.dub.co/${workspace.slug}/settings/notifications`;
 
-  const saleAmountInDollars = currencyFormatter(sale.amount / 100);
+  const saleAmountInDollars = currencyFormatter(commission.amount / 100);
 
-  const earningsInDollars = currencyFormatter(sale.earnings / 100);
+  const earningsInDollars = currencyFormatter(commission.earnings / 100);
 
   const profitInDollars = currencyFormatter(
-    (sale.amount - sale.earnings) / 100,
+    (commission.amount - commission.earnings) / 100,
   );
 
   let formattedDueDate = "";

--- a/packages/email/src/templates/welcome-email-partner.tsx
+++ b/packages/email/src/templates/welcome-email-partner.tsx
@@ -36,8 +36,8 @@ export default function WelcomeEmailPartner({
               Welcome {name || "to Dub Partners"}!
             </Heading>
             <Text className="mb-8 text-sm leading-6 text-gray-600">
-              You're officially a Dub Partner – time to start earning rewards by
-              referring your audience to the brands you work with.
+              Time to start earning rewards by referring your audience to the
+              brands you work with.
             </Text>
 
             <Hr />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Partner notifications now use a unified "commission" model covering sale, lead, click, and custom types with contextual messages and referral link when available.

- Enhancements
  - Program owner alerts are sent only for sale-type commissions.
  - Workflow triggers remain and run asynchronously for reliability; partner-notification timing adjusted.

- Content
  - Partner email templates updated (titles, messaging, dynamic commission wording).
  - Welcome email copy simplified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->