### PR TITLE
Add groups permissions to scopes

### DIFF
--- a/apps/web/lib/api/rbac/resources.ts
+++ b/apps/web/lib/api/rbac/resources.ts
@@ -7,6 +7,7 @@ export const RESOURCE_KEYS = [
   "folders",
   "tokens",
   "webhooks",
+  "groups",
 ] as const;
 
 export type ResourceKey = (typeof RESOURCE_KEYS)[number];

--- a/apps/web/lib/api/tokens/scopes.ts
+++ b/apps/web/lib/api/tokens/scopes.ts
@@ -16,6 +16,8 @@ export const SCOPES = [
   "workspaces.write",
   "webhooks.read",
   "webhooks.write",
+  "groups.read",
+  "groups.write",
   "apis.all", // All API scopes
   "apis.read", // All read scopes
 ] as const;
@@ -87,6 +89,20 @@ export const RESOURCE_SCOPES: {
     resource: "domains",
   },
   {
+    scope: "groups.read",
+    roles: ["owner", "member"],
+    permissions: ["groups.read"],
+    type: "read",
+    resource: "groups",
+  },
+  {
+    scope: "groups.write",
+    roles: ["owner", "member"],
+    permissions: ["groups.write", "groups.read"],
+    type: "write",
+    resource: "groups",
+  },
+  {
     scope: "workspaces.read",
     roles: ["owner", "member"],
     permissions: ["workspaces.read"],
@@ -131,6 +147,7 @@ export const RESOURCE_SCOPES: {
       "domains.read",
       "workspaces.read",
       "analytics.read",
+      "groups.read",
     ],
   },
   {
@@ -148,6 +165,8 @@ export const RESOURCE_SCOPES: {
       "workspaces.read",
       "workspaces.write",
       "analytics.read",
+      "groups.read",
+      "groups.write",
     ],
   },
 ];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added “groups” as a manageable resource in access controls.
  - Introduced new token scopes: groups.read and groups.write.
  - Tokens can now be granted read or read/write permissions for group resources.
  - Owner and member roles are supported for group-related permissions.
  - API-level permissions now include group scopes (apis.read includes groups.read; apis.all includes groups.read and groups.write).

- Chores
  - Expanded internal scope and resource lists to recognize group-related permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->