### PR TITLE
Add fallback support for Redis timeouts

### DIFF
--- a/apps/web/app/(ee)/api/cron/disposable-emails/route.ts
+++ b/apps/web/app/(ee)/api/cron/disposable-emails/route.ts
@@ -24,7 +24,7 @@ export async function GET(req: Request) {
 
     // Use a temporary set to avoid emptying the old set
     await redis.del("disposableEmailDomainsTmp");
-    await redis.sadd("disposableEmailDomainsTmp", ...domains);
+    await redis.sadd("disposableEmailDomainsTmp", undefined, ...domains);
     await redis.rename("disposableEmailDomainsTmp", "disposableEmailDomains");
 
     return NextResponse.json({ status: "OK" });

--- a/apps/web/app/(ee)/api/cron/disposable-emails/route.ts
+++ b/apps/web/app/(ee)/api/cron/disposable-emails/route.ts
@@ -24,7 +24,7 @@ export async function GET(req: Request) {
 
     // Use a temporary set to avoid emptying the old set
     await redis.del("disposableEmailDomainsTmp");
-    await redis.sadd("disposableEmailDomainsTmp", undefined, ...domains);
+    await redis.sadd("disposableEmailDomainsTmp", ...(domains as [string]));
     await redis.rename("disposableEmailDomainsTmp", "disposableEmailDomains");
 
     return NextResponse.json({ status: "OK" });

--- a/apps/web/app/(ee)/api/cron/framer/backfill-leads-batch/route.ts
+++ b/apps/web/app/(ee)/api/cron/framer/backfill-leads-batch/route.ts
@@ -316,11 +316,10 @@ export const POST = withWorkspace(async ({ req, workspace }) => {
       // Cache the externalId:eventName pairs
       redis.sadd(
         CACHE_KEY,
-        undefined,
-        ...dataArray.map(
+        ...(dataArray.map(
           ({ payload: { externalId, eventName } }) =>
             `${externalId}:${eventName}`,
-        ),
+        ) as [string]),
       ),
     ]);
 

--- a/apps/web/app/(ee)/api/cron/framer/backfill-leads-batch/route.ts
+++ b/apps/web/app/(ee)/api/cron/framer/backfill-leads-batch/route.ts
@@ -316,6 +316,7 @@ export const POST = withWorkspace(async ({ req, workspace }) => {
       // Cache the externalId:eventName pairs
       redis.sadd(
         CACHE_KEY,
+        undefined,
         ...dataArray.map(
           ({ payload: { externalId, eventName } }) =>
             `${externalId}:${eventName}`,

--- a/apps/web/app/(ee)/api/cron/import/csv/route.ts
+++ b/apps/web/app/(ee)/api/cron/import/csv/route.ts
@@ -352,7 +352,7 @@ const processMappedLinks = async ({
   }
 
   if (selectedDomains.length > 0) {
-    await redis.sadd(`${redisKey}:domains`, ...selectedDomains);
+    await redis.sadd(`${redisKey}:domains`, undefined, ...selectedDomains);
   }
 
   // Process the links

--- a/apps/web/app/(ee)/api/cron/import/csv/route.ts
+++ b/apps/web/app/(ee)/api/cron/import/csv/route.ts
@@ -352,7 +352,7 @@ const processMappedLinks = async ({
   }
 
   if (selectedDomains.length > 0) {
-    await redis.sadd(`${redisKey}:domains`, undefined, ...selectedDomains);
+    await redis.sadd(`${redisKey}:domains`, ...(selectedDomains as [string]));
   }
 
   // Process the links

--- a/apps/web/lib/middleware/link.ts
+++ b/apps/web/lib/middleware/link.ts
@@ -32,6 +32,7 @@ import { recordClickCache } from "../api/links/record-click-cache";
 import { getLinkViaEdge } from "../planetscale";
 import { getDomainViaEdge } from "../planetscale/get-domain-via-edge";
 import { getPartnerAndDiscount } from "../planetscale/get-partner-discount";
+import { RedisLinkProps } from "../types";
 import { cacheDeepLinkClickData } from "./utils/cache-deeplink-click-data";
 import { crawlBitly } from "./utils/crawl-bitly";
 import { isIosAppStoreUrl } from "./utils/is-ios-app-store-url";
@@ -79,7 +80,21 @@ export default async function LinkMiddleware(
     });
   }
 
-  let cachedLink = await linkCache.get({ domain, key });
+  let cachedLink: RedisLinkProps | null = null;
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 1000);
+
+    cachedLink = await linkCache.get({ domain, key });
+    clearTimeout(timeoutId);
+  } catch (error) {
+    console.error(
+      "[LinkMiddleware] – Timeout getting cached link from Redis:",
+      error,
+    );
+    cachedLink = null;
+  }
+
   let isPartnerLink = Boolean(cachedLink?.programId && cachedLink?.partnerId);
 
   if (!cachedLink) {

--- a/apps/web/lib/middleware/link.ts
+++ b/apps/web/lib/middleware/link.ts
@@ -32,7 +32,6 @@ import { recordClickCache } from "../api/links/record-click-cache";
 import { getLinkViaEdge } from "../planetscale";
 import { getDomainViaEdge } from "../planetscale/get-domain-via-edge";
 import { getPartnerAndDiscount } from "../planetscale/get-partner-discount";
-import { RedisLinkProps } from "../types";
 import { cacheDeepLinkClickData } from "./utils/cache-deeplink-click-data";
 import { crawlBitly } from "./utils/crawl-bitly";
 import { isIosAppStoreUrl } from "./utils/is-ios-app-store-url";
@@ -80,21 +79,7 @@ export default async function LinkMiddleware(
     });
   }
 
-  let cachedLink: RedisLinkProps | null = null;
-  try {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 1000);
-
-    cachedLink = await linkCache.get({ domain, key });
-    clearTimeout(timeoutId);
-  } catch (error) {
-    console.error(
-      "[LinkMiddleware] – Timeout getting cached link from Redis:",
-      error,
-    );
-    cachedLink = null;
-  }
-
+  let cachedLink = await linkCache.get({ domain, key });
   let isPartnerLink = Boolean(cachedLink?.programId && cachedLink?.partnerId);
 
   if (!cachedLink) {

--- a/apps/web/lib/upstash/ratelimit.ts
+++ b/apps/web/lib/upstash/ratelimit.ts
@@ -16,5 +16,6 @@ export const ratelimit = (
     limiter: Ratelimit.slidingWindow(requests, seconds),
     analytics: true,
     prefix: "dub",
+    timeout: 1000,
   });
 };

--- a/apps/web/lib/upstash/redis.ts
+++ b/apps/web/lib/upstash/redis.ts
@@ -5,3 +5,10 @@ export const redis = new Redis({
   url: process.env.UPSTASH_REDIS_REST_URL || "",
   token: process.env.UPSTASH_REDIS_REST_TOKEN || "",
 });
+
+// Special Redis instance with timeout
+export const redisWithTimeout = new Redis({
+  url: process.env.UPSTASH_REDIS_REST_URL || "",
+  token: process.env.UPSTASH_REDIS_REST_TOKEN || "",
+  signal: () => AbortSignal.timeout(1000),
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -46,7 +46,7 @@
     "@types/buffer-crc32": "0.2.0",
     "@upstash/qstash": "^2.8.2",
     "@upstash/ratelimit": "^2.0.5",
-    "@upstash/redis": "^1.25.1",
+    "@upstash/redis": "^1.35.3",
     "@vercel/edge-config": "^0.4.1",
     "@vercel/functions": "^1.4.2",
     "@vercel/og": "^0.6.5",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -45,7 +45,7 @@
     "@types/bcryptjs": "^2.4.6",
     "@types/buffer-crc32": "0.2.0",
     "@upstash/qstash": "^2.8.2",
-    "@upstash/ratelimit": "^2.0.5",
+    "@upstash/ratelimit": "^2.0.6",
     "@upstash/redis": "^1.35.3",
     "@vercel/edge-config": "^0.4.1",
     "@vercel/functions": "^1.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,10 +126,10 @@ importers:
         version: 2.8.2
       '@upstash/ratelimit':
         specifier: ^2.0.5
-        version: 2.0.5(@upstash/redis@1.25.1)
+        version: 2.0.5(@upstash/redis@1.35.3)
       '@upstash/redis':
-        specifier: ^1.25.1
-        version: 1.25.1
+        specifier: ^1.35.3
+        version: 1.35.3
       '@vercel/edge-config':
         specifier: ^0.4.1
         version: 0.4.1
@@ -4760,11 +4760,8 @@ packages:
     peerDependencies:
       '@upstash/redis': ^1.34.3
 
-  '@upstash/redis@1.25.1':
-    resolution: {integrity: sha512-ACj0GhJ4qrQyBshwFgPod6XufVEfKX2wcaihsEvSdLYnY+m+pa13kGt1RXm/yTHKf4TQi/Dy2A8z/y6WUEOmlg==}
-
-  '@upstash/redis@1.30.0':
-    resolution: {integrity: sha512-bkxl2n7qls27hONXNyItM6ccRT0NBJ8c6zl83wx+TlODpYXehgeiUJTkcTaXLp7hk+zy6Mqpzpeo3GX+wZSvBw==}
+  '@upstash/redis@1.35.3':
+    resolution: {integrity: sha512-hSjv66NOuahW3MisRGlSgoszU2uONAY2l5Qo3Sae8OT3/Tng9K+2/cBRuyPBX8egwEGcNNCF9+r0V6grNnhL+w==}
 
   '@vercel/edge-config-fs@0.1.0':
     resolution: {integrity: sha512-NRIBwfcS0bUoUbRWlNGetqjvLSwgYH/BqKqDN7vK1g32p7dN96k0712COgaz6VFizAm9b0g6IG6hR6+hc0KCPg==}
@@ -10042,6 +10039,9 @@ packages:
 
   unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
+
+  uncrypto@0.1.3:
+    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
 
   unicode-properties@1.4.1:
     resolution: {integrity: sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==}
@@ -15339,7 +15339,7 @@ snapshots:
 
   '@upstash/core-analytics@0.0.10':
     dependencies:
-      '@upstash/redis': 1.30.0
+      '@upstash/redis': 1.35.3
 
   '@upstash/qstash@2.8.2':
     dependencies:
@@ -15347,18 +15347,14 @@ snapshots:
       jose: 5.10.0
       neverthrow: 7.2.0
 
-  '@upstash/ratelimit@2.0.5(@upstash/redis@1.25.1)':
+  '@upstash/ratelimit@2.0.5(@upstash/redis@1.35.3)':
     dependencies:
       '@upstash/core-analytics': 0.0.10
-      '@upstash/redis': 1.25.1
+      '@upstash/redis': 1.35.3
 
-  '@upstash/redis@1.25.1':
+  '@upstash/redis@1.35.3':
     dependencies:
-      crypto-js: 4.2.0
-
-  '@upstash/redis@1.30.0':
-    dependencies:
-      crypto-js: 4.2.0
+      uncrypto: 0.1.3
 
   '@vercel/edge-config-fs@0.1.0': {}
 
@@ -21969,6 +21965,8 @@ snapshots:
       has-bigints: 1.0.2
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
+
+  uncrypto@0.1.3: {}
 
   unicode-properties@1.4.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,8 +125,8 @@ importers:
         specifier: ^2.8.2
         version: 2.8.2
       '@upstash/ratelimit':
-        specifier: ^2.0.5
-        version: 2.0.5(@upstash/redis@1.35.3)
+        specifier: ^2.0.6
+        version: 2.0.6(@upstash/redis@1.35.3)
       '@upstash/redis':
         specifier: ^1.35.3
         version: 1.35.3
@@ -4755,8 +4755,8 @@ packages:
   '@upstash/qstash@2.8.2':
     resolution: {integrity: sha512-gQMCs2YXmRJWGh28t3fsWuPTzGgVFVRBd4o5QeWM9l3HW8TMNwt1qzv5wtzzSlG7hv1ylEy/PQCznkxGcAwTfw==}
 
-  '@upstash/ratelimit@2.0.5':
-    resolution: {integrity: sha512-1FRv0cs3ZlBjCNOCpCmKYmt9BYGIJf0J0R3pucOPE88R21rL7jNjXG+I+rN/BVOvYJhI9niRAS/JaSNjiSICxA==}
+  '@upstash/ratelimit@2.0.6':
+    resolution: {integrity: sha512-Uak5qklMfzFN5RXltxY6IXRENu+Hgmo9iEgMPOlUs2etSQas2N+hJfbHw37OUy4vldLRXeD0OzL+YRvO2l5acg==}
     peerDependencies:
       '@upstash/redis': ^1.34.3
 
@@ -15347,7 +15347,7 @@ snapshots:
       jose: 5.10.0
       neverthrow: 7.2.0
 
-  '@upstash/ratelimit@2.0.5(@upstash/redis@1.35.3)':
+  '@upstash/ratelimit@2.0.6(@upstash/redis@1.35.3)':
     dependencies:
       '@upstash/core-analytics': 0.0.10
       '@upstash/redis': 1.35.3


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cache reads and rate-limiting now use timeouts and fail gracefully to avoid hanging requests and improve page-load consistency.
  * Background import/cron batch jobs add temporary placeholder entries to ensure stable processing (no expected user-facing change).

* **Chores**
  * Upgraded Redis client and related dependency versions for improved stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->