### PR TITLE
Add padding to usage chart selector

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/billing/usage-chart.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/billing/usage-chart.tsx
@@ -324,7 +324,7 @@ export function UsageChart() {
   return (
     <div className="space-y-4 pt-4 sm:pt-8">
       <div className="flex flex-col gap-3">
-        <div className="flex flex-col gap-2 px-4 md:flex-row md:items-center md:justify-between">
+        <div className="flex flex-col gap-2 px-4 md:flex-row md:items-center md:justify-between md:px-0">
           <div className="flex w-full flex-col gap-2 md:w-fit md:flex-row md:items-center">
             <Filter.Select
               className="h-9 w-full md:w-fit"
@@ -359,7 +359,7 @@ export function UsageChart() {
               onSelect={onSelect}
               onRemove={onRemove}
               onRemoveAll={onRemoveAll}
-              className="px-4"
+              className="px-4 md:px-0"
             />
           )}
         </AnimatedSizeContainer>


### PR DESCRIPTION
Filters were wider than the main actions

### Current
<img width="1253" height="467" alt="CleanShot 2025-11-27 at 08 43 36@2x" src="https://github.com/user-attachments/assets/f62e058f-a6e9-4131-b299-c5942adf0228" />


### Update
<img width="1267" height="390" alt="CleanShot 2025-11-27 at 08 43 27@2x" src="https://github.com/user-attachments/assets/92453e58-48b7-4104-93db-6f376bd80069" />

<img width="637" height="592" alt="CleanShot 2025-11-27 at 10 49 43@2x" src="https://github.com/user-attachments/assets/3224b5d1-4ca6-44d3-862b-7c98b605339a" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined horizontal spacing and responsive padding in the usage chart filter area for a cleaner layout across screen sizes.
  * Ensured filter controls maintain consistent padding alignment between mobile and desktop views.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->