### PR TITLE
Only run detectAndRecordFraudEvent if commission created for track-lead

### DIFF
--- a/apps/web/lib/api/conversions/track-lead.ts
+++ b/apps/web/lib/api/conversions/track-lead.ts
@@ -319,7 +319,8 @@ export const trackLead = async ({
               },
             });
 
-            const { webhookPartner, programEnrollment } = createdCommission;
+            const { commission, webhookPartner, programEnrollment } =
+              createdCommission;
 
             await Promise.allSettled([
               executeWorkflows({
@@ -339,7 +340,9 @@ export const trackLead = async ({
                 eventType: "lead",
               }),
 
-              webhookPartner &&
+              // only run fraud checks if the commission was created
+              commission &&
+                webhookPartner &&
                 detectAndRecordFraudEvent({
                   program: { id: link.programId },
                   partner: pick(webhookPartner, ["id", "email", "name"]),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced fraud detection validation to ensure workflows only execute when required commission data is present, preventing invalid detection attempts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->