### PR TITLE
Support sale amount in the reward condition

### DIFF
--- a/apps/web/app/(ee)/api/stripe/integration/webhook/checkout-session-completed.ts
+++ b/apps/web/app/(ee)/api/stripe/integration/webhook/checkout-session-completed.ts
@@ -377,6 +377,7 @@ export async function checkoutSessionCompleted(event: Stripe.Event) {
         },
         sale: {
           productId,
+          amount: saleData.amount,
         },
       },
     });

--- a/apps/web/app/(ee)/api/stripe/integration/webhook/invoice-paid.ts
+++ b/apps/web/app/(ee)/api/stripe/integration/webhook/invoice-paid.ts
@@ -224,6 +224,7 @@ export async function invoicePaid(event: Stripe.Event) {
         },
         sale: {
           productId: invoice.lines.data[0]?.pricing?.price_details?.product,
+          amount: saleData.amount,
         },
       },
     });

--- a/apps/web/lib/api/conversions/track-sale.ts
+++ b/apps/web/lib/api/conversions/track-sale.ts
@@ -533,6 +533,7 @@ const _trackSale = async ({
             },
             sale: {
               productId: metadata?.productId as string,
+              amount: saleData.amount,
             },
           },
         });

--- a/apps/web/lib/integrations/shopify/create-sale.ts
+++ b/apps/web/lib/integrations/shopify/create-sale.ts
@@ -145,6 +145,9 @@ export async function createShopifySale({
         customer: {
           country: customer.country,
         },
+        sale: {
+          amount: saleData.amount,
+        },
       },
     });
     webhookPartner = createdCommission?.webhookPartner;

