### PR TITLE
style: use text-violet-500 instead of hardcoded hex color

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/analytics/analytics-timeseries-chart.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/analytics/analytics-timeseries-chart.tsx
@@ -34,7 +34,7 @@ export function AnalyticsTimeseriesChart({
         {
           id: "amount",
           valueAccessor: (d) => d.values.amount,
-          colorClassName: "text-[#8B5CF6]",
+          colorClassName: "text-violet-500",
           isActive: true,
         },
       ]}

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/overview-chart.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/overview-chart.tsx
@@ -162,7 +162,7 @@ export function OverviewChart() {
               {
                 id: "amount",
                 valueAccessor: (d) => d.values.amount,
-                colorClassName: "text-[#8B5CF6]",
+                colorClassName: "text-violet-500",
                 isActive: true,
               },
             ]}


### PR DESCRIPTION
## Summary

- Replace hardcoded `text-[#8B5CF6]` with `text-violet-500` in chart components
- Aligns with existing usage of `bg-violet-500` in tooltip legends within the same components

## Context

Both `overview-chart.tsx` and `analytics-timeseries-chart.tsx` use the same violet color in two places:
1. Chart series: `colorClassName: "text-[#8B5CF6]"` (hardcoded)
2. Tooltip legend: `bg-violet-500` (proper token)

Since `#8B5CF6` is exactly Tailwind's `violet-500`, this PR makes the codebase consistent.

## Files changed
- `apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/overview-chart.tsx`
- `apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/analytics/analytics-timeseries-chart.tsx`

Closes #3312

---
*Found using [Buoy](https://github.com/buoy-design/buoy) - design system drift detection*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated color styling in analytics and overview charts to use standardized color classes for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->