### PR TITLE
Add program support email in campaign preview

### DIFF
--- a/apps/web/app/(ee)/api/campaigns/[campaignId]/preview/route.ts
+++ b/apps/web/app/(ee)/api/campaigns/[campaignId]/preview/route.ts
@@ -51,6 +51,7 @@ export const POST = withWorkspace(
         variant: campaign.type === "marketing" ? "marketing" : "notifications",
         to: email,
         ...(from && { from: `${program.name} <${from}>` }),
+        ...(program.supportEmail ? { replyTo: program.supportEmail } : {}),
         subject: `[TEST] ${subject}`,
         react: CampaignEmail({
           program: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved campaign email routing. Campaign emails now automatically configure the reply-to address based on program support email settings, ensuring recipient responses are directed to your designated support email when specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->