### PR TITLE
Invited partners action update

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/[partnerId]/layout.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/[partnerId]/layout.tsx
@@ -141,7 +141,6 @@ function PageControls({ partner }: { partner: EnrolledPartnerProps }) {
     useAction(resendProgramInviteAction, {
       onSuccess: async () => {
         toast.success("Resent the partner invite.");
-        setIsOpen(false);
       },
       onError: ({ error }) => {
         toast.error(error.serverError);


### PR DESCRIPTION
On the single partner page view for `invited partners` only, updated the actions to match the table dropdown, minus the change group action, as that already shows on the page.

Only invite delete, redirects the user back to the all partners table and displays toast message showing the partner invite has been deleted.

<img width="1359" height="371" alt="CleanShot 2025-12-15 at 08 52 31@2x" src="https://github.com/user-attachments/assets/1ed8a9df-a6e2-4ada-b325-0ba383aa9f85" />

<img width="1351" height="430" alt="CleanShot 2025-12-15 at 08 52 16@2x" src="https://github.com/user-attachments/assets/43941cf8-9c38-44d8-96ae-66ac1eb440c5" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resend partner invitations
  * Delete partner invitations with confirmation

* **Improvements**
  * Context-aware action menu and primary actions that change based on invitation status (message, create commission/clawback, advanced settings, archive/reactivate/ban)
  * Loading indicators and toast notifications for invite actions
  * Improved post-action navigation and mobile/compact menu behavior

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->