### PR TITLE
add Google user content support for workspace logo

### DIFF
--- a/apps/web/lib/zod/schemas/misc.ts
+++ b/apps/web/lib/zod/schemas/misc.ts
@@ -112,23 +112,33 @@ export const storedR2ImageUrlSchema = z
     message: `URL must start with ${R2_URL}`,
   });
 
+// Google user content URL schema - supports URLs like https://lh3.googleusercontent.com/...
+// This is needed when users sign up via Google OAuth and want to use their Google profile image
+// as their workspace logo or avatar
+export const googleUserContentUrlSchema = z
+  .url()
+  .trim()
+  .refine((url) => url.startsWith("https://lh3.googleusercontent.com/"), {
+    message: "Image URL must be a valid Google user content URL",
+  });
+
+// Google favicon URL schema - supports URLs starting with GOOGLE_FAVICON_URL
+export const googleFaviconUrlSchema = z
+  .url()
+  .trim()
+  .refine((url) => url.startsWith(GOOGLE_FAVICON_URL), {
+    message: `Image URL must start with ${GOOGLE_FAVICON_URL}`,
+  });
+
 // Uploaded image could be any of the following:
 // - Base64 encoded image
 // - R2_URL
 // - Special case for GOOGLE_FAVICON_URL
+// - Google user content URLs (e.g., https://lh3.googleusercontent.com/...)
 // This schema contains an async refinement check for base64 image validation,
 // which requires using parseAsync() instead of parse() when validating
 export const uploadedImageSchema = z
-  .union([
-    base64ImageSchema,
-    storedR2ImageUrlSchema,
-    z
-      .url()
-      .trim()
-      .refine((url) => url.startsWith(GOOGLE_FAVICON_URL), {
-        message: `Image URL must start with ${GOOGLE_FAVICON_URL}`,
-      }),
-  ])
+  .union([base64ImageSchema, storedR2ImageUrlSchema, googleFaviconUrlSchema])
   .transform((v) => v || null);
 
 // Base64 encoded image/SVG or R2_URL

--- a/apps/web/lib/zod/schemas/partners.ts
+++ b/apps/web/lib/zod/schemas/partners.ts
@@ -7,7 +7,7 @@ import {
   ProgramEnrollmentStatus,
   SalesChannel,
 } from "@dub/prisma/client";
-import { COUNTRY_CODES, GOOGLE_FAVICON_URL } from "@dub/utils";
+import { COUNTRY_CODES } from "@dub/utils";
 import * as z from "zod/v4";
 import { analyticsQuerySchema } from "./analytics";
 import { analyticsResponse } from "./analytics-response";
@@ -16,6 +16,7 @@ import {
   base64ImageSchema,
   booleanQuerySchema,
   getPaginationQuerySchema,
+  googleFaviconUrlSchema,
   publicHostedImageSchema,
   storedR2ImageUrlSchema,
 } from "./misc";
@@ -600,12 +601,7 @@ const partnerImageSchema = z
     base64ImageSchema,
     storedR2ImageUrlSchema,
     publicHostedImageSchema,
-    z
-      .url()
-      .trim()
-      .refine((url) => url.startsWith(GOOGLE_FAVICON_URL), {
-        message: `Image URL must start with ${GOOGLE_FAVICON_URL}`,
-      }),
+    googleFaviconUrlSchema,
   ])
   .transform((v) => v || "")
   .refine((v) => v !== "", {

--- a/apps/web/lib/zod/schemas/workspaces.ts
+++ b/apps/web/lib/zod/schemas/workspaces.ts
@@ -3,7 +3,12 @@ import { DEFAULT_REDIRECTS, RESERVED_SLUGS, validSlugRegex } from "@dub/utils";
 import slugify from "@sindresorhus/slugify";
 import * as z from "zod/v4";
 import { DomainSchema } from "./domains";
-import { planSchema, roleSchema, uploadedImageSchema } from "./misc";
+import {
+  googleUserContentUrlSchema,
+  planSchema,
+  roleSchema,
+  uploadedImageSchema,
+} from "./misc";
 
 export const workspaceIdSchema = z.object({
   workspaceId: z
@@ -149,7 +154,10 @@ export const createWorkspaceSchema = z.object({
         message: "Cannot use reserved slugs",
       },
     ),
-  logo: uploadedImageSchema.nullish(),
+  logo: z
+    .union([uploadedImageSchema, googleUserContentUrlSchema])
+    .transform((v) => v || null)
+    .nullish(),
   conversionEnabled: z.boolean().optional(),
 });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace logos now support Google user content image URLs in addition to existing formats

* **Improvements**
  * Enhanced image URL validation consistency across the platform

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->