### PR TITLE
fix(resend): make reply_to snake_case

### DIFF
--- a/packages/email/src/send-via-resend.ts
+++ b/packages/email/src/send-via-resend.ts
@@ -22,7 +22,7 @@ const resendEmailForOptions = (opts: ResendEmailOptions) => {
     to,
     from: from || VARIANT_TO_FROM_MAP[variant],
     bcc: bcc,
-    replyTo: replyTo || "support@dub.co",
+    reply_to: replyTo || "support@dub.co",
     subject,
     text,
     react,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected email payload to use the proper reply-to format for improved compatibility with the email provider.
  - Ensures replies route correctly while retaining the default support address fallback.
  - No user action required; existing behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->