### PR TITLE
feat: pass `tags` for Resend SDK options

### DIFF
--- a/apps/web/app/api/resend/webhook/email-opened.ts
+++ b/apps/web/app/api/resend/webhook/email-opened.ts
@@ -5,18 +5,13 @@ const NOTIFICATION_EMAIL_SUBJECT_KEYWORDS = ["bounty", "message"];
 export async function emailOpened({
   email_id: emailId,
   subject,
+  tags,
 }: {
   email_id: string;
   subject?: string;
+  tags?: Record<string, string>;
 }) {
-  // TODO: Ignore if not a message notification (when sendBatchEmail supports tags)
-  // if (!tags || tags.type !== "notification-email") {
-  //   console.log(
-  //     `Ignoring email.opened webhook for email ${emailId} because it's not a notification-email...`,
-  //   );
-  //   return;
-  // }
-
+  // TODO: replace this with tags once it's confirmed working
   if (
     !subject ||
     !NOTIFICATION_EMAIL_SUBJECT_KEYWORDS.some((keyword) =>
@@ -28,6 +23,15 @@ export async function emailOpened({
     );
     return;
   }
+
+  console.log(`Found tags: ${JSON.stringify(tags, null, 2)}`);
+
+  // if (!tags || tags.type !== "notification-email") {
+  //   console.log(
+  //     `Ignoring email.opened webhook for email ${emailId} because it doesn't have a notification-email tag...`,
+  //   );
+  //   return;
+  // }
 
   const notificationEmail = await prisma.notificationEmail.findUnique({
     where: {

--- a/packages/email/src/send-via-resend.ts
+++ b/packages/email/src/send-via-resend.ts
@@ -15,6 +15,7 @@ const resendEmailForOptions = (opts: ResendEmailOptions) => {
     react,
     scheduledAt,
     headers,
+    tags,
   } = opts;
 
   return {
@@ -26,6 +27,7 @@ const resendEmailForOptions = (opts: ResendEmailOptions) => {
     text,
     react,
     scheduledAt,
+    tags,
     ...(variant === "marketing"
       ? {
           headers: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added support for email tags in outgoing messages (single and batch sends via Resend); tags are included in the payload when provided to enable better segmentation and analytics.
  - Webhook handling updated to accept and surface incoming email tags (now logged for visibility), preparing for future tag-based processing and filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->