### PR TITLE
Fix program application sheet submissions

### DIFF
--- a/apps/web/ui/partners/groups/design/application-form/form-data-for-application-form-data.ts
+++ b/apps/web/ui/partners/groups/design/application-form/form-data-for-application-form-data.ts
@@ -1,0 +1,61 @@
+import { ProgramApplicationFormDataWithValues } from "@/lib/types";
+import {
+  programApplicationFormFieldSchema,
+  programApplicationFormLongTextFieldWithValueSchema,
+  programApplicationFormMultipleChoiceFieldSchema,
+  programApplicationFormMultipleChoiceFieldWithValueSchema,
+  programApplicationFormSelectFieldWithValueSchema,
+  programApplicationFormShortTextFieldWithValueSchema,
+  programApplicationFormWebsiteAndSocialsFieldWithValueSchema,
+} from "@/lib/zod/schemas/program-application-form";
+import { z } from "zod";
+
+export const formDataForApplicationFormData = (
+  fields: z.infer<typeof programApplicationFormFieldSchema>[],
+): ProgramApplicationFormDataWithValues => {
+  return {
+    fields: fields.map((field: any) => {
+      switch (field.type) {
+        case "short-text":
+          return {
+            ...field,
+            value: "",
+          } as z.infer<
+            typeof programApplicationFormShortTextFieldWithValueSchema
+          >;
+        case "long-text":
+          return {
+            ...field,
+            value: "",
+          } as z.infer<
+            typeof programApplicationFormLongTextFieldWithValueSchema
+          >;
+        case "select":
+          return {
+            ...field,
+            value: "",
+          } as z.infer<typeof programApplicationFormSelectFieldWithValueSchema>;
+        case "multiple-choice":
+          const multipleChoiceField = field as z.infer<
+            typeof programApplicationFormMultipleChoiceFieldSchema
+          >;
+          return {
+            ...field,
+            value: multipleChoiceField.data.multiple ? [] : "",
+          } as z.infer<
+            typeof programApplicationFormMultipleChoiceFieldWithValueSchema
+          >;
+        case "website-and-socials":
+          return {
+            ...field,
+            data: field.data.map((data) => ({
+              ...data,
+              value: "",
+            })),
+          } as z.infer<
+            typeof programApplicationFormWebsiteAndSocialsFieldWithValueSchema
+          >;
+      }
+    }),
+  } as any;
+};

--- a/apps/web/ui/partners/groups/design/application-form/program-application-form.tsx
+++ b/apps/web/ui/partners/groups/design/application-form/program-application-form.tsx
@@ -9,15 +9,6 @@ import {
   ProgramApplicationFormDataWithValues,
   ProgramProps,
 } from "@/lib/types";
-import {
-  programApplicationFormFieldSchema,
-  programApplicationFormLongTextFieldWithValueSchema,
-  programApplicationFormMultipleChoiceFieldSchema,
-  programApplicationFormMultipleChoiceFieldWithValueSchema,
-  programApplicationFormSelectFieldWithValueSchema,
-  programApplicationFormShortTextFieldWithValueSchema,
-  programApplicationFormWebsiteAndSocialsFieldWithValueSchema,
-} from "@/lib/zod/schemas/program-application-form";
 import { Button, useLocalStorage, useMediaQuery } from "@dub/ui";
 import { cn } from "@dub/utils";
 import { useSession } from "next-auth/react";
@@ -26,10 +17,10 @@ import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { toast } from "sonner";
-import { z } from "zod";
 import { CountryCombobox } from "../../../country-combobox";
 import { ProgramApplicationFormField } from "./fields";
 import { FormControlRequiredBadge } from "./fields/form-control";
+import { formDataForApplicationFormData } from "./form-data-for-application-form-data";
 
 type FormData = {
   name: string;
@@ -37,56 +28,6 @@ type FormData = {
   country: string;
   termsAgreement: boolean;
   formData: ProgramApplicationFormDataWithValues;
-};
-
-const formDataForApplicationFormData = (
-  fields: z.infer<typeof programApplicationFormFieldSchema>[],
-): ProgramApplicationFormDataWithValues => {
-  return {
-    fields: fields.map((field: any) => {
-      switch (field.type) {
-        case "short-text":
-          return {
-            ...field,
-            value: "",
-          } as z.infer<
-            typeof programApplicationFormShortTextFieldWithValueSchema
-          >;
-        case "long-text":
-          return {
-            ...field,
-            value: "",
-          } as z.infer<
-            typeof programApplicationFormLongTextFieldWithValueSchema
-          >;
-        case "select":
-          return {
-            ...field,
-            value: "",
-          } as z.infer<typeof programApplicationFormSelectFieldWithValueSchema>;
-        case "multiple-choice":
-          const multipleChoiceField = field as z.infer<
-            typeof programApplicationFormMultipleChoiceFieldSchema
-          >;
-          return {
-            ...field,
-            value: multipleChoiceField.data.multiple ? [] : "",
-          } as z.infer<
-            typeof programApplicationFormMultipleChoiceFieldWithValueSchema
-          >;
-        case "website-and-socials":
-          return {
-            ...field,
-            data: field.data.map((data) => ({
-              ...data,
-              value: "",
-            })),
-          } as z.infer<
-            typeof programApplicationFormWebsiteAndSocialsFieldWithValueSchema
-          >;
-      }
-    }),
-  } as any;
 };
 
 export function ProgramApplicationForm({

--- a/apps/web/ui/partners/program-application-sheet.tsx
+++ b/apps/web/ui/partners/program-application-sheet.tsx
@@ -23,10 +23,11 @@ import { toast } from "sonner";
 import { mutate } from "swr";
 import { z } from "zod";
 import { ProgramApplicationFormField } from "./groups/design/application-form/fields";
+import { formDataForApplicationFormData } from "./groups/design/application-form/form-data-for-application-form-data";
 
 interface ProgramApplicationSheetProps {
   setIsOpen: Dispatch<SetStateAction<boolean>>;
-  program?: ProgramProps;
+  program: ProgramProps;
   programEnrollment?: ProgramEnrollmentProps;
   onSuccess?: () => void;
 }
@@ -47,6 +48,9 @@ function ProgramApplicationSheetContent({
   const form = useForm<FormData>({
     defaultValues: {
       termsAgreement: false,
+      formData: formDataForApplicationFormData(
+        program["group"].applicationFormData?.fields ?? [],
+      ),
     },
   });
 
@@ -87,8 +91,6 @@ function ProgramApplicationSheetContent({
       toast.error(parseActionError(result, "Failed to submit application"));
     }
   };
-
-  if (!program) return null;
 
   const fields = program["group"].applicationFormData?.fields || [];
 


### PR DESCRIPTION
Makes the application form in `ProgramApplicationSheet` use the same `formDataForApplicationFormData` method as `ProgramApplicationForm` to populate default values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Extracted form initialization utilities into a dedicated module for improved code reusability and maintainability.
  * Updated form component requirements to ensure necessary data is always available before rendering, eliminating unnecessary conditional checks and improving reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->