### PR TITLE
Reduce Granola logo height

### DIFF
--- a/apps/web/app/app.dub.co/(auth)/customer-logos.tsx
+++ b/apps/web/app/app.dub.co/(auth)/customer-logos.tsx
@@ -11,7 +11,7 @@ const CUSTOMER_LOGOS: { name: string; src: string; className?: string }[] = [
   {
     name: "Granola",
     src: "https://assets.dub.co/companies/granola.svg",
-    className: "h-6",
+    className: "h-5",
   },
   { name: "Buffer", src: "https://assets.dub.co/companies/buffer.svg" },
   {


### PR DESCRIPTION
Summary
- shrink the Granola logo height on the workspace onboarding screen to match the updated h-5 sizing. Since the brand update, just needed to adjust it.

**Updated**
<img width="628" height="221" alt="CleanShot 2026-02-03 at 09 21 36@2x" src="https://github.com/user-attachments/assets/152fd25a-ca09-49b8-9bba-4c2f7aa7080c" />

Current
<img width="643" height="326" alt="CleanShot 2026-02-03 at 09 22 16@2x" src="https://github.com/user-attachments/assets/8d3cd365-fe70-44cd-803a-889c52f70328" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Adjusted the Granola logo size in the customer logos section for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->