### PR TITLE
Remove `tbOld` (complete Tinybird migration)

### DIFF
--- a/apps/web/app/(ee)/api/cron/framer/backfill-leads-batch/route.ts
+++ b/apps/web/app/(ee)/api/cron/framer/backfill-leads-batch/route.ts
@@ -303,18 +303,6 @@ export const POST = withWorkspace(async ({ req, workspace }) => {
           body: dataArray.map((d) => JSON.stringify(d.clickData)).join("\n"),
         },
       ),
-      // TODO: Remove after Tinybird migration
-      fetch(
-        `${process.env.TINYBIRD_API_URL}/v0/events?name=dub_click_events&wait=true`,
-        {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${process.env.TINYBIRD_API_KEY_OLD}`,
-            "Content-Type": "application/x-ndjson",
-          },
-          body: dataArray.map((d) => JSON.stringify(d.clickData)).join("\n"),
-        },
-      ),
 
       // Record leads
       recordLeadWithTimestamp(dataArray.map((d) => d.leadEventData)),

--- a/apps/web/lib/api/audit-logs/record-audit-log.ts
+++ b/apps/web/lib/api/audit-logs/record-audit-log.ts
@@ -1,7 +1,7 @@
 import { getIP } from "@/lib/api/utils/get-ip";
-import { tb, tbOld } from "@/lib/tinybird";
+import { tb } from "@/lib/tinybird";
 import { log } from "@dub/utils";
-import { ipAddress as getIPAddress, waitUntil } from "@vercel/functions";
+import { ipAddress as getIPAddress } from "@vercel/functions";
 import { headers } from "next/headers";
 import { z } from "zod";
 import { createId } from "../create-id";
@@ -56,7 +56,6 @@ export const recordAuditLog = async (data: AuditLogInput | AuditLogInput[]) => {
     : [transformAuditLogTB(data, { headersList, ipAddress })];
 
   try {
-    waitUntil(recordAuditLogTBOld(auditLogs));
     return await recordAuditLogTB(auditLogs);
   } catch (error) {
     console.error(
@@ -74,13 +73,6 @@ export const recordAuditLog = async (data: AuditLogInput | AuditLogInput[]) => {
 };
 
 const recordAuditLogTB = tb.buildIngestEndpoint({
-  datasource: "dub_audit_logs",
-  event: auditLogSchemaTB,
-  wait: true,
-});
-
-// TODO: Remove after Tinybird migration
-const recordAuditLogTBOld = tbOld.buildIngestEndpoint({
   datasource: "dub_audit_logs",
   event: auditLogSchemaTB,
   wait: true,

--- a/apps/web/lib/tinybird/client.ts
+++ b/apps/web/lib/tinybird/client.ts
@@ -4,9 +4,3 @@ export const tb = new Tinybird({
   token: process.env.TINYBIRD_API_KEY as string,
   baseUrl: process.env.TINYBIRD_API_URL as string,
 });
-
-// TODO: Remove after Tinybird migration
-export const tbOld = new Tinybird({
-  token: process.env.TINYBIRD_API_KEY_OLD as string,
-  baseUrl: process.env.TINYBIRD_API_URL as string,
-});

--- a/apps/web/lib/tinybird/log-conversion-events.ts
+++ b/apps/web/lib/tinybird/log-conversion-events.ts
@@ -1,6 +1,5 @@
-import { waitUntil } from "@vercel/functions";
 import { z } from "zod";
-import { tb, tbOld } from "./client";
+import { tb } from "./client";
 
 const schema = z.object({
   workspace_id: z.string(),
@@ -11,18 +10,7 @@ const schema = z.object({
 });
 
 // Log the conversion events for debugging purposes
-export const logConversionEventTB = tb.buildIngestEndpoint({
+export const logConversionEvent = tb.buildIngestEndpoint({
   datasource: "dub_conversion_events_log",
   event: schema,
 });
-
-// TODO: Remove after Tinybird migration
-export const logConversionEventTBOld = tbOld.buildIngestEndpoint({
-  datasource: "dub_conversion_events_log",
-  event: schema,
-});
-
-export const logConversionEvent = async (payload: any) => {
-  waitUntil(logConversionEventTBOld(payload));
-  return await logConversionEventTB(payload);
-};

--- a/apps/web/lib/tinybird/log-import-error.ts
+++ b/apps/web/lib/tinybird/log-import-error.ts
@@ -1,19 +1,7 @@
-import { waitUntil } from "@vercel/functions";
 import { importErrorLogSchema } from "../zod/schemas/import-error-log";
-import { tb, tbOld } from "./client";
+import { tb } from "./client";
 
-export const logImportErrorTB = tb.buildIngestEndpoint({
+export const logImportError = tb.buildIngestEndpoint({
   datasource: "dub_import_error_logs",
   event: importErrorLogSchema,
 });
-
-// TODO: Remove after Tinybird migration
-export const logImportErrorTBOld = tbOld.buildIngestEndpoint({
-  datasource: "dub_import_error_logs",
-  event: importErrorLogSchema,
-});
-
-export const logImportError = async (payload: any) => {
-  waitUntil(logImportErrorTBOld(payload));
-  return await logImportErrorTB(payload);
-};

--- a/apps/web/lib/tinybird/record-click-zod.ts
+++ b/apps/web/lib/tinybird/record-click-zod.ts
@@ -1,6 +1,5 @@
-import { waitUntil } from "@vercel/functions";
 import { z } from "zod";
-import { tb, tbOld } from "./client";
+import { tb } from "./client";
 
 export const recordClickZodSchema = z.object({
   timestamp: z.string().default(""),
@@ -37,20 +36,8 @@ export const recordClickZodSchema = z.object({
   trigger: z.string().default("link"),
 });
 
-export const recordClickZodTB = tb.buildIngestEndpoint({
+export const recordClickZod = tb.buildIngestEndpoint({
   datasource: "dub_click_events",
   event: recordClickZodSchema,
   wait: true,
 });
-
-// TODO: Remove after Tinybird migration
-export const recordClickZodTBOld = tbOld.buildIngestEndpoint({
-  datasource: "dub_click_events",
-  event: recordClickZodSchema,
-  wait: true,
-});
-
-export const recordClickZod = async (payload: any) => {
-  waitUntil(recordClickZodTBOld(payload));
-  return await recordClickZodTB(payload);
-};

--- a/apps/web/lib/tinybird/record-click.ts
+++ b/apps/web/lib/tinybird/record-click.ts
@@ -231,18 +231,6 @@ export async function recordClick({
               [programId, partnerId],
             );
           }),
-
-        // TODO: Remove after Tinybird migration
-        fetchWithRetry(
-          `${process.env.TINYBIRD_API_URL}/v0/events?name=dub_click_events&wait=true`,
-          {
-            method: "POST",
-            headers: {
-              Authorization: `Bearer ${process.env.TINYBIRD_API_KEY_OLD}`,
-            },
-            body: JSON.stringify(clickData),
-          },
-        ).then((res) => res.json()),
       ]);
 
       // Find the rejected promises and log them

--- a/apps/web/lib/tinybird/record-lead.ts
+++ b/apps/web/lib/tinybird/record-lead.ts
@@ -1,39 +1,15 @@
-import { waitUntil } from "@vercel/functions";
 import { z } from "zod";
 import { leadEventSchemaTB } from "../zod/schemas/leads";
-import { tb, tbOld } from "./client";
+import { tb } from "./client";
 
-export const recordLeadTB = tb.buildIngestEndpoint({
+export const recordLead = tb.buildIngestEndpoint({
   datasource: "dub_lead_events",
   event: leadEventSchemaTB,
 });
 
-// TODO: Remove after Tinybird migration
-export const recordLeadTBOld = tbOld.buildIngestEndpoint({
-  datasource: "dub_lead_events",
-  event: leadEventSchemaTB,
-});
-
-export const recordLead = async (payload: any) => {
-  waitUntil(recordLeadTBOld(payload));
-  return await recordLeadTB(payload);
-};
-
-export const recordLeadWithTimestampTB = tb.buildIngestEndpoint({
+export const recordLeadWithTimestamp = tb.buildIngestEndpoint({
   datasource: "dub_lead_events",
   event: leadEventSchemaTB.extend({
     timestamp: z.string(),
   }),
 });
-
-export const recordLeadWithTimestampTBOld = tbOld.buildIngestEndpoint({
-  datasource: "dub_lead_events",
-  event: leadEventSchemaTB.extend({
-    timestamp: z.string(),
-  }),
-});
-
-export const recordLeadWithTimestamp = async (payload: any) => {
-  waitUntil(recordLeadWithTimestampTBOld(payload));
-  return await recordLeadWithTimestampTB(payload);
-};

--- a/apps/web/lib/tinybird/record-sale.ts
+++ b/apps/web/lib/tinybird/record-sale.ts
@@ -1,39 +1,15 @@
-import { waitUntil } from "@vercel/functions";
 import z from "../zod";
 import { saleEventSchemaTB } from "../zod/schemas/sales";
-import { tb, tbOld } from "./client";
+import { tb } from "./client";
 
-export const recordSaleTB = tb.buildIngestEndpoint({
+export const recordSale = tb.buildIngestEndpoint({
   datasource: "dub_sale_events",
   event: saleEventSchemaTB,
 });
 
-// TODO: Remove after Tinybird migration
-export const recordSaleNewTB = tbOld.buildIngestEndpoint({
-  datasource: "dub_sale_events",
-  event: saleEventSchemaTB,
-});
-
-export const recordSale = async (payload: any) => {
-  waitUntil(recordSaleNewTB(payload));
-  return await recordSaleTB(payload);
-};
-
-export const recordSaleWithTimestampTB = tb.buildIngestEndpoint({
+export const recordSaleWithTimestamp = tb.buildIngestEndpoint({
   datasource: "dub_sale_events",
   event: saleEventSchemaTB.extend({
     timestamp: z.string(),
   }),
 });
-
-export const recordSaleWithTimestampNewTB = tbOld.buildIngestEndpoint({
-  datasource: "dub_sale_events",
-  event: saleEventSchemaTB.extend({
-    timestamp: z.string(),
-  }),
-});
-
-export const recordSaleWithTimestamp = async (payload: any) => {
-  waitUntil(recordSaleWithTimestampNewTB(payload));
-  return await recordSaleWithTimestampTB(payload);
-};

--- a/apps/web/lib/tinybird/record-webhook-event.ts
+++ b/apps/web/lib/tinybird/record-webhook-event.ts
@@ -1,19 +1,7 @@
-import { waitUntil } from "@vercel/functions";
 import { webhookEventSchemaTB } from "../zod/schemas/webhooks";
-import { tb, tbOld } from "./client";
+import { tb } from "./client";
 
-export const recordWebhookEventTB = tb.buildIngestEndpoint({
+export const recordWebhookEvent = tb.buildIngestEndpoint({
   datasource: "dub_webhook_events",
   event: webhookEventSchemaTB.omit({ timestamp: true }),
 });
-
-// TODO: Remove after Tinybird migration
-export const recordWebhookEventTBOld = tbOld.buildIngestEndpoint({
-  datasource: "dub_webhook_events",
-  event: webhookEventSchemaTB.omit({ timestamp: true }),
-});
-
-export const recordWebhookEvent = async (payload: any) => {
-  waitUntil(recordWebhookEventTBOld(payload));
-  return await recordWebhookEventTB(payload);
-};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated event tracking infrastructure to use single Tinybird API endpoints, removing deprecated dual-path migration code and legacy integrations.
  * Simplified analytics ingestion logic by eliminating redundant parallel requests and migration wrappers across all event types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->