### PR TITLE
Add `stripeCustomerId` to customer creation flow

### DIFF
--- a/apps/web/app/(ee)/api/customers/route.ts
+++ b/apps/web/app/(ee)/api/customers/route.ts
@@ -140,9 +140,8 @@ export const GET = withWorkspace(
 // POST /api/customers – Create a customer
 export const POST = withWorkspace(
   async ({ req, workspace }) => {
-    const { email, name, avatar, externalId } = createCustomerBodySchema.parse(
-      await parseRequestBody(req),
-    );
+    const { email, name, avatar, externalId, stripeCustomerId } =
+      createCustomerBodySchema.parse(await parseRequestBody(req));
 
     const customerId = createId({ prefix: "cus_" });
     const finalCustomerName = name || email || generateRandomName();
@@ -159,6 +158,7 @@ export const POST = withWorkspace(
           email,
           avatar: finalCustomerAvatar,
           externalId,
+          stripeCustomerId,
           projectId: workspace.id,
           projectConnectId: workspace.stripeConnectId,
         },

--- a/apps/web/lib/zod/schemas/customers.ts
+++ b/apps/web/lib/zod/schemas/customers.ts
@@ -98,6 +98,12 @@ export const createCustomerBodySchema = z.object({
   externalId: z
     .string()
     .describe("Unique identifier for the customer in the client's app."),
+  stripeCustomerId: z
+    .string()
+    .nullish()
+    .describe(
+      "The customer's Stripe customer ID. Useful for attribution recurring sale events to the partner who referred the customer.",
+    ),
 });
 
 export const updateCustomerBodySchema = createCustomerBodySchema.partial();

--- a/apps/web/ui/modals/add-customer-modal.tsx
+++ b/apps/web/ui/modals/add-customer-modal.tsx
@@ -34,6 +34,7 @@ const AddCustomerModal = ({
       name: null,
       email: null,
       externalId: "",
+      stripeCustomerId: null,
     },
   });
 
@@ -130,6 +131,24 @@ const AddCustomerModal = ({
                   setValueAs: (value) => (value === "" ? null : value),
                 })}
               />
+            </div>
+
+            <div>
+              <label className="text-sm font-normal text-neutral-500">
+                Stripe Customer ID
+              </label>
+              <input
+                type="text"
+                autoComplete="off"
+                className="mt-2 block w-full rounded-md border-neutral-300 text-neutral-900 placeholder-neutral-400 focus:border-neutral-500 focus:outline-none focus:ring-neutral-500 sm:text-sm"
+                placeholder="cus_NffrFeUfNV2Hib"
+                {...register("stripeCustomerId", {
+                  setValueAs: (value) => (value === "" ? null : value),
+                })}
+              />
+              <p className="mt-2 text-xs text-neutral-500">
+                The customer's Stripe customer ID (optional)
+              </p>
             </div>
           </div>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an optional Stripe Customer ID field to the Add Customer modal, with label, placeholder, and helper text.
  - Submissions now include this field when provided; leaving it blank won’t block creation.
  - The supplied Stripe Customer ID is saved with the customer record for future use, enabling improved attribution and reporting for recurring sales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->