### PR TITLE
Fixing the sidebar nav overflow clipping

### DIFF
--- a/apps/web/ui/layout/sidebar/sidebar-nav.tsx
+++ b/apps/web/ui/layout/sidebar/sidebar-nav.tsx
@@ -119,9 +119,9 @@ export function SidebarNav<T extends Record<any, any>>({
               <div className="pb-1 pt-2">
                 <Link
                   href="/"
-                  className="block rounded-lg px-1 py-4 outline-none transition-opacity focus-visible:ring-2 focus-visible:ring-black/50"
+                  className="block overflow-visible rounded-lg px-1 py-4 outline-none transition-opacity focus-visible:ring-2 focus-visible:ring-black/50"
                 >
-                  <NavWordmark className="h-5" isInApp />
+                  <NavWordmark className="h-5 overflow-visible" isInApp />
                 </Link>
               </div>
               {(!currentArea ||

--- a/packages/ui/src/wordmark.tsx
+++ b/packages/ui/src/wordmark.tsx
@@ -9,7 +9,6 @@ export function Wordmark({ className }: { className?: string }) {
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       className={cn("h-6 w-auto text-black dark:text-white", className)}
-      style={{ minWidth: "fit-content", width: "calc(100% + 1px)" }}
     >
       <path
         fillRule="evenodd"


### PR DESCRIPTION
Due to the height of the logo in the sidebar nav, it's creating some pixel clipping. So just added overflow-visible to it and that fixed it because it's essentially one pixel missing 

<img width="1961" height="761" alt="CleanShot 2026-01-02 at 09 18 35@2x" src="https://github.com/user-attachments/assets/d0f6f1de-7f2b-4b37-af7b-3f262df05991" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced visual presentation of sidebar navigation components for improved display in the navigation panel.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->