### PR TITLE
fix: align pnpm version in package.json with README documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,5 +32,5 @@
   "resolutions": {
     "chrono-node": "2.7.5"
   },
-  "packageManager": "pnpm@8.6.10"
+  "packageManager": "pnpm@9.15.9"
 }


### PR DESCRIPTION
## Description
Fixes version mismatch between [package.json](cci:7://file:///home/sahitya-07/Open-Source/dub/package.json:0:0-0:0) and [README.md](cci:7://file:///home/sahitya-07/Open-Source/dub/README.md:0:0-0:0) for the recommended pnpm version.

## Changes
- Updated `packageManager` field in root [package.json](cci:7://file:///home/sahitya-07/Open-Source/dub/package.json:0:0-0:0) from `pnpm@8.6.10` to `pnpm@9.15.9`

## Motivation
The README.md recommends using pnpm version 9.15.9, but package.json was configured to use 8.6.10. This inconsistency could cause confusion for new contributors following the local development guide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project tooling dependencies to improve development infrastructure and build performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->