### PR TITLE
Include searchParams in iOS deepview

### DIFF
--- a/apps/web/app/app.dub.co/(deeplink)/deeplink/[domain]/[key]/action-buttons.tsx
+++ b/apps/web/app/app.dub.co/(deeplink)/deeplink/[domain]/[key]/action-buttons.tsx
@@ -2,20 +2,26 @@
 
 import { Button, IOSAppStore, useCopyToClipboard } from "@dub/ui";
 import { Link } from "@prisma/client";
+import { useSearchParams } from "next/navigation";
 
 export function DeepLinkActionButtons({
   link,
 }: {
   link: Pick<Link, "shortLink">;
 }) {
+  const searchParams = useSearchParams();
+  const searchParamsString = searchParams.toString();
+
   const [_copied, copyToClipboard] = useCopyToClipboard();
 
   const handleClick = async ({ withCopy }: { withCopy?: boolean } = {}) => {
     if (withCopy) {
-      await copyToClipboard(link.shortLink);
+      await copyToClipboard(
+        `${link.shortLink}${searchParamsString ? `?${searchParamsString}` : ""}`,
+      );
     }
 
-    window.location.href = `${link.shortLink}?skip_deeplink_preview=1`;
+    window.location.href = `${link.shortLink}?skip_deeplink_preview=1${searchParamsString ? `&${searchParamsString}` : ""}`;
   };
 
   return (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Shortened links now correctly preserve and append existing query parameters when copied to clipboard, ensuring all tracking data and user context are maintained throughout the copy operation.
  * URL query parameters now properly persist when navigating through shortened links, preventing any loss of important URL data during the redirect process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->