### PR TITLE
chore: target ES2022 in react library tsconfig

### DIFF
--- a/packages/tsconfig/react-library.json
+++ b/packages/tsconfig/react-library.json
@@ -3,7 +3,7 @@
   "display": "React Library",
   "extends": "./base.json",
   "compilerOptions": {
-    "lib": ["ES2015", "DOM"],
+    "lib": ["ES2022", "DOM"],
     "module": "ESNext",
     "target": "ES2022",
     "jsx": "react-jsx",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript configuration to use the ES2022 JavaScript library while preserving DOM definitions; other compiler options unchanged, maintaining current module/target/jsx behavior and noEmit settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->