### PR TITLE
Partner UI tweaks

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/[partnerId]/about/page-client.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/[partnerId]/about/page-client.tsx
@@ -2,11 +2,25 @@
 
 import usePartner from "@/lib/swr/use-partner";
 import { PartnerAbout } from "@/ui/partners/partner-about";
+import { PartnerApplicationDetails } from "@/ui/partners/partner-application-details";
 import { useParams } from "next/navigation";
 
 export function ProgramPartnerAboutPageClient() {
   const { partnerId } = useParams() as { partnerId: string };
   const { partner, error } = usePartner({ partnerId });
 
-  return <PartnerAbout partner={partner} error={error} />;
+  return (
+    <>
+      <PartnerAbout partner={partner} error={error} />
+      {partner?.applicationId && (
+        <>
+          <hr className="border-border-subtle" />
+          <h3 className="text-content-emphasis text-lg font-semibold">
+            Application
+          </h3>
+          <PartnerApplicationDetails applicationId={partner.applicationId} />
+        </>
+      )}
+    </>
+  );
 }

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/[partnerId]/layout.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/[partnerId]/layout.tsx
@@ -71,7 +71,7 @@ export default function ProgramPartnerLayout({
         <PartnerStats partner={partner} error={Boolean(partnerError)} />
         <div className="@3xl/page:grid-cols-[minmax(440px,1fr)_minmax(0,360px)] mt-6 grid grid-cols-1 gap-x-6 gap-y-4">
           <div className="@3xl/page:order-2">
-            <PartnerInfoCards partner={partner} />
+            <PartnerInfoCards partner={partner} hideStatuses={["approved"]} />
           </div>
           <div className="@3xl/page:order-1">
             <div className="border-border-subtle overflow-hidden rounded-xl border bg-neutral-100">

--- a/apps/web/ui/partners/online-presence-summary.tsx
+++ b/apps/web/ui/partners/online-presence-summary.tsx
@@ -90,10 +90,12 @@ export function OnlinePresenceSummary({
   partner,
   showLabels = true,
   className,
+  emptyClassName,
 }: {
   partner: EnrolledPartnerProps;
   showLabels?: boolean;
   className?: string;
+  emptyClassName?: string;
 }) {
   const fieldData = fields
     .map((field) => ({
@@ -131,7 +133,13 @@ export function OnlinePresenceSummary({
       })}
     </div>
   ) : (
-    <div className={cn("text-sm italic text-neutral-400", className)}>
+    <div
+      className={cn(
+        "text-sm italic text-neutral-400",
+        className,
+        emptyClassName,
+      )}
+    >
       No online presence provided
     </div>
   );

--- a/apps/web/ui/partners/partner-about.tsx
+++ b/apps/web/ui/partners/partner-about.tsx
@@ -33,6 +33,7 @@ export function PartnerAbout({
           partner={partner}
           showLabels={false}
           className="gap-y-2"
+          emptyClassName="text-xs"
         />
       </div>
     </>

--- a/apps/web/ui/partners/partner-application-details.tsx
+++ b/apps/web/ui/partners/partner-application-details.tsx
@@ -1,0 +1,64 @@
+import useProgram from "@/lib/swr/use-program";
+import useWorkspace from "@/lib/swr/use-workspace";
+import { fetcher } from "@dub/utils";
+import { ProgramApplication } from "@prisma/client";
+import Linkify from "linkify-react";
+import useSWRImmutable from "swr/immutable";
+
+export function PartnerApplicationDetails({
+  applicationId,
+}: {
+  applicationId: string;
+}) {
+  const { id: workspaceId } = useWorkspace();
+  const { program } = useProgram();
+
+  const { data: application } = useSWRImmutable<ProgramApplication>(
+    program &&
+      workspaceId &&
+      `/api/programs/${program.id}/applications/${applicationId}?workspaceId=${workspaceId}`,
+    fetcher,
+  );
+
+  const fields = [
+    {
+      title: `How do you plan to promote ${program?.name}?`,
+      value: application?.proposal,
+    },
+    {
+      title: "Any additional questions or comments?",
+      value: application?.comments,
+    },
+  ];
+
+  return (
+    <div className="grid grid-cols-1 gap-5 text-xs">
+      {fields.map((field) => (
+        <div key={field.title}>
+          <h4 className="text-content-emphasis font-semibold">{field.title}</h4>
+          <div className="mt-2">
+            {field.value || field.value === "" ? (
+              <Linkify
+                as="p"
+                options={{
+                  target: "_blank",
+                  rel: "noopener noreferrer nofollow",
+                  className:
+                    "underline underline-offset-4 text-neutral-400 hover:text-neutral-700",
+                }}
+              >
+                {field.value || (
+                  <span className="text-content-muted italic">
+                    No response provided
+                  </span>
+                )}
+              </Linkify>
+            ) : (
+              <div className="h-4 w-28 min-w-0 animate-pulse rounded-md bg-neutral-200" />
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/ui/partners/partner-application-sheet.tsx
+++ b/apps/web/ui/partners/partner-application-sheet.tsx
@@ -15,15 +15,12 @@ import {
   useKeyboardShortcut,
   useRouterStuff,
 } from "@dub/ui";
-import { fetcher } from "@dub/utils";
-import { ProgramApplication } from "@prisma/client";
-import Linkify from "linkify-react";
 import { useAction } from "next-safe-action/hooks";
 import Link from "next/link";
 import { Dispatch, SetStateAction, useEffect, useState } from "react";
 import { toast } from "sonner";
-import useSWRImmutable from "swr/immutable";
 import { PartnerAbout } from "./partner-about";
+import { PartnerApplicationDetails } from "./partner-application-details";
 import { PartnerApplicationTabs } from "./partner-application-tabs";
 import { PartnerComments } from "./partner-comments";
 import { PartnerInfoCards } from "./partner-info-cards";
@@ -103,6 +100,7 @@ function PartnerApplicationSheetContent({
         <div className="@3xl/sheet:order-2">
           <PartnerInfoCards
             partner={partner}
+            hideStatuses={["pending"]}
             {...(partner.status === "rejected" && {
               selectedGroupId,
               setSelectedGroupId,
@@ -156,65 +154,11 @@ function PartnerApplicationAbout({
           <h3 className="text-content-emphasis text-lg font-semibold">
             Application
           </h3>
-          <PartnerApplication applicationId={partner.applicationId} />
+          <PartnerApplicationDetails applicationId={partner.applicationId} />
           <hr className="border-neutral-200" />
         </>
       )}
       <PartnerAbout partner={partner} />
-    </div>
-  );
-}
-
-function PartnerApplication({ applicationId }: { applicationId: string }) {
-  const { id: workspaceId } = useWorkspace();
-  const { program } = useProgram();
-
-  const { data: application } = useSWRImmutable<ProgramApplication>(
-    program &&
-      workspaceId &&
-      `/api/programs/${program.id}/applications/${applicationId}?workspaceId=${workspaceId}`,
-    fetcher,
-  );
-
-  const fields = [
-    {
-      title: `How do you plan to promote ${program?.name}?`,
-      value: application?.proposal,
-    },
-    {
-      title: "Any additional questions or comments?",
-      value: application?.comments,
-    },
-  ];
-
-  return (
-    <div className="grid grid-cols-1 gap-6 text-xs">
-      {fields.map((field) => (
-        <div key={field.title}>
-          <h4 className="text-content-emphasis font-semibold">{field.title}</h4>
-          <div className="mt-2">
-            {field.value || field.value === "" ? (
-              <Linkify
-                as="p"
-                options={{
-                  target: "_blank",
-                  rel: "noopener noreferrer nofollow",
-                  className:
-                    "underline underline-offset-4 text-neutral-400 hover:text-neutral-700",
-                }}
-              >
-                {field.value || (
-                  <span className="text-content-muted italic">
-                    No response provided
-                  </span>
-                )}
-              </Linkify>
-            ) : (
-              <div className="h-4 w-28 min-w-0 animate-pulse rounded-md bg-neutral-200" />
-            )}
-          </div>
-        </div>
-      ))}
     </div>
   );
 }

--- a/apps/web/ui/partners/partner-info-cards.tsx
+++ b/apps/web/ui/partners/partner-info-cards.tsx
@@ -42,7 +42,7 @@ export function PartnerInfoCards({
   partner?: EnrolledPartnerProps;
 
   /** Partner statuses to hide badges for */
-  hideStatuses?: string[];
+  hideStatuses?: EnrolledPartnerProps["status"][];
 
   // Only used for a controlled group selector that doesn't persist the selection itself
   selectedGroupId?: string | null;

--- a/apps/web/ui/partners/partner-info-cards.tsx
+++ b/apps/web/ui/partners/partner-info-cards.tsx
@@ -16,6 +16,7 @@ import {
   CopyButton,
   Heart,
   OfficeBuilding,
+  StatusBadge,
   Tooltip,
   Trophy,
 } from "@dub/ui";
@@ -29,15 +30,19 @@ import {
 import Link from "next/link";
 import useSWR from "swr";
 import { PartnerInfoGroup } from "./partner-info-group";
+import { PartnerStatusBadges } from "./partner-status-badges";
 import { ProgramRewardList } from "./program-reward-list";
 
 export function PartnerInfoCards({
   partner,
-
+  hideStatuses = [],
   selectedGroupId,
   setSelectedGroupId,
 }: {
   partner?: EnrolledPartnerProps;
+
+  /** Partner statuses to hide badges for */
+  hideStatuses?: string[];
 
   // Only used for a controlled group selector that doesn't persist the selection itself
   selectedGroupId?: string | null;
@@ -103,29 +108,42 @@ export function PartnerInfoCards({
     },
   ];
 
+  const badge =
+    partner && !hideStatuses.includes(partner.status)
+      ? PartnerStatusBadges[partner.status]
+      : null;
+
   return (
     <div className="flex flex-col gap-4">
       <div className="border-border-subtle flex flex-col rounded-xl border p-4">
-        <div className="relative w-fit">
-          {partner ? (
-            <img
-              src={partner.image || `${OG_AVATAR_URL}${partner.name}`}
-              alt={partner.name}
-              className="size-20 rounded-full"
-            />
-          ) : (
-            <div className="size-20 animate-pulse rounded-full bg-neutral-200" />
-          )}
-          {partner?.country && (
-            <Tooltip content={COUNTRIES[partner.country]}>
-              <div className="absolute right-0 top-0 overflow-hidden rounded-full bg-neutral-50 p-0.5 transition-transform duration-100 hover:scale-[1.15]">
-                <img
-                  alt=""
-                  src={`https://flag.vercel.app/m/${partner.country}.svg`}
-                  className="size-4 rounded-full"
-                />
-              </div>
-            </Tooltip>
+        <div className="flex justify-between gap-2">
+          <div className="relative w-fit">
+            {partner ? (
+              <img
+                src={partner.image || `${OG_AVATAR_URL}${partner.name}`}
+                alt={partner.name}
+                className="size-20 rounded-full"
+              />
+            ) : (
+              <div className="size-20 animate-pulse rounded-full bg-neutral-200" />
+            )}
+            {partner?.country && (
+              <Tooltip content={COUNTRIES[partner.country]}>
+                <div className="absolute right-0 top-0 overflow-hidden rounded-full bg-neutral-50 p-0.5 transition-transform duration-100 hover:scale-[1.15]">
+                  <img
+                    alt=""
+                    src={`https://flag.vercel.app/m/${partner.country}.svg`}
+                    className="size-4 rounded-full"
+                  />
+                </div>
+              </Tooltip>
+            )}
+          </div>
+
+          {badge && (
+            <StatusBadge icon={null} variant={badge.variant}>
+              {badge.label}
+            </StatusBadge>
           )}
         </div>
         <div className="mt-4">


### PR DESCRIPTION
* Add application details to enrolled partner page
* Add status badge to partner info cards

<img width="624" height="442" alt="Screenshot 2025-09-22 at 4 28 48 PM" src="https://github.com/user-attachments/assets/244aa6ca-d1dc-4cb4-bad8-137a5f92a439" />

<img width="311" height="266" alt="Screenshot 2025-09-22 at 4 25 58 PM" src="https://github.com/user-attachments/assets/8ad7ce75-4241-46bc-bc70-8b3b35d910d8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Partner About pages show an Application section with proposal and comments when available, including loading states and “No response provided” fallbacks.
  - Partner info cards can hide specific status badges (e.g., Approved or Pending) for cleaner views in different contexts.

- Style
  - Partner info card header layout updated to include a status badge beside avatar and country info.
  - Online presence empty-state uses smaller, clearer text styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->