### PR TITLE
Changing partner hover data

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/analytics/analytics-partners-table.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/analytics/analytics-partners-table.tsx
@@ -1,5 +1,6 @@
 import { AnalyticsResponse } from "@/lib/analytics/types";
 import { editQueryString } from "@/lib/analytics/utils";
+import useGroups from "@/lib/swr/use-groups";
 import { AnalyticsContext } from "@/ui/analytics/analytics-provider";
 import { PartnerRowItem } from "@/ui/partners/partner-row-item";
 import { FilterButtonTableRow } from "@/ui/shared/filter-button-table-row";
@@ -17,6 +18,7 @@ import useSWR from "swr";
 
 export function AnalyticsPartnersTable() {
   const { selectedTab, queryString } = useContext(AnalyticsContext);
+  const { groups } = useGroups();
 
   const { pagination, setPagination } = usePagination(10);
 
@@ -52,14 +54,15 @@ export function AnalyticsPartnersTable() {
         minSize: 250,
         cell: ({ row }) => {
           const p = row.original.partner;
+          // Note: groupId not available in analytics data, so no group rewards will be shown
           return (
             <PartnerRowItem
               partner={{
-                ...p,
-                payoutsEnabledAt: p.payoutsEnabledAt
-                  ? new Date(p.payoutsEnabledAt)
-                  : null,
+                id: p.id,
+                name: p.name,
+                image: p.image,
               }}
+              group={null}
             />
           );
         },

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/partners-table.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/partners-table.tsx
@@ -166,8 +166,17 @@ export function PartnersTable() {
           enableHiding: false,
           minSize: 250,
           cell: ({ row }) => {
+            const group = groups?.find((g) => g.id === row.original.groupId);
             return (
-              <PartnerRowItem partner={row.original} showPermalink={false} />
+              <PartnerRowItem 
+                partner={{
+                  id: row.original.id,
+                  name: row.original.name,
+                  image: row.original.image,
+                }} 
+                group={group}
+                showPermalink={false} 
+              />
             );
           },
         },

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/payouts/payout-table.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/payouts/payout-table.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import useGroups from "@/lib/swr/use-groups";
 import usePayoutsCount from "@/lib/swr/use-payouts-count";
 import useProgram from "@/lib/swr/use-program";
 import useWorkspace from "@/lib/swr/use-workspace";
@@ -52,6 +53,7 @@ const PayoutTableInner = memo(
     setSelectedFilter,
   }: ReturnType<typeof usePayoutFilters>) => {
     const { id: workspaceId, defaultProgramId } = useWorkspace();
+    const { groups } = useGroups();
     const { queryParams, searchParams, getQueryString } = useRouterStuff();
 
     const sortBy = searchParams.get("sortBy") || "periodEnd";
@@ -110,7 +112,17 @@ const PayoutTableInner = memo(
         {
           header: "Partner",
           cell: ({ row }) => {
-            return <PartnerRowItem partner={row.original.partner} />;
+            // Note: groupId not available in payout data, so no group rewards will be shown
+            return (
+              <PartnerRowItem 
+                partner={{
+                  id: row.original.partner.id,
+                  name: row.original.partner.name,
+                  image: row.original.partner.image,
+                }} 
+                group={null} 
+              />
+            );
           },
         },
         {

--- a/apps/web/ui/partners/partner-row-item.tsx
+++ b/apps/web/ui/partners/partner-row-item.tsx
@@ -126,8 +126,11 @@ export function PartnerRowItem({
         </div>
       </DynamicTooltipWrapper>
       <As
-        href={`/${slug}/program/partners?partnerId=${partner.id}`}
-        {...(showPermalink && { target: "_blank" })}
+        {...(showPermalink && {
+          href: `/${slug}/program/partners?partnerId=${partner.id}`,
+          target: "_blank",
+          rel: "noopener noreferrer",
+        })}
         className={cn(
           "min-w-0 truncate",
           showPermalink && "cursor-alias decoration-dotted hover:underline",

--- a/apps/web/ui/partners/partner-row-item.tsx
+++ b/apps/web/ui/partners/partner-row-item.tsx
@@ -33,8 +33,8 @@ export function PartnerRowItem({
 
   // Helper function to get duration text
   const getDurationText = (maxDuration?: number | null) => {
-    if (!maxDuration) return "for the customer's lifetime";
     if (maxDuration === 0) return "one-time";
+    if (maxDuration == null) return "for the customer's lifetime";
     return `for ${maxDuration} month${maxDuration > 1 ? 's' : ''}`;
   };
 

--- a/apps/web/ui/partners/partner-row-item.tsx
+++ b/apps/web/ui/partners/partner-row-item.tsx
@@ -47,9 +47,9 @@ export function PartnerRowItem({
       case "sale":
         return `Up to ${amount} per sale ${duration}`;
       case "lead":
-        return `$${(reward.amount / 100).toFixed(0)} per lead`;
+        return `${amount} per lead`;
       case "click":
-        return `$${(reward.amount / 100).toFixed(2)} per click`;
+        return `${amount} per click`;
       default:
         return `${amount} per ${reward.event}`;
     }

--- a/apps/web/ui/partners/partner-row-item.tsx
+++ b/apps/web/ui/partners/partner-row-item.tsx
@@ -1,57 +1,94 @@
-import { DynamicTooltipWrapper, GreekTemple } from "@dub/ui";
+import { DynamicTooltipWrapper } from "@dub/ui";
+import { CursorRays, InvoiceDollar, UserPlus, Gift } from "@dub/ui/icons";
 import { cn } from "@dub/utils";
 import { OG_AVATAR_URL } from "@dub/utils/src/constants";
-import { CircleMinus } from "lucide-react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
+import { getGroupRewardsAndDiscount } from "@/lib/partners/get-group-rewards-and-discount";
+import { GroupProps, RewardProps, DiscountProps } from "@/lib/types";
 
 export function PartnerRowItem({
   partner,
+  group,
   showPermalink = true,
 }: {
   partner: {
     id: string;
     name: string;
     image?: string | null;
-    payoutsEnabledAt?: Date | null;
   };
+  group?: GroupProps | null;
   showPermalink?: boolean;
 }) {
   const { slug } = useParams();
   const As = showPermalink ? Link : "div";
 
-  const showPayoutsEnabled = "payoutsEnabledAt" in partner;
+  // Helper function to format reward amount
+  const formatRewardAmount = (reward: RewardProps) => {
+    if (reward.type === "percentage") {
+      return `${reward.amount}%`;
+    }
+    return `$${(reward.amount / 100).toFixed(2)}`;
+  };
+
+  // Helper function to get reward description
+  const getRewardDescription = (reward: RewardProps) => {
+    const amount = formatRewardAmount(reward);
+    const duration = reward.maxDuration 
+      ? reward.maxDuration === 0 
+        ? "one-time" 
+        : `for ${reward.maxDuration} month${reward.maxDuration > 1 ? 's' : ''}`
+      : "lifetime";
+    
+    switch (reward.event) {
+      case "sale":
+        return `Up to ${amount} per sale ${duration}`;
+      case "lead":
+        return `$${(reward.amount / 100).toFixed(0)} per lead`;
+      case "click":
+        return `$${(reward.amount / 100).toFixed(2)} per click`;
+      default:
+        return `${amount} per ${reward.event}`;
+    }
+  };
+
+  // Get group rewards and discount
+  const { rewards, discount } = group ? getGroupRewardsAndDiscount(group) : { rewards: [], discount: null };
 
   return (
     <div className="flex items-center gap-2">
       <DynamicTooltipWrapper
         tooltipProps={
-          showPayoutsEnabled
+          group && (rewards.length > 0 || discount)
             ? {
                 content: (
-                  <div className="grid max-w-xs gap-2 p-4">
-                    <div className="flex items-center gap-2 text-sm font-medium">
-                      Payouts{" "}
-                      {partner.payoutsEnabledAt ? "enabled" : "disabled"}
-                      <div
-                        className={cn(
-                          "flex size-5 items-center justify-center rounded-md border border-green-300 bg-green-200 text-green-800",
-                          !partner.payoutsEnabledAt &&
-                            "border-red-300 bg-red-200 text-red-800",
-                        )}
-                      >
-                        {partner.payoutsEnabledAt ? (
-                          <GreekTemple className="size-3" />
-                        ) : (
-                          <CircleMinus className="size-3" />
-                        )}
+                  <div className="grid max-w-xs gap-1 p-2">
+                    {rewards.map((reward) => {
+                      const Icon = reward.event === "sale" ? InvoiceDollar 
+                                  : reward.event === "lead" ? UserPlus 
+                                  : CursorRays;
+                      
+                      return (
+                        <div key={reward.id} className="flex items-start gap-2">
+                          <div className="flex size-6 shrink-0 items-center justify-center rounded-md bg-neutral-100 text-neutral-600">
+                            <Icon className="size-4" />
+                          </div>
+                          <span className="text-xs font-medium text-neutral-700 mt-1">
+                            {getRewardDescription(reward)}
+                          </span>
+                        </div>
+                      );
+                    })}
+                    {discount && (
+                      <div className="flex items-start gap-2">
+                        <div className="flex size-6 shrink-0 items-center justify-center rounded-md bg-neutral-100 text-neutral-600">
+                          <Gift className="size-4" />
+                        </div>
+                        <span className="text-xs font-medium text-neutral-700 mt-1">
+                          New users get {discount.type === "percentage" ? `${discount.amount}%` : `$${(discount.amount / 100).toFixed(0)}`} off {discount.maxDuration ? `for ${discount.maxDuration} month${discount.maxDuration > 1 ? 's' : ''}` : 'lifetime'}
+                        </span>
                       </div>
-                    </div>
-                    <div className="text-pretty text-sm text-neutral-500">
-                      {partner.payoutsEnabledAt
-                        ? "This partner has payouts enabled, which means they will be able to receive payouts from this program"
-                        : "This partner does not have payouts enabled, which means they will not be able to receive any payouts from this program"}
-                    </div>
+                    )}
                   </div>
                 ),
               }
@@ -64,14 +101,6 @@ export function PartnerRowItem({
             alt={partner.name}
             className="size-5 shrink-0 rounded-full"
           />
-          {showPayoutsEnabled && (
-            <div
-              className={cn(
-                "absolute -bottom-0.5 -right-0.5 size-2 rounded-full bg-green-500",
-                !partner.payoutsEnabledAt && "bg-red-500",
-              )}
-            />
-          )}
         </div>
       </DynamicTooltipWrapper>
       <As


### PR DESCRIPTION
Instead of showing the payout connection status, show the rewards the partner is on.

https://github.com/user-attachments/assets/cf45075c-05c9-4a75-84c9-2c3cf205e54d





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Partner rows show a tooltip with group-specific rewards and discount details when a group is available.
  - API now returns groups enriched with associated rewards and discounts, enabling richer displays across the UI.

- Refactor
  - Removed the previous payouts status indicator from partner avatars.
  - Partner cells pass only minimal partner info (id, name, image) and include group context when available.
  - Analytics and Payouts tables preload groups but won’t show rewards where group context is absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->