### PR TITLE
Bounty submission character limit

### DIFF
--- a/apps/web/lib/actions/partners/create-bounty-submission.ts
+++ b/apps/web/lib/actions/partners/create-bounty-submission.ts
@@ -5,6 +5,7 @@ import { getWorkspaceUsers } from "@/lib/api/get-workspace-users";
 import { getProgramEnrollmentOrThrow } from "@/lib/api/programs/get-program-enrollment-or-throw";
 import {
   BountySubmissionFileSchema,
+  MAX_BOUNTY_SUBMISSION_DESCRIPTION_LENGTH,
   MAX_SUBMISSION_FILES,
   MAX_SUBMISSION_URLS,
   submissionRequirementsSchema,
@@ -27,7 +28,11 @@ const schema = z.object({
     .max(MAX_SUBMISSION_FILES)
     .default([]),
   urls: z.array(z.string().url()).max(MAX_SUBMISSION_URLS).default([]),
-  description: z.string().trim().max(1000).optional(),
+  description: z
+    .string()
+    .trim()
+    .max(MAX_BOUNTY_SUBMISSION_DESCRIPTION_LENGTH)
+    .optional(),
   isDraft: z
     .boolean()
     .default(false)

--- a/apps/web/lib/zod/schemas/bounties.ts
+++ b/apps/web/lib/zod/schemas/bounties.ts
@@ -20,6 +20,8 @@ export const MAX_SUBMISSION_FILES = 4;
 
 export const MAX_SUBMISSION_URLS = 20;
 
+export const MAX_BOUNTY_SUBMISSION_DESCRIPTION_LENGTH = 1000;
+
 export const REJECT_BOUNTY_SUBMISSION_REASONS = {
   invalidProof: "Invalid proof",
   duplicateSubmission: "Duplicate submission",

--- a/apps/web/ui/partners/bounties/claim-bounty-modal.tsx
+++ b/apps/web/ui/partners/bounties/claim-bounty-modal.tsx
@@ -5,6 +5,7 @@ import { mutatePrefix } from "@/lib/swr/mutate";
 import useProgramEnrollment from "@/lib/swr/use-program-enrollment";
 import { PartnerBountyProps } from "@/lib/types";
 import {
+  MAX_BOUNTY_SUBMISSION_DESCRIPTION_LENGTH,
   MAX_SUBMISSION_FILES,
   MAX_SUBMISSION_URLS,
   REJECT_BOUNTY_SUBMISSION_REASONS,
@@ -582,9 +583,22 @@ function ClaimBountyModalContent({ bounty }: ClaimBountyModalProps) {
                           "border-neutral-300 text-neutral-900 placeholder-neutral-400 focus:border-neutral-500 focus:ring-neutral-500",
                         )}
                         minRows={2}
+                        maxLength={MAX_BOUNTY_SUBMISSION_DESCRIPTION_LENGTH}
                         value={description}
-                        onChange={(e) => setDescription(e.target.value)}
+                        onChange={(e) => {
+                          const value = e.target.value;
+                          if (value.length <= MAX_BOUNTY_SUBMISSION_DESCRIPTION_LENGTH) {
+                            setDescription(value);
+                          }
+                        }}
                       />
+                      <div className="mt-1 text-left">
+                        <span className="text-xs text-neutral-500">
+                          {MAX_BOUNTY_SUBMISSION_DESCRIPTION_LENGTH -
+                            description.length}{" "}
+                          / {MAX_BOUNTY_SUBMISSION_DESCRIPTION_LENGTH}
+                        </span>
+                      </div>
                     </div>
                   </div>
                 </motion.div>


### PR DESCRIPTION
On the backend there was an 1000 character limit but we weren't enforcing it on the form and/or displaying it to the partners when they are submitting. This would create submission loops with no error message.

**Current**
<img width="578" height="1343" alt="CleanShot 2025-10-31 at 13 46 43@2x" src="https://github.com/user-attachments/assets/18b8608f-3399-4dee-b8b3-e1c9594331a7" />



**Updated**
<img width="731" height="1025" alt="CleanShot 2025-10-31 at 13 39 39@2x" src="https://github.com/user-attachments/assets/c003c9d3-23c2-46a7-97af-689a278f89a2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a 1000-character limit to bounty submission descriptions with a live character counter displaying remaining characters.
  * Enhanced validation to prevent exceeding the description character limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->