### PR TITLE
Omit tax amount from sale total in Stripe integration

### DIFF
--- a/apps/web/app/(ee)/api/stripe/integration/webhook/checkout-session-completed.ts
+++ b/apps/web/app/(ee)/api/stripe/integration/webhook/checkout-session-completed.ts
@@ -265,7 +265,8 @@ export async function checkoutSessionCompleted(
   let chargeAmountTotal =
     (charge.amount_total ?? 0) - (charge.total_details?.amount_tax ?? 0);
 
-  if (chargeAmountTotal === 0) {
+  // should never be below 0, but just in case
+  if (chargeAmountTotal <= 0) {
     return `Checkout session completed for Stripe customer ${stripeCustomerId} with invoice ID ${invoiceId} but amount is 0, skipping...`;
   }
 

--- a/apps/web/app/(ee)/api/stripe/integration/webhook/invoice-paid.ts
+++ b/apps/web/app/(ee)/api/stripe/integration/webhook/invoice-paid.ts
@@ -66,7 +66,7 @@ export async function invoicePaid(event: Stripe.Event, mode: StripeMode) {
     return `Customer with stripeCustomerId ${stripeCustomerId} not found on Dub (nor does the connected customer ${stripeCustomerId} have a valid dubCustomerExternalId), skipping...`;
   }
 
-  let invoiceSaleAmount = invoice.total_excluding_tax || invoice.amount_paid;
+  let invoiceSaleAmount = invoice.total_excluding_tax ?? invoice.amount_paid;
 
   // Skip if invoice id is already processed
   const ok = await redis.set(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected payment amount calculations in Stripe webhooks so recorded amounts exclude tax and are used consistently across billing records, sales tracking, and payment metrics.
  * Ensured invoice and checkout events use the adjusted amounts during currency conversion and downstream reporting, improving accuracy of totals, leads/sales counts, and customer metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->