### PR TITLE
Update CommentCard markdown text styling

### DIFF
--- a/apps/web/ui/partners/partner-comments.tsx
+++ b/apps/web/ui/partners/partner-comments.tsx
@@ -356,8 +356,7 @@ function CommentCard({
               ) : (
                 <ReactMarkdown
                   className={cn(
-                    "neutral-700 font-regular",
-                    "prose prose-sm break-words",
+                    "prose prose-sm text-content-default break-words font-normal",
                     PROSE_STYLES.condensed,
                     "prose-a:font-medium prose-a:underline-offset-4",
                   )}


### PR DESCRIPTION
Darkened the text, and defaulted to regular weight.

After

<img width="838" height="572" alt="CleanShot 2025-12-22 at 16 48 12@2x" src="https://github.com/user-attachments/assets/0847220e-196e-4727-a23d-9145104651b7" />

Before

<img width="821" height="402" alt="CleanShot 2025-12-22 at 16 48 50@2x" src="https://github.com/user-attachments/assets/fbfdd620-3617-4bd6-9c80-0f1d40183371" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated comment display styling: non-editing rendered comments now use adjusted typography and color to improve readability — changed font weight and text color for displayed comments while preserving behavior and layout.
* **Note**
  * No functional, data-flow, or public API changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->