### PR TITLE
Add `partner.application_submitted` to webhook triggers in Zapier settings

### DIFF
--- a/apps/web/lib/integrations/zapier/ui/settings.tsx
+++ b/apps/web/lib/integrations/zapier/ui/settings.tsx
@@ -18,6 +18,7 @@ export const ZapierSettings = (props: InstalledIntegrationInfoProps) => {
             "link.clicked",
             "lead.created",
             "sale.created",
+            "partner.application_submitted",
             "partner.enrolled",
           ]}
         />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Zapier webhook configuration now supports the partner application submitted event, enabling new automation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->