### PR TITLE
Expanding the partner unlocks guide and requirements logic

### DIFF
--- a/apps/web/app/(ee)/partners.dub.co/(dashboard)/profile/page-client.tsx
+++ b/apps/web/app/(ee)/partners.dub.co/(dashboard)/profile/page-client.tsx
@@ -24,16 +24,16 @@ import { toast } from "sonner";
 import { AboutYouForm } from "./about-you-form";
 import { HowYouWorkForm } from "./how-you-work-form";
 import { ProfileDetailsForm } from "./profile-details-form";
-import { ProfileDiscoveryGuide } from "./profile-discovery-guide";
-import { usePartnerDiscoveryRequirements } from "./use-partner-discovery-requirements";
+import { ProfileUnlocksGuide } from "./profile-unlocks-guide";
+import { usePartnerUnlocks } from "./use-partner-unlocks";
 
 export function ProfileSettingsPageClient() {
   const { partner } = usePartnerProfile();
-  const tasks = usePartnerDiscoveryRequirements();
+  const unlocks = usePartnerUnlocks();
 
   const allTasksCompleted = useMemo(
-    () => tasks?.every(({ completed }) => completed) ?? false,
-    [tasks],
+    () => unlocks?.completedTasks === unlocks?.totalTasks,
+    [unlocks],
   );
 
   return (
@@ -53,7 +53,7 @@ export function ProfileSettingsPageClient() {
       }
     >
       <PageWidthWrapper className="mb-20 flex flex-col gap-6">
-        {partner && !allTasksCompleted && <ProfileDiscoveryGuide />}
+        {partner && unlocks && <ProfileUnlocksGuide />}
         <ProfileDetailsForm partner={partner} />
         <AboutYouForm partner={partner} />
         <HowYouWorkForm partner={partner} />

--- a/apps/web/app/(ee)/partners.dub.co/(dashboard)/profile/profile-unlocks-guide.tsx
+++ b/apps/web/app/(ee)/partners.dub.co/(dashboard)/profile/profile-unlocks-guide.tsx
@@ -15,7 +15,7 @@ import { cn, isClickOnInteractiveChild } from "@dub/utils";
 import { motion } from "motion/react";
 import { useAction } from "next-safe-action/hooks";
 import Link from "next/link";
-import { HTMLProps, useState } from "react";
+import { ComponentProps, ReactNode, useState } from "react";
 import { toast } from "sonner";
 import { usePartnerUnlocks } from "./use-partner-unlocks";
 
@@ -51,10 +51,19 @@ export function ProfileUnlocksGuide() {
       <div className="text-content-inverted rounded-xl bg-neutral-900">
           {/* Collapsed Header */}
           <div
+            role="button"
+            tabIndex={0}
+            aria-expanded={isExpanded}
             className="flex cursor-pointer select-none items-center gap-4 p-3 pr-6"
             onClick={(e) => {
               if (isClickOnInteractiveChild(e)) return;
-              setIsExpanded((e) => !e);
+              setIsExpanded((prev) => !prev);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                setIsExpanded((prev) => !prev);
+              }
             }}
           >
             {/* Lock Icon */}
@@ -71,7 +80,7 @@ export function ProfileUnlocksGuide() {
               <h2 className="text-sm font-semibold">Dub unlocks</h2>
               <div className="flex items-center gap-1.5">
                 <ProgressCircle
-                  progress={completedTasks / totalTasks}
+                  progress={totalTasks === 0 ? 0 : completedTasks / totalTasks}
                   className="text-green-500 [--track-color:#fff3]"
                 />
                 <span className="text-content-inverted/60 text-sm">
@@ -182,12 +191,18 @@ export function ProfileUnlocksGuide() {
   );
 }
 
+type ConditionalLinkProps = {
+  href?: string;
+  className?: string;
+  children?: ReactNode;
+} & Omit<ComponentProps<typeof Link>, "href">;
+
 function ConditionalLink({
   href,
   className,
   children,
   ...rest
-}: Partial<HTMLProps<HTMLAnchorElement>>) {
+}: ConditionalLinkProps) {
   return href ? (
     <Link href={href} className={className} {...rest}>
       {children}

--- a/apps/web/app/(ee)/partners.dub.co/(dashboard)/profile/profile-unlocks-guide.tsx
+++ b/apps/web/app/(ee)/partners.dub.co/(dashboard)/profile/profile-unlocks-guide.tsx
@@ -7,7 +7,8 @@ import {
   CircleCheckFill,
   CircleDotted,
   ExpandingArrow,
-  LockFill,
+  Lock,
+  LockOpen2,
   ProgressCircle,
 } from "@dub/ui";
 import { cn, isClickOnInteractiveChild } from "@dub/utils";
@@ -20,6 +21,7 @@ import { usePartnerUnlocks } from "./use-partner-unlocks";
 
 export function ProfileUnlocksGuide() {
   const [isExpanded, setIsExpanded] = useState(false);
+  const [simulateComplete, setSimulateComplete] = useState(false);
   const unlocks = usePartnerUnlocks();
 
   const { executeAsync: dismissBanner, isPending: isDismissing } = useAction(
@@ -38,141 +40,157 @@ export function ProfileUnlocksGuide() {
   if (!unlocks) return null;
 
   const { categories, totalTasks, completedTasks } = unlocks;
-  const allTasksCompleted = completedTasks === totalTasks;
+  const allTasksCompleted = simulateComplete || completedTasks === totalTasks;
 
   return (
-    <motion.div
-      initial={{ opacity: 0, height: 0 }}
-      animate={{ opacity: 1, height: "auto" }}
-      transition={{ duration: 0.2, ease: "easeOut" }}
-      className="overflow-hidden"
-    >
-      <div
-        className="text-content-inverted cursor-pointer rounded-2xl bg-neutral-900"
-        onClick={(e) => {
-          if (isClickOnInteractiveChild(e)) return;
-          setIsExpanded((e) => !e);
-        }}
+    <>
+      {process.env.NODE_ENV === "development" && (
+        <button
+          type="button"
+          className="fixed bottom-4 right-4 z-50 rounded-md bg-neutral-800 px-3 py-1.5 text-xs text-white shadow-lg"
+          onClick={() => setSimulateComplete((s) => !s)}
+        >
+          {simulateComplete ? "Simulating ✓" : "Simulate Unlock"}
+        </button>
+      )}
+      <motion.div
+        initial={{ opacity: 0, height: 0 }}
+        animate={{ opacity: 1, height: "auto" }}
+        transition={{ duration: 0.2, ease: "easeOut" }}
+        className="overflow-hidden"
       >
-        {/* Collapsed Header */}
-        <div className="flex select-none items-center gap-4 p-4">
-          {/* Lock Icon */}
-          <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-white/10">
-            <LockFill className="size-5 text-white/60" />
-          </div>
+        <div className="text-content-inverted rounded-xl bg-neutral-900">
+          {/* Collapsed Header */}
+          <div
+            className="flex cursor-pointer select-none items-center gap-4 p-3 pr-6"
+            onClick={(e) => {
+              if (isClickOnInteractiveChild(e)) return;
+              setIsExpanded((e) => !e);
+            }}
+          >
+            {/* Lock Icon */}
+            <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-white/10">
+              {allTasksCompleted ? (
+                <LockOpen2 className="size-5 text-neutral-300" />
+              ) : (
+                <Lock className="size-5 text-neutral-300" />
+              )}
+            </div>
 
-          {/* Title and Progress */}
-          <div className="min-w-0 flex-1">
-            <h2 className="text-sm font-semibold">Dub unlocks</h2>
-            <div className="flex items-center gap-1.5">
-              <ProgressCircle
-                progress={completedTasks / totalTasks}
-                className="text-green-500 [--track-color:#fff3]"
+            {/* Title and Progress */}
+            <div className="min-w-0 flex-1">
+              <h2 className="text-sm font-semibold">Dub unlocks</h2>
+              <div className="flex items-center gap-1.5">
+                <ProgressCircle
+                  progress={completedTasks / totalTasks}
+                  className="text-green-500 [--track-color:#fff3]"
+                />
+                <span className="text-content-inverted/60 text-sm">
+                  {completedTasks} of {totalTasks} tasks completed
+                </span>
+              </div>
+            </div>
+
+            {/* Actions */}
+            <div className="flex shrink-0 items-center gap-4">
+              {allTasksCompleted && (
+                <Button
+                  type="button"
+                  text="Dismiss"
+                  variant="secondary"
+                  className="h-8 px-3 text-sm"
+                  loading={isDismissing}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    dismissBanner({});
+                  }}
+                />
+              )}
+              <ChevronUp
+                className={cn(
+                  "text-content-inverted/60 size-4.5 shrink-0 transition-transform duration-200",
+                  isExpanded && "-rotate-180",
+                )}
               />
-              <span className="text-content-inverted/60 text-sm">
-                {completedTasks} of {totalTasks} tasks completed
-              </span>
             </div>
           </div>
 
-          {/* Actions */}
-          <div className="flex shrink-0 items-center gap-2">
-            {allTasksCompleted && (
-              <Button
-                type="button"
-                text="Dismiss"
-                variant="secondary"
-                className="h-8 px-3 text-sm"
-                loading={isDismissing}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  dismissBanner({});
-                }}
-              />
-            )}
-            <ChevronUp
-              className={cn(
-                "text-content-inverted/60 size-5 transition-transform duration-200",
-                !isExpanded && "-scale-y-100",
-              )}
-            />
-          </div>
-        </div>
-
-        {/* Expanded Content */}
-        <motion.div
-          initial={false}
-          animate={{
-            height: isExpanded ? "auto" : 0,
-            opacity: isExpanded ? 1 : 0,
-          }}
-          transition={{ duration: 0.15, ease: "easeOut" }}
-          className="overflow-hidden"
-        >
-          <div
-            className="space-y-4 rounded-lg bg-neutral-800 p-4"
-            onClick={(e) => e.stopPropagation()}
+          {/* Expanded Content */}
+          <motion.div
+            initial={false}
+            animate={{
+              height: isExpanded ? "auto" : 0,
+              opacity: isExpanded ? 1 : 0,
+            }}
+            transition={{ duration: 0.15, ease: "easeOut" }}
+            className="overflow-hidden"
           >
-            {categories.map((category) => (
-              <div key={category.title}>
-                {/* Category Header */}
-                <div className="mb-3 flex items-start justify-between gap-4">
-                  <div>
-                    <h3 className="text-sm font-semibold text-white">
-                      {category.title}
-                    </h3>
-                    <p className="text-xs text-neutral-400">
-                      {category.description}
-                    </p>
-                  </div>
-                  {category.action && (
-                    <Link
-                      href={category.action.href}
-                      className={cn(
-                        buttonVariants({ variant: "secondary" }),
-                        "flex h-8 shrink-0 items-center justify-center whitespace-nowrap rounded-md border px-3 text-sm",
-                      )}
-                    >
-                      {category.action.label}
-                    </Link>
-                  )}
-                </div>
-
-                {/* Task Grid */}
-                <div className="grid grid-cols-1 gap-1 sm:grid-cols-2">
-                  {category.tasks.map(({ label, completed, href }) => (
-                    <ConditionalLink
-                      key={label}
-                      href={completed ? undefined : href}
-                      className={cn(
-                        "group flex items-center justify-between gap-2 rounded-md px-3 py-2",
-                        !completed &&
-                          href &&
-                          "transition-colors duration-100 ease-out hover:bg-neutral-700",
-                      )}
-                    >
-                      <div className="flex min-w-0 items-center gap-2">
-                        {completed ? (
-                          <CircleCheckFill className="size-4 shrink-0 text-green-500" />
-                        ) : (
-                          <CircleDotted className="size-4 shrink-0 text-neutral-400" />
+            <div className="space-y-4 rounded-b-xl bg-neutral-800 p-4">
+              {categories.map((category) => (
+                <div key={category.title}>
+                  {/* Category Header */}
+                  <div className="mb-3 flex items-start justify-between gap-4">
+                    <div>
+                      <h3 className="text-sm font-semibold text-white">
+                        {category.title}
+                      </h3>
+                      <p className="text-xs text-neutral-400">
+                        {category.description}
+                      </p>
+                    </div>
+                    {category.action && (
+                      <Link
+                        href={category.action.href}
+                        className={cn(
+                          buttonVariants({ variant: "secondary" }),
+                          "flex h-8 shrink-0 items-center justify-center whitespace-nowrap rounded-md border px-3 text-sm",
                         )}
-                        <span className="min-w-0 truncate text-sm">{label}</span>
-                      </div>
-                      {!completed && href && (
-                        <div className="shrink-0 pr-4">
-                          <ExpandingArrow className="group-hover:text-content-inverted text-neutral-500" />
-                        </div>
-                      )}
-                    </ConditionalLink>
-                  ))}
+                      >
+                        {category.action.label}
+                      </Link>
+                    )}
+                  </div>
+
+                  {/* Task Grid */}
+                  <div className="rounded-lg bg-white/5 p-1">
+                    <div className="grid grid-cols-1 gap-1 sm:grid-cols-2">
+                      {category.tasks.map(({ label, completed, href }) => (
+                        <ConditionalLink
+                          key={label}
+                          href={completed ? undefined : href}
+                          className={cn(
+                            "group flex items-center justify-between gap-2 rounded-md px-3 py-2",
+                            !completed &&
+                              href &&
+                              "transition-colors duration-100 ease-out hover:bg-white/10",
+                          )}
+                        >
+                          <div className="flex min-w-0 items-center gap-2">
+                            {completed ? (
+                              <CircleCheckFill className="size-4 shrink-0 text-green-500" />
+                            ) : (
+                              <CircleDotted className="size-4 shrink-0 text-neutral-400" />
+                            )}
+                            <span className="min-w-0 truncate text-sm">
+                              {label}
+                            </span>
+                          </div>
+                          {!completed && href && (
+                            <div className="shrink-0 pr-4">
+                              <ExpandingArrow className="group-hover:text-content-inverted text-neutral-500" />
+                            </div>
+                          )}
+                        </ConditionalLink>
+                      ))}
+                    </div>
+                  </div>
                 </div>
-              </div>
-            ))}
-          </div>
-        </motion.div>
-      </div>
-    </motion.div>
+              ))}
+            </div>
+          </motion.div>
+        </div>
+      </motion.div>
+    </>
   );
 }
 

--- a/apps/web/app/(ee)/partners.dub.co/(dashboard)/profile/profile-unlocks-guide.tsx
+++ b/apps/web/app/(ee)/partners.dub.co/(dashboard)/profile/profile-unlocks-guide.tsx
@@ -1,0 +1,192 @@
+import { dismissUnlocksBannerAction } from "@/lib/actions/partners/dismiss-unlocks-banner";
+import { mutatePrefix } from "@/lib/swr/mutate";
+import {
+  Button,
+  buttonVariants,
+  ChevronUp,
+  CircleCheckFill,
+  CircleDotted,
+  ExpandingArrow,
+  LockFill,
+  ProgressCircle,
+} from "@dub/ui";
+import { cn, isClickOnInteractiveChild } from "@dub/utils";
+import { motion } from "motion/react";
+import { useAction } from "next-safe-action/hooks";
+import Link from "next/link";
+import { HTMLProps, useState } from "react";
+import { toast } from "sonner";
+import { usePartnerUnlocks } from "./use-partner-unlocks";
+
+export function ProfileUnlocksGuide() {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const unlocks = usePartnerUnlocks();
+
+  const { executeAsync: dismissBanner, isPending: isDismissing } = useAction(
+    dismissUnlocksBannerAction,
+    {
+      onSuccess: () => {
+        toast.success("Unlocks guide dismissed");
+        mutatePrefix("/api/partner-profile");
+      },
+      onError: ({ error }) => {
+        toast.error(error.serverError || "Failed to dismiss");
+      },
+    },
+  );
+
+  if (!unlocks) return null;
+
+  const { categories, totalTasks, completedTasks } = unlocks;
+  const allTasksCompleted = completedTasks === totalTasks;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, height: 0 }}
+      animate={{ opacity: 1, height: "auto" }}
+      transition={{ duration: 0.2, ease: "easeOut" }}
+      className="overflow-hidden"
+    >
+      <div
+        className="text-content-inverted cursor-pointer rounded-2xl bg-neutral-900"
+        onClick={(e) => {
+          if (isClickOnInteractiveChild(e)) return;
+          setIsExpanded((e) => !e);
+        }}
+      >
+        {/* Collapsed Header */}
+        <div className="flex select-none items-center gap-4 p-4">
+          {/* Lock Icon */}
+          <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-white/10">
+            <LockFill className="size-5 text-white/60" />
+          </div>
+
+          {/* Title and Progress */}
+          <div className="min-w-0 flex-1">
+            <h2 className="text-sm font-semibold">Dub unlocks</h2>
+            <div className="flex items-center gap-1.5">
+              <ProgressCircle
+                progress={completedTasks / totalTasks}
+                className="text-green-500 [--track-color:#fff3]"
+              />
+              <span className="text-content-inverted/60 text-sm">
+                {completedTasks} of {totalTasks} tasks completed
+              </span>
+            </div>
+          </div>
+
+          {/* Actions */}
+          <div className="flex shrink-0 items-center gap-2">
+            {allTasksCompleted && (
+              <Button
+                type="button"
+                text="Dismiss"
+                variant="secondary"
+                className="h-8 px-3 text-sm"
+                loading={isDismissing}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  dismissBanner({});
+                }}
+              />
+            )}
+            <ChevronUp
+              className={cn(
+                "text-content-inverted/60 size-5 transition-transform duration-200",
+                !isExpanded && "-scale-y-100",
+              )}
+            />
+          </div>
+        </div>
+
+        {/* Expanded Content */}
+        <motion.div
+          initial={false}
+          animate={{
+            height: isExpanded ? "auto" : 0,
+            opacity: isExpanded ? 1 : 0,
+          }}
+          transition={{ duration: 0.15, ease: "easeOut" }}
+          className="overflow-hidden"
+        >
+          <div
+            className="space-y-4 rounded-lg bg-neutral-800 p-4"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {categories.map((category) => (
+              <div key={category.title}>
+                {/* Category Header */}
+                <div className="mb-3 flex items-start justify-between gap-4">
+                  <div>
+                    <h3 className="text-sm font-semibold text-white">
+                      {category.title}
+                    </h3>
+                    <p className="text-xs text-neutral-400">
+                      {category.description}
+                    </p>
+                  </div>
+                  {category.action && (
+                    <Link
+                      href={category.action.href}
+                      className={cn(
+                        buttonVariants({ variant: "secondary" }),
+                        "flex h-8 shrink-0 items-center justify-center whitespace-nowrap rounded-md border px-3 text-sm",
+                      )}
+                    >
+                      {category.action.label}
+                    </Link>
+                  )}
+                </div>
+
+                {/* Task Grid */}
+                <div className="grid grid-cols-1 gap-1 sm:grid-cols-2">
+                  {category.tasks.map(({ label, completed, href }) => (
+                    <ConditionalLink
+                      key={label}
+                      href={completed ? undefined : href}
+                      className={cn(
+                        "group flex items-center justify-between gap-2 rounded-md px-3 py-2",
+                        !completed &&
+                          href &&
+                          "transition-colors duration-100 ease-out hover:bg-neutral-700",
+                      )}
+                    >
+                      <div className="flex min-w-0 items-center gap-2">
+                        {completed ? (
+                          <CircleCheckFill className="size-4 shrink-0 text-green-500" />
+                        ) : (
+                          <CircleDotted className="size-4 shrink-0 text-neutral-400" />
+                        )}
+                        <span className="min-w-0 truncate text-sm">{label}</span>
+                      </div>
+                      {!completed && href && (
+                        <div className="shrink-0 pr-4">
+                          <ExpandingArrow className="group-hover:text-content-inverted text-neutral-500" />
+                        </div>
+                      )}
+                    </ConditionalLink>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </motion.div>
+      </div>
+    </motion.div>
+  );
+}
+
+function ConditionalLink({
+  href,
+  className,
+  children,
+  ...rest
+}: Partial<HTMLProps<HTMLAnchorElement>>) {
+  return href ? (
+    <Link href={href} className={className} {...rest}>
+      {children}
+    </Link>
+  ) : (
+    <div className={className}>{children}</div>
+  );
+}

--- a/apps/web/app/(ee)/partners.dub.co/(dashboard)/profile/profile-unlocks-guide.tsx
+++ b/apps/web/app/(ee)/partners.dub.co/(dashboard)/profile/profile-unlocks-guide.tsx
@@ -21,7 +21,6 @@ import { usePartnerUnlocks } from "./use-partner-unlocks";
 
 export function ProfileUnlocksGuide() {
   const [isExpanded, setIsExpanded] = useState(false);
-  const [simulateComplete, setSimulateComplete] = useState(false);
   const unlocks = usePartnerUnlocks();
 
   const { executeAsync: dismissBanner, isPending: isDismissing } = useAction(
@@ -40,26 +39,16 @@ export function ProfileUnlocksGuide() {
   if (!unlocks) return null;
 
   const { categories, totalTasks, completedTasks } = unlocks;
-  const allTasksCompleted = simulateComplete || completedTasks === totalTasks;
+  const allTasksCompleted = completedTasks === totalTasks;
 
   return (
-    <>
-      {process.env.NODE_ENV === "development" && (
-        <button
-          type="button"
-          className="fixed bottom-4 right-4 z-50 rounded-md bg-neutral-800 px-3 py-1.5 text-xs text-white shadow-lg"
-          onClick={() => setSimulateComplete((s) => !s)}
-        >
-          {simulateComplete ? "Simulating ✓" : "Simulate Unlock"}
-        </button>
-      )}
-      <motion.div
-        initial={{ opacity: 0, height: 0 }}
-        animate={{ opacity: 1, height: "auto" }}
-        transition={{ duration: 0.2, ease: "easeOut" }}
-        className="overflow-hidden"
-      >
-        <div className="text-content-inverted rounded-xl bg-neutral-900">
+    <motion.div
+      initial={{ opacity: 0, height: 0 }}
+      animate={{ opacity: 1, height: "auto" }}
+      transition={{ duration: 0.2, ease: "easeOut" }}
+      className="overflow-hidden"
+    >
+      <div className="text-content-inverted rounded-xl bg-neutral-900">
           {/* Collapsed Header */}
           <div
             className="flex cursor-pointer select-none items-center gap-4 p-3 pr-6"
@@ -188,9 +177,8 @@ export function ProfileUnlocksGuide() {
               ))}
             </div>
           </motion.div>
-        </div>
-      </motion.div>
-    </>
+      </div>
+    </motion.div>
   );
 }
 

--- a/apps/web/app/(ee)/partners.dub.co/(dashboard)/profile/use-partner-unlocks.ts
+++ b/apps/web/app/(ee)/partners.dub.co/(dashboard)/profile/use-partner-unlocks.ts
@@ -1,0 +1,40 @@
+import { EXCLUDED_PROGRAM_IDS } from "@/lib/constants/partner-profile";
+import { partnerHasEarnedCommissions } from "@/lib/network/get-discoverability-requirements";
+import { getUnlocksRequirements } from "@/lib/network/get-unlocks-requirements";
+import usePartnerProfile from "@/lib/swr/use-partner-profile";
+import useProgramEnrollments from "@/lib/swr/use-program-enrollments";
+import { useMemo } from "react";
+
+export function usePartnerUnlocks() {
+  const { partner } = usePartnerProfile();
+  const { programEnrollments } = useProgramEnrollments();
+
+  return useMemo(() => {
+    if (!partner || !programEnrollments) return undefined;
+
+    // Banner was dismissed - don't show it
+    if (partner.unlocksCompletedAt) {
+      return undefined;
+    }
+
+    const enrollmentProgramIds = new Set(
+      programEnrollments.map((e) => e.programId),
+    );
+    const hasExcludedProgram = EXCLUDED_PROGRAM_IDS.some((id) =>
+      enrollmentProgramIds.has(id),
+    );
+
+    // Don't show to excluded program partners who haven't earned commissions
+    if (
+      hasExcludedProgram &&
+      !partnerHasEarnedCommissions(programEnrollments)
+    ) {
+      return undefined;
+    }
+
+    return getUnlocksRequirements({
+      partner,
+      programEnrollments,
+    });
+  }, [partner, programEnrollments]);
+}

--- a/apps/web/app/(ee)/partners.dub.co/(dashboard)/programs/marketplace/layout.tsx
+++ b/apps/web/app/(ee)/partners.dub.co/(dashboard)/programs/marketplace/layout.tsx
@@ -1,20 +1,5 @@
-"use client";
-
-import { partnerCanViewMarketplace } from "@/lib/network/get-discoverability-requirements";
-import usePartnerProfile from "@/lib/swr/use-partner-profile";
-import useProgramEnrollments from "@/lib/swr/use-program-enrollments";
-import { redirect } from "next/navigation";
 import { PropsWithChildren } from "react";
 
 export default function MarketplaceLayout({ children }: PropsWithChildren) {
-  const { partner } = usePartnerProfile();
-  const { programEnrollments, isLoading } = useProgramEnrollments();
-  if (
-    !isLoading &&
-    programEnrollments &&
-    !partnerCanViewMarketplace({ partner, programEnrollments })
-  )
-    redirect("/programs");
-
   return children;
 }

--- a/apps/web/app/(ee)/partners.dub.co/(dashboard)/programs/marketplace/page-client.tsx
+++ b/apps/web/app/(ee)/partners.dub.co/(dashboard)/programs/marketplace/page-client.tsx
@@ -1,8 +1,11 @@
 "use client";
 
+import { canAccessMarketplace } from "@/lib/network/get-marketplace-requirements";
 import useNetworkProgramsCount from "@/lib/swr/use-network-programs-count";
+import usePartnerProfile from "@/lib/swr/use-partner-profile";
 import { NetworkProgramProps } from "@/lib/types";
 import { PROGRAM_NETWORK_MAX_PAGE_SIZE } from "@/lib/zod/schemas/program-network";
+import { MarketplaceUnlockGate } from "@/ui/partners/program-marketplace/marketplace-unlock-gate";
 import { SearchBoxPersisted } from "@/ui/shared/search-box";
 import {
   AnimatedSizeContainer,
@@ -20,8 +23,9 @@ import ProgramSort from "./program-sort";
 import { useProgramNetworkFilters } from "./use-program-network-filters";
 
 export function ProgramMarketplacePageClient() {
+  // All hooks must be called before any conditional returns
+  const { partner } = usePartnerProfile();
   const { getQueryString } = useRouterStuff();
-
   const { data: programsCount, error: countError } = useNetworkProgramsCount();
 
   const {
@@ -46,6 +50,14 @@ export function ProgramMarketplacePageClient() {
     onRemove,
     onRemoveAll,
   } = useProgramNetworkFilters();
+
+  // Check access after all hooks
+  const hasAccess = partner ? canAccessMarketplace(partner) : true;
+
+  // Show unlock gate if partner loaded and doesn't have access
+  if (partner && !hasAccess) {
+    return <MarketplaceUnlockGate />;
+  }
 
   return (
     <div className="flex flex-col gap-6">

--- a/apps/web/lib/actions/partners/dismiss-unlocks-banner.ts
+++ b/apps/web/lib/actions/partners/dismiss-unlocks-banner.ts
@@ -1,0 +1,27 @@
+"use server";
+
+import { throwIfNoPermission } from "@/lib/auth/partner-users/throw-if-no-permission";
+import { prisma } from "@dub/prisma";
+import { authPartnerActionClient } from "../safe-action";
+
+export const dismissUnlocksBannerAction = authPartnerActionClient.action(
+  async ({ ctx }) => {
+    const { partner, partnerUser } = ctx;
+
+    throwIfNoPermission({
+      role: partnerUser.role,
+      permission: "partner_profile.update",
+    });
+
+    await prisma.partner.update({
+      where: {
+        id: partner.id,
+      },
+      data: {
+        unlocksCompletedAt: new Date(),
+      },
+    });
+
+    return { success: true };
+  },
+);

--- a/apps/web/lib/network/get-discoverability-requirements.ts
+++ b/apps/web/lib/network/get-discoverability-requirements.ts
@@ -3,7 +3,6 @@ import {
   EXCLUDED_PROGRAM_IDS,
   PARTNER_NETWORK_MIN_COMMISSIONS_CENTS,
 } from "../constants/partner-profile";
-import { ONLINE_PRESENCE_FIELDS } from "../partners/online-presence";
 import { EnrolledPartnerProps, PartnerProps } from "../types";
 
 export const partnerHasEarnedCommissions = (
@@ -70,10 +69,10 @@ export function getDiscoverabilityRequirements({
       completed: true,
     },
     {
-      label: "Connect your website or social account",
+      label: "Verify a connected website",
       href: "#sites",
-      completed: ONLINE_PRESENCE_FIELDS.some(
-        (field) => field.data(partner.platforms).value, // TODO: update this to also check for "verified" in the future
+      completed: partner.platforms.some(
+        (p) => p.type === "website" && p.verifiedAt !== null,
       ),
     },
     {
@@ -97,7 +96,7 @@ export function getDiscoverabilityRequirements({
       completed: Boolean(partner.salesChannels?.length),
     },
     {
-      label: "Maintain a healthy partner profile",
+      label: "Maintain good network standing",
       completed: partnerIsNotBanned(programEnrollments),
     },
     {

--- a/apps/web/lib/network/get-discoverability-requirements.ts
+++ b/apps/web/lib/network/get-discoverability-requirements.ts
@@ -69,7 +69,7 @@ export function getDiscoverabilityRequirements({
       completed: true,
     },
     {
-      label: "Verify a connected website",
+      label: "Verify your website",
       href: "#sites",
       completed: partner.platforms.some(
         (p) => p.type === "website" && p.verifiedAt !== null,
@@ -101,6 +101,7 @@ export function getDiscoverabilityRequirements({
     },
     {
       label: `Earn ${currencyFormatter(PARTNER_NETWORK_MIN_COMMISSIONS_CENTS, { trailingZeroDisplay: "stripIfInteger" })} in commissions`,
+      href: "/payouts",
       completed: partnerHasEarnedCommissions(programEnrollments),
     },
   ];

--- a/apps/web/lib/network/get-marketplace-requirements.ts
+++ b/apps/web/lib/network/get-marketplace-requirements.ts
@@ -13,8 +13,9 @@ export function hasVerifiedSocialAccount(
 ): boolean {
   return platforms.some(
     (p) =>
-      SOCIAL_PLATFORM_TYPES.includes(p.type as (typeof SOCIAL_PLATFORM_TYPES)[number]) &&
-      p.verifiedAt !== null,
+      SOCIAL_PLATFORM_TYPES.includes(
+        p.type as (typeof SOCIAL_PLATFORM_TYPES)[number],
+      ) && p.verifiedAt !== null,
   );
 }
 
@@ -63,7 +64,7 @@ export function getMarketplaceRequirements({
 }) {
   return [
     {
-      label: "Verify a connected social account",
+      label: "Verify a social account",
       href: "#sites",
       completed: hasVerifiedSocialAccount(partner.platforms),
     },

--- a/apps/web/lib/network/get-marketplace-requirements.ts
+++ b/apps/web/lib/network/get-marketplace-requirements.ts
@@ -46,6 +46,26 @@ export function isPartnerProfileComplete(
   );
 }
 
+export function canAccessMarketplace(
+  partner: Pick<
+    PartnerProps,
+    | "name"
+    | "country"
+    | "profileType"
+    | "description"
+    | "monthlyTraffic"
+    | "preferredEarningStructures"
+    | "salesChannels"
+    | "industryInterests"
+    | "platforms"
+  >,
+): boolean {
+  return (
+    hasVerifiedSocialAccount(partner.platforms) &&
+    isPartnerProfileComplete(partner)
+  );
+}
+
 export function getMarketplaceRequirements({
   partner,
 }: {
@@ -65,12 +85,12 @@ export function getMarketplaceRequirements({
   return [
     {
       label: "Verify a social account",
-      href: "#sites",
+      href: "/profile#sites",
       completed: hasVerifiedSocialAccount(partner.platforms),
     },
     {
       label: "Complete your partner profile",
-      href: "#about",
+      href: "/profile#about",
       completed: isPartnerProfileComplete(partner),
     },
   ];

--- a/apps/web/lib/network/get-marketplace-requirements.ts
+++ b/apps/web/lib/network/get-marketplace-requirements.ts
@@ -8,30 +8,37 @@ const SOCIAL_PLATFORM_TYPES = [
   "tiktok",
 ] as const;
 
+type MarketplacePartnerFields = Pick<
+  PartnerProps,
+  | "name"
+  | "country"
+  | "profileType"
+  | "description"
+  | "monthlyTraffic"
+  | "preferredEarningStructures"
+  | "salesChannels"
+  | "industryInterests"
+  | "platforms"
+>;
+
+function isSocialPlatformType(
+  type: string,
+): type is (typeof SOCIAL_PLATFORM_TYPES)[number] {
+  return SOCIAL_PLATFORM_TYPES.includes(
+    type as (typeof SOCIAL_PLATFORM_TYPES)[number],
+  );
+}
+
 export function hasVerifiedSocialAccount(
   platforms: PartnerPlatformProps[],
 ): boolean {
   return platforms.some(
-    (p) =>
-      SOCIAL_PLATFORM_TYPES.includes(
-        p.type as (typeof SOCIAL_PLATFORM_TYPES)[number],
-      ) && p.verifiedAt !== null,
+    (p) => isSocialPlatformType(p.type) && p.verifiedAt !== null,
   );
 }
 
 export function isPartnerProfileComplete(
-  partner: Pick<
-    PartnerProps,
-    | "name"
-    | "country"
-    | "profileType"
-    | "description"
-    | "monthlyTraffic"
-    | "preferredEarningStructures"
-    | "salesChannels"
-    | "industryInterests"
-    | "platforms"
-  >,
+  partner: MarketplacePartnerFields,
 ): boolean {
   return Boolean(
     partner.name &&
@@ -47,18 +54,7 @@ export function isPartnerProfileComplete(
 }
 
 export function canAccessMarketplace(
-  partner: Pick<
-    PartnerProps,
-    | "name"
-    | "country"
-    | "profileType"
-    | "description"
-    | "monthlyTraffic"
-    | "preferredEarningStructures"
-    | "salesChannels"
-    | "industryInterests"
-    | "platforms"
-  >,
+  partner: MarketplacePartnerFields,
 ): boolean {
   return (
     hasVerifiedSocialAccount(partner.platforms) &&
@@ -69,18 +65,7 @@ export function canAccessMarketplace(
 export function getMarketplaceRequirements({
   partner,
 }: {
-  partner: Pick<
-    PartnerProps,
-    | "name"
-    | "country"
-    | "profileType"
-    | "description"
-    | "monthlyTraffic"
-    | "preferredEarningStructures"
-    | "salesChannels"
-    | "industryInterests"
-    | "platforms"
-  >;
+  partner: MarketplacePartnerFields;
 }) {
   return [
     {

--- a/apps/web/lib/network/get-marketplace-requirements.ts
+++ b/apps/web/lib/network/get-marketplace-requirements.ts
@@ -1,0 +1,76 @@
+import { PartnerPlatformProps, PartnerProps } from "../types";
+
+const SOCIAL_PLATFORM_TYPES = [
+  "youtube",
+  "instagram",
+  "twitter",
+  "linkedin",
+  "tiktok",
+] as const;
+
+export function hasVerifiedSocialAccount(
+  platforms: PartnerPlatformProps[],
+): boolean {
+  return platforms.some(
+    (p) =>
+      SOCIAL_PLATFORM_TYPES.includes(p.type as (typeof SOCIAL_PLATFORM_TYPES)[number]) &&
+      p.verifiedAt !== null,
+  );
+}
+
+export function isPartnerProfileComplete(
+  partner: Pick<
+    PartnerProps,
+    | "name"
+    | "country"
+    | "profileType"
+    | "description"
+    | "monthlyTraffic"
+    | "preferredEarningStructures"
+    | "salesChannels"
+    | "industryInterests"
+    | "platforms"
+  >,
+): boolean {
+  return Boolean(
+    partner.name &&
+      partner.country &&
+      partner.profileType &&
+      partner.platforms.length > 0 &&
+      partner.description &&
+      partner.industryInterests?.length &&
+      partner.monthlyTraffic &&
+      partner.preferredEarningStructures?.length &&
+      partner.salesChannels?.length,
+  );
+}
+
+export function getMarketplaceRequirements({
+  partner,
+}: {
+  partner: Pick<
+    PartnerProps,
+    | "name"
+    | "country"
+    | "profileType"
+    | "description"
+    | "monthlyTraffic"
+    | "preferredEarningStructures"
+    | "salesChannels"
+    | "industryInterests"
+    | "platforms"
+  >;
+}) {
+  return [
+    {
+      label: "Verify a connected social account",
+      href: "#sites",
+      completed: hasVerifiedSocialAccount(partner.platforms),
+    },
+    {
+      label: "Complete your partner profile",
+      href: "#about",
+      completed: isPartnerProfileComplete(partner),
+    },
+  ];
+}

--- a/apps/web/lib/network/get-unlocks-requirements.ts
+++ b/apps/web/lib/network/get-unlocks-requirements.ts
@@ -1,0 +1,78 @@
+import { EnrolledPartnerProps, PartnerProps } from "../types";
+import { getDiscoverabilityRequirements } from "./get-discoverability-requirements";
+import { getMarketplaceRequirements } from "./get-marketplace-requirements";
+
+export type UnlockTask = {
+  label: string;
+  href?: string;
+  completed: boolean;
+};
+
+export type UnlockCategory = {
+  title: string;
+  description: string;
+  tasks: UnlockTask[];
+  action?: {
+    label: string;
+    href: string;
+  };
+};
+
+export function getUnlocksRequirements({
+  partner,
+  programEnrollments,
+}: {
+  partner: Pick<
+    PartnerProps,
+    | "name"
+    | "country"
+    | "profileType"
+    | "description"
+    | "monthlyTraffic"
+    | "preferredEarningStructures"
+    | "salesChannels"
+    | "industryInterests"
+    | "platforms"
+  >;
+  programEnrollments: Pick<
+    EnrolledPartnerProps,
+    "programId" | "status" | "totalCommissions"
+  >[];
+}): {
+  categories: UnlockCategory[];
+  totalTasks: number;
+  completedTasks: number;
+} {
+  const discoveryTasks = getDiscoverabilityRequirements({
+    partner,
+    programEnrollments,
+  });
+
+  const marketplaceTasks = getMarketplaceRequirements({ partner });
+
+  const categories: UnlockCategory[] = [
+    {
+      title: "Get discovered",
+      description:
+        "Appear in the Dub Partner Network and get invited to more programs.",
+      tasks: discoveryTasks,
+    },
+    {
+      title: "Access Dub Marketplace",
+      description: "Discover more programs to apply to on the Dub Program Network.",
+      tasks: marketplaceTasks,
+      action: {
+        label: "View marketplace",
+        href: "/programs/marketplace",
+      },
+    },
+  ];
+
+  const allTasks = [...discoveryTasks, ...marketplaceTasks];
+
+  return {
+    categories,
+    totalTasks: allTasks.length,
+    completedTasks: allTasks.filter((t) => t.completed).length,
+  };
+}

--- a/apps/web/lib/zod/schemas/partners.ts
+++ b/apps/web/lib/zod/schemas/partners.ts
@@ -341,6 +341,12 @@ export const PartnerSchema = z
       .describe(
         "The date when the partner received the trusted badge in the partner network.",
       ),
+    unlocksCompletedAt: z
+      .date()
+      .nullable()
+      .describe(
+        "The date when the partner dismissed the unlocks guide on their profile.",
+      ),
   })
   .extend(PartnerOnlinePresenceSchema.shape)
   .extend(PartnerProfileSchema.partial().shape);

--- a/apps/web/ui/layout/sidebar/partners-sidebar-nav.tsx
+++ b/apps/web/ui/layout/sidebar/partners-sidebar-nav.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { partnerCanViewMarketplace } from "@/lib/network/get-discoverability-requirements";
-import usePartnerProfile from "@/lib/swr/use-partner-profile";
 import usePartnerProgramBounties from "@/lib/swr/use-partner-program-bounties";
 import useProgramEnrollment from "@/lib/swr/use-program-enrollment";
 import useProgramEnrollments from "@/lib/swr/use-program-enrollments";
@@ -44,7 +42,6 @@ type SidebarNavData = {
   unreadMessagesCount?: number;
   programBountiesCount?: number;
   showDetailedAnalytics?: boolean;
-  showMarketplace?: boolean;
 };
 
 const NAV_GROUPS: SidebarNavGroups<SidebarNavData> = ({
@@ -87,7 +84,7 @@ const NAV_GROUPS: SidebarNavGroups<SidebarNavData> = ({
 
 const NAV_AREAS: SidebarNavAreas<SidebarNavData> = {
   // Top-level
-  programs: ({ invitationsCount, showMarketplace }) => ({
+  programs: ({ invitationsCount }) => ({
     title: (
       <div className="mb-3">
         <PartnerProgramDropdown />
@@ -108,16 +105,12 @@ const NAV_AREAS: SidebarNavAreas<SidebarNavData> = {
                 (k) => !pathname.startsWith(`${href}/${k}`),
               ),
           },
-          ...(showMarketplace
-            ? [
-                {
-                  name: "Marketplace",
-                  icon: Shop,
-                  href: "/programs/marketplace" as `/${string}`,
-                  badge: "New",
-                },
-              ]
-            : []),
+          {
+            name: "Marketplace",
+            icon: Shop,
+            href: "/programs/marketplace",
+            badge: "New",
+          },
           {
             name: "Invitations",
             icon: UserCheck,
@@ -292,8 +285,6 @@ export function PartnersSidebarNav({
   const pathname = usePathname();
   const { getQueryString } = useRouterStuff();
 
-  const { partner } = usePartnerProfile();
-
   const isEnrolledProgramPage =
     pathname.startsWith(`/programs/${programSlug}`) &&
     pathname !== `/programs/${programSlug}/apply`;
@@ -356,10 +347,6 @@ export function PartnersSidebarNav({
         unreadMessagesCount,
         programBountiesCount: bountiesCount.active,
         showDetailedAnalytics,
-        showMarketplace: partnerCanViewMarketplace({
-          partner,
-          programEnrollments: programEnrollments || [],
-        }),
       }}
       toolContent={toolContent}
       newsContent={newsContent}

--- a/apps/web/ui/partners/program-marketplace/marketplace-unlock-gate.tsx
+++ b/apps/web/ui/partners/program-marketplace/marketplace-unlock-gate.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { getMarketplaceRequirements } from "@/lib/network/get-marketplace-requirements";
+import usePartnerProfile from "@/lib/swr/use-partner-profile";
+import {
+  ChevronRight,
+  CircleCheckFill,
+  CircleDotted,
+  Lock,
+} from "@dub/ui/icons";
+import Link from "next/link";
+
+function PlaceholderCard() {
+  return (
+    <div className="border-border-subtle flex w-[180px] shrink-0 flex-col gap-4 rounded-xl border bg-white p-3 shadow-[0px_4px_12px_0px_rgba(0,0,0,0.05)]">
+      <Lock className="text-content-subtle size-6" />
+      <div className="flex flex-col gap-2">
+        <div className="h-2.5 w-8 rounded bg-neutral-200" />
+        <div className="h-2.5 w-[74px] rounded bg-neutral-200" />
+      </div>
+      <div className="h-5 w-full rounded bg-neutral-800" />
+    </div>
+  );
+}
+
+export function MarketplaceUnlockGate() {
+  const { partner } = usePartnerProfile();
+
+  if (!partner) return null;
+
+  const requirements = getMarketplaceRequirements({ partner });
+
+  return (
+    <div className="flex min-h-[calc(100dvh-120px)] flex-col items-center justify-center py-16">
+      <div className="flex w-[350px] flex-col items-center gap-6">
+        {/* Decorative Cards with scroll animation */}
+        <div className="relative flex h-[132px] w-full items-center overflow-hidden [mask-image:linear-gradient(to_right,transparent,black_20%,black_80%,transparent)]">
+          {/* Duplicate cards for seamless loop */}
+          {[...Array(2)].map((_, idx) => (
+            <div
+              key={idx}
+              className="flex w-max min-w-max animate-infinite-scroll items-center gap-6 pl-6 [--scroll:-100%] [animation-duration:30s]"
+              aria-hidden={idx !== 0}
+            >
+              {[0, 1, 2].map((i) => (
+                <PlaceholderCard key={i} />
+              ))}
+            </div>
+          ))}
+        </div>
+
+        {/* Text */}
+        <div className="flex flex-col gap-2 text-center">
+          <h2 className="text-content-emphasis text-base font-semibold">
+            Unlock marketplace access
+          </h2>
+          <p className="text-content-subtle text-sm">
+            Complete the following tasks to unlock the Dub marketplace.
+          </p>
+        </div>
+
+        {/* Tasks Card */}
+        <div className="border-border-subtle flex w-full flex-col rounded-[10px] border bg-white p-2">
+          {requirements.map(({ label, href, completed }) => (
+            <Link
+              key={label}
+              href={href}
+              className="hover:bg-bg-subtle flex items-center justify-between rounded-lg p-2.5 transition-colors"
+            >
+              <div className="flex items-center gap-2">
+                {completed ? (
+                  <CircleCheckFill className="size-[18px] text-green-500" />
+                ) : (
+                  <CircleDotted className="text-content-subtle size-[18px]" />
+                )}
+                <span className="text-content-secondary text-sm font-medium">
+                  {label}
+                </span>
+              </div>
+              <ChevronRight className="text-content-subtle size-2.5" />
+            </Link>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/prisma/schema/partner.prisma
+++ b/packages/prisma/schema/partner.prisma
@@ -34,10 +34,11 @@ model Partner {
   connectPayoutsLastRemindedAt DateTime?
 
   // timestamp fields
-  createdAt      DateTime  @default(now())
-  updatedAt      DateTime  @updatedAt
-  discoverableAt DateTime?
-  trustedAt      DateTime?
+  createdAt           DateTime  @default(now())
+  updatedAt           DateTime  @updatedAt
+  discoverableAt      DateTime?
+  trustedAt           DateTime?
+  unlocksCompletedAt  DateTime?
 
   // online presence fields
   website                String?

--- a/packages/ui/src/icons/nucleo/index.ts
+++ b/packages/ui/src/icons/nucleo/index.ts
@@ -161,6 +161,7 @@ export * from "./link4";
 export * from "./location-pin";
 export * from "./lock";
 export * from "./lock-fill";
+export * from "./lock-open-2";
 export * from "./magnifier";
 export * from "./map-position";
 export * from "./marketing-target";

--- a/packages/ui/src/icons/nucleo/lock-open-2.tsx
+++ b/packages/ui/src/icons/nucleo/lock-open-2.tsx
@@ -1,0 +1,48 @@
+import { SVGProps } from "react";
+
+export function LockOpen2(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      height="18"
+      width="18"
+      viewBox="0 0 18 18"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <g fill="currentColor">
+        <path
+          d="M7.25,8.25v-3.25c0-1.795-1.455-3.25-3.25-3.25h0c-1.795,0-3.25,1.455-3.25,3.25v1.25"
+          fill="none"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="1.5"
+        />
+        <line
+          fill="none"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="1.5"
+          x1="9.5"
+          x2="9.5"
+          y1="11.75"
+          y2="12.75"
+        />
+        <rect
+          height="8"
+          width="11.5"
+          fill="none"
+          rx="2"
+          ry="2"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="1.5"
+          x="3.75"
+          y="8.25"
+        />
+      </g>
+    </svg>
+  );
+}


### PR DESCRIPTION
Expanding on the partner unlocks guide component for partner profiles, including logic to determine and display unlockable tasks and categories. 

Adds supporting hooks, actions, and requirement utilities for both discoverability and marketplace access. Updates the Partner schema and database model to track when the unlocks guide is dismissed.

On the marketplace page, locks it down based off of tasks completed which correlate to the profile tasks as well. Once the tasks are completed, the user can dismiss the onboarding banner and the marketplace is available.

https://github.com/user-attachments/assets/e629c59a-7a65-4743-9290-7dbd31371ed9




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unlocks Guide on partner profile showing progress, expandable task lists, and dismissible banner.
  * Marketplace access gate that prompts required steps before entry.

* **Improvements**
  * Track dismissals and unlock completion to hide the guide when finished.
  * Clarified website verification and network standing labels.
  * Marketplace menu now always visible in navigation.
* **Misc**
  * New icon added for unlocked state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->