### PR TITLE
Skip the invoice failure fee for failed ACH payments that are blocked

### DIFF
--- a/apps/web/app/(ee)/api/stripe/webhook/utils/process-payout-invoice-failure.ts
+++ b/apps/web/app/(ee)/api/stripe/webhook/utils/process-payout-invoice-failure.ts
@@ -103,6 +103,10 @@ export async function processPayoutInvoiceFailure({
       if (paymentMethod?.card) {
         cardLast4 = paymentMethod.card.last4;
       }
+    } else {
+      console.log(
+        `Skipped charging failure fee for blocked direct debit charge on invoice ${invoice.id}.`,
+      );
     }
   }
 


### PR DESCRIPTION
…m failure fee

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Blocked direct-debit payout failures no longer trigger failure fees or record card details. The system now skips fee charging and avoids storing payment method info for blocked charges, while preserving existing fee-charging behavior for non-blocked direct-debit failures. Log messages now reflect when a blocked charge was skipped and when a fee was successfully charged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->