### PR TITLE
Add tooltip to Monthly Traffic label in PartnerAbout

### DIFF
--- a/apps/web/ui/partners/partner-about.tsx
+++ b/apps/web/ui/partners/partner-about.tsx
@@ -8,8 +8,7 @@ import {
 } from "@/lib/partners/partner-profile";
 import { EnrolledPartnerExtendedProps } from "@/lib/types";
 import { OnlinePresenceSummary } from "@/ui/partners/online-presence-summary";
-import { Icon, Tooltip } from "@dub/ui";
-import { HelpCircle } from "lucide-react";
+import { Icon, InfoTooltip } from "@dub/ui";
 
 export function PartnerAbout({
   partner,
@@ -103,9 +102,7 @@ export function PartnerAbout({
             <h3 className="text-content-emphasis text-xs font-semibold">
               Monthly traffic
             </h3>
-            <Tooltip content="Shared by the partner, not verified by Dub.">
-              <HelpCircle className="h-3.5 w-3.5 text-neutral-500" />
-            </Tooltip>
+            <InfoTooltip content="Shared by the partner, not verified by Dub." />
           </div>
           <span className="text-content-default text-xs">
             {monthlyTrafficAmountsMap[partner.monthlyTraffic!]?.label ?? "-"}


### PR DESCRIPTION
Making it clear to the program owners that the monthly traffic is self-declared and not verified by Dub.

| Current | Updated |
| --- | --- |
| <img width="348" height="155" alt="CleanShot 2026-01-18 at 14 51 24@2x" src="https://github.com/user-attachments/assets/3466d0ee-453d-40e8-82cf-fcc030fbab8c" /> | <img width="496" height="212" alt="CleanShot 2026-01-18 at 14 51 15@2x" src="https://github.com/user-attachments/assets/a0c31bac-6f76-4545-8c25-7b2562e54da1" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an informational tooltip to the Monthly Traffic metric clarifying that the data is shared by partners and not verified by Dub, improving transparency and helping users interpret traffic numbers. This is a UI-only enhancement with no changes to behavior or exported interfaces.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->