### PR TITLE
Hide "On Hold" from commission status filter

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/commissions/use-commission-filters.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/commissions/use-commission-filters.tsx
@@ -103,8 +103,9 @@ export function useCommissionFilters() {
         key: "status",
         icon: CircleDotted,
         label: "Status",
-        options: Object.entries(CommissionStatusBadges).map(
-          ([value, { label }]) => {
+        options: Object.entries(CommissionStatusBadges)
+          .filter(([key]) => key !== "hold")
+          .map(([value, { label }]) => {
             const Icon = CommissionStatusBadges[value].icon;
             return {
               value,
@@ -123,8 +124,7 @@ export function useCommissionFilters() {
                   })
                 : undefined,
             };
-          },
-        ),
+          }),
       },
     ],
     [commissionsCount, partners, customers, groups],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed invalid "hold" status option from commission status filters to ensure only valid statuses appear when filtering commissions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->