### PR TITLE
Add rows and maxLength to folder description textarea

### DIFF
--- a/apps/web/ui/folders/edit-folder-form.tsx
+++ b/apps/web/ui/folders/edit-folder-form.tsx
@@ -77,6 +77,8 @@ export function EditFolderForm({
         </span>
         <textarea
           className="mt-2 block w-full rounded-md border-neutral-300 text-neutral-900 placeholder-neutral-400 focus:border-neutral-500 focus:outline-none focus:ring-neutral-500 sm:text-sm"
+          rows={4}
+          maxLength={FOLDER_MAX_DESCRIPTION_LENGTH}
           onKeyDown={handleKeyDown}
           {...register("description", {
             maxLength: FOLDER_MAX_DESCRIPTION_LENGTH,


### PR DESCRIPTION
Increase the row height of the text area field and ensure that the user can't type more than 500 characters into the description. They couldn't save (and we didn't show an error), but it just creates a weird experience allowing the user to type beyond 500 characters. 

**Before**
<img width="574" height="488" alt="CleanShot 2025-10-22 at 09 14 19@2x" src="https://github.com/user-attachments/assets/938cfd10-cd05-47a5-93e3-f20c20f4c3a6" />


**After**
<img width="624" height="690" alt="CleanShot 2025-10-22 at 09 13 16@2x" src="https://github.com/user-attachments/assets/7effdb57-99d8-4564-8453-1fed3fb0cd4a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the folder description field to display 4 rows by default and enforce the character limit visually during editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->