### PR TITLE
Include partner's groupId in webhook events

### DIFF
--- a/apps/web/lib/partners/create-partner-commission.ts
+++ b/apps/web/lib/partners/create-partner-commission.ts
@@ -49,6 +49,7 @@ const constructWebhookPartner = (
 ) => {
   return {
     ...programEnrollment.partner,
+    groupId: programEnrollment.groupId,
     ...aggregatePartnerLinksStats(programEnrollment.links),
     totalCommissions: totalCommissions || programEnrollment.totalCommissions,
   };

--- a/apps/web/lib/zod/schemas/partners.ts
+++ b/apps/web/lib/zod/schemas/partners.ts
@@ -441,6 +441,7 @@ export const WebhookPartnerSchema = PartnerSchema.pick({
   country: true,
 }).merge(
   z.object({
+    groupId: z.string().nullish(),
     totalClicks: z.number(),
     totalLeads: z.number(),
     totalConversions: z.number(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Partner-related webhook payloads now include an optional groupId (when available), enabling integrations to group or segment partners by enrollment. Existing fields and totals are unchanged.
  * The new field is nullable and additive, so existing integrations continue to work without changes. Consumers can start reading groupId to enhance routing, reporting, or analytics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->