### PR TITLE
Add Marketplace link to partner program dropdown

### DIFF
--- a/apps/web/ui/layout/sidebar/partner-program-dropdown.tsx
+++ b/apps/web/ui/layout/sidebar/partner-program-dropdown.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { partnerCanViewMarketplace } from "@/lib/network/get-discoverability-requirements";
 import usePartnerProfile from "@/lib/swr/use-partner-profile";
 import useProgramEnrollments from "@/lib/swr/use-program-enrollments";
 import { ProgramProps } from "@/lib/types";
@@ -9,7 +10,7 @@ import {
   Popover,
   ScrollContainer,
 } from "@dub/ui";
-import { Check2, GridIcon, Magnifier } from "@dub/ui/icons";
+import { Check2, GridIcon, Magnifier, Shop } from "@dub/ui/icons";
 import { cn, OG_AVATAR_URL } from "@dub/utils";
 import { Command } from "cmdk";
 import { ChevronsUpDown } from "lucide-react";
@@ -42,6 +43,10 @@ export function PartnerProgramDropdown() {
         }
       : undefined;
   }, [programSlug, programEnrollments]);
+
+  const canViewMarketplace =
+    programEnrollments &&
+    partnerCanViewMarketplace({ partner, programEnrollments });
 
   const [openPopover, setOpenPopover] = useState(false);
 
@@ -86,6 +91,21 @@ export function PartnerProgramDropdown() {
                     All programs
                   </span>
                 </Link>
+                {canViewMarketplace && (
+                  <Link
+                    href="/programs/marketplace"
+                    className={cn(
+                      "flex items-center gap-x-2.5 rounded-md px-2.5 py-2 text-sm transition-all duration-75 hover:bg-neutral-200/50 active:bg-neutral-200/80",
+                      "outline-none focus-visible:ring-2 focus-visible:ring-black/50",
+                    )}
+                    onClick={() => setOpenPopover(false)}
+                  >
+                    <Shop className="size-4 text-neutral-500" />
+                    <span className="text-content-default block truncate">
+                      Marketplace
+                    </span>
+                  </Link>
+                )}
               </div>
             </div>
           </div>


### PR DESCRIPTION
Introduces a conditional 'Marketplace' link in the partner program dropdown, visible only to partners who meet the marketplace view requirements. Imports the necessary utility and icon for this feature.

<img width="394" height="391" alt="CleanShot 2025-12-10 at 16 07 13@2x" src="https://github.com/user-attachments/assets/8563259e-9091-42c8-b120-058a50cf012a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- **Marketplace in Partner Sidebar** - Partners can now access the Marketplace directly from the partner program sidebar dropdown menu. The Marketplace link is intelligently displayed based on your program eligibility and enrollment status, making it easier to access marketplace features without navigating through multiple sections. The link includes a helpful icon for quick identification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->