### PR TITLE
Add lead params to /track/sale/client

### DIFF
--- a/apps/web/app/(ee)/api/track/sale/client/route.ts
+++ b/apps/web/app/(ee)/api/track/sale/client/route.ts
@@ -29,13 +29,17 @@ export const POST = withPublishableKey(
 
     const {
       customerExternalId,
-      paymentProcessor,
-      invoiceId,
+      customerName,
+      customerEmail,
+      customerAvatar,
+      clickId,
       amount,
       currency,
-      metadata,
       eventName,
+      paymentProcessor,
+      invoiceId,
       leadEventName,
+      metadata,
     } = trackSaleRequestSchema.parse(body);
 
     if (!customerExternalId) {
@@ -47,6 +51,10 @@ export const POST = withPublishableKey(
 
     const response = await trackSale({
       customerExternalId,
+      customerName,
+      customerEmail,
+      customerAvatar,
+      clickId,
       amount,
       currency,
       eventName,

--- a/apps/web/app/(ee)/api/track/sale/route.ts
+++ b/apps/web/app/(ee)/api/track/sale/route.ts
@@ -19,13 +19,13 @@ export const POST = withWorkspace(
       customerEmail,
       customerAvatar,
       clickId,
-      paymentProcessor,
-      invoiceId,
       amount,
       currency,
-      metadata,
       eventName,
+      paymentProcessor,
+      invoiceId,
       leadEventName,
+      metadata,
     } = trackSaleRequestSchema
       .extend({
         // add backwards compatibility

--- a/apps/web/scripts/perplexity/backfill-leads.ts
+++ b/apps/web/scripts/perplexity/backfill-leads.ts
@@ -2,7 +2,7 @@ import { createId } from "@/lib/api/create-id";
 import { generateRandomName } from "@/lib/names";
 import { determinePartnerReward } from "@/lib/partners/determine-partner-reward";
 import { prisma } from "@dub/prisma";
-import { EventType, Prisma } from "@dub/prisma/client";
+import { EventType } from "@dub/prisma/client";
 import { capitalize, nanoid } from "@dub/utils";
 import { COUNTRIES_TO_CONTINENTS } from "@dub/utils/src/constants/continents";
 import { geolocation } from "@vercel/functions";
@@ -162,27 +162,26 @@ async function main() {
         }),
       ).then((res) => res.filter((r) => r !== null));
 
-      const customersToCreate: Prisma.CustomerCreateManyInput[] =
-        leadsToBackfill
-          .map((lead, idx) => {
-            const clickData = clicksToCreate[idx];
-            if (!clickData) {
-              return null;
-            }
-            return {
-              id: createId({ prefix: "cus_" }),
-              name: generateRandomName(),
-              externalId: lead.customerExternalId,
-              projectId: workspace.id,
-              projectConnectId: workspace.stripeConnectId,
-              clickId: clickData.click_id,
-              linkId: clickData.link_id,
-              country: clickData.country,
-              clickedAt: new Date(lead.timestamp).toISOString(),
-              createdAt: new Date(lead.timestamp).toISOString(),
-            };
-          })
-          .filter((c) => c !== null);
+      const customersToCreate = leadsToBackfill
+        .map((lead, idx) => {
+          const clickData = clicksToCreate[idx];
+          if (!clickData) {
+            return null;
+          }
+          return {
+            id: createId({ prefix: "cus_" }),
+            name: generateRandomName(),
+            externalId: lead.customerExternalId,
+            projectId: workspace.id,
+            projectConnectId: workspace.stripeConnectId,
+            clickId: clickData.click_id,
+            linkId: clickData.link_id,
+            country: clickData.country,
+            clickedAt: new Date(lead.timestamp).toISOString(),
+            createdAt: new Date(lead.timestamp).toISOString(),
+          };
+        })
+        .filter((c) => c !== null);
 
       const leadsToCreate = clicksToCreate.map((clickData, idx) => ({
         ...clickData,

--- a/apps/web/scripts/perplexity/backfill-leads.ts
+++ b/apps/web/scripts/perplexity/backfill-leads.ts
@@ -1,3 +1,5 @@
+// @ts-nocheck some weird typing issues below
+
 import { createId } from "@/lib/api/create-id";
 import { generateRandomName } from "@/lib/names";
 import { determinePartnerReward } from "@/lib/partners/determine-partner-reward";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Client-side sale tracking now captures customer name, email, avatar, and click ID for richer attribution.

* **Refactor**
  * Reordered request field handling in sale-tracking endpoints for consistent payload processing; no change to validations or supported fields.
  * Simplified a lead-backfill script by removing unnecessary imports and relying on inferred types for cleaner code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->