### PR TITLE
Move the partner permission checks to `withPartnerProfile` middleware

### DIFF
--- a/apps/web/app/(ee)/api/partner-profile/users/route.ts
+++ b/apps/web/app/(ee)/api/partner-profile/users/route.ts
@@ -61,7 +61,7 @@ const updateRoleSchema = z.object({
 
 // PATCH /api/partner-profile/users - update a user's role
 export const PATCH = withPartnerProfile(
-  async ({ req, partner, partnerUser, session }) => {
+  async ({ req, partner, session }) => {
     const { userId, role } = updateRoleSchema.parse(
       await parseRequestBody(req),
     );
@@ -72,11 +72,6 @@ export const PATCH = withPartnerProfile(
         message: "You cannot change your own role.",
       });
     }
-
-    throwIfNoPermission({
-      role: partnerUser.role,
-      permission: "users.update",
-    });
 
     // Wrap read and mutation in a transaction to prevent TOCTOU race conditions
     const response = await prisma.$transaction(async (tx) => {
@@ -131,6 +126,9 @@ export const PATCH = withPartnerProfile(
     });
 
     return NextResponse.json(response);
+  },
+  {
+    requiredPermission: "users.update",
   },
 );
 

--- a/apps/web/lib/auth/partner-user-permissions.ts
+++ b/apps/web/lib/auth/partner-user-permissions.ts
@@ -1,7 +1,7 @@
 import type { PartnerRole } from "@prisma/client";
 import { DubApiError } from "../api/errors";
 
-type Permission = (typeof PERMISSIONS)[number];
+export type Permission = (typeof PERMISSIONS)[number];
 
 const PERMISSIONS = [
   "users.update",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured permission validation system for partner profile management endpoints, moving from inline checks to metadata-driven configuration for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->