### PR TITLE
Invite team members delete fix

### DIFF
--- a/apps/web/ui/workspaces/invite-teammates-form.tsx
+++ b/apps/web/ui/workspaces/invite-teammates-form.tsx
@@ -104,8 +104,8 @@ export function InviteTeammatesForm({
     >
       <div className="flex flex-col gap-2">
         {fields.map((field, index) => (
-          <div key={field.id} className="relative">
-            <label>
+          <div key={field.id} className="flex items-end gap-2">
+            <label className="flex-1">
               {index === 0 && (
                 <span className="mb-2 block text-sm font-medium text-neutral-700">
                   {pluralize("Email", fields.length)}
@@ -144,14 +144,12 @@ export function InviteTeammatesForm({
               </div>
             </label>
             {index > 0 && (
-              <div className="absolute -right-1 top-1/2 -translate-y-1/2 translate-x-full">
-                <Button
-                  variant="outline"
-                  icon={<Trash className="size-4" />}
-                  className="h-8 px-1"
-                  onClick={() => remove(index)}
-                />
-              </div>
+              <Button
+                variant="outline"
+                icon={<Trash className="size-4" />}
+                className="h-9 w-9 shrink-0 px-0"
+                onClick={() => remove(index)}
+              />
             )}
           </div>
         ))}


### PR DESCRIPTION
Updated the layout of the invite teammates form to use a flex row for each field, so that each row outside the first shows the delete action in-line with the content and not outside.

| Current | Updated |
| --- | --- |
| <img width="505" height="409" alt="CleanShot 2026-01-20 at 15 20 19@2x" src="https://github.com/user-attachments/assets/a20df0b9-664e-4250-92c7-7006a2afca03" /> | <img width="594" height="507" alt="CleanShot 2026-01-20 at 15 20 09@2x" src="https://github.com/user-attachments/assets/e54fcb0b-d3f6-4df8-b92f-e44426a6a68c" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the invite form field layout to use improved spacing and alignment.
  * Repositioned the delete button to display inline with form fields with updated styling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->