### PR TITLE
Add folder permissions to OAuth scopes and descriptions

### DIFF
--- a/apps/web/lib/api/oauth/constants.ts
+++ b/apps/web/lib/api/oauth/constants.ts
@@ -30,6 +30,8 @@ export const OAUTH_SCOPES = [
   "domains.write",
   "webhooks.read",
   "webhooks.write",
+  "folders.read",
+  "folders.write",
   "user.read", // default scope, no need to request it
 ];
 
@@ -47,4 +49,6 @@ export const OAUTH_SCOPE_DESCRIPTIONS = {
   "user.read": "Read your name, email and profile image",
   "webhooks.read": "Read access to webhooks",
   "webhooks.write": "Read and Write access to webhooks",
+  "folders.read": "Read access to folders",
+  "folders.write": "Read and Write access to folders",
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced folder-specific OAuth permissions with separate Read and Read/Write options. When connecting integrations, you can now grant access limited to reading folders or allow both reading and updating folder contents. This provides clearer consent prompts and finer control over what connected apps can do with your folders. No changes required to existing connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->