### PR TITLE
Add WebhookPartner to sale & lead webhooks

### DIFF
--- a/apps/web/lib/actions/partners/approve-bounty-submission.ts
+++ b/apps/web/lib/actions/partners/approve-bounty-submission.ts
@@ -65,7 +65,7 @@ export const approveBountySubmissionAction = authActionClient
       );
     }
 
-    const commission = await createPartnerCommission({
+    const { commission } = await createPartnerCommission({
       event: "custom",
       partnerId: bountySubmission.partnerId,
       programId: bountySubmission.programId,

--- a/apps/web/lib/api/workflows/execute-award-bounty-action.ts
+++ b/apps/web/lib/api/workflows/execute-award-bounty-action.ts
@@ -160,7 +160,7 @@ export const executeAwardBountyAction = async ({
   }
 
   // Create the commission for the partner
-  const commission = await createPartnerCommission({
+  const { commission } = await createPartnerCommission({
     event: "custom",
     partnerId,
     programId: bounty.programId,

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -69,6 +69,7 @@ import {
   createPartnerSchema,
   EnrolledPartnerSchema,
   PartnerSchema,
+  WebhookPartnerSchema,
 } from "./zod/schemas/partners";
 import {
   PartnerPayoutResponseSchema,
@@ -393,6 +394,8 @@ export type WebhookCacheProps = Pick<
   Webhook,
   "id" | "url" | "secret" | "triggers" | "disabledAt"
 >;
+
+export type WebhookPartner = z.infer<typeof WebhookPartnerSchema>;
 
 export type TrackLeadResponse = z.infer<typeof trackLeadResponseSchema>;
 

--- a/apps/web/lib/webhook/schemas.ts
+++ b/apps/web/lib/webhook/schemas.ts
@@ -3,7 +3,10 @@ import { clickEventSchema } from "../zod/schemas/clicks";
 import { CommissionWebhookSchema } from "../zod/schemas/commissions";
 import { CustomerSchema } from "../zod/schemas/customers";
 import { linkEventSchema } from "../zod/schemas/links";
-import { EnrolledPartnerSchema } from "../zod/schemas/partners";
+import {
+  EnrolledPartnerSchema,
+  WebhookPartnerSchema,
+} from "../zod/schemas/partners";
 import { WEBHOOK_TRIGGERS } from "./constants";
 
 const webhookSaleSchema = z.object({
@@ -23,6 +26,7 @@ export const leadWebhookEventSchema = z.object({
   customer: CustomerSchema,
   click: clickEventSchema,
   link: linkEventSchema,
+  partner: WebhookPartnerSchema.nullish(),
   metadata: z.record(z.unknown()).nullable().default(null),
 });
 
@@ -32,6 +36,7 @@ export const saleWebhookEventSchema = z.object({
   click: clickEventSchema,
   link: linkEventSchema,
   sale: webhookSaleSchema,
+  partner: WebhookPartnerSchema.nullish(),
   metadata: z.record(z.unknown()).nullable().default(null),
 });
 

--- a/apps/web/lib/zod/schemas/commissions.ts
+++ b/apps/web/lib/zod/schemas/commissions.ts
@@ -3,7 +3,7 @@ import { CommissionStatus, CommissionType } from "@dub/prisma/client";
 import { z } from "zod";
 import { CustomerSchema } from "./customers";
 import { getPaginationQuerySchema } from "./misc";
-import { PartnerSchema } from "./partners";
+import { PartnerSchema, WebhookPartnerSchema } from "./partners";
 import { parseDateSchema } from "./utils";
 
 export const CommissionSchema = z.object({
@@ -44,23 +44,7 @@ export const CommissionEnrichedSchema = CommissionSchema.merge(
 // "commission.created" webhook event schema
 export const CommissionWebhookSchema = CommissionSchema.merge(
   z.object({
-    partner: PartnerSchema.pick({
-      id: true,
-      name: true,
-      email: true,
-      image: true,
-      payoutsEnabledAt: true,
-      country: true,
-    }).merge(
-      z.object({
-        totalClicks: z.number(),
-        totalLeads: z.number(),
-        totalConversions: z.number(),
-        totalSales: z.number(),
-        totalSaleAmount: z.number(),
-        totalCommissions: z.number(),
-      }),
-    ),
+    partner: WebhookPartnerSchema,
     customer: CustomerSchema.nullish(), // customer can be null for click-based / custom commissions
   }),
 );

--- a/apps/web/lib/zod/schemas/partners.ts
+++ b/apps/web/lib/zod/schemas/partners.ts
@@ -369,6 +369,24 @@ export const EnrolledPartnerSchema = PartnerSchema.pick({
   })
   .merge(PartnerOnlinePresenceSchema);
 
+export const WebhookPartnerSchema = PartnerSchema.pick({
+  id: true,
+  name: true,
+  email: true,
+  image: true,
+  payoutsEnabledAt: true,
+  country: true,
+}).merge(
+  z.object({
+    totalClicks: z.number(),
+    totalLeads: z.number(),
+    totalConversions: z.number(),
+    totalSales: z.number(),
+    totalSaleAmount: z.number(),
+    totalCommissions: z.number(),
+  }),
+);
+
 export const LeaderboardPartnerSchema = z.object({
   id: z.string(),
   name: z.string(),
@@ -376,15 +394,11 @@ export const LeaderboardPartnerSchema = z.object({
   totalCommissions: z.number().default(0),
 });
 
-export const PARTNER_CUSTOMERS_MAX_PAGE_SIZE = 100;
-
 export const getPartnerCustomersQuerySchema = z
   .object({
     search: z.string().optional(),
   })
-  .merge(
-    getPaginationQuerySchema({ pageSize: PARTNER_CUSTOMERS_MAX_PAGE_SIZE }),
-  );
+  .merge(getPaginationQuerySchema({ pageSize: 100 }));
 
 export const createPartnerSchema = z.object({
   name: z


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * lead.created and sale.created webhooks now include a partner object when available, with totals (clicks, leads, conversions, sales, sale amount, commissions).
  * Standardized partner payload across lead, sale, and commission webhooks.
  * Shopify sale webhooks are enriched to include partner details when commissions are created.

* Refactor
  * Unified partner schema across webhooks for consistency.
  * Partner customers query now uses a fixed page size of 100.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->