### PR TITLE
Add `messagingEnabled` props

### DIFF
--- a/apps/web/app/(ee)/api/partner-profile/programs/[programId]/route.ts
+++ b/apps/web/app/(ee)/api/partner-profile/programs/[programId]/route.ts
@@ -1,7 +1,8 @@
 import { getProgramEnrollmentOrThrow } from "@/lib/api/programs/get-program-enrollment-or-throw";
 import { withPartnerProfile } from "@/lib/auth/partner";
 import { sortRewardsByEventOrder } from "@/lib/partners/sort-rewards-by-event-order";
-import { ProgramEnrollmentSchema } from "@/lib/zod/schemas/programs";
+import { getPlanCapabilities } from "@/lib/plan-capabilities";
+import { PartnerProgramEnrollmentSchema } from "@/lib/zod/schemas/partner-profile";
 import { Reward } from "@prisma/client";
 import { NextResponse } from "next/server";
 
@@ -15,6 +16,7 @@ export const GET = withPartnerProfile(async ({ partner, params }) => {
     includeSaleReward: true,
     includeDiscount: true,
     includeGroup: true,
+    includeWorkspace: true,
   });
 
   const rewards = sortRewardsByEventOrder(
@@ -26,9 +28,12 @@ export const GET = withPartnerProfile(async ({ partner, params }) => {
   );
 
   return NextResponse.json(
-    ProgramEnrollmentSchema.parse({
+    PartnerProgramEnrollmentSchema.parse({
       ...programEnrollment,
       rewards,
+      messagingEnabled: getPlanCapabilities(
+        programEnrollment.program["workspace"].plan,
+      ).canMessagePartners,
     }),
   );
 });

--- a/apps/web/app/(ee)/partners.dub.co/(dashboard)/messages/layout.tsx
+++ b/apps/web/app/(ee)/partners.dub.co/(dashboard)/messages/layout.tsx
@@ -51,9 +51,7 @@ export default function MessagesLayout({ children }: { children: ReactNode }) {
                 setSelectedProgramSlug={(slug) =>
                   router.push(`/messages/${slug}`)
                 }
-                query={{
-                  messagingEnabled: true,
-                }}
+                showMessagingEnabledOnly={true}
                 trigger={
                   <Button
                     type="button"

--- a/apps/web/lib/api/programs/get-program-enrollment-or-throw.ts
+++ b/apps/web/lib/api/programs/get-program-enrollment-or-throw.ts
@@ -12,6 +12,7 @@ export async function getProgramEnrollmentOrThrow({
   includeSaleReward = false,
   includeDiscount = false,
   includeGroup = false,
+  includeWorkspace = false,
 }: {
   partnerId: string;
   programId: string;
@@ -21,9 +22,16 @@ export async function getProgramEnrollmentOrThrow({
   includeSaleReward?: boolean;
   includeDiscount?: boolean;
   includeGroup?: boolean;
+  includeWorkspace?: boolean;
 }) {
   const include: Prisma.ProgramEnrollmentInclude = {
-    program: true,
+    program: includeWorkspace
+      ? {
+          include: {
+            workspace: true,
+          },
+        }
+      : true,
     links: {
       orderBy: {
         createdAt: "asc",

--- a/apps/web/lib/swr/use-program-enrollment.ts
+++ b/apps/web/lib/swr/use-program-enrollment.ts
@@ -2,7 +2,7 @@ import { fetcher } from "@dub/utils";
 import { useSession } from "next-auth/react";
 import { useParams } from "next/navigation";
 import useSWR, { SWRConfiguration } from "swr";
-import { ProgramEnrollmentProps } from "../types";
+import { PartnerProgramEnrollmentProps } from "../types";
 
 export default function useProgramEnrollment({
   swrOpts,
@@ -18,7 +18,7 @@ export default function useProgramEnrollment({
     data: programEnrollment,
     error,
     isLoading,
-  } = useSWR<ProgramEnrollmentProps>(
+  } = useSWR<PartnerProgramEnrollmentProps>(
     partnerId && programSlug
       ? `/api/partner-profile/programs/${programSlug}`
       : undefined,

--- a/apps/web/lib/swr/use-program-enrollments.ts
+++ b/apps/web/lib/swr/use-program-enrollments.ts
@@ -2,7 +2,7 @@ import { fetcher } from "@dub/utils";
 import { useSession } from "next-auth/react";
 import useSWR from "swr";
 import { z } from "zod";
-import { ProgramEnrollmentProps } from "../types";
+import { PartnerProgramEnrollmentProps } from "../types";
 import { partnerProfileProgramsQuerySchema } from "../zod/schemas/partner-profile";
 
 export default function useProgramEnrollments(
@@ -12,7 +12,7 @@ export default function useProgramEnrollments(
   const partnerId = session?.user?.["defaultPartnerId"];
 
   const { data: programEnrollments, isLoading } = useSWR<
-    ProgramEnrollmentProps[]
+    PartnerProgramEnrollmentProps[]
   >(
     partnerId &&
       `/api/partner-profile/programs?${new URLSearchParams(

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -4,6 +4,7 @@ import {
   PartnerEarningsSchema,
   PartnerProfileCustomerSchema,
   PartnerProfileLinkSchema,
+  PartnerProgramEnrollmentSchema,
 } from "@/lib/zod/schemas/partner-profile";
 import { DirectorySyncProviders } from "@boxyhq/saml-jackson";
 import {
@@ -449,6 +450,10 @@ export type PartnerProgramInviteProps = z.infer<
 >;
 
 export type ProgramEnrollmentProps = z.infer<typeof ProgramEnrollmentSchema>;
+
+export type PartnerProgramEnrollmentProps = z.infer<
+  typeof PartnerProgramEnrollmentSchema
+>;
 
 export type PayoutsCount = {
   status: PayoutStatus;

--- a/apps/web/lib/zod/schemas/partner-profile.ts
+++ b/apps/web/lib/zod/schemas/partner-profile.ts
@@ -14,6 +14,7 @@ import {
 import { customerActivityResponseSchema } from "./customer-activity";
 import { CustomerEnrichedSchema } from "./customers";
 import { LinkSchema } from "./links";
+import { ProgramEnrollmentSchema } from "./programs";
 import { workflowConditionSchema } from "./workflows";
 
 export const PartnerEarningsSchema = CommissionSchema.omit({
@@ -125,7 +126,10 @@ export const partnerProfileEventsQuerySchema = eventsQuerySchema.omit({
 export const partnerProfileProgramsQuerySchema = z.object({
   includeRewardsDiscounts: z.coerce.boolean().optional(),
   status: z.nativeEnum(ProgramEnrollmentStatus).optional(),
-  messagingEnabled: z.coerce.boolean().optional(),
+});
+
+export const PartnerProgramEnrollmentSchema = ProgramEnrollmentSchema.extend({
+  messagingEnabled: z.boolean(),
 });
 
 export const partnerProfileProgramsCountQuerySchema =

--- a/apps/web/ui/layout/sidebar/partners-sidebar-nav.tsx
+++ b/apps/web/ui/layout/sidebar/partners-sidebar-nav.tsx
@@ -140,17 +140,13 @@ const NAV_AREAS: SidebarNavAreas<SidebarNavData> = {
             href: `/programs/${programSlug}/links`,
             locked: isUnapproved,
           },
-          ...(messagingEnabled
-            ? [
-                {
-                  name: "Messages",
-                  icon: Msgs,
-                  href: `/messages/${programSlug}` as `/${string}`,
-                  locked: isUnapproved,
-                  arrow: true,
-                },
-              ]
-            : []),
+          {
+            name: "Messages",
+            icon: Msgs,
+            href: `/messages/${programSlug}` as `/${string}`,
+            locked: isUnapproved || !messagingEnabled,
+            arrow: messagingEnabled ? true : undefined,
+          },
         ],
       },
       {

--- a/apps/web/ui/layout/sidebar/partners-sidebar-nav.tsx
+++ b/apps/web/ui/layout/sidebar/partners-sidebar-nav.tsx
@@ -38,8 +38,9 @@ type SidebarNavData = {
   programSlug?: string;
   isUnapproved: boolean;
   invitationsCount?: number;
-  programBountiesCount?: number;
   unreadMessagesCount?: number;
+  messagingEnabled?: boolean;
+  programBountiesCount?: number;
 };
 
 const NAV_GROUPS: SidebarNavGroups<SidebarNavData> = ({
@@ -116,6 +117,7 @@ const NAV_AREAS: SidebarNavAreas<SidebarNavData> = {
     programSlug,
     isUnapproved,
     queryString,
+    messagingEnabled,
     programBountiesCount,
   }) => ({
     title: (
@@ -138,13 +140,17 @@ const NAV_AREAS: SidebarNavAreas<SidebarNavData> = {
             href: `/programs/${programSlug}/links`,
             locked: isUnapproved,
           },
-          {
-            name: "Messages",
-            icon: Msgs,
-            href: `/messages/${programSlug}`,
-            locked: isUnapproved,
-            arrow: true,
-          },
+          ...(messagingEnabled
+            ? [
+                {
+                  name: "Messages",
+                  icon: Msgs,
+                  href: `/messages/${programSlug}` as `/${string}`,
+                  locked: isUnapproved,
+                  arrow: true,
+                },
+              ]
+            : []),
         ],
       },
       {
@@ -342,8 +348,9 @@ export function PartnersSidebarNav({
         isUnapproved:
           !!programEnrollment && programEnrollment.status !== "approved",
         invitationsCount,
-        programBountiesCount: bounties?.length,
         unreadMessagesCount,
+        messagingEnabled: programEnrollment?.messagingEnabled,
+        programBountiesCount: bounties?.length,
       }}
       toolContent={toolContent}
       newsContent={newsContent}

--- a/apps/web/ui/layout/sidebar/sidebar-nav.tsx
+++ b/apps/web/ui/layout/sidebar/sidebar-nav.tsx
@@ -380,16 +380,16 @@ function NavItem({ item }: { item: NavItemType | NavSubItemType }) {
       <Link
         href={locked ? "#" : href}
         data-active={isActive}
-        onPointerEnter={() => setHovered(true)}
-        onPointerLeave={() => setHovered(false)}
+        onPointerEnter={() => !locked && setHovered(true)}
+        onPointerLeave={() => !locked && setHovered(false)}
         className={cn(
           "text-content-default group flex h-8 items-center justify-between rounded-lg p-2 text-sm leading-none transition-[background-color,color,font-weight] duration-75",
           "outline-none focus-visible:ring-2 focus-visible:ring-black/50",
           isActive && !items
             ? "bg-blue-100/50 font-medium text-blue-600 hover:bg-blue-100/80 active:bg-blue-100"
-            : "hover:bg-bg-inverted/5 active:bg-bg-inverted/10",
-
-          locked && "pointer-events-none",
+            : locked
+              ? "cursor-not-allowed opacity-75"
+              : "hover:bg-bg-inverted/5 active:bg-bg-inverted/10",
         )}
         aria-disabled={locked}
       >

--- a/apps/web/ui/partners/program-selector.tsx
+++ b/apps/web/ui/partners/program-selector.tsx
@@ -8,6 +8,7 @@ import { z } from "zod";
 type ProgramSelectorProps = {
   selectedProgramSlug: string | null;
   setSelectedProgramSlug: (programSlug: string) => void;
+  showMessagingEnabledOnly: boolean;
   disabled?: boolean;
   query?: Partial<z.infer<typeof partnerProfileProgramsQuerySchema>>;
 } & Partial<ComboboxProps<false, any>>;
@@ -15,29 +16,32 @@ type ProgramSelectorProps = {
 export function ProgramSelector({
   selectedProgramSlug,
   setSelectedProgramSlug,
+  showMessagingEnabledOnly = false,
   disabled,
-  query,
   ...rest
 }: ProgramSelectorProps) {
   const [openPopover, setOpenPopover] = useState(false);
 
   const { programEnrollments, isLoading } = useProgramEnrollments({
     status: "approved",
-    ...query,
   });
 
   const programOptions = useMemo(() => {
-    return programEnrollments?.map(({ program }) => ({
-      value: program.slug,
-      label: program.name,
-      icon: (
-        <img
-          src={program.logo || `${OG_AVATAR_URL}${program.name}`}
-          className="size-4 rounded-full"
-        />
-      ),
-    }));
-  }, [programEnrollments]);
+    return programEnrollments
+      ?.filter(({ messagingEnabled }) =>
+        showMessagingEnabledOnly ? messagingEnabled : true,
+      )
+      .map(({ program }) => ({
+        value: program.slug,
+        label: program.name,
+        icon: (
+          <img
+            src={program.logo || `${OG_AVATAR_URL}${program.name}`}
+            className="size-4 rounded-full"
+          />
+        ),
+      }));
+  }, [programEnrollments, showMessagingEnabledOnly]);
 
   const selectedOption = useMemo(() => {
     if (!selectedProgramSlug) return null;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Messaging is now gated per workspace plan; Messages appear only for programs that support partner messaging.
  - Program enrollment data includes a messagingEnabled flag so UI shows availability consistently.
  - Attempting to message from a program without messaging support now returns a clear "forbidden" error.

- Changes
  - Program selector can optionally show only programs with messaging enabled; dashboard no longer relies on manual query filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->