### PR TITLE
Add program marketplace announcement template

### DIFF
--- a/packages/email/src/templates/partner-marketplace-announcement.tsx
+++ b/packages/email/src/templates/partner-marketplace-announcement.tsx
@@ -1,0 +1,132 @@
+import { DUB_WORDMARK } from "@dub/utils";
+import {
+  Body,
+  Container,
+  Head,
+  Heading,
+  Html,
+  Img,
+  Link,
+  Preview,
+  Section,
+  Tailwind,
+  Text,
+} from "@react-email/components";
+import { Footer } from "../components/footer";
+
+export default function PartnerMarketplaceAnnouncement({
+  email = "panic@thedis.co",
+}: {
+  email: string;
+}) {
+  return (
+    <Html>
+      <Head>
+        <style>{`
+          @media only screen and (max-width: 600px) {
+            .email-container {
+              padding-left: 16px !important;
+              padding-right: 16px !important;
+            }
+          }
+        `}</style>
+      </Head>
+      <Preview>
+        Dub Program Marketplace is here – discover and apply for programs inside
+        Dub.
+      </Preview>
+      <Tailwind>
+        <Body className="mx-auto my-auto bg-white font-sans">
+          <Container className="email-container mx-auto my-10 max-w-[600px] px-10 py-5">
+            {/* Header with Dub logo */}
+            <Section className="mt-2 text-center">
+              <Img
+                src={DUB_WORDMARK}
+                width="65"
+                height="32"
+                alt="Dub"
+                style={{
+                  display: "block",
+                  margin: "0 auto",
+                }}
+              />
+            </Section>
+
+            {/* Main heading */}
+            <Heading className="mx-0 mb-2 mt-8 p-0 text-center text-2xl font-semibold text-black">
+              Dub Program Marketplace is here
+            </Heading>
+
+            {/* Subheading */}
+            <Text className="mb-8 mt-0 text-center text-base leading-6 text-neutral-600">
+              Discover a new way to browse, discover, and apply for
+              <br />
+              many more programs inside Dub.
+            </Text>
+
+            {/* Visual element */}
+            <Section className="mb-8 text-center">
+              <Link
+                href="https://partners.dub.co/programs"
+                style={{ textDecoration: "none" }}
+              >
+                <Img
+                  src="https://assets.dub.co/cms/marketplace-announcement-logo-full-optimize.gif"
+                  width="500"
+                  height="292"
+                  alt="Dub Program Marketplace"
+                  style={{
+                    display: "block",
+                    maxWidth: "100%",
+                    height: "auto",
+                    margin: "0 auto",
+                  }}
+                />
+              </Link>
+            </Section>
+
+            {/* Just the beginning section */}
+            <Heading className="mx-0 mb-3 mt-0 p-0 text-center text-lg font-semibold text-black">
+              Just the beginning
+            </Heading>
+
+            {/* Body text */}
+            <Text className="mx-auto mb-8 mt-0 max-w-[420px] text-center text-sm leading-6 text-neutral-600">
+              Find programs that fit your audience, compare rewards, and apply
+              quickly. It is the easiest way to expand your reach and unlock new
+              earning possibilities.
+            </Text>
+
+            {/* CTA Button */}
+            <Section className="mb-8 text-center">
+              <Link
+                href="https://partners.dub.co/programs"
+                className="box-border inline-block rounded-lg bg-neutral-900 px-6 py-3 text-center text-sm font-medium text-white no-underline"
+                style={{
+                  backgroundColor: "#171717",
+                  color: "#ffffff",
+                  borderRadius: "8px",
+                  padding: "12px 24px",
+                  textDecoration: "none",
+                  display: "inline-block",
+                  fontWeight: "500",
+                  fontSize: "14px",
+                }}
+              >
+                Explore the program marketplace
+              </Link>
+            </Section>
+
+            {/* Footer */}
+            <Section className="mx-auto max-w-[400px] text-center">
+              <Footer
+                email={email}
+                notificationSettingsUrl="https://partners.dub.co/settings/notifications"
+              />
+            </Section>
+          </Container>
+        </Body>
+      </Tailwind>
+    </Html>
+  );
+}


### PR DESCRIPTION
Introduces a new email template for announcing the Dub Program Marketplace. The template includes branding, program details, a call-to-action button, and a footer for notification settings.

Like the previous email, added the asset file to payload for initial use before moving to AWS.

Tested on:
- Gmail
- Apple Mail


https://github.com/user-attachments/assets/0772fbad-0470-4e60-a4cf-4ecfab535e6d

<img width="1090" height="1081" alt="CleanShot 2025-12-01 at 15 21 22@2x" src="https://github.com/user-attachments/assets/bf0f7805-41fa-47e9-a981-ddbd8a622d7e" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new email template for partner marketplace announcements featuring customizable content sections, a prominent call-to-action button, and responsive design for mobile devices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->