### PR TITLE
Update link styling in ProgramHelpLinks

### DIFF
--- a/apps/web/ui/partners/program-help-links.tsx
+++ b/apps/web/ui/partners/program-help-links.tsx
@@ -51,7 +51,7 @@ export const ProgramHelpLinks = memo(() => {
           href={href}
           target="_blank"
           rel="noopener noreferrer"
-          className="text-content-default hover:text-content-emphasis hover:bg-bg-inverted/5 active:bg-bg-inverted/10 flex items-center gap-2 rounded-md py-1.5 text-sm transition-all hover:px-2.5"
+          className="text-content-default hover:text-content-emphasis hover:bg-bg-inverted/5 active:bg-bg-inverted/10 flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-sm transition-all"
         >
           <Icon className="size-4" />
           {label}


### PR DESCRIPTION
Added w-full and px-2.5 to the link class for improved layout and consistent padding in the ProgramHelpLinks component.

The link starting position was off to the right. I think this had carried over from an earlier version we had.

**Before**
<img width="396" height="145" alt="CleanShot 2025-10-30 at 16 32 39@2x" src="https://github.com/user-attachments/assets/be653875-fb1a-4ce8-90f6-a3ad8d8b409d" />

**After**
<img width="410" height="227" alt="CleanShot 2025-10-30 at 16 32 22@2x" src="https://github.com/user-attachments/assets/a53e678b-1b4f-48bf-b071-bd3b66d32381" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enhanced partner program help links with full-width layout and consistent padding styling for improved usability and visual presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->