### PR TITLE
Fix queueStripePayouts

### DIFF
--- a/apps/web/app/(ee)/api/cron/payouts/charge-succeeded/queue-stripe-payouts.ts
+++ b/apps/web/app/(ee)/api/cron/payouts/charge-succeeded/queue-stripe-payouts.ts
@@ -49,9 +49,8 @@ export async function queueStripePayouts(
         stripeConnectId: {
           not: null,
         },
-        payoutsEnabledAt: {
-          not: null,
-        },
+        // here we're not checking for payoutsEnabledAt since we want visiblity
+        // if a stripe.transfers.create fails due to restricted Stripe account
       },
     },
   });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Payout queuing now only includes partners with a Stripe connection; the previous check against a payout-enabled timestamp was removed, improving which partners are selected for processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->