### PR TITLE
Default percentage to 0 if undefined in reward amount

### DIFF
--- a/apps/web/lib/api/sales/construct-reward-amount.ts
+++ b/apps/web/lib/api/sales/construct-reward-amount.ts
@@ -72,7 +72,7 @@ export const constructRewardAmount = (
   // 1. There are no modifiers OR
   // 2. type AND timelines doesn't match the primary reward
   return reward.type === "percentage"
-    ? `${reward.amountInPercentage}%`
+    ? `${reward.amountInPercentage ?? 0}%`
     : currencyFormatter(reward.amountInCents ?? 0, {
         trailingZeroDisplay: "stripIfInteger",
       });


### PR DESCRIPTION
Updated the empty sale reward builder. Instead of `undefined` shows as 0 to match the flat rate empty state, and to be more natural language

| Current | Updated |
| ---- | ---- |
| <img width="586" height="440" alt="CleanShot 2026-01-18 at 14 29 08@2x" src="https://github.com/user-attachments/assets/488e552d-6955-43fa-9294-20606601da27" /> | <img width="592" height="454" alt="CleanShot 2026-01-18 at 14 29 45@2x" src="https://github.com/user-attachments/assets/15885482-48b1-4131-b588-4b0e3ee26a52" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where reward amounts could display as "undefined%" under certain conditions. The calculation now safely defaults to 0 to ensure correct percentage values are always displayed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->