### PR TITLE
Improve partner name text wrapping in info section

### DIFF
--- a/apps/web/ui/partners/partner-info-section.tsx
+++ b/apps/web/ui/partners/partner-info-section.tsx
@@ -50,8 +50,8 @@ export function PartnerInfoSection({
             </Tooltip>
           )}
         </div>
-        <div className="mt-4 flex items-start gap-2">
-          <span className="text-lg font-semibold leading-tight text-neutral-900">
+        <div className="mt-4 flex min-w-0 items-start gap-2">
+          <span className="min-w-0 max-w-full text-lg font-semibold leading-tight text-neutral-900" style={{ wordBreak: 'break-word', overflowWrap: 'anywhere' }}>
             {partner.name}
           </span>
           {badge && (


### PR DESCRIPTION
Noticed some overflow on partner names. There's no straight fix with Tailwind alone, so it needs a CSS fallback to catch when there are space breaks within a name.

**Current overflow**
<img width="358" height="556" alt="CleanShot 2025-09-30 at 10 21 24@2x" src="https://github.com/user-attachments/assets/db1235ec-93dc-4366-82bb-3ab786969de0" />

**Updated fix**
<img width="358" height="565" alt="CleanShot 2025-09-30 at 10 22 30@2x" src="https://github.com/user-attachments/assets/9c46a7c9-bebe-46c4-80c1-66c517f10998" />


**Works with breaks in names**
<img width="348" height="551" alt="CleanShot 2025-09-30 at 10 21 44@2x" src="https://github.com/user-attachments/assets/f03feb34-16cc-48e6-9f4f-1c85e84b3bff" />

