### PR TITLE
Fix messages overflow/wrapping

### DIFF
--- a/apps/web/ui/messages/messages-panel.tsx
+++ b/apps/web/ui/messages/messages-panel.tsx
@@ -176,7 +176,7 @@ export function MessagesPanel({
                         {/* Message box */}
                         <div
                           className={cn(
-                            "w-full max-w-lg whitespace-pre-wrap break-words rounded-xl px-4 py-2.5 text-sm",
+                            "max-w-[min(100%,512px)] whitespace-pre-wrap break-words rounded-xl px-4 py-2.5 text-sm",
                             isMySide
                               ? "text-content-inverted rounded-br bg-neutral-700"
                               : "text-content-default rounded-bl bg-neutral-100",
@@ -405,7 +405,7 @@ function CampaignMessage({
 
         <div
           className={cn(
-            "w-full max-w-lg rounded-xl text-sm",
+            "max-w-[min(100%,512px)] rounded-xl text-sm",
             isMySide
               ? "text-content-inverted rounded-br bg-neutral-700"
               : "text-content-default rounded-bl bg-neutral-100",


### PR DESCRIPTION
| Before | After |
| - | - |
| <img width="502" height="230" alt="Screenshot 2025-10-17 at 12 03 41 PM" src="https://github.com/user-attachments/assets/180d16df-93a6-4856-b977-00c4157f1794" /> | <img width="502" height="291" alt="Screenshot 2025-10-17 at 12 03 32 PM" src="https://github.com/user-attachments/assets/2b18c931-8390-424f-a576-9cdd86155bc2" /> |
| <img width="419" height="274" alt="Screenshot 2025-10-17 at 12 27 05 PM" src="https://github.com/user-attachments/assets/f81b2467-8460-465f-a96c-614020dff6a9" /> | <img width="419" height="269" alt="Screenshot 2025-10-17 at 12 27 11 PM" src="https://github.com/user-attachments/assets/e210b6ef-ef78-4186-b283-16c68e4e6ba5" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed message text wrapping to prevent content overflow in the messages panel.
  * Improved message container layout so messages can shrink correctly and use available width on narrow screens.
  * Ensured message bubbles wrap long words and maintain consistent appearance for both sender and receiver sides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->