### PR TITLE
Fix payout minimum amount display

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/payouts/payout-table.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/payouts/payout-table.tsx
@@ -337,7 +337,7 @@ function AmountRowItem({
           content={
             <TooltipContent
               title={`Your program's minimum payout amount is ${currencyFormatter(
-                minPayoutAmount / 100,
+                minPayoutAmount,
               )}. This payout will be accrued and processed during the next payout period.`}
               cta="Update minimum payout amount"
               href={`/${slug}/program/payouts?status=pending&sortBy=amount`}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect minimum payout amount display in the payout information tooltip. The value now displays accurately without improper unit conversion.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->