### PR TITLE
Add group selector to program overview links

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/overview-links.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/overview-links.tsx
@@ -25,14 +25,18 @@ export function OverviewLinks() {
 
   const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null);
 
-  // Initialize with the default group when groups are loaded
+  // Initialize or reset selection when groups change
   useEffect(() => {
-    if (groups?.length && !selectedGroupId) {
+    if (!groups?.length) return;
+
+    // Check if current selection is still valid
+    const isCurrentSelectionValid =
+      selectedGroupId && groups.some((g) => g.id === selectedGroupId);
+
+    if (!isCurrentSelectionValid) {
       const defaultGroup =
         groups.find((g) => g.slug === "default") || groups[0];
-      if (defaultGroup) {
-        setSelectedGroupId(defaultGroup.id);
-      }
+      setSelectedGroupId(defaultGroup.id);
     }
   }, [groups, selectedGroupId]);
 
@@ -44,34 +48,46 @@ export function OverviewLinks() {
   const showGroupSelector = groups && groups.length > 1;
 
   const links = useMemo(() => {
+    const programSlug = program?.slug;
     const groupSlug = selectedGroup?.slug;
     const isDefault = groupSlug === "default";
 
-    const landingPageHref = isDefault
-      ? `${PARTNERS_DOMAIN}/${program?.slug}`
-      : `${PARTNERS_DOMAIN}/${program?.slug}/${groupSlug}`;
+    // Build URLs only when we have valid slugs
+    const landingPageHref =
+      programSlug && groupSlug
+        ? isDefault
+          ? `${PARTNERS_DOMAIN}/${programSlug}`
+          : `${PARTNERS_DOMAIN}/${programSlug}/${groupSlug}`
+        : "#";
 
-    const applicationHref = isDefault
-      ? `${PARTNERS_DOMAIN}/${program?.slug}/apply`
-      : `${PARTNERS_DOMAIN}/${program?.slug}/${groupSlug}/apply`;
+    const applicationHref =
+      programSlug && groupSlug
+        ? isDefault
+          ? `${PARTNERS_DOMAIN}/${programSlug}/apply`
+          : `${PARTNERS_DOMAIN}/${programSlug}/${groupSlug}/apply`
+        : "#";
+
+    const partnerPortalHref = programSlug
+      ? `${PARTNERS_DOMAIN}/programs/${programSlug}`
+      : "#";
 
     return [
       {
         icon: Post,
         label: "Landing page",
         href: landingPageHref,
-        disabled: !selectedGroup?.landerPublishedAt,
+        disabled: !selectedGroup?.landerPublishedAt || !programSlug,
       },
       {
         icon: InputField,
         label: "Application form",
         href: applicationHref,
-        disabled: !selectedGroup?.applicationFormPublishedAt,
+        disabled: !selectedGroup?.applicationFormPublishedAt || !programSlug,
       },
       {
         icon: Window,
         label: "Partner portal",
-        href: `${PARTNERS_DOMAIN}/programs/${program?.slug}`,
+        href: partnerPortalHref,
         disabled: !program,
       },
     ];


### PR DESCRIPTION
Replaces the default group logic with a group selector, allowing users to choose among multiple groups when viewing program links. Updates link generation to use the selected group's slug and publication status, and removes unused imports and branding button.

| Current | Updated |
| --- | --- | 
| <img width="1310" height="709" alt="CleanShot 2026-01-26 at 17 52 42@2x" src="https://github.com/user-attachments/assets/c13881e7-fe27-4f6c-80fb-7f51aac4d3a2" /> | <img width="1330" height="777" alt="CleanShot 2026-01-26 at 17 52 31@2x" src="https://github.com/user-attachments/assets/06998d8e-b168-4480-bfb5-5f133dc690c9" /> |

If the program doesn't have other groups, the button doesn't show.

<img width="534" height="305" alt="CleanShot 2026-01-26 at 17 55 10@2x" src="https://github.com/user-attachments/assets/bf1fba5a-a19a-4ec8-8312-dc51ca4dbfdd" />

### Video
https://github.com/user-attachments/assets/918b4cfd-2321-4d2e-8c09-afe6d88c4855



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added group selection UI in the program overview header when multiple groups are available.
* Program links (landing page and application form) now dynamically adjust based on the selected group and its publication status.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->