### PR TITLE
Add support for unpublishing branding pages

### DIFF
--- a/apps/web/lib/actions/partners/update-group-branding.ts
+++ b/apps/web/lib/actions/partners/update-group-branding.ts
@@ -26,6 +26,7 @@ const schema = z.object({
   brandColor: z.string().nullish(),
   applicationFormData: programApplicationFormSchema.nullish(),
   landerData: programLanderSchema.nullish(),
+  unpublish: z.boolean().optional(),
 });
 
 export const updateGroupBrandingAction = authActionClient
@@ -39,6 +40,7 @@ export const updateGroupBrandingAction = authActionClient
       brandColor,
       applicationFormData: applicationFormDataInput,
       landerData: landerDataInputRaw,
+      unpublish,
     } = parsedInput;
 
     const programId = getDefaultProgramIdOrThrow(workspace);
@@ -90,11 +92,17 @@ export const updateGroupBrandingAction = authActionClient
         applicationFormData: applicationFormDataInput
           ? applicationFormDataInput
           : undefined,
-        applicationFormPublishedAt: applicationFormDataInput
-          ? new Date()
-          : undefined,
+        applicationFormPublishedAt: unpublish
+          ? null
+          : applicationFormDataInput
+            ? new Date()
+            : undefined,
         landerData: landerDataInput ? landerDataInput : undefined,
-        landerPublishedAt: landerDataInput ? new Date() : undefined,
+        landerPublishedAt: unpublish
+          ? null
+          : landerDataInput
+            ? new Date()
+            : undefined,
       },
     });
 
@@ -106,7 +114,7 @@ export const updateGroupBrandingAction = authActionClient
          - lander data
          - application form data
         */
-          ...(landerDataInput || applicationFormDataInput
+          ...(landerDataInput || applicationFormDataInput || unpublish
             ? [
                 revalidatePath(`/partners.dub.co/${program.slug}`),
                 revalidatePath(`/partners.dub.co/${program.slug}/apply`),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to unpublish group branding with a confirmation modal to prevent accidental changes.
  * Redesigned the publish interface into a menu that shows Publish and Unpublish actions when content is published.
  * Publishing and unpublishing now update live pages accordingly; unpublishing clears published state so changes are removed from public view.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->