### PR TITLE
Add link details to `commission.created` webhook event

### DIFF
--- a/apps/web/lib/partners/create-partner-commission.ts
+++ b/apps/web/lib/partners/create-partner-commission.ts
@@ -274,6 +274,14 @@ export const createPartnerCommission = async ({
       },
       include: {
         customer: true,
+        link: {
+          select: {
+            id: true,
+            shortLink: true,
+            domain: true,
+            key: true,
+          },
+        },
       },
     });
 

--- a/apps/web/lib/webhook/sample-events/commission-created.json
+++ b/apps/web/lib/webhook/sample-events/commission-created.json
@@ -35,5 +35,11 @@
     "sales": 1,
     "saleAmount": 50000,
     "createdAt": "2025-07-16T10:48:01.739Z"
+  },
+  "link": {
+    "id": "cm0lcuvtz000xcutmqw4a7wi3",
+    "shortLink": "https://dub.sh/track-test",
+    "domain": "dub.sh",
+    "key": "track-test"
   }
 }

--- a/apps/web/lib/zod/schemas/commissions.ts
+++ b/apps/web/lib/zod/schemas/commissions.ts
@@ -2,6 +2,7 @@ import { DATE_RANGE_INTERVAL_PRESETS } from "@/lib/analytics/constants";
 import { CommissionStatus, CommissionType } from "@dub/prisma/client";
 import * as z from "zod/v4";
 import { CustomerSchema } from "./customers";
+import { LinkSchema } from "./links";
 import { getPaginationQuerySchema } from "./misc";
 import { EnrolledPartnerSchema, WebhookPartnerSchema } from "./partners";
 import { parseDateSchema } from "./utils";
@@ -44,6 +45,12 @@ export const CommissionEnrichedSchema = CommissionSchema.extend({
 export const CommissionWebhookSchema = CommissionSchema.extend({
   partner: WebhookPartnerSchema,
   customer: CustomerSchema.nullish(), // customer can be null for click-based / custom commissions
+  link: LinkSchema.pick({
+    id: true,
+    shortLink: true,
+    domain: true,
+    key: true,
+  }).nullable(),
 });
 
 export const COMMISSIONS_MAX_PAGE_SIZE = 100;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Commission data now includes associated link information (ID, short link, domain, key) in API responses and webhook events. The link field is optional and nullable for backward compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->