### PR TITLE
Mobile domain improvements

### DIFF
--- a/apps/web/ui/domains/free-dot-link-banner.tsx
+++ b/apps/web/ui/domains/free-dot-link-banner.tsx
@@ -53,7 +53,7 @@ export function FreeDotLinkBanner() {
           </div>
           <button
             type="button"
-            className="absolute inset-y-0 right-2.5 p-1 text-sm text-green-700 underline transition-colors hover:text-green-900"
+            className="absolute right-2.5 top-2.5 p-1 text-sm text-green-700 underline transition-colors hover:text-green-900 sm:top-1/2 sm:-translate-y-1/2"
             onClick={() => setShow(false)}
           >
             <X className="size-[18px]" />

--- a/apps/web/ui/layout/page-content/index.tsx
+++ b/apps/web/ui/layout/page-content/index.tsx
@@ -21,14 +21,14 @@ export function PageContent({
   return (
     <div
       className={cn(
-        "rounded-t-[inherit] bg-neutral-100 md:bg-white",
+        "min-h-full flex flex-col rounded-t-[inherit] bg-neutral-100 md:bg-white",
         className,
       )}
     >
       <PageContentHeader {...headerProps} />
       <div
         className={cn(
-          "rounded-t-[inherit] bg-white pt-3 lg:pt-6",
+          "flex-1 rounded-t-[inherit] bg-white pt-3 lg:pt-6",
           contentWrapperClassName,
         )}
       >


### PR DESCRIPTION
Adjusted the close button alignment in FreeDotLinkBanner for better vertical centering on small screens. Updated PageContent to use flex layout for full height and flexible content area.

### Current
<img width="1216" height="1634" alt="CleanShot 2026-01-08 at 17 51 40@2x" src="https://github.com/user-attachments/assets/c1756d29-a388-4767-a4ea-db59c2e0eeb9" />

### After
<img width="1128" height="1872" alt="CleanShot 2026-01-08 at 17 52 19@2x" src="https://github.com/user-attachments/assets/9048b05a-edbf-453c-910b-668415317432" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved close button positioning with responsive layout that adapts across screen sizes
  * Enhanced page layout structure with improved flex properties for better visual presentation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->