### PR TITLE
Align ban partner API response with OpenAPI schema

### DIFF
--- a/apps/web/app/(ee)/api/partners/ban/route.ts
+++ b/apps/web/app/(ee)/api/partners/ban/route.ts
@@ -42,14 +42,16 @@ export const POST = withWorkspace(
       partnerId = programEnrollment.partnerId;
     }
 
-    const response = await banPartner({
+    await banPartner({
       workspace,
       partnerId: partnerId!, // coerce here because we're already throwing if no partnerId or tenantId
       reason,
       user: session.user,
     });
 
-    return NextResponse.json(response);
+    return NextResponse.json({
+      partnerId,
+    });
   },
   {
     requiredPlan: ["advanced", "enterprise"],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Simplified the partner ban API response structure to return only the partner identifier, providing a more streamlined response format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->