### PR TITLE
fix: invite teammates modal trash icon spacing

### DIFF
--- a/apps/web/ui/modals/invite-workspace-user-modal.tsx
+++ b/apps/web/ui/modals/invite-workspace-user-modal.tsx
@@ -39,9 +39,9 @@ function InviteWorkspaceUserModal({
     <Modal
       showModal={showInviteWorkspaceUserModal}
       setShowModal={setShowInviteWorkspaceUserModal}
-      className="max-h-[95dvh]"
+      className="max-h-[95dvh] overflow-x-hidden"
     >
-      <div className="space-y-2 border-b border-neutral-200 px-4 py-4 sm:px-6">
+      <div className="space-y-2 border-b border-neutral-200 px-4 pr-8 py-4 sm:px-6 sm:pr-10">
         <h3 className="text-lg font-medium">Invite Teammates</h3>
         <p className="text-sm text-neutral-500">
           Invite teammates with{" "}
@@ -62,7 +62,7 @@ function InviteWorkspaceUserModal({
       ) : (
         <InviteTeammatesForm
           onSuccess={() => setShowInviteWorkspaceUserModal(false)}
-          className="bg-neutral-50 px-4 py-4 sm:px-6"
+          className="bg-neutral-50 px-4 pr-8 py-4 sm:px-6 sm:pr-10"
           invites={invites}
         />
       )}


### PR DESCRIPTION
Closes #3298

#### Problem
The delete (trash) icon for additional invite rows was absolutely positioned too close to the right edge of the modal, causing awkward spacing and horizontal overflow.

#### Solution
- Added `overflow-x-hidden` to the modal container to prevent horizontal scrolling
- Increased right padding (`pr-8 sm:pr-10`) on modal header and form sections
- This keeps the trash icon visually aligned while preserving layout consistency

#### Steps to reproduce
1. Go to Members → Invite member
2. Click **Add email** to add a second invite row
3. Observe the delete (trash) icon near the right edge of the modal

#### Screenshots
##### Before 
<img width="1792" height="974" alt="Screenshot 2026-01-01 at 4 18 05 PM" src="https://github.com/user-attachments/assets/5bfa52b6-4430-4ef2-bc92-746c97bbba9e" />

##### After
<img width="1723" height="1117" alt="Screenshot 2026-01-01 at 5 10 57 PM" src="https://github.com/user-attachments/assets/a5cd95cf-36ce-4359-9dfb-e3af4e29b85b" />



#### Notes
Pure UI change — no behavior or API changes.


cc @steven-tey — happy to adjust if you prefer a different approach

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved horizontal spacing and layout in the invite workspace user modal for better visual presentation on larger screens.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->