### PR TITLE
Fix the `metadata` property in webhook payload

### DIFF
--- a/apps/web/app/(ee)/api/stripe/integration/webhook/checkout-session-completed.ts
+++ b/apps/web/app/(ee)/api/stripe/integration/webhook/checkout-session-completed.ts
@@ -410,6 +410,7 @@ export async function checkoutSessionCompleted(event: Stripe.Event) {
             eventName: "Checkout session completed",
             link: linkUpdated,
             customer,
+            metadata: null,
           }),
         });
       }
@@ -423,6 +424,7 @@ export async function checkoutSessionCompleted(event: Stripe.Event) {
           clickedAt: customer.clickedAt || customer.createdAt,
           link: linkUpdated,
           customer,
+          metadata: null,
         }),
       });
     })(),

--- a/apps/web/app/(ee)/api/stripe/integration/webhook/invoice-paid.ts
+++ b/apps/web/app/(ee)/api/stripe/integration/webhook/invoice-paid.ts
@@ -242,6 +242,7 @@ export async function invoicePaid(event: Stripe.Event) {
         clickedAt: customer.clickedAt || customer.createdAt,
         link: linkUpdated,
         customer,
+        metadata: null,
       }),
     }),
   );

--- a/apps/web/app/(ee)/api/stripe/integration/webhook/utils.ts
+++ b/apps/web/app/(ee)/api/stripe/integration/webhook/utils.ts
@@ -127,6 +127,7 @@ export async function createNewCustomer(event: Stripe.Event) {
           eventName,
           link: linkUpdated,
           customer,
+          metadata: null,
         }),
       }),
 

--- a/apps/web/lib/integrations/shopify/create-lead.ts
+++ b/apps/web/lib/integrations/shopify/create-lead.ts
@@ -102,6 +102,7 @@ export async function createShopifyLead({
         eventName,
         link,
         customer,
+        metadata: null,
       }),
     }),
   );

--- a/apps/web/lib/integrations/shopify/create-sale.ts
+++ b/apps/web/lib/integrations/shopify/create-sale.ts
@@ -133,6 +133,7 @@ export async function createShopifySale({
         link,
         clickedAt: customer.clickedAt || customer.createdAt,
         customer,
+        metadata: null,
       }),
     }),
   );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized webhook payloads for lead and sale events by setting metadata to null across Stripe and Shopify integrations.
  * Removed previously included invoice/order metadata from sale event payloads to ensure consistent structure.

* **Chores**
  * Aligned event payload formatting across related webhook flows without altering control flow or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->