### PR TITLE
Partner messages panel updates

### DIFF
--- a/apps/web/app/(ee)/partners.dub.co/(dashboard)/messages/[programSlug]/page-client.tsx
+++ b/apps/web/app/(ee)/partners.dub.co/(dashboard)/messages/[programSlug]/page-client.tsx
@@ -14,7 +14,7 @@ import { useMessagesContext } from "@/ui/messages/messages-context";
 import { MessagesPanel } from "@/ui/messages/messages-panel";
 import { ToggleSidePanelButton } from "@/ui/messages/toggle-side-panel-button";
 import { ProgramHelpLinks } from "@/ui/partners/program-help-links";
-import { ProgramRewardList } from "@/ui/partners/program-reward-list";
+import { ProgramRewardsPanel } from "@/ui/partners/program-rewards-panel";
 import { X } from "@/ui/shared/icons";
 import { Button, Grid, useCopyToClipboard, useMediaQuery } from "@dub/ui";
 import {
@@ -323,9 +323,9 @@ function ProgramInfoPanel({
           <img
             src={program.logo || `${OG_AVATAR_URL}${program.name}`}
             alt={`${program.name} logo`}
-            className="size-12 rounded-full"
+            className="size-10 rounded-full"
           />
-          <div>
+          <div className="flex flex-col">
             <span className="text-content-emphasis block truncate text-lg font-semibold">
               {program.name}
             </span>
@@ -338,7 +338,7 @@ function ProgramInfoPanel({
 
       {/* Referral link */}
       {programEnrollment.links && programEnrollment.links.length > 0 && (
-        <div className="border-border-subtle border-b p-6">
+        <div className="pl-6 pr-6 pt-7">
           <div className="flex items-end justify-between">
             <h3 className="text-content-emphasis text-sm font-semibold">
               Referral link
@@ -352,23 +352,31 @@ function ProgramInfoPanel({
             </Link>
           </div>
 
-          <input
-            type="text"
-            readOnly
-            value={getPrettyUrl(partnerLink)}
-            className="border-border-default text-content-default focus:border-border-emphasis bg-bg-default mt-2 block h-10 w-full rounded-md border px-3 text-sm focus:outline-none focus:ring-neutral-500"
-          />
-
-          <Button
-            icon={
-              <div className="relative size-4">
+          <div className="relative mt-2">
+            <input
+              type="text"
+              readOnly
+              value={getPrettyUrl(partnerLink)}
+              className="text-content-default focus:border-border-emphasis bg-bg-default block h-11 w-full rounded-xl border border-neutral-200 pl-3 pr-12 text-sm focus:outline-none focus:ring-neutral-500"
+            />
+            {/* Gradient fade overlay */}
+            <div className="pointer-events-none absolute right-12 top-1 h-8 w-10 bg-gradient-to-r from-transparent to-white" />
+            <button
+              type="button"
+              onClick={() => {
+                copyToClipboard(partnerLink);
+                toast.success("Link copied");
+              }}
+              className="absolute right-2 top-2 flex h-7 w-7 items-center justify-center rounded-lg bg-neutral-900 text-white transition-colors hover:bg-gray-800"
+            >
+              <div className="relative size-3">
                 <div
                   className={cn(
                     "absolute inset-0 transition-[transform,opacity]",
                     copied && "translate-y-1 opacity-0",
                   )}
                 >
-                  <Copy className="size-4" />
+                  <Copy className="size-3" />
                 </div>
                 <div
                   className={cn(
@@ -376,34 +384,23 @@ function ProgramInfoPanel({
                     !copied && "translate-y-1 opacity-0",
                   )}
                 >
-                  <Check className="size-4" />
+                  <Check className="size-3" />
                 </div>
               </div>
-            }
-            text={copied ? "Copied link" : "Copy link"}
-            className="mt-3 h-8 rounded-lg"
-            onClick={() => copyToClipboard(partnerLink)}
-          />
+            </button>
+          </div>
         </div>
       )}
 
-      {/* Rewards */}
-      <div className="border-border-subtle border-b p-6">
-        <h3 className="text-content-emphasis text-sm font-semibold">Rewards</h3>
-        <ProgramRewardList
-          rewards={programEnrollment.rewards ?? []}
-          discount={programEnrollment.discount}
-          className="mt-2"
-        />
-      </div>
-
       {/* Stats */}
-      <div className="border-border-subtle border-b p-6">
-        <h3 className="text-content-emphasis text-sm font-semibold">Stats</h3>
-        <div className="divide-border-subtle border-border-subtle mt-2 divide-y rounded-lg border">
+      <div className="pl-6 pr-6 pt-7">
+        <h3 className="text-content-emphasis text-sm font-semibold">
+          Performance
+        </h3>
+        <div className="divide-border-subtle border-border-subtle mt-2 divide-y rounded-xl border">
           <div className="divide-border-subtle grid grid-cols-3 divide-x">
             {["clicks", "leads", "sales"].map((event) => (
-              <div key={event} className="flex flex-col gap-1 p-3">
+              <div key={event} className="flex flex-col px-3 py-2.5">
                 <span className="text-content-subtle text-xs font-medium">
                   {capitalize(event)}
                 </span>
@@ -422,7 +419,7 @@ function ProgramInfoPanel({
               { label: "Revenue", value: statsTotals?.saleAmount },
               { label: "Earnings", value: programEnrollment.totalCommissions },
             ].map(({ label, value }) => (
-              <div key={label} className="flex flex-col gap-1 p-3">
+              <div key={label} className="flex flex-col px-3 py-2.5">
                 <span className="text-content-subtle text-xs font-medium">
                   {label}
                 </span>
@@ -439,12 +436,23 @@ function ProgramInfoPanel({
         </div>
       </div>
 
+      {/* Rewards */}
+      <div className="pl-6 pr-6 pt-7">
+        <h3 className="text-content-emphasis text-sm font-semibold">Rewards</h3>
+        <div className="mt-1">
+          <ProgramRewardsPanel
+            rewards={programEnrollment.rewards ?? []}
+            discount={programEnrollment.discount}
+          />
+        </div>
+      </div>
+
       {/* Help & support */}
-      <div className="border-border-subtle border-b p-6">
+      <div className="border-border-subtle pl-6 pr-6 pt-7">
         <h3 className="text-content-emphasis text-sm font-semibold">
           Help and support
         </h3>
-        <div className="border-border-subtle mt-2 rounded-lg border p-2">
+        <div className="mt-1">
           <ProgramHelpLinks />
         </div>
       </div>

--- a/apps/web/ui/partners/program-help-links.tsx
+++ b/apps/web/ui/partners/program-help-links.tsx
@@ -51,7 +51,7 @@ export const ProgramHelpLinks = memo(() => {
           href={href}
           target="_blank"
           rel="noopener noreferrer"
-          className="text-content-default hover:text-content-emphasis hover:bg-bg-inverted/5 active:bg-bg-inverted/10 flex items-center gap-2 rounded-md px-2.5 py-1.5 text-sm transition-colors"
+          className="text-content-default hover:text-content-emphasis hover:bg-bg-inverted/5 active:bg-bg-inverted/10 flex items-center gap-2 rounded-md py-1.5 text-sm transition-all hover:px-2.5"
         >
           <Icon className="size-4" />
           {label}

--- a/apps/web/ui/partners/program-reward-modifiers-tooltip.tsx
+++ b/apps/web/ui/partners/program-reward-modifiers-tooltip.tsx
@@ -45,7 +45,7 @@ export function ProgramRewardModifiersTooltip({
   );
 }
 
-function ProgramRewardModifiersTooltipContent({
+export function ProgramRewardModifiersTooltipContent({
   reward,
 }: ProgramRewardModifiersTooltipProps) {
   const scrollRef = useRef<HTMLDivElement>(null);

--- a/apps/web/ui/partners/program-rewards-panel.tsx
+++ b/apps/web/ui/partners/program-rewards-panel.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { constructRewardAmount } from "@/lib/api/sales/construct-reward-amount";
+import { DiscountProps, RewardProps } from "@/lib/types";
+import { Gift, Tooltip } from "@dub/ui";
+import { HelpCircle } from "lucide-react";
+import { memo } from "react";
+import { REWARD_EVENTS } from "./constants";
+import { ProgramRewardModifiersTooltipContent } from "./program-reward-modifiers-tooltip";
+
+interface ProgramRewardsPanelProps {
+  rewards: RewardProps[];
+  discount?: DiscountProps | null;
+}
+
+// Custom tooltip with smaller icon
+function CustomRewardModifiersTooltip({ reward }: { reward: RewardProps }) {
+  return (
+    <div className="inline-block align-text-top">
+      <Tooltip
+        content={<ProgramRewardModifiersTooltipContent reward={reward} />}
+      >
+        <HelpCircle className="h-3.5 w-3.5 translate-y-px text-neutral-400" />
+      </Tooltip>
+    </div>
+  );
+}
+
+export const ProgramRewardsPanel = memo(
+  ({ rewards, discount }: ProgramRewardsPanelProps) => {
+    const sortedFilteredRewards = rewards.filter((r) => r.amount >= 0);
+
+    const rewardItems = [
+      ...sortedFilteredRewards.map((reward) => ({
+        icon: REWARD_EVENTS[reward.event].icon,
+        label: reward.description || (
+          <>
+            {constructRewardAmount(reward)}{" "}
+            {reward.event === "sale" && reward.maxDuration === 0 ? (
+              <>for the first sale</>
+            ) : (
+              <>per {reward.event}</>
+            )}
+            {reward.maxDuration === null ? (
+              <>
+                {" "}
+                for the{" "}
+                <strong className="font-semibold">customer's lifetime</strong>
+              </>
+            ) : reward.maxDuration && reward.maxDuration > 1 ? (
+              <>
+                {" "}
+                for{" "}
+                <strong className="font-semibold">
+                  {reward.maxDuration % 12 === 0
+                    ? `${reward.maxDuration / 12} year${reward.maxDuration / 12 > 1 ? "s" : ""}`
+                    : `${reward.maxDuration} months`}
+                </strong>
+              </>
+            ) : null}
+            {!!reward.modifiers?.length && (
+              <>
+                {" "}
+                <CustomRewardModifiersTooltip reward={reward} />
+              </>
+            )}
+          </>
+        ),
+      })),
+      ...(discount
+        ? [
+            {
+              icon: Gift,
+              label: discount.description || (
+                <>
+                  New users get {constructRewardAmount(discount)} off{" "}
+                  {discount.maxDuration === null
+                    ? "for their lifetime"
+                    : discount.maxDuration === 0
+                      ? "for their first purchase"
+                      : discount.maxDuration === 1
+                        ? "for their first month"
+                        : discount.maxDuration && discount.maxDuration > 1
+                          ? `for ${discount.maxDuration} months`
+                          : null}
+                </>
+              ),
+            },
+          ]
+        : []),
+    ];
+
+    if (rewardItems.length === 0) return null;
+
+    return (
+      <div className="grid grid-cols-1">
+        {rewardItems.map(({ icon: Icon, label }, index) => (
+          <div
+            key={index}
+            className="text-content-default flex items-start gap-2 rounded-md py-1.5 text-sm"
+          >
+            <Icon className="size-4 shrink-0 translate-y-px" />
+            <div>{label}</div>
+          </div>
+        ))}
+      </div>
+    );
+  },
+);
+
+ProgramRewardsPanel.displayName = "ProgramRewardsPanel";


### PR DESCRIPTION
On smaller screens, the Help and Support links were below laptop heights, so reworked this section to tighten everything up and to make everything more consistent and consumable.

A new rewards section was created to not impact other places that file is being used. 

<img width="974" height="1101" alt="CleanShot 2025-10-01 at 13 28 15@2x" src="https://github.com/user-attachments/assets/3f751f4e-0d39-4ac6-a082-95c674a6465b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added a dedicated Rewards panel showing program rewards and discounts.
  * Improved referral link copying with an inline button, toast feedback, and subtle gradient overlay.

* Style
  * Refreshed Program details layout: smaller avatar, vertical info stack, and updated referral link input/button design.
  * Renamed “Stats” to “Performance” with refined spacing and typography.
  * Standardized padding, borders, and rounded styles across sections.
  * Aligned Help & Support block spacing with the new layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->