### PR TITLE
Fix Stripe webhook mode handling for live mode installations receiving test events

### DIFF
--- a/apps/web/app/(ee)/api/stripe/integration/webhook/route.ts
+++ b/apps/web/app/(ee)/api/stripe/integration/webhook/route.ts
@@ -67,11 +67,14 @@ export const POST = withAxiom(async (req: Request) => {
     });
   }
 
-  // When an app is installed in live mode, it receives both live and test mode events
-  // We need to check the event's livemode property to determine the correct mode to use
-  // See: https://docs.stripe.com/stripe-apps/build-backend#sandbox-mode
-  if (mode === "live" && !event.livemode) {
-    mode = "test";
+  // When an app is installed in both live & test mode,
+  // test mode events are sent to both the test mode and live mode endpoints,
+  // and live mode events are sent to the live mode endpoint.
+  // See: https://docs.stripe.com/stripe-apps/build-backend#event-behavior-depends-on-install-mode
+  if (!event.livemode && mode === "live") {
+    return logAndRespond(
+      `Received a test webhook event (${event.type}) on our live webhook receiver endpoint, skipping...`,
+    );
   }
 
   let response = "OK";

--- a/apps/web/app/(ee)/partners.dub.co/(dashboard)/profile/profile-details-form.tsx
+++ b/apps/web/app/(ee)/partners.dub.co/(dashboard)/profile/profile-details-form.tsx
@@ -309,7 +309,6 @@ function BasicInfoForm({
               <CountryCombobox
                 value={field.value || ""}
                 onChange={field.onChange}
-                error={errors.country ? true : false}
                 disabledTooltip="Your country cannot be changed once set. If you need to update your country, please contact support."
               />
             )}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook now ignores Stripe test-mode events on live endpoints to prevent accidental processing.
* **Bug Fixes**
  * Country field in the profile form no longer uses an explicit error flag; it now relies on default validation/display behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->