### PR TITLE
Fix `waitUntil` call in `/api/analytics/dashboard`

### DIFF
--- a/apps/web/app/api/analytics/dashboard/route.ts
+++ b/apps/web/app/api/analytics/dashboard/route.ts
@@ -163,7 +163,7 @@ export const GET = async (req: Request) => {
     console.log(
       `[Analytics Dashboard] Caching response for ${JSON.stringify(parsedParams, null, 2)}`,
     );
-    waitUntil(await redis.set(cacheKey, response, { ex: 60 }));
+    waitUntil(redis.set(cacheKey, response, { ex: 60 }));
 
     return NextResponse.json(response);
   } catch (error) {


### PR DESCRIPTION
Fix `waitUntil can only be called with a Promise, got string`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized analytics dashboard API response handling for improved performance by adjusting how background data persistence operations are managed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->