### PR TITLE
Pin table menu columns

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/groups/groups-table.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/groups/groups-table.tsx
@@ -158,6 +158,7 @@ export function GroupsTable() {
         cell: ({ row }) => <RowMenuButton row={row} />,
       },
     ],
+    columnPinning: { right: ["menu"] },
     onRowClick: (row, e) => {
       const url = getGroupUrl({
         workspaceSlug: slug!,

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/applications/page-client.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/applications/page-client.tsx
@@ -332,6 +332,7 @@ export function ProgramPartnersApplicationsPageClient() {
   const { table, ...tableProps } = useTable<EnrolledPartnerProps>({
     data: partners || [],
     columns,
+    columnPinning: { right: ["menu"] },
     onRowClick: (row) => {
       queryParams({
         set: {

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/applications/rejected/page-client.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/applications/rejected/page-client.tsx
@@ -258,6 +258,7 @@ export function ProgramPartnersRejectedApplicationsPageClient() {
   const { table, ...tableProps } = useTable<EnrolledPartnerProps>({
     data: partners || [],
     columns,
+    columnPinning: { right: ["menu"] },
     onRowClick: (row) => {
       queryParams({
         set: {

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/partners-table.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/partners-table.tsx
@@ -408,6 +408,7 @@ export function PartnersTable() {
   const { table, ...tableProps } = useTable({
     data: partners || [],
     columns,
+    columnPinning: { right: ["menu"] },
     onRowClick: (row, e) => {
       const url = getPartnerUrl({
         workspaceSlug: workspaceSlug!,


### PR DESCRIPTION
Pins the menu columns in tables:
* Partners
* Partner applications
* Partner rejected applications
* Groups

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced table navigation by pinning menu columns to remain visible during horizontal scrolling across dashboard tables for partner applications, rejected applications, group management, and partner programs. Action items and controls now remain consistently accessible when viewing data-rich tables, eliminating the need to scroll back to access menu options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->