### PR TITLE
Polyfill workspace_id in case it's not defined

### DIFF
--- a/apps/web/app/(ee)/api/stripe/integration/webhook/checkout-session-completed.ts
+++ b/apps/web/app/(ee)/api/stripe/integration/webhook/checkout-session-completed.ts
@@ -138,6 +138,7 @@ export async function checkoutSessionCompleted(
     const { timestamp, ...rest } = clickEvent;
     leadEvent = {
       ...rest,
+      workspace_id: clickEvent.workspace_id || customer.projectId, // in case for some reason the click event doesn't have workspace_id
       event_id: nanoid(16),
       event_name: "Sign up",
       customer_id: customer.id,
@@ -321,6 +322,7 @@ export async function checkoutSessionCompleted(
 
   const saleData = {
     ...leadEvent,
+    workspace_id: leadEvent.workspace_id || customer.projectId, // in case for some reason the lead event doesn't have workspace_id
     event_id: nanoid(16),
     // if the charge is a one-time payment, we set the event name to "Purchase"
     event_name:
@@ -623,6 +625,7 @@ async function attributeViaPromoCode({
 
   const leadEvent = {
     ...rest,
+    workspace_id: clickEvent.workspace_id || customer.projectId, // in case for some reason the click event doesn't have workspace_id
     event_id: nanoid(16),
     event_name: "Sign up",
     customer_id: customer.id,

--- a/apps/web/app/(ee)/api/stripe/integration/webhook/invoice-paid.ts
+++ b/apps/web/app/(ee)/api/stripe/integration/webhook/invoice-paid.ts
@@ -126,6 +126,7 @@ export async function invoicePaid(event: Stripe.Event, mode: StripeMode) {
 
   const saleData = {
     ...leadEvent.data[0],
+    workspace_id: leadEvent.data[0].workspace_id || customer.projectId, // in case for some reason the lead event doesn't have workspace_id
     event_id: eventId,
     event_name: isOneTimePayment ? "Purchase" : "Invoice paid",
     payment_processor: "stripe",

--- a/apps/web/app/(ee)/api/stripe/integration/webhook/utils/create-new-customer.ts
+++ b/apps/web/app/(ee)/api/stripe/integration/webhook/utils/create-new-customer.ts
@@ -64,6 +64,7 @@ export async function createNewCustomer(event: Stripe.Event) {
 
   const leadData = {
     ...clickData,
+    workspace_id: clickData.workspace_id || customer.projectId, // in case for some reason the click event doesn't have workspace_id
     event_id: nanoid(16),
     event_name: eventName,
     customer_id: customer.id,

--- a/apps/web/lib/api/conversions/track-lead.ts
+++ b/apps/web/lib/api/conversions/track-lead.ts
@@ -141,6 +141,7 @@ export const trackLead = async ({
     const createLeadEventPayload = (customerId: string) => {
       const basePayload = {
         ...clickData,
+        workspace_id: clickData.workspace_id || workspace.id, // in case for some reason the click event doesn't have workspace_id
         event_id: leadEventId,
         event_name: eventName,
         customer_id: customerId,

--- a/apps/web/lib/api/conversions/track-sale.ts
+++ b/apps/web/lib/api/conversions/track-sale.ts
@@ -125,9 +125,15 @@ export const trackSale = async ({
         });
       }
 
-      leadEventData = cachedLeadEvent;
+      leadEventData = {
+        ...cachedLeadEvent,
+        workspace_id: cachedLeadEvent.workspace_id || workspace.id, // in case for some reason the lead event doesn't have workspace_id
+      };
     } else {
-      leadEventData = leadEvent.data[0];
+      leadEventData = {
+        ...leadEvent.data[0],
+        workspace_id: leadEvent.data[0].workspace_id || workspace.id, // in case for some reason the lead event doesn't have workspace_id
+      };
     }
   }
 
@@ -300,7 +306,10 @@ const _trackLead = async ({
     (async () => {
       const [_leadEvent, link, _workspace] = await Promise.all([
         // Record the lead event for the customer
-        recordLead(leadEventData),
+        recordLead({
+          ...leadEventData,
+          workspace_id: leadEventData.workspace_id || workspace.id, // in case for some reason the lead event doesn't have workspace_id
+        }),
 
         // Update link leads count + lastLeadAt date
         prisma.link.update({
@@ -419,6 +428,7 @@ const _trackSale = async ({
 
   const saleData = {
     ...leadEventData,
+    workspace_id: leadEventData.workspace_id || workspace.id, // in case for some reason the lead event doesn't have workspace_id
     event_id: nanoid(16),
     event_name: eventName,
     customer_id: customer.id,

--- a/apps/web/lib/integrations/shopify/create-lead.ts
+++ b/apps/web/lib/integrations/shopify/create-lead.ts
@@ -65,6 +65,7 @@ export async function createShopifyLead({
 
   const leadData = leadEventSchemaTB.parse({
     ...clickData,
+    workspace_id: clickData.workspace_id || customer.projectId, // in case for some reason the click event doesn't have workspace_id
     event_id: nanoid(16),
     event_name: eventName,
     customer_id: customer.id,

--- a/apps/web/lib/integrations/shopify/create-sale.ts
+++ b/apps/web/lib/integrations/shopify/create-sale.ts
@@ -55,6 +55,7 @@ export async function createShopifySale({
 
   const saleData = {
     ...leadData,
+    workspace_id: leadData.workspace_id || workspaceId, // in case for some reason the lead event doesn't have workspace_id
     event_id: nanoid(16),
     event_name: "Purchase",
     payment_processor: "shopify",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced workspace context tracking by standardizing workspace identification across all lead and sale event payloads. Workspace context is now consistently maintained throughout Stripe webhook processing, lead tracking, and Shopify integration flows. Fallback mechanisms ensure workspace information is always present, improving data consistency and attribution tracking accuracy across all integration points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->