### PR TITLE
Make `clickId` required in SDK

### DIFF
--- a/apps/web/app/(ee)/api/track/lead/route.ts
+++ b/apps/web/app/(ee)/api/track/lead/route.ts
@@ -25,6 +25,8 @@ export const POST = withWorkspace(
       metadata,
     } = trackLeadRequestSchema
       .extend({
+        // we if clickId is undefined/nullish, we'll coerce into an empty string
+        clickId: z.string().nullish(),
         // add backwards compatibility
         customerExternalId: z.string().nullish(),
         externalId: z.string().nullish(),
@@ -42,7 +44,7 @@ export const POST = withWorkspace(
     }
 
     const response = await trackLead({
-      clickId,
+      clickId: clickId ?? "",
       eventName,
       eventQuantity,
       customerExternalId,

--- a/apps/web/app/(ee)/api/track/lead/route.ts
+++ b/apps/web/app/(ee)/api/track/lead/route.ts
@@ -26,11 +26,11 @@ export const POST = withWorkspace(
     } = trackLeadRequestSchema
       .extend({
         // we if clickId is undefined/nullish, we'll coerce into an empty string
-        clickId: z.string().nullish(),
+        clickId: z.string().trim().nullish(),
         // add backwards compatibility
-        customerExternalId: z.string().nullish(),
-        externalId: z.string().nullish(),
-        customerId: z.string().nullish(),
+        customerExternalId: z.string().trim().nullish(),
+        externalId: z.string().trim().nullish(),
+        customerId: z.string().trim().nullish(),
       })
       .parse(body);
 

--- a/apps/web/lib/api/conversions/track-lead.ts
+++ b/apps/web/lib/api/conversions/track-lead.ts
@@ -49,7 +49,7 @@ export const trackLead = async ({
     },
   });
 
-  // if clickId is not provided, use the existing customer's clickId if it exists
+  // if clickId is an empty string, use the existing customer's clickId if it exists
   // otherwise, throw an error (this is for mode="deferred" lead tracking)
   if (!clickId) {
     if (!customer || !customer.clickId) {

--- a/apps/web/lib/zod/schemas/leads.ts
+++ b/apps/web/lib/zod/schemas/leads.ts
@@ -8,9 +8,8 @@ export const trackLeadRequestSchema = z.object({
   clickId: z
     .string()
     .trim()
-    .nullish()
     .describe(
-      "The unique ID of the click that the lead conversion event is attributed to. You can read this value from `dub_id` cookie. If not provided, Dub will try to find an existing customer with the provided `customerExternalId` and use the `clickId` from the customer if found.",
+      "The unique ID of the click that the lead conversion event is attributed to. You can read this value from `dub_id` cookie. If an empty string is provided, Dub will try to find an existing customer with the provided `customerExternalId` and use the `clickId` from the customer if found.",
     ),
   eventName: z
     .string()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lead tracking endpoint now accepts a clickId parameter so clients can attach click identifiers for attribution.
  * ID fields (customerExternalId, externalId, customerId) accept trimmed string input for more consistent handling.

* **Bug Fixes**
  * Input is normalized so missing/null clickId is treated as an empty string, improving robustness and preventing null/undefined issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->