--- a/apps/web/lib/partners/create-partner-commission.ts
+++ b/apps/web/lib/partners/create-partner-commission.ts
@@ -91,13 +91,7 @@ export const createPartnerCommission = async ({
     reward = determinePartnerReward({
       event: event as EventType,
       programEnrollment,
-      context: {
-        ...context,
-        sale: {
-          ...context?.sale,
-          amount,
-        },
-      },
+      context,
     });
 
     // if there is no reward, skip commission creation

--- a/apps/web/lib/partners/create-partner-commission.ts
+++ b/apps/web/lib/partners/create-partner-commission.ts
@@ -91,7 +91,13 @@ export const createPartnerCommission = async ({
     reward = determinePartnerReward({
       event: event as EventType,
       programEnrollment,
-      context,
+      context: {
+        ...context,
+        sale: {
+          ...context?.sale,
+          amount,
+        },
+      },
     });
 
     // if there is no reward, skip commission creation

--- a/apps/web/lib/zod/schemas/rewards.ts
+++ b/apps/web/lib/zod/schemas/rewards.ts
@@ -19,7 +19,7 @@ export const CONDITION_ENTITIES = ["customer", "sale", "partner"] as const;
 
 export const CONDITION_CUSTOMER_ATTRIBUTES = ["country"] as const;
 
-export const CONDITION_SALE_ATTRIBUTES = ["productId"] as const;
+export const CONDITION_SALE_ATTRIBUTES = ["productId", "amount"] as const;
 
 export const CONDITION_PARTNER_ATTRIBUTES = [
   "totalClicks",
@@ -53,6 +53,9 @@ export const ENTITY_ATTRIBUTE_TYPES: Partial<
     totalSaleAmount: "currency",
     totalCommissions: "currency",
   },
+  sale: {
+    amount: "currency",
+  },
 };
 
 export const CONDITION_OPERATORS = [
@@ -84,6 +87,7 @@ export const NUMBER_CONDITION_OPERATORS: (typeof CONDITION_OPERATORS)[number][] 
 export const ATTRIBUTE_LABELS = {
   country: "Country",
   productId: "Product ID",
+  amount: "Amount",
   totalClicks: "Total clicks",
   totalLeads: "Total leads",
   totalConversions: "Total conversions",
@@ -199,6 +203,7 @@ export const rewardContextSchema = z.object({
   sale: z
     .object({
       productId: z.string().nullish(),
+      amount: z.number().nullish(),
     })
     .optional(),
 

--- a/apps/web/tests/tracks/track-sale.test.ts
+++ b/apps/web/tests/tracks/track-sale.test.ts
@@ -293,7 +293,7 @@ describe("POST /track/sale", async () => {
 
     // Test with a large sale amount
     const largeSaleInvoiceId = `INV_${randomId()}`;
-    const largeSaleAmount = 15000; // $150.00
+    const largeSaleAmount = 20000; // $200.00
 
     const response2 = await http.post<TrackSaleResponse>({
       path: "/track/sale",

--- a/apps/web/tests/tracks/track-sale.test.ts
+++ b/apps/web/tests/tracks/track-sale.test.ts
@@ -272,4 +272,57 @@ describe("POST /track/sale", async () => {
       },
     });
   });
+
+  test("track sales with different amounts (verifies sale amount is passed via context for reward conditions)", async () => {
+    // Test with a small sale amount
+    const smallSaleInvoiceId = `INV_${randomId()}`;
+    const smallSaleAmount = 10000; // $100.00
+
+    const response1 = await http.post<TrackSaleResponse>({
+      path: "/track/sale",
+      body: {
+        ...sale,
+        amount: smallSaleAmount,
+        customerExternalId: E2E_CUSTOMER_EXTERNAL_ID_2,
+        invoiceId: smallSaleInvoiceId,
+      },
+    });
+
+    expect(response1.status).toEqual(200);
+    expect(response1.data.sale?.amount).toEqual(smallSaleAmount);
+
+    // Test with a large sale amount
+    const largeSaleInvoiceId = `INV_${randomId()}`;
+    const largeSaleAmount = 15000; // $150.00
+
+    const response2 = await http.post<TrackSaleResponse>({
+      path: "/track/sale",
+      body: {
+        ...sale,
+        amount: largeSaleAmount,
+        customerExternalId: E2E_CUSTOMER_EXTERNAL_ID_2,
+        invoiceId: largeSaleInvoiceId,
+      },
+    });
+
+    expect(response2.status).toEqual(200);
+    expect(response2.data.sale?.amount).toEqual(largeSaleAmount);
+
+    // Pause for 2 seconds for data to be fully processed
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    await verifyCommission(
+      http,
+      smallSaleInvoiceId,
+      response2.data.sale?.amount!,
+      E2E_REWARD.modifiers[1].amount,
+    );
+
+    await verifyCommission(
+      http,
+      largeSaleInvoiceId,
+      response2.data.sale?.amount!,
+      E2E_REWARD.modifiers[1].amount,
+    );
+  });
 });

--- a/apps/web/tests/tracks/track-sale.test.ts
+++ b/apps/web/tests/tracks/track-sale.test.ts
@@ -314,7 +314,7 @@ describe("POST /track/sale", async () => {
     await verifyCommission(
       http,
       smallSaleInvoiceId,
-      response2.data.sale?.amount!,
+      response1.data.sale?.amount!,
       E2E_REWARD.amount,
     );
 

--- a/apps/web/tests/tracks/track-sale.test.ts
+++ b/apps/web/tests/tracks/track-sale.test.ts
@@ -315,7 +315,7 @@ describe("POST /track/sale", async () => {
       http,
       smallSaleInvoiceId,
       response2.data.sale?.amount!,
-      E2E_REWARD.modifiers[1].amount,
+      E2E_REWARD.amount,
     );
 
     await verifyCommission(

--- a/apps/web/tests/utils/resource.ts
+++ b/apps/web/tests/utils/resource.ts
@@ -55,6 +55,18 @@ export const E2E_REWARD = {
         },
       ],
     },
+    {
+      operator: "AND",
+      amount: 5000,
+      conditions: [
+        {
+          entity: "sale",
+          attribute: "amount",
+          operator: "greater_than",
+          value: 15000,
+        },
+      ],
+    },
   ],
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sale amount support across rewards and partner commission flows; reward context and UI now reflect amount with currency semantics.

* **Integrations**
  * Stripe checkout/invoice and Shopify sale events include sale amount in commission processing; general sale tracking forwards amount for evaluation.

* **Tests**
  * E2E tests added to verify tracking and commission behavior for differing sale amounts.

* **Chores**
  * Reward rules expanded with an additional high-value sale modifier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->