### PR TITLE
Use hex encoding for encodeKeyIfCaseSensitive

### DIFF
--- a/apps/web/lib/api/links/case-sensitivity.ts
+++ b/apps/web/lib/api/links/case-sensitivity.ts
@@ -37,11 +37,14 @@ export const decodeKey = (hash: string): string => {
   let xored: string;
 
   // Backwards compatibility: detect format by prefix
-  // New format: "h:" prefix indicates hex encoding
+  // New format: "h:" prefix (case-insensitive) indicates hex encoding
   // Old format: no prefix, base64 encoding
-  if (hash.startsWith("h:")) {
+  // Normalize prefix check to handle case-insensitive databases
+  const normalizedHash = hash.toLowerCase();
+  if (normalizedHash.startsWith("h:")) {
     // New hex format - remove prefix and decode as hex
-    const hexPart = hash.slice(2).toLowerCase();
+    // Normalize to lowercase to handle case-insensitive database storage
+    const hexPart = normalizedHash.slice(2);
     xored = Buffer.from(hexPart, "hex").toString("utf8");
   } else {
     // Old base64 format - decode as base64

--- a/apps/web/tests/redirects/index.test.ts
+++ b/apps/web/tests/redirects/index.test.ts
@@ -16,6 +16,8 @@ describe.runIf(env.CI)("Link Redirects", async () => {
   const h = new IntegrationHarness();
 
   test("root", async () => {
+    console.log({baseUrl: h.baseUrl})
+
     const response = await fetch(h.baseUrl, fetchOptions);
 
     // the location should start with "https://dub.co"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Domain-aware encoding/decoding for link keys so keys on case-sensitive domains are handled reliably.
  * Public helpers to transparently encode/decode keys when needed, improving link stability across domains.

* **Bug Fixes**
  * Preserved backward compatibility so existing links continue to work.
  * More consistent link handling to avoid case-related issues.

* **Tests**
  * Minor test instrumentation added to aid debugging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->