### PR TITLE
Update payout pending status descriptions

### DIFF
--- a/apps/web/app/(ee)/partners.dub.co/(dashboard)/payouts/payout-table.tsx
+++ b/apps/web/app/(ee)/partners.dub.co/(dashboard)/payouts/payout-table.tsx
@@ -282,9 +282,10 @@ function AmountRowItem({ payout }: { payout: PartnerPayoutResponse }) {
   ) {
     return (
       <Tooltip
-        content={`This program's minimum payout amount is ${currencyFormatter(
+        content={`This program's [minimum payout amount](https://dub.co/help/article/commissions-payouts#what-does-minimum-payout-amount-mean) is ${currencyFormatter(
           payout.program.minPayoutAmount,
-        )}. This payout will be accrued and processed during the next payout period. [Learn more.](https://dub.co/help/article/receiving-payouts)`}
+          { trailingZeroDisplay: "stripIfInteger" },
+        )}. This payout will be accrued and processed during the next payout period.`}
       >
         <span className="cursor-help truncate text-neutral-400 underline decoration-dotted underline-offset-2">
           {display}

--- a/apps/web/ui/partners/payout-status-badge-partner.tsx
+++ b/apps/web/ui/partners/payout-status-badge-partner.tsx
@@ -30,7 +30,7 @@ export const PayoutStatusBadgePartner = ({
       payout.status === "pending" &&
       payout.amount < program.minPayoutAmount
     ) {
-      return `This program's minimum payout amount is ${currencyFormatter(
+      return `This program's [minimum payout amount](https://dub.co/help/article/commissions-payouts#what-does-minimum-payout-amount-mean) is ${currencyFormatter(
         program.minPayoutAmount,
         { trailingZeroDisplay: "stripIfInteger" },
       )}. This payout will be accrued and processed during the next payout period.`;

--- a/apps/web/ui/partners/payout-status-descriptions.ts
+++ b/apps/web/ui/partners/payout-status-descriptions.ts
@@ -4,10 +4,10 @@ import { currencyFormatter } from "@dub/utils";
 export const PAYOUT_STATUS_DESCRIPTIONS = {
   stripe: {
     pending:
-      "Payouts that have passed the holding period and are awaiting payment. This may include payouts that have not yet met the program minimum.",
+      "Payouts that have passed the [program's holding period](https://dub.co/help/article/commissions-payouts#what-does-holding-period-mean) and are awaiting payment from the program (as long as it reaches the [program's minimum payout amount](https://dub.co/help/article/commissions-payouts#what-does-minimum-payout-amount-mean)).",
     processing:
       "Payouts that are being processed by the program – this can take up to 5 business days.",
-    processed: `Payouts that have been processed by the program and will be paid out to your connected bank account once they reach the minimum withdrawal amount of ${currencyFormatter(MIN_WITHDRAWAL_AMOUNT_CENTS, { trailingZeroDisplay: "stripIfInteger" })}.`,
+    processed: `Payouts that have been processed by the program and will be paid out to your connected bank account once they reach the [${currencyFormatter(MIN_WITHDRAWAL_AMOUNT_CENTS, { trailingZeroDisplay: "stripIfInteger" })} minimum withdrawal amount](https://dub.co/help/article/receiving-payouts#what-is-the-minimum-withdrawal-amount-and-how-does-it-work).`,
     sent: "Payouts that are on their way to your connected bank account – this can take anywhere from 1 to 14 business days depending on your bank location.",
     completed:
       "Payouts that have been paid out to your connected bank account.",
@@ -15,7 +15,7 @@ export const PAYOUT_STATUS_DESCRIPTIONS = {
 
   paypal: {
     pending:
-      "Payouts that have passed the holding period and are awaiting payment. This may include payouts that have not yet met the program minimum.",
+      "Payouts that have passed the [program's holding period](https://dub.co/help/article/commissions-payouts#what-does-holding-period-mean) and are awaiting payment from the program (once it reaches the [program's minimum payout amount](https://dub.co/help/article/commissions-payouts#what-does-minimum-payout-amount-mean)).",
     processing:
       "Payouts that have been processed by the program and are on their way to your PayPal account - this can take up to 5 business days.",
     processed: "",


### PR DESCRIPTION
Clarified the 'pending' payout status descriptions for both Stripe and PayPal to indicate that payouts may not have met the program minimum.

<img width="422" height="161" alt="CleanShot 2025-12-10 at 15 18 59@2x" src="https://github.com/user-attachments/assets/029db8af-bdc4-4147-81e8-b6edb1a0b402" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified pending and processed payout descriptions for Stripe and PayPal to include links, reference the holding period, and note that the program minimum payout must be met before release.
* **UI**
  * Updated amount tooltip and pending-badge tooltip to surface the minimum payout link and improve numeric display handling (trim trailing zeros).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->