### PR TITLE
Update text styles in partner UI components

### DIFF
--- a/apps/web/ui/partners/partner-about.tsx
+++ b/apps/web/ui/partners/partner-about.tsx
@@ -23,7 +23,7 @@ export function PartnerAbout({
         <h3 className="text-content-emphasis text-xs font-semibold">
           Description
         </h3>
-        <p className="text-content-default text-xs">
+        <p className="text-content-default text-sm max-w-prose">
           {partner.description || (
             <span className="italic text-neutral-400">
               No description provided

--- a/apps/web/ui/partners/partner-application-details.tsx
+++ b/apps/web/ui/partners/partner-application-details.tsx
@@ -44,7 +44,7 @@ export function PartnerApplicationDetails({
                   target: "_blank",
                   rel: "noopener noreferrer nofollow",
                   className:
-                    "underline underline-offset-4 text-neutral-400 hover:text-neutral-700",
+                    "underline underline-offset-4 text-sm max-w-prosetext-neutral-400 hover:text-neutral-700",
                 }}
               >
                 {field.value || (


### PR DESCRIPTION
Adjusted text size and max width for the partner description and application answers. Using max-w-prose sets the max width to 65 characters per line, making the large blocks of text much more readable.

<img width="1202" height="614" alt="CleanShot 2025-09-28 at 13 54 31@2x" src="https://github.com/user-attachments/assets/f4ebf044-7dbd-4b4c-aeec-70ce4998caf3" />
