### PR TITLE
Update onboarding account type note

### DIFF
--- a/apps/web/app/(ee)/partners.dub.co/(onboarding)/onboarding/onboarding-form.tsx
+++ b/apps/web/app/(ee)/partners.dub.co/(onboarding)/onboarding/onboarding-form.tsx
@@ -237,6 +237,9 @@ export function OnboardingForm({
               )}
               indicatorClassName="bg-white"
             />
+            <p className="mt-1.5 text-xs text-neutral-500">
+              You can update this later in your partner profile settings.
+            </p>
           </div>
         </div>
 
@@ -272,9 +275,6 @@ export function OnboardingForm({
                     required: profileType === "company",
                   })}
                 />
-                <p className="mt-1.5 text-xs text-neutral-500">
-                  This cannot be changed once set.
-                </p>
               </label>
             </motion.div>
           )}


### PR DESCRIPTION
To reduce decision paralysis during partner onboarding, I've added a note to the account type, letting partners know they can change this anytime later.

We've also removed the note "This cannot be changed once set." from the company name as it's not true anymore.

<img width="593" height="202" alt="CleanShot 2025-09-17 at 08 10 17@2x" src="https://github.com/user-attachments/assets/32f84915-eba4-44a3-a560-9b5eefa57933" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- UI/UX
  - Updated onboarding form copy for clarity and predictability.
  - Removed the immutability warning under the Legal company name field.
  - Added a note after the Profile Type toggle indicating it can be updated later in partner profile settings.
  - No changes to form behavior, validation, read-only states, or submission flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->