### PR TITLE
Add custom date range usage display to billing

### DIFF
--- a/apps/web/lib/swr/use-usage.ts
+++ b/apps/web/lib/swr/use-usage.ts
@@ -11,7 +11,11 @@ import useWorkspace from "./use-workspace";
 // TODO: Improve this since it's a bit hacky right now
 export default function useUsage({
   disabledWhenNoFilters = false,
-}: { disabledWhenNoFilters?: boolean } = {}) {
+  resource,
+}: {
+  disabledWhenNoFilters?: boolean;
+  resource?: "links" | "events";
+} = {}) {
   const { id: workspaceId, billingCycleStart, totalLinks } = useWorkspace();
   const { firstDay, lastDay } = getFirstAndLastDay(billingCycleStart ?? 0);
   const searchParams = useSearchParams();
@@ -24,12 +28,13 @@ export default function useUsage({
   }, [totalLinks]);
 
   const activeResource = useMemo(() => {
+    if (resource) return resource;
     const tab = searchParams.get("tab");
     if (tab && ["links", "events"].includes(tab)) {
       return tab as "links" | "events";
     }
     return defaultActiveTab;
-  }, [searchParams, defaultActiveTab]);
+  }, [searchParams, defaultActiveTab, resource]);
 
   // Get filter parameters from URL
   const folderId = searchParams.get("folderId");


### PR DESCRIPTION
Enhances the billing plan usage page to support custom date ranges, showing total usage for 'events' and 'links' when a custom range is selected. Updates the usage card to display custom totals and loading states, and refactors useUsage to support resource-specific queries. This improves clarity for users viewing usage outside the current billing cycle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added custom date range selection for billing usage tracking.
  * Separated usage metrics display to show events and links independently.
  * Enhanced UI with improved animations and layout adjustments for custom date ranges.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->