### PR TITLE
Handle `folderId='unsorted'`

### DIFF
--- a/apps/web/lib/zod/schemas/links.ts
+++ b/apps/web/lib/zod/schemas/links.ts
@@ -120,6 +120,7 @@ const LinksQuerySchema = z.object({
   folderId: z
     .string()
     .optional()
+    .transform((v) => (v === "unsorted" ? null : v))
     .describe("The folder ID to filter the links by."),
   search: z
     .string()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated folder filtering behavior for links: filtering by "unsorted" now displays all links instead of applying an unsorted-specific filter, providing more intuitive filtering results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->