### PR TITLE
Complete TODOs: links & payouts limit updates

### DIFF
--- a/apps/web/app/api/links/bulk/route.ts
+++ b/apps/web/app/api/links/bulk/route.ts
@@ -43,7 +43,7 @@ export const POST = withWorkspace(
     const links = bulkCreateLinksBodySchema.parse(await parseRequestBody(req));
     if (
       workspace.linksUsage + links.length > workspace.linksLimit &&
-      (workspace.plan === "free" || workspace.plan === "pro")
+      workspace.plan !== "enterprise" //  don't throw an error for enterprise plans
     ) {
       throw new DubApiError({
         code: "exceeded_limit",

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/links/page-client.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/links/page-client.tsx
@@ -394,9 +394,9 @@ function ImportOption({
   children: ReactNode;
   onClick: () => void;
 }) {
-  const { slug, exceededLinks, nextPlan } = useWorkspace();
+  const { slug, exceededLinks, plan, nextPlan } = useWorkspace();
 
-  return exceededLinks ? (
+  return exceededLinks && plan !== "enterprise" ? (
     <Tooltip
       content={
         <TooltipContent

--- a/apps/web/lib/actions/partners/confirm-payouts.ts
+++ b/apps/web/lib/actions/partners/confirm-payouts.ts
@@ -59,6 +59,12 @@ export const confirmPayoutsAction = authActionClient
       );
     }
 
+    if (amount < 1000) {
+      throw new Error(
+        "Your payout total is less than the minimum invoice amount of $10.",
+      );
+    }
+
     const paymentMethod = await stripe.paymentMethods.retrieve(paymentMethodId);
 
     if (paymentMethod.customer !== workspace.stripeId) {

--- a/apps/web/lib/api/links/usage-checks.ts
+++ b/apps/web/lib/api/links/usage-checks.ts
@@ -19,7 +19,7 @@ export const throwIfClicksUsageExceeded = (workspace: WorkspaceWithUsers) => {
 export const throwIfLinksUsageExceeded = (workspace: WorkspaceWithUsers) => {
   if (
     workspace.linksUsage >= workspace.linksLimit &&
-    (workspace.plan === "free" || workspace.plan === "pro")
+    workspace.plan !== "enterprise" //  don't throw an error for enterprise plans
   ) {
     throw new DubApiError({
       code: "forbidden",

--- a/apps/web/ui/modals/link-builder/index.tsx
+++ b/apps/web/ui/modals/link-builder/index.tsx
@@ -262,7 +262,7 @@ export function CreateLinkButton({
 }: {
   setShowLinkBuilder: Dispatch<SetStateAction<boolean>>;
 } & CreateLinkButtonProps) {
-  const { slug, nextPlan, exceededLinks } = useWorkspace();
+  const { slug, plan, nextPlan, exceededLinks } = useWorkspace();
 
   useKeyboardShortcut("c", () => setShowLinkBuilder(true));
 
@@ -299,7 +299,7 @@ export function CreateLinkButton({
       text="Create link"
       shortcut="C"
       disabledTooltip={
-        exceededLinks ? (
+        exceededLinks && plan !== "enterprise" ? (
           <TooltipContent
             title="Your workspace has exceeded its monthly links limit. We're still collecting data on your existing links, but you need to upgrade to add more links."
             cta={`Upgrade to ${nextPlan.name}`}

--- a/apps/web/ui/partners/payout-invoice-sheet.tsx
+++ b/apps/web/ui/partners/payout-invoice-sheet.tsx
@@ -500,6 +500,8 @@ function PayoutInvoiceSheetContent() {
                 cta="Upgrade"
                 href={`/${slug}/settings/billing/upgrade`}
               />
+            ) : amount && amount < 1000 ? (
+              "Your payout total is less than the minimum invoice amount of $10."
             ) : (
               permissionsError || undefined
             )

--- a/packages/email/src/templates/links-limit.tsx
+++ b/packages/email/src/templates/links-limit.tsx
@@ -71,7 +71,7 @@ export default function LinksLimitAlert({
               links) in your current billing cycle.
             </Text>
 
-            {plan === "business-max" || plan === "enterprise" ? (
+            {plan === "enterprise" ? (
               <Text className="text-sm leading-6 text-black">
                 Since you're on the {capitalize(plan)} plan, you will still be
                 able to create links even after you hit your limit. We're


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Enterprise workspaces can create/import links beyond usage limits; related tooltips no longer block actions for enterprise users.
  * Create Link and import interfaces now show upgrade tooltips only when limits are exceeded on non-enterprise plans.
  * Partners payouts now enforce a $10 minimum; attempts below this show a clear tooltip/message and are prevented.
  * Updated links limit notification email to display enterprise-specific messaging, removing the previous business-max path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->