### PR TITLE
Fix application approval success toast

### DIFF
--- a/apps/web/ui/partners/partner-application-sheet.tsx
+++ b/apps/web/ui/partners/partner-application-sheet.tsx
@@ -129,6 +129,7 @@ function PartnerApplicationSheetContent({
       {["pending", "rejected"].includes(partner.status) && (
         <div className="shrink-0 border-t border-neutral-200 p-5">
           <PartnerApproval
+            key={partner.id} // Reset when navigating between partners to avoid memoized action callback issues
             partner={partner}
             groupId={
               partner.status === "rejected" ? selectedGroupId : partner.groupId


### PR DESCRIPTION
Fixes outdated state in `onSuccess` callback by forcing a remount of `PartnerApproval` when the partner changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue in the Partner Application sheet where approval/rejection actions could appear stale or act on the wrong partner when navigating between pending or rejected entries. Actions now consistently reflect the currently selected partner, preventing misapplied operations and improving reliability when switching between partners.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->