### PR TITLE
Fix `sortBy` for getPartners and getGroups

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/groups/groups-table.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/groups/groups-table.tsx
@@ -43,7 +43,7 @@ export function GroupsTable() {
   const { pagination, setPagination } = usePagination();
   const { queryParams, searchParams, getQueryString } = useRouterStuff();
 
-  const sortBy = searchParams.get("sortBy") || "saleAmount";
+  const sortBy = searchParams.get("sortBy") || "totalSaleAmount";
   const sortOrder = searchParams.get("sortOrder") === "asc" ? "asc" : "desc";
 
   const {
@@ -105,29 +105,29 @@ export function GroupsTable() {
         accessorFn: (d) => nFormatter(d.partners, { full: true }),
       },
       {
-        id: "clicks",
+        id: "totalClicks",
         header: "Clicks",
-        accessorFn: (d) => nFormatter(d.clicks),
+        accessorFn: (d) => nFormatter(d.totalClicks),
       },
       {
-        id: "leads",
+        id: "totalLeads",
         header: "Leads",
-        accessorFn: (d) => nFormatter(d.leads),
+        accessorFn: (d) => nFormatter(d.totalLeads),
       },
       {
-        id: "conversions",
+        id: "totalConversions",
         header: "Conversions",
-        accessorFn: (d) => nFormatter(d.conversions),
+        accessorFn: (d) => nFormatter(d.totalConversions),
       },
       {
-        id: "saleAmount",
+        id: "totalSaleAmount",
         header: "Revenue",
-        accessorFn: (d) => currencyFormatter(d.saleAmount / 100),
+        accessorFn: (d) => currencyFormatter(d.totalSaleAmount / 100),
       },
       {
-        id: "commissions",
+        id: "totalCommissions",
         header: "Commissions",
-        accessorFn: (d) => currencyFormatter(d.commissions / 100),
+        accessorFn: (d) => currencyFormatter(d.totalCommissions / 100),
       },
       {
         id: "netRevenue",
@@ -162,11 +162,11 @@ export function GroupsTable() {
     onPaginationChange: setPagination,
     sortableColumns: [
       "partners",
-      "clicks",
-      "leads",
-      "conversions",
-      "saleAmount",
-      "commissions",
+      "totalClicks",
+      "totalLeads",
+      "totalConversions",
+      "totalSaleAmount",
+      "totalCommissions",
       "netRevenue",
     ],
     sortBy,

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/partners-table.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/partners-table.tsx
@@ -305,7 +305,7 @@ export function PartnersTable() {
       "conversions",
       "sales",
       "saleAmount",
-      "commissions",
+      "totalCommissions",
       "netRevenue",
     ],
     sortBy,

--- a/apps/web/lib/api/groups/get-groups.ts
+++ b/apps/web/lib/api/groups/get-groups.ts
@@ -10,12 +10,12 @@ type GroupFilters = z.infer<typeof getGroupsQuerySchema> & {
 const sortColumnsMap = {
   createdAt: "pg.createdAt",
   partners: "partners",
-  clicks: "totalClicks",
-  leads: "totalLeads",
-  conversions: "totalConversions",
-  sales: "totalSales",
-  saleAmount: "totalSaleAmount",
-  commissions: "totalCommissions",
+  totalClicks: "totalClicks",
+  totalLeads: "totalLeads",
+  totalConversions: "totalConversions",
+  totalSales: "totalSales",
+  totalSaleAmount: "totalSaleAmount",
+  totalCommissions: "totalCommissions",
   netRevenue: "netRevenue",
 };
 
@@ -98,12 +98,12 @@ export async function getGroups(filters: GroupFilters) {
   return groups.map((group) => ({
     ...group,
     partners: Number(group.partners),
-    clicks: Number(group.totalClicks),
-    leads: Number(group.totalLeads),
-    sales: Number(group.totalSales),
-    saleAmount: Number(group.totalSaleAmount),
-    conversions: Number(group.totalConversions),
-    commissions: Number(group.totalCommissions),
+    totalClicks: Number(group.totalClicks),
+    totalLeads: Number(group.totalLeads),
+    totalSales: Number(group.totalSales),
+    totalSaleAmount: Number(group.totalSaleAmount),
+    totalConversions: Number(group.totalConversions),
+    totalCommissions: Number(group.totalCommissions),
     netRevenue: Number(group.netRevenue),
   }));
 }

--- a/apps/web/lib/api/partners/get-partners.ts
+++ b/apps/web/lib/api/partners/get-partners.ts
@@ -10,7 +10,7 @@ const sortColumnsMap = {
   conversions: "totalConversions",
   sales: "totalSales",
   saleAmount: "totalSaleAmount",
-  commissions: "totalCommissions",
+  totalCommissions: "totalCommissions",
   netRevenue: "netRevenue",
 };
 
@@ -22,7 +22,7 @@ const sortColumnExtraMap = {
   conversions: "totalSaleAmount",
   sales: "totalClicks",
   saleAmount: "totalClicks",
-  commissions: "totalSaleAmount",
+  totalCommissions: "totalSaleAmount",
   netRevenue: "totalSaleAmount",
 };
 

--- a/apps/web/lib/zod/schemas/groups.ts
+++ b/apps/web/lib/zod/schemas/groups.ts
@@ -26,12 +26,12 @@ export const GroupSchema = z.object({
 
 export const GroupSchemaExtended = GroupSchema.extend({
   partners: z.number().default(0),
-  clicks: z.number().default(0),
-  leads: z.number().default(0),
-  sales: z.number().default(0),
-  saleAmount: z.number().default(0),
-  conversions: z.number().default(0),
-  commissions: z.number().default(0),
+  totalClicks: z.number().default(0),
+  totalLeads: z.number().default(0),
+  totalSales: z.number().default(0),
+  totalSaleAmount: z.number().default(0),
+  totalConversions: z.number().default(0),
+  totalCommissions: z.number().default(0),
   netRevenue: z.number().default(0),
   partnersCount: z.number().default(0),
 });
@@ -79,15 +79,15 @@ export const getGroupsQuerySchema = z
       .enum([
         "createdAt",
         "partners",
-        "clicks",
-        "leads",
-        "sales",
-        "saleAmount",
-        "conversions",
-        "commissions",
+        "totalClicks",
+        "totalLeads",
+        "totalSales",
+        "totalSaleAmount",
+        "totalConversions",
+        "totalCommissions",
         "netRevenue",
       ])
-      .default("partners"),
+      .default("totalSaleAmount"),
     sortOrder: z.enum(["asc", "desc"]).default("desc"),
     includeExpandedFields: booleanQuerySchema.optional(),
   })

--- a/apps/web/lib/zod/schemas/partners.ts
+++ b/apps/web/lib/zod/schemas/partners.ts
@@ -121,7 +121,7 @@ export const getPartnersQuerySchema = z
         "conversions",
         "sales",
         "saleAmount",
-        "commissions",
+        "totalCommissions",
         "netRevenue",
       ])
       .default("saleAmount")

--- a/apps/web/scripts/partners/merge-partner-profile.ts
+++ b/apps/web/scripts/partners/merge-partner-profile.ts
@@ -35,7 +35,6 @@ async function main() {
       partnerId: newPartnerId,
     },
   });
-  console.log("commissions", commissions);
 
   // update payouts
 
@@ -48,7 +47,6 @@ async function main() {
       partnerId: newPartnerId,
     },
   });
-  console.log("payouts", payouts);
 
   // update links + recordLink in TB
   await prisma.link.updateMany({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Groups table now uses total-based metrics (Total Clicks, Leads, Conversions, Sales, Sale Amount, Commissions) with default sort updated to Total Sale Amount.
  - Sorting options updated to match the new total metrics; Net Revenue and Partners remain available.
  - Partners table “Commissions” sorting now aligns with Total Commissions for consistency.

- Chores
  - Removed debug logging from partner profile merge script to reduce noise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->