### PR TITLE
fix: Remove `openid` scope from Framer OAuth authorization

### DIFF
--- a/apps/web/lib/auth/options.ts
+++ b/apps/web/lib/auth/options.ts
@@ -295,7 +295,13 @@ export const authOptions: NextAuthOptions = {
       clientId: process.env.FRAMER_CLIENT_ID,
       clientSecret: process.env.FRAMER_CLIENT_SECRET,
       checks: ["state"],
-      authorization: `${FRAMER_API_HOST}/auth/oauth/authorize`,
+      authorization: {
+        url: `${FRAMER_API_HOST}/auth/oauth/authorize`,
+        params: {
+          scope: "",
+          response_type: "code",
+        },
+      },
       token: `${FRAMER_API_HOST}/auth/oauth/token`,
       userinfo: `${FRAMER_API_HOST}/auth/oauth/profile`,
       profile({ sub, email, name, picture }) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Framer sign-in reliability by explicitly setting authorization parameters (response type and scope), enhancing compatibility and reducing potential login errors.
  * Refines the initial OAuth handshake without changing token or profile retrieval, mitigating edge-case failures during the authorization redirect.
  * Users should experience a smoother, more consistent authentication flow with no interface changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->