### PR TITLE
Adding reward amount back

### DIFF
--- a/apps/web/app/(ee)/partners.dub.co/(dashboard)/programs/[programSlug]/(enrolled)/bounties/partner-bounty-card.tsx
+++ b/apps/web/app/(ee)/partners.dub.co/(dashboard)/programs/[programSlug]/(enrolled)/bounties/partner-bounty-card.tsx
@@ -1,9 +1,11 @@
+import { getBountyRewardDescription } from "@/lib/partners/get-bounty-reward-description";
 import { PartnerBountyProps } from "@/lib/types";
 import { BountyPerformance } from "@/ui/partners/bounties/bounty-performance";
 import { BountyThumbnailImage } from "@/ui/partners/bounties/bounty-thumbnail-image";
 import { useClaimBountyModal } from "@/ui/partners/bounties/claim-bounty-modal";
 import {
   DynamicTooltipWrapper,
+  Gift,
   StatusBadge,
   TimestampTooltip,
   TooltipContent,
@@ -90,6 +92,13 @@ export function PartnerBountyCard({ bounty }: { bounty: PartnerBountyProps }) {
                 )}
               </span>
             </div>
+
+            {getBountyRewardDescription(bounty) && (
+              <div className="text-content-subtle flex items-center gap-2 text-sm font-medium">
+                <Gift className="size-3.5" />
+                <span>{getBountyRewardDescription(bounty)}</span>
+              </div>
+            )}
           </div>
 
           <div className="flex grow flex-col justify-end px-2 pb-1">

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/bounties/[bountyId]/bounty-info.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/bounties/[bountyId]/bounty-info.tsx
@@ -63,7 +63,7 @@ export function BountyInfo() {
 
   return (
     <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:gap-6">
-      <div className="relative flex h-[100px] w-full items-center justify-center rounded-lg bg-neutral-100 p-4 sm:h-[100px] sm:w-[100px] sm:shrink-0">
+      <div className="relative flex h-[100px] w-full items-center justify-center rounded-lg bg-neutral-100 p-4 sm:h-[128px] sm:w-[100px] sm:shrink-0">
         <BountyThumbnailImage bounty={bounty} />
         <div className="absolute right-2 top-2 sm:hidden">
           <BountyActionButton bounty={bounty} />
@@ -86,7 +86,7 @@ export function BountyInfo() {
           </span>
         </div>
 
-        {!isOwner && (
+        {getBountyRewardDescription(bounty) && (
           <div className="text-content-subtle font-regular flex items-center gap-2 text-sm">
             <Gift className="size-4 shrink-0" />
             <span className="text-ellipsis">
@@ -190,7 +190,7 @@ export function BountyInfo() {
 function BountyInfoSkeleton() {
   return (
     <div className="flex flex-col items-center gap-3 sm:flex-row sm:items-start sm:gap-6">
-      <div className="relative flex h-[100px] w-[100px] shrink-0 items-center justify-center rounded-lg bg-neutral-100 p-3" />
+      <div className="relative flex h-[100px] w-[100px] shrink-0 items-center justify-center rounded-lg bg-neutral-100 p-3 sm:h-[128px]" />
       <div className="flex min-w-0 flex-1 flex-col gap-1.5">
         <div className="h-6 w-48 animate-pulse rounded-md bg-neutral-200" />
         <div className="flex items-center space-x-2">

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/bounties/bounty-card.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/bounties/bounty-card.tsx
@@ -1,3 +1,4 @@
+import { getBountyRewardDescription } from "@/lib/partners/get-bounty-reward-description";
 import useGroups from "@/lib/swr/use-groups";
 import { usePartnersCountByGroupIds } from "@/lib/swr/use-partners-count-by-groupids";
 import useWorkspace from "@/lib/swr/use-workspace";
@@ -5,7 +6,7 @@ import { BountyListProps } from "@/lib/types";
 import { BountyThumbnailImage } from "@/ui/partners/bounties/bounty-thumbnail-image";
 import { GroupColorCircle } from "@/ui/partners/groups/group-color-circle";
 import { DynamicTooltipWrapper, ScrollableTooltipContent } from "@dub/ui";
-import { Calendar6, Users, Users6 } from "@dub/ui/icons";
+import { Calendar6, Gift, Users, Users6 } from "@dub/ui/icons";
 import { formatDate, nFormatter, pluralize } from "@dub/utils";
 import Link from "next/link";
 import { useMemo } from "react";
@@ -69,6 +70,13 @@ export function BountyCard({ bounty }: { bounty: BountyListProps }) {
               )}
             </span>
           </div>
+
+          {getBountyRewardDescription(bounty) && (
+            <div className="text-content-subtle font-regular flex items-center gap-2 text-sm">
+              <Gift className="size-3.5" />
+              <span>{getBountyRewardDescription(bounty)}</span>
+            </div>
+          )}
 
           <div className="text-content-subtle font-regular flex items-center gap-2 text-sm">
             <Users className="size-3.5" />

--- a/apps/web/ui/partners/bounties/claim-bounty-modal.tsx
+++ b/apps/web/ui/partners/bounties/claim-bounty-modal.tsx
@@ -6,6 +6,7 @@ import {
   BOUNTY_MAX_SUBMISSION_URLS,
   REJECT_BOUNTY_SUBMISSION_REASONS,
 } from "@/lib/constants/bounties";
+import { getBountyRewardDescription } from "@/lib/partners/get-bounty-reward-description";
 import { mutatePrefix } from "@/lib/swr/mutate";
 import useProgramEnrollment from "@/lib/swr/use-program-enrollment";
 import { PartnerBountyProps } from "@/lib/types";
@@ -17,6 +18,7 @@ import {
   Button,
   Calendar6,
   FileUpload,
+  Gift,
   LoadingSpinner,
   Modal,
   PROSE_STYLES,
@@ -297,6 +299,13 @@ function ClaimBountyModalContent({ bounty }: ClaimBountyModalProps) {
                       )}
                     </span>
                   </div>
+
+                  {getBountyRewardDescription(bounty) && (
+                    <div className="text-content-subtle flex items-center gap-2 text-sm font-medium">
+                      <Gift className="size-3.5" />
+                      <span>{getBountyRewardDescription(bounty)}</span>
+                    </div>
+                  )}
 
                   {submission ? (
                     <div className="mt-3 grid gap-2">


### PR DESCRIPTION
Was and oversight to remove from the partner side since there are custom reward amounts that don't show in the title.

Added back to the workspace view as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bounty reward descriptions now display across all bounty views (cards, info page, and claim modal)
  * Gift icon indicator added to highlight reward information

* **Improvements**
  * Reward descriptions visibility improved—now display when available rather than by user role
  * Enhanced thumbnail sizing on bounty detail pages for better clarity

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->