### PR TITLE
Clean up sidebar "New" badges

### DIFF
--- a/apps/web/ui/layout/sidebar/app-sidebar-nav.tsx
+++ b/apps/web/ui/layout/sidebar/app-sidebar-nav.tsx
@@ -237,7 +237,7 @@ const NAV_AREAS: SidebarNavAreas<SidebarNavData> = {
               ? unreadMessagesCount > 99
                 ? "99+"
                 : unreadMessagesCount
-              : "New",
+              : undefined,
           },
         ],
       },
@@ -326,7 +326,6 @@ const NAV_AREAS: SidebarNavAreas<SidebarNavData> = {
             name: "Email Campaigns",
             icon: PaperPlane,
             href: `/${slug}/program/campaigns` as `/${string}`,
-            badge: "New",
           },
           {
             name: "Resources",


### PR DESCRIPTION
Removes "New" badges for Messages and Email Campaigns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined notification badge display in the Engagement section: the Messages badge no longer shows a default label when unread messages count is zero, and the Email Campaigns item badge has been removed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->