### PR TITLE
`/profile/sites` -> `/profile`

### DIFF
--- a/apps/web/app/(ee)/api/partners/online-presence/callback/route.ts
+++ b/apps/web/app/(ee)/api/partners/online-presence/callback/route.ts
@@ -141,4 +141,4 @@ export async function GET(req: Request) {
 const getRedirectUrl = (source: string) =>
   source === "onboarding"
     ? `${PARTNERS_DOMAIN}/onboarding/online-presence`
-    : `${PARTNERS_DOMAIN}/profile/sites`;
+    : `${PARTNERS_DOMAIN}/profile`;

--- a/apps/web/lib/middleware/utils/partners-redirect.ts
+++ b/apps/web/lib/middleware/utils/partners-redirect.ts
@@ -2,6 +2,7 @@ const PARTNERS_REDIRECTS = {
   "/settings": "/profile",
   "/settings/payouts": "/payouts",
   "/settings/notifications": "/account/settings/notifications",
+  "/profile/sites": "/profile",
 };
 
 export const partnersRedirect = (path: string) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized post-authorization redirects to the Profile page, ensuring users land on /profile after OAuth callbacks.
  * Added a redirect from /profile/sites to /profile to prevent broken links and outdated bookmarks from causing errors.
  * Simplified routing behavior so the destination is consistent regardless of source, reducing confusion and improving navigation continuity after partner integrations and login flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->