### PR TITLE
Update MainNav component styles to match the original designs

### DIFF
--- a/apps/web/ui/layout/main-nav.tsx
+++ b/apps/web/ui/layout/main-nav.tsx
@@ -79,8 +79,8 @@ export function MainNav({
           <Sidebar toolContent={toolContent} newsContent={newsContent} />
         </div>
       </div>
-      <div className="bg-neutral-200 [--page-top-margin:0px] md:pt-[var(--page-top-margin)] md:[--page-top-margin:0.5rem]">
-        <div className="relative min-h-full bg-neutral-100 pt-px md:rounded-tl-xl md:bg-white">
+      <div className="bg-neutral-200 [--page-top-margin:0px] md:h-screen md:pb-2 md:pr-2 md:pt-[var(--page-top-margin)] md:[--page-top-margin:0.5rem]">
+        <div className="relative h-full overflow-y-auto bg-neutral-100 pt-px md:rounded-xl md:bg-white">
           <SideNavContext.Provider value={{ isOpen, setIsOpen }}>
             {children}
           </SideNavContext.Provider>


### PR DESCRIPTION
Added padding to the right and bottom to the main page content on larger screens and added rounded corners to match. This was the original intention with the designs so just updating it to match 

Before
<img width="2364" height="1361" alt="CleanShot 2025-10-31 at 10 52 25@2x" src="https://github.com/user-attachments/assets/075d8ad5-5d7f-471a-a892-8b731f34b2a0" />


After
<img width="1583" height="959" alt="CleanShot 2025-10-31 at 10 51 31@2x" src="https://github.com/user-attachments/assets/9b2fd96e-9a24-4657-94a1-0b3241fbe396" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive layout adjustments for medium-sized screens with enhanced spacing and padding configuration
  * Enhanced vertical scrolling capability for the main content area to support longer content
  * Refined visual presentation with adjusted corner rounding scheme for improved design consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->