### PR TITLE
Add link feature filters to links UI and API

### DIFF
--- a/apps/web/lib/api/links/get-links-count.ts
+++ b/apps/web/lib/api/links/get-links-count.ts
@@ -2,6 +2,7 @@ import { combineTagIds } from "@/lib/api/tags/combine-tag-ids";
 import { getLinksCountQuerySchema } from "@/lib/zod/schemas/links";
 import { prisma } from "@dub/prisma";
 import { z } from "zod";
+import { buildLinkFeaturesWhere } from "./utils";
 
 interface GetLinksCountParams extends z.infer<typeof getLinksCountQuerySchema> {
   workspaceId: string;
@@ -22,6 +23,7 @@ export async function getLinksCount({
   tenantId,
   workspaceId,
   folderIds,
+  linkFeatures,
 }: GetLinksCountParams) {
   const combinedTagIds = combineTagIds({ tagId, tagIds });
 
@@ -71,6 +73,7 @@ export async function getLinksCount({
         userId,
       }),
     ...(tenantId && { tenantId }),
+    ...buildLinkFeaturesWhere(linkFeatures),
   };
 
   if (groupBy === "tagId") {

--- a/apps/web/lib/api/links/get-links-for-workspace.ts
+++ b/apps/web/lib/api/links/get-links-for-workspace.ts
@@ -3,7 +3,7 @@ import { prisma } from "@dub/prisma";
 import { z } from "zod";
 import { combineTagIds } from "../tags/combine-tag-ids";
 import { encodeKeyIfCaseSensitive } from "./case-sensitivity";
-import { transformLink } from "./utils";
+import { buildLinkFeaturesWhere, transformLink } from "./utils";
 
 export interface GetLinksForWorkspaceProps
   extends z.infer<typeof getLinksQuerySchemaExtended> {
@@ -39,6 +39,7 @@ export async function getLinksForWorkspace({
   partnerId,
   startDate,
   endDate,
+  linkFeatures,
 }: GetLinksForWorkspaceProps) {
   const combinedTagIds = combineTagIds({ tagId, tagIds });
 
@@ -143,6 +144,7 @@ export async function getLinksForWorkspace({
             lte: endDate,
           },
         }),
+      ...buildLinkFeaturesWhere(linkFeatures),
     },
     include: {
       tags: {

--- a/apps/web/lib/api/links/utils/build-link-features-where.ts
+++ b/apps/web/lib/api/links/utils/build-link-features-where.ts
@@ -1,0 +1,52 @@
+import { Prisma } from "@dub/prisma/client";
+
+export function buildLinkFeaturesWhere(
+  linkFeatures?: string[],
+): Record<string, unknown> | undefined {
+  if (!linkFeatures || linkFeatures.length === 0) {
+    return undefined;
+  }
+
+  return {
+    OR: linkFeatures.map((feature) => {
+      switch (feature) {
+        case "conversionTracking":
+          return { trackConversion: true };
+        case "customLinkPreview":
+          return { proxy: true };
+        case "geoTargeting":
+          return { geo: { not: Prisma.DbNull } };
+        case "utmTags":
+          return {
+            OR: [
+              { utm_source: { not: null } },
+              { utm_medium: { not: null } },
+              { utm_campaign: { not: null } },
+              { utm_term: { not: null } },
+              { utm_content: { not: null } },
+            ],
+          };
+        case "abTest":
+          return { testVariants: { not: Prisma.DbNull } };
+        case "tags":
+          return { tags: { some: {} } };
+        case "comments":
+          return { comments: { not: null } };
+        case "iosTargeting":
+          return { ios: { not: null } };
+        case "androidTargeting":
+          return { android: { not: null } };
+        case "expiration":
+          return { expiresAt: { not: null } };
+        case "password":
+          return { password: { not: null } };
+        case "linkCloaking":
+          return { rewrite: true };
+        case "searchEngineIndexing":
+          return { doIndex: true };
+        default:
+          return {};
+      }
+    }),
+  };
+}

--- a/apps/web/lib/api/links/utils/index.ts
+++ b/apps/web/lib/api/links/utils/index.ts
@@ -1,3 +1,4 @@
+export * from "./build-link-features-where";
 export * from "./check-if-links-have-tags";
 export * from "./check-if-links-have-webhooks";
 export * from "./key-checks";

--- a/apps/web/lib/swr/use-links.ts
+++ b/apps/web/lib/swr/use-links.ts
@@ -46,6 +46,7 @@ export default function useLinks(
               "tagIds",
               "domain",
               "userId",
+              "linkFeatures",
               "search",
               "page",
               "sortBy",

--- a/apps/web/lib/zod/schemas/links.ts
+++ b/apps/web/lib/zod/schemas/links.ts
@@ -148,6 +148,43 @@ const LinksQuerySchema = z.object({
       "DEPRECATED. Filter for links that have at least one tag assigned to them.",
     )
     .openapi({ deprecated: true }),
+  linkFeatures: z
+    .union([z.string(), z.array(z.string())])
+    .transform((v) => (Array.isArray(v) ? v : v.split(",")))
+    .optional()
+    .describe("Filter links by enabled features (comma-separated)")
+    .openapi({
+      param: {
+        style: "form",
+        explode: false,
+      },
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "array",
+          items: {
+            type: "string",
+            enum: [
+              "conversionTracking",
+              "customLinkPreview",
+              "geoTargeting",
+              "utmTags",
+              "abTest",
+              "tags",
+              "comments",
+              "iosTargeting",
+              "androidTargeting",
+              "expiration",
+              "password",
+              "linkCloaking",
+              "searchEngineIndexing",
+            ],
+          },
+        },
+      ],
+    }),
 });
 
 const sortBy = z


### PR DESCRIPTION
Introduces link filtering by enabled features (e.g., conversion tracking, geo targeting, UTM tags) in both the API and the UI. Adds a utility to build Prisma where clauses for these features, updates Zod schemas to accept the new filter, and enhances the UI to allow users to filter links by feature with counts and icons.

Behaves similarly to the link tag filter.

<img width="986" height="494" alt="CleanShot 2025-12-18 at 15 04 58@2x" src="https://github.com/user-attachments/assets/712c9a6d-baf1-4b12-b012-276d0142c297" />

<img width="1198" height="949" alt="CleanShot 2025-12-18 at 15 05 04@2x" src="https://github.com/user-attachments/assets/d1e9a40d-b784-428e-9edf-cb1bc7a348f6" />

<img width="1076" height="687" alt="CleanShot 2025-12-18 at 15 05 14@2x" src="https://github.com/user-attachments/assets/c3320b0c-9c76-48fc-b88f-b27f0c619586" />



https://github.com/user-attachments/assets/b581032c-944c-4134-bdda-682fefe50513



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Link feature" filter in the link management interface. Users can now filter links by their enabled features including conversion tracking, custom preview, geo-targeting, UTM tags, A/B testing, tags, comments, platform-specific targeting, expiration, password protection, link cloaking, and search engine indexing. Filter options display dynamic counts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->