### PR TITLE
Track and display user last login date

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/members/page-client.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/members/page-client.tsx
@@ -137,7 +137,7 @@ export default function WorkspacePeopleClient() {
         header: "Name",
         accessorFn: (row) => row.name || row.email,
         minSize: 360,
-        size: 870,
+        size: 750,
         maxSize: 900,
         cell: ({ row }) => {
           const user = row.original;
@@ -160,6 +160,29 @@ export default function WorkspacePeopleClient() {
                 </p>
               </div>
             </div>
+          );
+        },
+      },
+      {
+        id: "lastActive",
+        header: "Last active",
+        accessorFn: (row) => row.lastLoginAt,
+        minSize: 100,
+        size: 120,
+        maxSize: 150,
+        cell: ({ row }) => {
+          const user = row.original;
+          if (status === "invited" || !user.lastLoginAt) {
+            return <span className="text-neutral-400">-</span>;
+          }
+          return (
+            <span className="text-sm text-neutral-500">
+              {new Date(user.lastLoginAt).toLocaleDateString("en-US", {
+                month: "short",
+                day: "numeric",
+                year: "numeric",
+              })}
+            </span>
           );
         },
       },

--- a/apps/web/lib/auth/options.ts
+++ b/apps/web/lib/auth/options.ts
@@ -575,6 +575,15 @@ export const authOptions: NextAuthOptions = {
         );
         return;
       }
+
+      // Update lastLoginAt in the background
+      waitUntil(
+        prisma.user.update({
+          where: { id: user.id },
+          data: { lastLoginAt: new Date() },
+        }),
+      );
+
       // only process new user workflow if the user was created in the last 15s (newly created user)
       if (
         user.createdAt &&

--- a/apps/web/lib/zod/schemas/workspaces.ts
+++ b/apps/web/lib/zod/schemas/workspaces.ts
@@ -213,4 +213,5 @@ export const workspaceUserSchema = z.object({
   role: z.enum(WorkspaceRole),
   isMachine: z.boolean().default(false),
   createdAt: z.date(),
+  lastLoginAt: z.date().nullish(),
 });

--- a/packages/prisma/schema/schema.prisma
+++ b/packages/prisma/schema/schema.prisma
@@ -21,6 +21,8 @@ model User {
   invalidLoginAttempts Int       @default(0)
   lockedAt             DateTime?
 
+  lastLoginAt             DateTime?
+
   createdAt               DateTime                     @default(now())
   subscribed              Boolean                      @default(true) // TODO: deprecrate once notificationPreferences is fully migrated
   notificationPreferences UserNotificationPreferences?


### PR DESCRIPTION
Adds a lastLoginAt field to the User model and updates it on login. The workspace members page now displays the last active date for each user. The zod schema and relevant UI components were updated to support this new field.

- The field won't populate until the user logs in for the first time after the change. 
- If the user never logs in, will show as `-`

<img width="1188" height="648" alt="CleanShot 2026-01-07 at 16 40 11@2x" src="https://github.com/user-attachments/assets/ca9267b3-7c97-4e8e-85a0-aaf0911da64e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Last active" column to the member table, displaying when each team member last logged in with formatted timestamps. Invited members without login history show a placeholder. Member table layout adjusted for improved display.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->