### PR TITLE
fix(stripe): accept snake_case dub_customer_id as fallback

### DIFF
--- a/apps/web/app/(ee)/api/stripe/integration/webhook/checkout-session-completed.ts
+++ b/apps/web/app/(ee)/api/stripe/integration/webhook/checkout-session-completed.ts
@@ -31,7 +31,7 @@ import {
 // Handle event "checkout.session.completed"
 export async function checkoutSessionCompleted(event: Stripe.Event) {
   let charge = event.data.object as Stripe.Checkout.Session;
-  let dubCustomerId = charge.metadata?.dubCustomerId;
+  let dubCustomerId = charge.metadata?.dubCustomerId || charge.metadata?.dub_customer_id;
   const clientReferenceId = charge.client_reference_id;
   const stripeAccountId = event.account as string;
   const stripeCustomerId = charge.customer as string;

--- a/apps/web/app/(ee)/api/stripe/integration/webhook/customer-created.ts
+++ b/apps/web/app/(ee)/api/stripe/integration/webhook/customer-created.ts
@@ -6,7 +6,7 @@ import { createNewCustomer } from "./utils";
 export async function customerCreated(event: Stripe.Event) {
   const stripeCustomer = event.data.object as Stripe.Customer;
   const stripeAccountId = event.account as string;
-  const dubCustomerExternalId = stripeCustomer.metadata?.dubCustomerId;
+  const dubCustomerExternalId = stripeCustomer.metadata?.dubCustomerId || stripeCustomer.metadata?.dub_customer_id;
 
   if (!dubCustomerExternalId) {
     return "External ID not found in Stripe customer metadata, skipping...";

--- a/apps/web/app/(ee)/api/stripe/integration/webhook/customer-updated.ts
+++ b/apps/web/app/(ee)/api/stripe/integration/webhook/customer-updated.ts
@@ -6,7 +6,7 @@ import { createNewCustomer } from "./utils";
 export async function customerUpdated(event: Stripe.Event) {
   const stripeCustomer = event.data.object as Stripe.Customer;
   const stripeAccountId = event.account as string;
-  const dubCustomerExternalId = stripeCustomer.metadata?.dubCustomerId;
+  const dubCustomerExternalId = stripeCustomer.metadata?.dubCustomerId || stripeCustomer.metadata?.dub_customer_id;
 
   if (!dubCustomerExternalId) {
     return "External ID not found in Stripe customer metadata, skipping...";

--- a/apps/web/app/(ee)/api/stripe/integration/webhook/utils.ts
+++ b/apps/web/app/(ee)/api/stripe/integration/webhook/utils.ts
@@ -16,7 +16,7 @@ import type Stripe from "stripe";
 export async function createNewCustomer(event: Stripe.Event) {
   const stripeCustomer = event.data.object as Stripe.Customer;
   const stripeAccountId = event.account as string;
-  const dubCustomerExternalId = stripeCustomer.metadata?.dubCustomerId;
+  const dubCustomerExternalId = stripeCustomer.metadata?.dubCustomerId || stripeCustomer.metadata?.dub_customer_id;
   const clickId = stripeCustomer.metadata?.dubClickId;
 
   // The client app should always send dubClickId (dub_id) via metadata


### PR DESCRIPTION
This PR adds support for using dub_customer_id as a fallback when processing events from the Stripe webhook integration.

This is useful for libraries that normalize checkoutSessionParams to follow Stripe’s snake_case convention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Improved Stripe integration compatibility by recognizing both dubCustomerId and dub_customer_id in metadata.
  - Ensures reliable customer identification during checkout completion, customer creation, and customer updates.
  - Reduces missed customer associations and improves sync accuracy across connected projects.

- Chores
  - No user-facing changes beyond reliability improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->