### PR TITLE
Add integration tests for `/campaigns/**` endpoints

### DIFF
--- a/apps/web/tests/utils/integration.ts
+++ b/apps/web/tests/utils/integration.ts
@@ -106,4 +106,13 @@ export class IntegrationHarness {
       path: `/bounties/${id}`,
     });
   }
+
+  // Delete campaign
+  public async deleteCampaign(id: string) {
+    if (!id) return;
+
+    await this.http.delete({
+      path: `/campaigns/${id}`,
+    });
+  }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end coverage for campaign lifecycle: create draft, update content/groups, publish, pause, resume, duplicate, list, retrieve, and delete; validates responses, status transitions, identifiers, timestamps, metrics, and field shapes.
  * Added a test utility helper to support campaign deletion and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->