### PR TITLE
Schedule bounty email for newly-joined partners

### DIFF
--- a/apps/web/app/(ee)/api/cron/bounties/notify-partners/route.ts
+++ b/apps/web/app/(ee)/api/cron/bounties/notify-partners/route.ts
@@ -112,7 +112,7 @@ export async function POST(req: Request) {
     }
 
     console.log(
-      `Sending emails to ${programEnrollments.length} partners: ${programEnrollments.map(({ partner }) => partner.email).join(", ")}`,
+      `Sending emails to ${programEnrollments.length} partners for bounty ${bountyId}.`,
     );
 
     await resend.batch.send(

--- a/apps/web/lib/api/bounties/get-bounties-by-group.ts
+++ b/apps/web/lib/api/bounties/get-bounties-by-group.ts
@@ -1,0 +1,90 @@
+import { prisma } from "@dub/prisma";
+import { Bounty } from "@dub/prisma/client";
+
+type GetBountiesByGroupProps = {
+  programId: string;
+  groupIds: string[];
+};
+
+export async function getBountiesByGroup({
+  programId,
+  groupIds,
+}: GetBountiesByGroupProps) {
+  const now = new Date();
+  const targetGroupIds = [...new Set(groupIds)];
+
+  const bounties = await prisma.bounty.findMany({
+    where: {
+      programId,
+      startsAt: {
+        lte: now,
+      },
+      // Check if the bounty is active
+      OR: [
+        {
+          endsAt: null,
+        },
+        {
+          endsAt: {
+            gt: now,
+          },
+        },
+      ],
+      // Only fetch bounties that are relevant to the specified groups
+      AND: [
+        {
+          OR: [
+            {
+              groups: {
+                none: {},
+              },
+            },
+            {
+              groups: {
+                some: {
+                  groupId: {
+                    in: targetGroupIds,
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
+    select: {
+      id: true,
+      name: true,
+      groups: {
+        select: {
+          groupId: true,
+        },
+      },
+    },
+  });
+
+  if (bounties.length === 0) {
+    return {};
+  }
+
+  const groupIdToBounties = bounties.reduce(
+    (acc, bounty) => {
+      const targetIds =
+        bounty.groups.length > 0
+          ? bounty.groups.map((g) => g.groupId)
+          : targetGroupIds;
+
+      targetIds.forEach((groupId) => {
+        (acc[groupId] ||= []).push({
+          id: bounty.id,
+          name: bounty.name,
+        });
+      });
+
+      return acc;
+    },
+    {} as Record<string, Pick<Bounty, "id" | "name">[]>,
+  );
+
+  return groupIdToBounties;
+}

--- a/apps/web/lib/api/bounties/get-bounties-by-group.ts
+++ b/apps/web/lib/api/bounties/get-bounties-by-group.ts
@@ -13,6 +13,10 @@ export async function getBountiesByGroup({
   const now = new Date();
   const targetGroupIds = [...new Set(groupIds)];
 
+  if (targetGroupIds.length === 0) {
+    return {};
+  }
+
   const bounties = await prisma.bounty.findMany({
     where: {
       programId,

--- a/apps/web/lib/partners/approve-partner-enrollment.ts
+++ b/apps/web/lib/partners/approve-partner-enrollment.ts
@@ -233,11 +233,11 @@ export async function approvePartnerEnrollment({
           ],
         }),
 
-        ...(bountiesByGroupId[group.id] || []).map((bountyId) =>
+        ...(bountiesByGroupId[group.id] || []).map(({ id }) =>
           qstash.publishJSON({
             url: `${APP_DOMAIN_WITH_NGROK}/api/cron/bounties/notify-partners`,
             body: {
-              bountyId,
+              bountyId: id,
               partnerIds: [partner.id],
             },
             notBefore: Math.floor(new Date().getTime() / 1000) + 1 * 60 * 60, // 1 hour from now

--- a/apps/web/lib/partners/approve-partner-enrollment.ts
+++ b/apps/web/lib/partners/approve-partner-enrollment.ts
@@ -233,11 +233,11 @@ export async function approvePartnerEnrollment({
           ],
         }),
 
-        ...(bountiesByGroupId[group.id] || []).map(({ id }) =>
+        ...(bountiesByGroupId[group.id] || []).map((bounty) =>
           qstash.publishJSON({
             url: `${APP_DOMAIN_WITH_NGROK}/api/cron/bounties/notify-partners`,
             body: {
-              bountyId: id,
+              bountyId: bounty.id,
               partnerIds: [partner.id],
             },
             notBefore: Math.floor(new Date().getTime() / 1000) + 1 * 60 * 60, // 1 hour from now


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Newly approved partners are queued to receive notifications about active, relevant bounties roughly 1 hour after approval.
  * Bulk approvals schedule targeted bounty notifications to the affected partners; notifications can be limited to specific partner IDs.

* **Bug Fixes / Notes**
  * When processing paginated notification jobs, a partner filter provided on the first page is not propagated to subsequent pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->