### PR TITLE
Persist drafts through page navigation

### DIFF
--- a/apps/web/ui/partners/groups/design/application-form/fields/form-control.tsx
+++ b/apps/web/ui/partners/groups/design/application-form/fields/form-control.tsx
@@ -8,6 +8,14 @@ export type FormControlProps = PropsWithChildren<{
   error?: string;
 }>;
 
+export const FormControlRequiredBadge = () => {
+  return (
+    <span className="min-h-4 rounded-md bg-orange-100 px-1 text-xs font-semibold text-orange-600">
+      Required
+    </span>
+  );
+};
+
 export const FormControl = ({
   label,
   required,
@@ -21,11 +29,7 @@ export const FormControl = ({
         <span className="text-content-emphasis text-sm font-medium">
           {label}
         </span>
-        {required && (
-          <span className="min-h-4 rounded-md bg-orange-100 px-1 text-xs font-semibold text-orange-600">
-            Required
-          </span>
-        )}
+        {required && <FormControlRequiredBadge />}
       </div>
 
       <div className="mt-2">

--- a/apps/web/ui/partners/groups/design/application-form/modals/long-text-field-modal.tsx
+++ b/apps/web/ui/partners/groups/design/application-form/modals/long-text-field-modal.tsx
@@ -308,8 +308,8 @@ export function LongTextFieldThumbnail() {
           y2="59"
           gradientUnits="userSpaceOnUse"
         >
-          <stop stop-color="white" />
-          <stop offset="1" stop-color="white" stop-opacity="0" />
+          <stop stopColor="white" />
+          <stop offset="1" stopColor="white" stopOpacity="0" />
         </linearGradient>
         <clipPath id="clip0_2001_4135">
           <rect width="168" height="100" rx="6" fill="white" />

--- a/apps/web/ui/partners/groups/design/application-form/program-application-form.tsx
+++ b/apps/web/ui/partners/groups/design/application-form/program-application-form.tsx
@@ -29,6 +29,7 @@ import { Controller, FormProvider, useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { CountryCombobox } from "../../../country-combobox";
 import { ProgramApplicationFormField } from "./fields";
+import { FormControlRequiredBadge } from "./fields/form-control";
 
 type FormData = {
   name: string;
@@ -195,7 +196,12 @@ export function ProgramApplicationForm({
         className="flex flex-col gap-6"
       >
         <label>
-          <span className="text-sm font-medium text-neutral-800">Name</span>
+          <div className="flex items-center gap-1.5">
+            <span className="text-content-emphasis text-sm font-medium">
+              Name
+            </span>
+            <FormControlRequiredBadge />
+          </div>
           <input
             type="text"
             autoComplete="name"
@@ -214,7 +220,12 @@ export function ProgramApplicationForm({
         </label>
 
         <label>
-          <span className="text-sm font-medium text-neutral-800">Email</span>
+          <div className="flex items-center gap-1.5">
+            <span className="text-content-emphasis text-sm font-medium">
+              Email
+            </span>
+            <FormControlRequiredBadge />
+          </div>
           <input
             type="email"
             autoComplete="email"
@@ -232,7 +243,13 @@ export function ProgramApplicationForm({
         </label>
 
         <label className="flex flex-col">
-          <span className="text-sm font-medium text-neutral-800">Country</span>
+          <div className="flex items-center gap-1.5">
+            <span className="text-content-emphasis text-sm font-medium">
+              Country
+            </span>
+            <FormControlRequiredBadge />
+          </div>
+
           <Controller
             control={control}
             name="country"

--- a/apps/web/ui/partners/groups/design/branding-form.tsx
+++ b/apps/web/ui/partners/groups/design/branding-form.tsx
@@ -330,9 +330,10 @@ function BrandingFormInner({
         if (!result?.data?.success) {
           toast.error("Failed to update application form.");
           setError("root", { message: "Failed to update application form." });
-          setDraft(null);
           return;
         }
+
+        setDraft(null);
       })}
       className="overflow-hidden rounded-lg border border-neutral-200 bg-neutral-100"
     >

--- a/apps/web/ui/partners/groups/design/branding-form.tsx
+++ b/apps/web/ui/partners/groups/design/branding-form.tsx
@@ -267,7 +267,10 @@ function BrandingFormInner({
     draft: landerDraftUsed,
   } = getDefaultLanderData(group, draft);
 
-  const isDefaultValueDirty = applicationFormDataDirty || landerDataDirty;
+  const isDefaultValueDirty = useMemo(
+    () => applicationFormDataDirty || landerDataDirty,
+    [applicationFormDataDirty, landerDataDirty],
+  );
 
   const form = useForm<BrandingFormData>({
     defaultValues: {

--- a/apps/web/ui/partners/groups/design/branding-form.tsx
+++ b/apps/web/ui/partners/groups/design/branding-form.tsx
@@ -247,7 +247,6 @@ function BrandingFormInner({
   const isDefaultValueDirty = applicationFormDataDirty || landerDataDirty;
 
   const form = useForm<BrandingFormData>({
-    reValidateMode: "onChange",
     defaultValues: {
       logo: group.program?.logo ?? draft?.logo ?? null,
       wordmark: group.program?.wordmark ?? draft?.wordmark ?? null,


### PR DESCRIPTION
- Adds `draftSavedAt` to draft and removed enabled condition from drafts
- If there is a draft and it is newer than the application form / lander data, use that instead of the value and enable publishing
- Adds required badge to name, email, and country

https://github.com/user-attachments/assets/e47ee5c3-460d-4c07-81aa-1901ab229e69


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Drafts now persist per-group with timestamps, auto-save when changes exist, hydrate forms reliably, and clear after successful publish.
  - Added a reusable required-field badge used across application forms for clearer labels.

- **Bug Fixes / Improvements**
  - Publish button logic simplified and more accurate (disables only when generating or when there are no changes).
  - SVG gradient attributes corrected for consistent rendering across browsers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->