### PR TITLE
Workspace drop-down visual updates

### DIFF
--- a/apps/web/ui/layout/sidebar/workspace-dropdown.tsx
+++ b/apps/web/ui/layout/sidebar/workspace-dropdown.tsx
@@ -11,7 +11,7 @@ import {
   useScrollProgress,
 } from "@dub/ui";
 import { Check2, Gear, Plus, UserPlus } from "@dub/ui/icons";
-import { cn } from "@dub/utils";
+import { cn, pluralize } from "@dub/utils";
 import { isLegacyBusinessPlan } from "@dub/utils/src/constants/pricing";
 import { useSession } from "next-auth/react";
 import Link from "next/link";
@@ -195,7 +195,7 @@ function WorkspaceList({
                   )}
                 >
                   {selected.plan} · {membersCount}{" "}
-                  {membersCount === 1 ? "member" : "members"}
+                  {pluralize("member", membersCount)}
                 </div>
               )}
             </div>


### PR DESCRIPTION
To address some feedback about the workspace switcher to accommodate users who are on multiple workspaces, made the following changes: 
- Change the actions `settings` and `invite members` to be buttons that are in a row instead of a column
- Reduced the overall padding to tighten things up
- Aligned all the content better
- Increased the overall width
- Changed "Create New Workspace" to "Create Workspace." 
- Added the member count next to the plan name
- Increased the max height

This will give those users more visual real estate to be able to select another workspace a bit faster while reducing some of the visual clutter.

**Current**
<img width="383" height="393" alt="CleanShot 2025-10-31 at 12 28 56@2x" src="https://github.com/user-attachments/assets/783d4cf8-732b-4c80-b153-5e6378264d7f" />

**Updates**
<img width="399" height="320" alt="CleanShot 2025-10-31 at 12 28 44@2x" src="https://github.com/user-attachments/assets/affd3f4c-a7e9-46aa-b395-0649895d6eea" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Show workspace member counts alongside plan info everywhere in the workspace dropdown and current workspace header, with correct singular/plural wording.

* **Style**
  * Refined layout, spacing, and typography for a more compact workspace dropdown and header; improved text truncation.
  * Adjusted avatar/item sizing, list padding, borders, and rounded button styling.
  * Updated action icon colors, hover/active states, and renamed "Create new workspace" to "Create workspace" with refined icon spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->