### PR TITLE
Quick fix for campaign groups selector overflow

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/campaigns/[campaignId]/campaign-groups-selector.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/campaigns/[campaignId]/campaign-groups-selector.tsx
@@ -7,7 +7,7 @@ import { Popover, Users6 } from "@dub/ui";
 import { cn } from "@dub/utils";
 import { useMemo, useState } from "react";
 
-const MAX_DISPLAYED_GROUPS = 4;
+const MAX_DISPLAYED_GROUPS = 1;
 
 interface CampaignGroupsSelectorProps {
   selectedGroupIds: string[] | null;
@@ -73,7 +73,7 @@ export function CampaignGroupsSelector({
             </span>
           </div>
         ) : selectedGroups && selectedGroups.length > 0 ? (
-          <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
+          <div className="flex min-w-0 flex-1 items-center gap-2">
             {selectedGroups.slice(0, MAX_DISPLAYED_GROUPS).map((group) => (
               <div
                 key={group.id}


### PR DESCRIPTION
Just show one selected group with a "+N" to avoid awkward overflow

<img width="459" height="177" alt="Screenshot 2025-10-31 at 10 51 37 AM" src="https://github.com/user-attachments/assets/8f173568-e305-412d-b1fd-5d7fba013562" />
<img width="532" height="188" alt="Screenshot 2025-10-31 at 10 51 50 AM" src="https://github.com/user-attachments/assets/1e067fec-e296-453a-9c7c-63aed3a973ac" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Campaign groups selector now displays one selected group at a time with a counter showing additional selections instead of displaying multiple groups simultaneously.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->