### PR TITLE
Update modal title for multiple choice field

### DIFF
--- a/apps/web/ui/partners/groups/design/application-form/modals/multiple-choice-field-modal.tsx
+++ b/apps/web/ui/partners/groups/design/application-form/modals/multiple-choice-field-modal.tsx
@@ -80,7 +80,7 @@ function MultipleChoiceFieldModalInner({
     <FormProvider {...form}>
       <div className="p-4 pt-3">
         <h3 className="text-base font-semibold leading-6 text-neutral-800">
-          {defaultValues ? "Edit" : "Add"} checkbox
+          {defaultValues ? "Edit" : "Add"} multiple choice
         </h3>
         <form
           className="mt-4 flex flex-col gap-6"


### PR DESCRIPTION
Realizing the designs, I had it as a "checkbox", but the input is multiple choice.

**Current**
<img width="527" height="473" alt="CleanShot 2025-10-01 at 09 53 06@2x" src="https://github.com/user-attachments/assets/3357dfa7-7240-42d8-b052-215e60a3913b" />


**Updated**
<img width="666" height="631" alt="CleanShot 2025-10-01 at 09 52 10@2x" src="https://github.com/user-attachments/assets/cfc117c3-fca8-4722-9432-85e7332f70ea" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the modal heading in the multiple-choice field editor from “checkbox” to “multiple choice” to accurately reflect the field type.
  * Improves clarity when adding or editing options and ensures consistent terminology across application forms.
  * No changes to behavior or workflows; this is a copy update only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->