### PR TITLE
Show allowed domains for bounty URL submissions

### DIFF
--- a/apps/web/ui/partners/bounties/claim-bounty-modal.tsx
+++ b/apps/web/ui/partners/bounties/claim-bounty-modal.tsx
@@ -582,6 +582,16 @@ function ClaimBountyModalContent({ bounty }: ClaimBountyModalProps) {
                               }
                             />
                           )}
+                          {bounty.submissionRequirements?.url?.domains &&
+                            bounty.submissionRequirements.url.domains.length >
+                              0 && (
+                              <p className="text-xs text-neutral-400">
+                                Allowed domains:{" "}
+                                {bounty.submissionRequirements.url.domains.join(
+                                  ", ",
+                                )}
+                              </p>
+                            )}
                         </div>
                       </div>
                     )}


### PR DESCRIPTION
Adds a message displaying the list of allowed domains when the bounty has URL submission requirements with domain restrictions. This improves user guidance during the bounty claim process.

### Single URL allowed
<img width="486" height="631" alt="CleanShot 2026-01-26 at 22 34 14@2x" src="https://github.com/user-attachments/assets/724e2a4f-b21e-44db-951a-73cadb1b8793" />

### Multiple URLs allowed
<img width="514" height="688" alt="CleanShot 2026-01-26 at 22 34 00@2x" src="https://github.com/user-attachments/assets/7c572338-9a70-4ebc-93d0-adc93c8d1d0c" />

### Use case with lots of allowed domains added
<img width="536" height="703" alt="CleanShot 2026-01-26 at 22 33 52@2x" src="https://github.com/user-attachments/assets/05486be1-4f6d-4058-97e7-b1061a58065f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added display of allowed submission domains in the bounty claim modal when domain restrictions are configured for submissions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->