### PR TITLE
Partner success svg updated

### DIFF
--- a/apps/web/app/(ee)/partners.dub.co/(apply)/[programSlug]/(default)/apply/success/page.tsx
+++ b/apps/web/app/(ee)/partners.dub.co/(apply)/[programSlug]/(default)/apply/success/page.tsx
@@ -159,7 +159,7 @@ export default async function SuccessPage(props: {
           <div className="relative mt-16">
             <Screenshot
               program={{ name: program.name, logo: program.logo }}
-              className="h-auto w-full rounded border border-black/10 [mask-image:linear-gradient(black_80%,transparent)]"
+              className="h-auto w-full [mask-image:linear-gradient(black_80%,transparent)]"
             />
             <div className="absolute bottom-0 left-1/2 -translate-x-1/2">
               <div className="absolute -inset-[50%] rounded-full bg-white blur-lg" />

--- a/apps/web/app/(ee)/partners.dub.co/(apply)/[programSlug]/(default)/apply/success/screenshot.tsx
+++ b/apps/web/app/(ee)/partners.dub.co/(apply)/[programSlug]/(default)/apply/success/screenshot.tsx
@@ -7,1232 +7,491 @@ export function Screenshot({
   ...rest
 }: { program: Pick<ProgramProps, "name" | "logo"> } & SVGProps<SVGSVGElement>) {
   const id = useId();
-
   return (
     <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="1695"
-      height="890"
+      width="1200"
+      height="631"
       fill="none"
-      viewBox="0 0 1695 890"
+      viewBox="0 0 1200 631"
       {...rest}
       className={cn("select-none text-[var(--brand)]", rest.className)}
     >
-      <g clipPath={`url(#${id}-a)`}>
-        <path fill="#F5F5F5" d="M0 0h1695v940H0z" />
-        <path fill="#F5F5F5" d="M0 0h240v940H0z" />
-        <path
-          fill="#000"
-          fillRule="evenodd"
-          d="M26.083 14.833h2.75V32.25h-2.75V31.1a6.417 6.417 0 1 1 0-10.533zM22.417 29.5a3.667 3.667 0 1 0 0-7.333 3.667 3.667 0 0 0 0 7.333m22.916-14.667h2.75v5.734a6.417 6.417 0 1 1-2.75 5.267zM51.75 29.5a3.667 3.667 0 1 0 0-7.334 3.667 3.667 0 0 0 0 7.334M33.417 19.417h-2.75v6.416a6.416 6.416 0 1 0 12.833 0v-6.416h-2.75v6.416a3.667 3.667 0 0 1-7.333 0z"
-          clipRule="evenodd"
-        />
-        <g clipPath={`url(#${id}-b)`}>
-          <path
-            stroke="#737373"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth="1.5"
-            d="M183.999 30.444a6.445 6.445 0 1 0 0-12.89 6.445 6.445 0 0 0 0 12.89"
-          />
-          <path
-            stroke="#737373"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth="1.5"
-            d="M182.156 21.884c.345-.94 1.15-1.327 1.938-1.327.796 0 1.616.567 1.616 1.607 0 1.586-1.614 1.305-1.863 2.725"
-          />
-          <path
-            fill="#737373"
-            d="M183.815 28.06a.89.89 0 1 1 .001-1.78.89.89 0 0 1-.001 1.78"
-          />
-        </g>
-        <path
-          fill="currentColor"
-          d="M204 24c0-6.627 5.373-12 12-12s12 5.373 12 12-5.373 12-12 12-12-5.373-12-12"
-          opacity="0.4"
-        />
-        <g filter={`url(#${id}-c)`} opacity="0.1">
-          <circle
-            cx="181.5"
-            cy="181.5"
-            r="181.5"
-            fill={`url(#${id}-d)`}
-            transform="matrix(-1 0 0 1 186 661)"
-          />
-        </g>
-        {/* Little logo */}
-        <image
-          x="18"
-          y="70"
-          href={program.logo || `${OG_AVATAR_URL}${program.name}`}
-          width="32"
-          height="32"
-          clipPath="inset(0% round 32px)"
-        />
-        <text
-          xmlSpace="preserve"
-          fill="#171717"
-          fontSize="13"
-          fontWeight="600"
-          letterSpacing="0em"
-          style={{ whiteSpace: "pre" }}
-        >
-          <tspan x="60" y="83.727">
-            {truncate(program.name, 18)}
-          </tspan>
-        </text>
-        <circle cx="62" cy="94" r="2" fill="#4ADE80" />
-        <text
-          xmlSpace="preserve"
-          fill="#737373"
-          fontSize="10"
-          fontWeight="500"
-          letterSpacing="0em"
-          style={{ whiteSpace: "pre" }}
-        >
-          <tspan x="68" y="97.636">
-            Enrolled
-          </tspan>
-        </text>
-        <g clipPath={`url(#${id}-e)`}>
-          <path fill="currentColor" d="M12 124h216v30H12z" opacity="0.1" />
-          <g clipPath={`url(#${id}-f)`}>
-            <path
-              fill="currentColor"
-              stroke="currentColor"
-              d="M28.167 135.222a.167.167 0 1 1-.334 0c0-.092.075-.166.167-.166s.167.074.167.166ZM30.838 136.329a.167.167 0 1 1-.334 0 .167.167 0 0 1 .334 0ZM31.944 139a.167.167 0 1 1-.334 0 .167.167 0 0 1 .334 0ZM25.496 136.329a.167.167 0 1 1-.334 0 .167.167 0 0 1 .334 0Z"
-            />
-            <path
-              fill="currentColor"
-              d="M24.222 139.667a.667.667 0 1 0 0-1.334.667.667 0 0 0 0 1.334"
-            />
-            <path
-              stroke="currentColor"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="1.5"
-              d="M31.527 144.389A6.43 6.43 0 0 0 34.444 139a6.444 6.444 0 0 0-12.889 0 6.43 6.43 0 0 0 2.918 5.389"
-            />
-            <path
-              stroke="currentColor"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="1.5"
-              d="M26.667 144.111c0-.736 1.333-6.222 1.333-6.222s1.333 5.486 1.333 6.222a1.334 1.334 0 0 1-2.666 0"
-            />
-          </g>
-          <text
-            xmlSpace="preserve"
-            fill="currentColor"
-            fontSize="13"
-            fontWeight="500"
-            letterSpacing="0em"
-            style={{ whiteSpace: "pre" }}
-          >
-            <tspan x="46" y="143.727">
-              Overview
-            </tspan>
-          </text>
-        </g>
-        <path
-          stroke="#737373"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth="1.5"
-          d="M28 171.667a1.778 1.778 0 1 0 0-3.556 1.778 1.778 0 0 0 0 3.556"
-        />
-        <path
-          stroke="#737373"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth="1.5"
-          d="M32.667 165.222h-9.334c-.981 0-1.777.796-1.777 1.778v5.778c0 .982.796 1.778 1.777 1.778h9.334c.981 0 1.777-.796 1.777-1.778V167c0-.982-.796-1.778-1.777-1.778"
-        />
-        <path
-          fill="#737373"
-          d="M23.778 170.556a.667.667 0 1 0-.001-1.334.667.667 0 0 0 0 1.334M32.222 170.556a.667.667 0 1 0 0-1.334.667.667 0 0 0 0 1.334"
-        />
-        <path
-          stroke="#737373"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth="1.5"
-          d="M23.333 162.556h9.334"
-        />
-        <text
-          xmlSpace="preserve"
-          fill="#525252"
-          fontSize="13"
-          fontWeight="500"
-          letterSpacing="0em"
-          style={{ whiteSpace: "pre" }}
-        >
-          <tspan x="46" y="173.727">
-            Payouts
-          </tspan>
-        </text>
-        <g
-          stroke="#737373"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth="1.5"
-          clipPath={`url(#${id}-g)`}
-        >
-          <path d="m27.193 197.914 6.501 2.231c.197.067.201.345.006.418l-2.914 1.096a.22.22 0 0 0-.13.129l-1.096 2.915a.222.222 0 0 1-.418-.006l-2.231-6.501a.222.222 0 0 1 .283-.283zM30.691 201.694l3.744 3.744M26.887 192.556v1.777M30.66 194.117l-1.258 1.258M23.117 201.66l1.258-1.257M21.555 197.889h1.777M23.117 194.117l1.258 1.258" />
-        </g>
-        <text
-          xmlSpace="preserve"
-          fill="#525252"
-          fontSize="13"
-          fontWeight="500"
-          letterSpacing="0em"
-          style={{ whiteSpace: "pre" }}
-        >
-          <tspan x="46" y="203.727">
-            Events
-          </tspan>
-        </text>
-        <path
-          stroke="#737373"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth="1.5"
-          d="M27.556 227.068a3.1 3.1 0 0 0-.864.614l-.01.009a3.14 3.14 0 0 0 0 4.444l1.934 1.933a3.14 3.14 0 0 0 4.444 0l.01-.008a3.143 3.143 0 0 0 0-4.445l-.828-.827"
-        />
-        <path
-          stroke="#737373"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth="1.5"
-          d="M28.445 230.932a3.1 3.1 0 0 0 .865-.614l.01-.009a3.14 3.14 0 0 0 0-4.444l-1.934-1.933a3.14 3.14 0 0 0-4.445 0l-.009.008a3.143 3.143 0 0 0 0 4.445l.828.827"
-        />
-        <text
-          xmlSpace="preserve"
-          fill="#525252"
-          fontSize="13"
-          fontWeight="500"
-          letterSpacing="0em"
-          style={{ whiteSpace: "pre" }}
-        >
-          <tspan x="46" y="233.727">
-            Links
-          </tspan>
-        </text>
-        <path
-          stroke="#737373"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth="1.5"
-          d="m25.859 263.97 5.814-5.814a.89.89 0 0 0 0-1.257l-1.572-1.572a.89.89 0 0 0-1.256 0l-.178.178"
-        />
-        <path
-          stroke="#737373"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth="1.5"
-          d="M24.445 264.556h8.222a.89.89 0 0 0 .889-.889v-2.223a.89.89 0 0 0-.89-.888h-.25"
-        />
-        <path
-          fill="#737373"
-          d="M24.444 263.222a.666.666 0 1 0 .001-1.332.666.666 0 0 0 0 1.332"
-        />
-        <path
-          stroke="#737373"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth="1.5"
-          d="M24.445 264.556a2 2 0 0 1-2-2v-8.223a.89.89 0 0 1 .888-.889h2.223a.89.89 0 0 1 .889.889v8.223a2 2 0 0 1-2 2"
-        />
-        <text
-          xmlSpace="preserve"
-          fill="#525252"
-          fontSize="13"
-          fontWeight="500"
-          letterSpacing="0em"
-          style={{ whiteSpace: "pre" }}
-        >
-          <tspan x="46" y="263.727">
-            Resources
-          </tspan>
-        </text>
-        <path
-          fill="#fff"
-          d="M1695.5 8v-.5H256c-9.113 0-16.5 7.387-16.5 16.5v916.5h1456V8"
-        />
-        <path
-          stroke="#E5E5E5"
-          d="M1695.5 8v-.5H256c-9.113 0-16.5 7.387-16.5 16.5v916.5h1456V8Z"
-        />
-        <text
-          xmlSpace="preserve"
-          fill="#171717"
-          fontSize="24"
-          fontWeight="600"
-          letterSpacing="-.02em"
-          style={{ whiteSpace: "pre" }}
-        >
-          <tspan x="367.5" y="72.727">
-            Overview
-          </tspan>
-        </text>
-        <g clipPath={`url(#${id}-h)`}>
-          <rect
-            width="1200"
-            height="306"
-            x="367.5"
-            y="104"
-            fill="#FAFAFA"
-            rx="12"
-          />
-          <rect
-            xmlns="http://www.w3.org/2000/svg"
-            width="1200"
-            height="306"
-            x="367.5"
-            y="104"
-            fill={`url(#${id}-grid)`}
-          />
-          <path fill={`url(#${id}-i)`} d="M367 104h1201v306H367z" />
-          <path
-            stroke="#737373"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth="1.5"
-            d="M400.5 139a2 2 0 1 0 .001-3.999A2 2 0 0 0 400.5 139"
-          />
-          <path
-            stroke="#737373"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth="1.5"
-            d="M393.25 141.75v-9.5c2.396 1.074 4.568 1.221 7.25 0s4.854-1.25 7.25 0v9.5c-2.396-1.25-4.568-1.221-7.25 0s-4.854 1.074-7.25 0"
-          />
-          <text
-            xmlSpace="preserve"
-            fill="#737373"
-            fontSize="14"
-            letterSpacing="0em"
-            style={{ whiteSpace: "pre" }}
-          >
-            <tspan x="417.5" y="142.091">
-              Refer and Earn
-            </tspan>
-          </text>
-          <text
-            xmlSpace="preserve"
-            fill="#171717"
-            fontSize="18"
-            fontWeight="600"
-            letterSpacing="0em"
-            style={{ whiteSpace: "pre" }}
-          >
-            <tspan x="852.891" y="262.045" />
-            <tspan x="416.004" y="289.045" />
-          </text>
-          <text
-            xmlSpace="preserve"
-            fill="#171717"
-            fontSize="18"
-            letterSpacing="0em"
-            style={{ whiteSpace: "pre" }}
-            x="391.5"
-            y="262.045"
-          >
-            <tspan>Earn </tspan>
-            <tspan
-              fontWeight="600"
-              // Blur to avoid confusing a placeholder number for a real number
-              style={{ filter: "blur(4px)", opacity: 0.4 }}
-            >
-              20%
-            </tspan>
-            <tspan> for each conversion</tspan>
-          </text>
-          <text
-            xmlSpace="preserve"
-            fill="#171717"
-            fontSize="18"
-            fontWeight="600"
-            letterSpacing="0em"
-            style={{ whiteSpace: "pre" }}
-            x="391.5"
-            y="289.045"
-          >
-            for the customer's lifetime.
-          </text>
-          <text
-            xmlSpace="preserve"
-            fill="#262626"
-            fontSize="14"
-            fontWeight="500"
-            letterSpacing="0em"
-            style={{ whiteSpace: "pre" }}
-          >
-            <tspan x="391.5" y="334.091">
-              Referral link
-            </tspan>
-          </text>
-          <path
-            fill="#fff"
-            d="M392 355.6c0-1.688 0-2.925.08-3.9.079-.97.234-1.637.519-2.197a5.5 5.5 0 0 1 2.404-2.404c.56-.285 1.227-.44 2.197-.519.975-.08 2.212-.08 3.9-.08h280.8c1.688 0 2.925 0 3.9.08.97.079 1.637.234 2.197.519a5.5 5.5 0 0 1 2.404 2.404c.285.56.44 1.227.519 2.197.08.975.08 2.212.08 3.9v20.8c0 1.688 0 2.925-.08 3.9-.079.97-.234 1.637-.519 2.197a5.5 5.5 0 0 1-2.404 2.404c-.56.285-1.227.44-2.197.519-.975.08-2.212.08-3.9.08H401.1c-1.688 0-2.925 0-3.9-.08-.97-.079-1.637-.234-2.197-.519a5.5 5.5 0 0 1-2.404-2.404c-.285-.56-.44-1.227-.519-2.197-.08-.975-.08-2.212-.08-3.9z"
-          />
-          <path
-            stroke="#D4D4D4"
-            d="M392 355.6c0-1.688 0-2.925.08-3.9.079-.97.234-1.637.519-2.197a5.5 5.5 0 0 1 2.404-2.404c.56-.285 1.227-.44 2.197-.519.975-.08 2.212-.08 3.9-.08h280.8c1.688 0 2.925 0 3.9.08.97.079 1.637.234 2.197.519a5.5 5.5 0 0 1 2.404 2.404c.285.56.44 1.227.519 2.197.08.975.08 2.212.08 3.9v20.8c0 1.688 0 2.925-.08 3.9-.079.97-.234 1.637-.519 2.197a5.5 5.5 0 0 1-2.404 2.404c-.56.285-1.227.44-2.197.519-.975.08-2.212.08-3.9.08H401.1c-1.688 0-2.925 0-3.9-.08-.97-.079-1.637-.234-2.197-.519a5.5 5.5 0 0 1-2.404-2.404c-.285-.56-.44-1.227-.519-2.197-.08-.975-.08-2.212-.08-3.9z"
-          />
-          <text
-            xmlSpace="preserve"
-            fill="#262626"
-            fontSize="14"
-            letterSpacing="0em"
-            style={{ whiteSpace: "pre" }}
-          >
-            <tspan x="403.5" y="371.091">
-              refer.dub.co/steven
-            </tspan>
-          </text>
-          <path
-            stroke="#737373"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth="1.5"
-            d="M667.722 368.889h-.889a1.777 1.777 0 0 1-1.777-1.778v-4.889c0-.982.795-1.778 1.777-1.778h6.667c.982 0 1.778.796 1.778 1.778v.889m.889 8.445H669.5a1.78 1.78 0 0 1-1.778-1.778v-4.889c0-.982.796-1.778 1.778-1.778h6.667c.982 0 1.777.796 1.777 1.778v4.889c0 .982-.795 1.778-1.777 1.778"
-          />
-          <path
-            fill="#171717"
-            d="M707.5 352a6 6 0 0 1 6-6h135a6 6 0 0 1 6 6v28a6 6 0 0 1-6 6h-135a6 6 0 0 1-6-6z"
-          />
-          <path
-            stroke="#fff"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth="1.5"
-            d="M733.5 369.778a1.78 1.78 0 0 1-1.778-1.778v-4.222a4.222 4.222 0 1 0-8.444 0V368c0 .982-.796 1.778-1.778 1.778z"
-          />
-          <path
-            fill="#fff"
-            d="M728.912 371.498a.45.45 0 0 0-.345-.165h-2.133a.446.446 0 0 0-.434.536 1.53 1.53 0 0 0 1.501 1.242c.73 0 1.347-.511 1.501-1.242a.44.44 0 0 0-.09-.371"
-          />
-          <text
-            xmlSpace="preserve"
-            fill="#fff"
-            fontSize="14"
-            fontWeight="500"
-            letterSpacing="0em"
-            style={{ whiteSpace: "pre" }}
-          >
-            <tspan x="743.521" y="371.091">
-              Invite via email
-            </tspan>
-          </text>
-          <g filter={`url(#${id}-j)`} style={{ mixBlendMode: "overlay" }}>
-            <path
-              fill="#000"
-              fillOpacity="0.5"
-              d="M1680 507h-70.15c0-327.214-574.37-436.919-854.85-429.005V21h925z"
-            />
-          </g>
-          <g filter={`url(#${id}-k)`} style={{ mixBlendMode: "soft-light" }}>
-            <circle
-              cx="600"
-              cy="600"
-              r="600"
-              fill="currentColor"
-              transform="matrix(-1 0 0 1 2007.5 -343)"
-            />
-          </g>
-          <g clipPath={`url(#${id}-l)`}>
-            <rect width="6" height="6" x="1404.5" y="174" fill="#fff" rx="3" />
-            <rect
-              width="6.75"
-              height="6.75"
-              x="1404.12"
-              y="173.625"
-              stroke="#000"
-              strokeOpacity="0.3"
-              strokeWidth="0.75"
-              rx="3.375"
-            />
-            <circle cx="1407.5" cy="177" r="1" fill="#000" fillOpacity="0.3" />
-            <rect
-              width="6"
-              height="6"
-              x="1490.5"
-              y="254"
-              fill="#fff"
-              rx="3"
-              transform="rotate(90 1490.5 254)"
-            />
-            <rect
-              width="6.75"
-              height="6.75"
-              x="1490.88"
-              y="253.625"
-              stroke="#000"
-              strokeOpacity="0.3"
-              strokeWidth="0.75"
-              rx="3.375"
-              transform="rotate(90 1490.88 253.625)"
-            />
-            <circle
-              cx="1487.5"
-              cy="257"
-              r="1"
-              fill="#000"
-              fillOpacity="0.3"
-              transform="rotate(90 1487.5 257)"
-            />
-            <rect
-              width="6"
-              height="6"
-              x="1450.5"
-              y="340"
-              fill="#fff"
-              rx="3"
-              transform="rotate(-180 1450.5 340)"
-            />
-            <rect
-              width="6.75"
-              height="6.75"
-              x="1450.87"
-              y="340.375"
-              stroke="#000"
-              strokeOpacity="0.3"
-              strokeWidth="0.75"
-              rx="3.375"
-              transform="rotate(-180 1450.87 340.375)"
-            />
-            <circle
-              cx="1447.5"
-              cy="337"
-              r="1"
-              fill="#000"
-              fillOpacity="0.3"
-              transform="rotate(-180 1447.5 337)"
-            />
-            <rect
-              width="6"
-              height="6"
-              x="1324.5"
-              y="260"
-              fill="#fff"
-              rx="3"
-              transform="rotate(-90 1324.5 260)"
-            />
-            <rect
-              width="6.75"
-              height="6.75"
-              x="1324.12"
-              y="260.375"
-              stroke="#000"
-              strokeOpacity="0.3"
-              strokeWidth="0.75"
-              rx="3.375"
-              transform="rotate(-90 1324.12 260.375)"
-            />
-            <circle
-              cx="1327.5"
-              cy="257"
-              r="1"
-              fill="#000"
-              fillOpacity="0.3"
-              transform="rotate(-90 1327.5 257)"
-            />
-            <rect
-              width="6"
-              height="6"
-              x="1370.5"
-              y="340"
-              fill="#fff"
-              rx="3"
-              transform="rotate(-180 1370.5 340)"
-            />
-            <rect
-              width="6.75"
-              height="6.75"
-              x="1370.87"
-              y="340.375"
-              stroke="#000"
-              strokeOpacity="0.3"
-              strokeWidth="0.75"
-              rx="3.375"
-              transform="rotate(-180 1370.87 340.375)"
-            />
-            <circle
-              cx="1367.5"
-              cy="337"
-              r="1"
-              fill="#000"
-              fillOpacity="0.3"
-              transform="rotate(-180 1367.5 337)"
-            />
-            <path
-              stroke={`url(#${id}-m)`}
-              strokeWidth="0.75"
-              d="M1407.5 175.5V157m20-65v22.929c0 1.326-.53 2.598-1.46 3.535l-17.08 17.072a5.03 5.03 0 0 0-1.46 3.535V157m0 0-18.54-18.536a5.03 5.03 0 0 1-1.46-3.535V94.5"
-              opacity="0.3"
-            />
-            <path
-              stroke={`url(#${id}-n)`}
-              strokeWidth="0.75"
-              d="M1489 257h18.5m65 20h-22.93a4.97 4.97 0 0 1-3.53-1.464l-17.08-17.072a4.97 4.97 0 0 0-3.53-1.464h-17.93m0 0 18.54-18.536a4.97 4.97 0 0 1 3.53-1.464H1570"
-              opacity="0.3"
-            />
-            <path
-              stroke={`url(#${id}-o)`}
-              strokeWidth="0.75"
-              d="M1447.5 338.5V357m20 65v-22.929c0-1.326-.53-2.598-1.46-3.535l-17.08-17.072a5.03 5.03 0 0 1-1.46-3.535V357m0 0-18.54 18.536a5.03 5.03 0 0 0-1.46 3.535V419.5"
-              opacity="0.3"
-            />
-            <path
-              stroke={`url(#${id}-p)`}
-              strokeWidth="0.75"
-              d="M1326 257h-18.5m0 0h-17.93c-1.33 0-2.6.527-3.53 1.464l-17.08 17.072a4.97 4.97 0 0 1-3.53 1.464h-15.86a4.97 4.97 0 0 1-3.53-1.464l-17.08-17.072a4.97 4.97 0 0 0-3.53-1.464h-33.93m116 0-18.54-18.536a4.97 4.97 0 0 0-3.53-1.464h-77.93"
-              opacity="0.3"
-            />
-            <path
-              stroke={`url(#${id}-q)`}
-              strokeWidth="0.75"
-              d="M1367.5 338.5v16.429c0 1.326-.53 2.598-1.46 3.535l-17.08 17.072a5.03 5.03 0 0 0-1.46 3.535V419.5"
-              opacity="0.3"
-            />
-          </g>
-          <g filter={`url(#${id}-r)`}>
-            <path
-              fill={`url(#${id}-s)`}
-              fillOpacity="0.01"
-              d="M1327.5 177h160v160h-160z"
-            />
-            <path fill="#fff" fillOpacity="0.5" d="M1327.5 177h160v160h-160z" />
-          </g>
-          <path
-            stroke="#000"
-            strokeOpacity="0.1"
-            strokeWidth="0.75"
-            d="M1327.5 177h160v160h-160z"
-          />
-          {/* Big logo */}
-          <image
-            x="1367.5"
-            y="217"
-            href={program.logo || `${OG_AVATAR_URL}${program.name}`}
-            width="80"
-            height="80"
-            clipPath="inset(0% round 80px)"
-          />
-          <g filter={`url(#${id}-t)`} opacity="0.5">
-            <path fill="#fff" fillOpacity="0.4" d="M1227.5 137h40v40h-40z" />
-            <path
-              stroke="#000"
-              strokeOpacity="0.2"
-              strokeWidth="0.75"
-              d="M1227.5 137h40v40h-40z"
-            />
-            <g
-              stroke="#212121"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="1.5"
-              opacity="0.5"
-            >
-              <path d="M1247.5 159.222c1.23 0 2.22-.995 2.22-2.222s-.99-2.222-2.22-2.222-2.22.995-2.22 2.222.99 2.222 2.22 2.222" />
-              <path d="M1239.44 162.278v-10.556c2.67 1.194 5.08 1.357 8.06 0s5.39-1.389 8.06 0v10.556c-2.67-1.389-5.08-1.357-8.06 0s-5.39 1.193-8.06 0" />
-            </g>
-          </g>
-          <g filter={`url(#${id}-u)`} opacity="0.5">
-            <path fill="#fff" fillOpacity="0.4" d="M1507.5 337h40v40h-40z" />
-            <path
-              stroke="#000"
-              strokeOpacity="0.2"
-              strokeWidth="0.75"
-              d="M1507.5 337h40v40h-40z"
-            />
-            <g
-              stroke="#212121"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="1.5"
-              clipPath={`url(#${id}-v)`}
-              opacity="0.5"
-            >
-              <path d="M1527.5 357.917c1.35 0 2.44-1.095 2.44-2.445a2.44 2.44 0 1 0-4.88 0c0 1.35 1.09 2.445 2.44 2.445M1522.77 364.639a4.88 4.88 0 0 1 4.73-3.667c2.28 0 4.19 1.559 4.73 3.667" />
-              <path d="M1535.14 356.389v5.805a2.45 2.45 0 0 1-2.45 2.445h-10.38a2.443 2.443 0 0 1-2.45-2.445v-10.388a2.443 2.443 0 0 1 2.45-2.445h5.8M1534.53 346.917v6.111M1537.58 349.972h-6.11" />
-            </g>
-          </g>
-          <g filter={`url(#${id}-w)`} opacity="0.1">
-            <circle
-              cx="600"
-              cy="600"
-              r="600"
-              fill="currentColor"
-              transform="matrix(-1 0 0 1 2007.5 -356)"
-            />
-          </g>
-        </g>
-        <rect
-          width="1199"
-          height="305"
-          x="368"
-          y="104.5"
-          stroke="#E5E5E5"
-          rx="11.5"
-        />
-        <path
-          stroke="#E5E5E5"
-          d="M368 442a7.5 7.5 0 0 1 7.5-7.5h1184c4.14 0 7.5 3.358 7.5 7.5v441c0 4.142-3.36 7.5-7.5 7.5h-1184a7.5 7.5 0 0 1-7.5-7.5z"
-        />
-        <text
-          xmlSpace="preserve"
-          fill="#737373"
-          fontSize="14"
-          letterSpacing="0em"
-          style={{ whiteSpace: "pre" }}
-        >
-          <tspan x="391.5" y="470.591">
-            Earnings
-          </tspan>
-        </text>
-        <text
-          xmlSpace="preserve"
-          fill="#262626"
-          fontSize="24"
-          fontWeight="500"
-          letterSpacing="0em"
-          style={{ whiteSpace: "pre" }}
-        >
-          <tspan x="391.5" y="502.727">
-            $1,234.00
-          </tspan>
-        </text>
-        <path
-          fill="#FAFAFA"
-          d="M1403 464c0-3.038 2.46-5.5 5.5-5.5h129c3.04 0 5.5 2.462 5.5 5.5v20c0 3.038-2.46 5.5-5.5 5.5h-129c-3.04 0-5.5-2.462-5.5-5.5z"
-        />
-        <path
-          stroke="#E5E5E5"
-          d="M1403 464c0-3.038 2.46-5.5 5.5-5.5h129c3.04 0 5.5 2.462 5.5 5.5v20c0 3.038-2.46 5.5-5.5 5.5h-129c-3.04 0-5.5-2.462-5.5-5.5z"
-        />
-        <g
-          stroke="#171717"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth="1.5"
-          clipPath={`url(#${id}-x)`}
-        >
-          <path d="M1417.61 468.444v-1.777M1423.39 468.444v-1.777M1424.72 468.444h-8.44c-.98 0-1.78.796-1.78 1.778v7.556c0 .982.8 1.778 1.78 1.778h8.44c.98 0 1.78-.796 1.78-1.778v-7.556c0-.982-.8-1.778-1.78-1.778M1414.5 471.556h12" />
-        </g>
-        <text
-          xmlSpace="preserve"
-          fill="#171717"
-          fontSize="12"
-          fontWeight="500"
-          letterSpacing="0em"
-          style={{ whiteSpace: "pre" }}
-        >
-          <tspan x="1436.5" y="478.364">
-            Last 24 hours
-          </tspan>
-        </text>
-        <path
-          stroke="#A3A3A3"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth="1.5"
-          d="m1531.97 472.611-3.47 3.472-3.47-3.472"
-        />
-        <text
-          xmlSpace="preserve"
-          fill="#525252"
-          fontSize="12"
-          letterSpacing="0em"
-          style={{ whiteSpace: "pre" }}
-        >
-          <tspan x="394.922" y="549.864">
-            100
-          </tspan>
-        </text>
-        <path stroke="#E5E5E5" strokeWidth="0.75" d="M423.5 545.5h1120" />
-        <text
-          xmlSpace="preserve"
-          fill="#525252"
-          fontSize="12"
-          letterSpacing="0em"
-          style={{ whiteSpace: "pre" }}
-        >
-          <tspan x="400.605" y="607.064">
-            80
-          </tspan>
-        </text>
-        <path stroke="#E5E5E5" strokeWidth="0.75" d="M423.5 602.7h1120" />
-        <text
-          xmlSpace="preserve"
-          fill="#525252"
-          fontSize="12"
-          letterSpacing="0em"
-          style={{ whiteSpace: "pre" }}
-        >
-          <tspan x="400.512" y="664.264">
-            60
-          </tspan>
-        </text>
-        <path stroke="#E5E5E5" strokeWidth="0.75" d="M423.5 659.9h1120" />
-        <text
-          xmlSpace="preserve"
-          fill="#525252"
-          fontSize="12"
-          letterSpacing="0em"
-          style={{ whiteSpace: "pre" }}
-        >
-          <tspan x="400.301" y="721.464">
-            40
-          </tspan>
-        </text>
-        <path stroke="#E5E5E5" strokeWidth="0.75" d="M423.5 717.1h1120" />
-        <text
-          xmlSpace="preserve"
-          fill="#525252"
-          fontSize="12"
-          letterSpacing="0em"
-          style={{ whiteSpace: "pre" }}
-        >
-          <tspan x="400.734" y="778.664">
-            20
-          </tspan>
-        </text>
-        <path stroke="#E5E5E5" strokeWidth="0.75" d="M423.5 774.3h1120" />
-        <text
-          xmlSpace="preserve"
-          fill="#525252"
-          fontSize="12"
-          letterSpacing="0em"
-          style={{ whiteSpace: "pre" }}
-        >
-          <tspan x="408" y="835.864">
-            0
-          </tspan>
-        </text>
-        <path stroke="#E5E5E5" strokeWidth="0.75" d="M423.5 831.5h1120" />
-        <text
-          xmlSpace="preserve"
-          fill="#525252"
-          fontSize="12"
-          letterSpacing="0em"
-          style={{ whiteSpace: "pre" }}
-        >
-          <tspan x="431.5" y="856.864">
-            Oct 1
-          </tspan>
-        </text>
-        <text
-          xmlSpace="preserve"
-          fill="#525252"
-          fontSize="12"
-          letterSpacing="0em"
-          style={{ whiteSpace: "pre" }}
-        >
-          <tspan x="605.167" y="856.864">
-            Oct 5
-          </tspan>
-        </text>
-        <text
-          xmlSpace="preserve"
-          fill="#525252"
-          fontSize="12"
-          letterSpacing="0em"
-          style={{ whiteSpace: "pre" }}
-        >
-          <tspan x="779.833" y="856.864">
-            Oct 10
-          </tspan>
-        </text>
-        <text
-          xmlSpace="preserve"
-          fill="#525252"
-          fontSize="12"
-          letterSpacing="0em"
-          style={{ whiteSpace: "pre" }}
-        >
-          <tspan x="960.5" y="856.864">
-            Oct 15
-          </tspan>
-        </text>
-        <text
-          xmlSpace="preserve"
-          fill="#525252"
-          fontSize="12"
-          letterSpacing="0em"
-          style={{ whiteSpace: "pre" }}
-        >
-          <tspan x="1141.17" y="856.864">
-            Oct 20
-          </tspan>
-        </text>
-        <text
-          xmlSpace="preserve"
-          fill="#525252"
-          fontSize="12"
-          letterSpacing="0em"
-          style={{ whiteSpace: "pre" }}
-        >
-          <tspan x="1323.83" y="856.864">
-            Oct 25
-          </tspan>
-        </text>
-        <text
-          xmlSpace="preserve"
-          fill="#525252"
-          fontSize="12"
-          letterSpacing="0em"
-          style={{ whiteSpace: "pre" }}
-        >
-          <tspan x="1506.5" y="856.864">
-            Oct 31
-          </tspan>
-        </text>
-        <mask
-          id={`${id}-z`}
-          width="1112"
-          height="293"
-          x="433"
-          y="539"
-          maskUnits="userSpaceOnUse"
-          style={{ maskType: "alpha" }}
-        >
-          <path fill={`url(#${id}-y)`} d="M433 539h1112v293H433z" />
+
+  <g clipPath={`url(#${id}-a)`}>
+    <path fill="#e5e5e5" d="M0 16C0 7.163 7.163 0 16 0h1168c8.84 0 16 7.163 16 16v614.089H0z"/>
+    <path fill="#e5e5e5" d="M0 0h46v630.089H0z"/>
+    <path fill="#171717" fillRule="evenodd" d="M15.636 22.714h1.755v11.209h-1.755v-.74a4.05 4.05 0 0 1-2.339.74c-2.261 0-4.094-1.849-4.094-4.13s1.833-4.13 4.094-4.13c.87 0 1.676.274 2.34.74zm-2.339 9.44a2.35 2.35 0 0 0 2.34-2.36 2.35 2.35 0 0 0-2.34-2.36 2.35 2.35 0 0 0-2.34 2.36 2.35 2.35 0 0 0 2.34 2.36M27.918 22.714h1.754v3.69a4.05 4.05 0 0 1 2.34-.74c2.26 0 4.094 1.849 4.094 4.13s-1.833 4.13-4.094 4.13-4.094-1.85-4.094-4.13zm4.094 9.44a2.35 2.35 0 0 0 2.34-2.36 2.35 2.35 0 0 0-2.34-2.36 2.35 2.35 0 0 0-2.34 2.36 2.35 2.35 0 0 0 2.34 2.36" clipRule="evenodd"/>
+    <path fill="#171717" d="M20.315 25.664H18.56v4.13a4.16 4.16 0 0 0 1.2 2.92 4.064 4.064 0 0 0 5.79 0 4.13 4.13 0 0 0 1.198-2.92v-4.13h-1.754v4.13a2.37 2.37 0 0 1-.686 1.668 2.33 2.33 0 0 1-3.308 0 2.37 2.37 0 0 1-.685-1.668z"/>
+    <path fill="#fff" d="M7.08 56.637a5.664 5.664 0 0 1 5.664-5.663h19.823a5.664 5.664 0 0 1 5.663 5.663V76.46a5.664 5.664 0 0 1-5.663 5.664H12.744A5.664 5.664 0 0 1 7.08 76.46z"/>
+    <path fill="#404040" d="M20.084 60.96a.357.357 0 0 0-.357-.358h-2.661a.357.357 0 0 0-.357.357v2.662c0 .197.16.357.357.357h2.661c.197 0 .357-.16.357-.357zM21.5 63.62c0 .979-.794 1.773-1.773 1.773h-2.661a1.773 1.773 0 0 1-1.773-1.773v-2.662c0-.979.794-1.772 1.773-1.773h2.661c.98 0 1.773.794 1.773 1.773zM28.602 60.96a.357.357 0 0 0-.356-.358h-2.662a.357.357 0 0 0-.357.357v2.662c0 .197.16.357.357.357h2.662c.197 0 .356-.16.356-.357zm1.416 2.661c0 .979-.793 1.773-1.772 1.773h-2.662a1.773 1.773 0 0 1-1.773-1.773v-2.662c0-.979.794-1.772 1.773-1.773h2.662c.979 0 1.772.794 1.772 1.773zM20.084 69.477a.357.357 0 0 0-.357-.356h-2.661a.357.357 0 0 0-.357.356v2.662c0 .197.16.357.357.357h2.661c.197 0 .357-.16.357-.357zM21.5 72.14c0 .98-.794 1.773-1.773 1.773h-2.661a1.773 1.773 0 0 1-1.773-1.773v-2.662c0-.979.794-1.772 1.773-1.772h2.661c.98 0 1.773.793 1.773 1.772zM28.602 69.477a.357.357 0 0 0-.356-.356h-2.662a.357.357 0 0 0-.357.356v2.662c0 .197.16.357.357.357h2.662c.197 0 .356-.16.356-.357zm1.416 2.662c0 .98-.793 1.773-1.772 1.773h-2.662a1.773 1.773 0 0 1-1.773-1.773v-2.662c0-.979.794-1.772 1.773-1.772h2.662c.979 0 1.772.793 1.772 1.772zM23.918 110.506a1.264 1.264 0 1 0-2.527 0 1.264 1.264 0 0 0 2.527 0m1.416 0a2.679 2.679 0 1 1-5.358 0 2.679 2.679 0 0 1 5.358 0"/>
+    <path fill="#404040" d="M29.094 107.302c0-.698-.566-1.264-1.264-1.264H17.48c-.698 0-1.264.566-1.264 1.264v6.408c0 .698.566 1.264 1.264 1.264H27.83c.698 0 1.263-.566 1.263-1.264zm1.416 6.408c0 1.48-1.2 2.68-2.68 2.68H17.48a2.68 2.68 0 0 1-2.68-2.68v-6.408c0-1.48 1.2-2.68 2.68-2.68H27.83c1.48 0 2.68 1.2 2.68 2.68z"/>
+    <path fill="#404040" d="M17.972 111.245a.74.74 0 1 0 0-1.479.74.74 0 0 0 0 1.479M27.338 111.245a.74.74 0 1 0 0-1.479.74.74 0 0 0 0 1.479M27.83 101.664a.708.708 0 0 1 0 1.416H17.48a.708.708 0 0 1 0-1.416zM23.746 150.669a1.079 1.079 0 1 0-2.158 0 1.079 1.079 0 0 0 2.158 0m1.416 0a2.495 2.495 0 1 1-4.99 0 2.495 2.495 0 0 1 4.99 0M22.667 154.301a4.794 4.794 0 0 1 4.757 4.195.708.708 0 0 1-1.406.175 3.378 3.378 0 0 0-6.702 0 .708.708 0 1 1-1.405-.175 4.794 4.794 0 0 1 4.756-4.195"/>
+    <path fill="#404040" d="M15.576 156.542v-8.682a2.75 2.75 0 0 1 2.75-2.75h5.124a.708.708 0 0 1 0 1.416h-5.124c-.737 0-1.334.598-1.334 1.334v8.682c0 .736.597 1.334 1.334 1.334h8.682c.737 0 1.334-.598 1.334-1.334v-5.171a.708.708 0 0 1 1.416 0v5.171a2.75 2.75 0 0 1-2.75 2.75h-8.682a2.75 2.75 0 0 1-2.75-2.75M31.44 145.448l-1.548-.517-.516-1.547c-.167-.5-.996-.5-1.163 0l-.516 1.547-1.547.517a.612.612 0 0 0 0 1.162l1.547.517.516 1.547a.613.613 0 0 0 1.164 0l.516-1.547 1.547-.517a.61.61 0 0 0 0-1.162M13.688 193.154a7.29 7.29 0 0 1 7.29-7.292 7.27 7.27 0 0 1 5.905 3.026.708.708 0 1 1-1.148.829 5.86 5.86 0 0 0-4.757-2.439 5.876 5.876 0 0 0-5.875 5.876 5.8 5.8 0 0 0 .698 2.766l.091.164.013.022c.172.323.226.697.226 1.037a4.3 4.3 0 0 1-.149 1.086 5 5 0 0 1-.215.639q.128-.031.255-.067c.558-.163 1.029-.375 1.286-.542l.087-.048a.71.71 0 0 1 .652.029c.314.181.773.408 1.355.572a.708.708 0 1 1-.383 1.363 7.3 7.3 0 0 1-1.317-.514 7.6 7.6 0 0 1-1.284.499c-.643.187-1.385.32-2.06.284a.708.708 0 0 1-.463-1.208c.304-.304.574-.82.718-1.367.07-.266.103-.516.103-.721-.001-.216-.038-.333-.061-.377a7.24 7.24 0 0 1-.967-3.617"/>
+    <path fill="#404040" d="M30.206 197.007a3.697 3.697 0 0 0-3.677-3.697l-.02.002a3.697 3.697 0 1 0 .68 7.329l.189-.041c.425-.104.757-.266.975-.392l.089-.043a.7.7 0 0 1 .649.061c.11.072.301.163.538.249q0-.007-.003-.013a3 3 0 0 1-.108-.786c0-.249.04-.542.18-.805l.012-.02a3.7 3.7 0 0 0 .496-1.844m1.416 0c0 .923-.25 1.785-.675 2.531.01-.017-.012.018-.013.142 0 .113.019.259.062.422.089.339.253.644.42.81a.709.709 0 0 1-.464 1.207c-.488.027-1.013-.069-1.457-.199a5.5 5.5 0 0 1-.794-.298 5.1 5.1 0 0 1-2.192.499 5.112 5.112 0 0 1-.04-10.224l.04-.003a5.113 5.113 0 0 1 5.113 5.113"/>
+    <path fill="#f5f5f5" d="M43.31 14.16a8.496 8.496 0 0 1 8.496-8.496h149.257a8.495 8.495 0 0 1 8.495 8.496v601.77a8.495 8.495 0 0 1-8.495 8.495H51.806a8.495 8.495 0 0 1-8.495-8.495z"/>
+    {/* Small sidebar logo */}
+    <image
+      x="59.471"
+      y="21.239"
+      href={program.logo || `${OG_AVATAR_URL}${program.name}`}
+      width="14.159"
+      height="14.159"
+      clipPath="circle(50%)"
+    />
+    <text xmlSpace="preserve" fill="#171717" fontFamily="Inter" fontSize="12.743" fontWeight="600" letterSpacing="-.02em" style={{ "whiteSpace": "pre" }}>
+      <tspan x="80.709" y="32.865">{truncate(program.name, 18)}</tspan>
+    </text>
+    <path fill="#eff6ff" d="M59.47 51.327H195.4a5.31 5.31 0 0 1 5.31 5.31v11.328a5.31 5.31 0 0 1-5.31 5.31H59.471a5.31 5.31 0 0 1-5.31-5.31V56.638a5.31 5.31 0 0 1 5.31-5.31"/>
+    <path stroke="#dbeafe" strokeWidth=".708" d="M59.47 51.327H195.4a5.31 5.31 0 0 1 5.31 5.31v11.328a5.31 5.31 0 0 1-5.31 5.31H59.471a5.31 5.31 0 0 1-5.31-5.31V56.638a5.31 5.31 0 0 1 5.31-5.31Z"/>
+    <g fill="#155dfc" clipPath={`url(#${id}-c)`}>
+      <path d="M66.55 60.099a.472.472 0 1 0 0-.944.472.472 0 0 0 0 .944M68.442 60.882a.472.472 0 1 0 0-.944.472.472 0 0 0 0 .944M69.225 62.773a.472.472 0 1 0 0-.944.472.472 0 0 0 0 .944M64.66 60.882a.472.472 0 1 0 0-.944.472.472 0 0 0 0 .944M63.876 62.773a.472.472 0 1 0 0-.944.472.472 0 0 0 0 .944"/>
+      <path d="m66.962 65.903-.005-.055-.027-.18c-.024-.148-.06-.335-.104-.55a61 61 0 0 0-.276-1.274c-.101.45-.2.899-.275 1.273-.044.216-.08.403-.104.55l-.027.181-.006.055v.017a.413.413 0 0 0 .825 0zm3.62-3.602a4.031 4.031 0 0 0-8.063 0 4.02 4.02 0 0 0 1.624 3.23l.201.142.044.032a.531.531 0 0 1-.579.883l-.047-.027-.254-.178a5.08 5.08 0 0 1-2.051-4.082 5.094 5.094 0 0 1 10.187 0c0 1.785-.92 3.351-2.305 4.26a.531.531 0 0 1-.582-.888 4.03 4.03 0 0 0 1.825-3.372m-2.557 3.619a1.475 1.475 0 0 1-2.95 0c0-.115.023-.275.048-.426.028-.165.066-.366.11-.588.09-.443.21-.982.328-1.502a157 157 0 0 1 .433-1.846l.03-.124.01-.042v-.002l.029-.086a.532.532 0 0 1 1.003.085v.003l.011.042.03.124.108.449c.088.373.207.877.325 1.397s.238 1.059.327 1.502c.045.222.083.423.11.588.025.151.048.31.048.426"/>
+    </g>
+    <text xmlSpace="preserve" fill="#155dfc" fontFamily="Inter" fontSize="9.912" fontWeight="500" letterSpacing="-.02em" style={{ "whiteSpace": "pre" }}>
+      <tspan x="80.709" y="65.485">Overview</tspan>
+    </text>
+    <path fill="#404040" d="M63.99 83.876a.531.531 0 0 1 .71.787l-1 1.002a1.514 1.514 0 1 0 2.14 2.14l1.002-1a.53.53 0 1 1 .75.75l-1 1.001a2.577 2.577 0 0 1-3.644-3.643l1.002-1.001zm3.186-.297a.53.53 0 0 1 .75.75l-2.002 2.003a.531.531 0 0 1-.75-.751zm-.572-2.317a2.577 2.577 0 0 1 3.639 3.638l-.092.097-1 1a.53.53 0 1 1-.752-.75l1.001-1.001.104-.115a1.514 1.514 0 0 0-2.13-2.13l-.115.104-1.002 1a.531.531 0 0 1-.75-.75l1-1.002z"/>
+    <text xmlSpace="preserve" fill="#404040" fontFamily="Inter" fontSize="9.912" fontWeight="500" letterSpacing="-.02em" style={{ "whiteSpace": "pre" }}>
+      <tspan x="80.709" y="88.14">Links</tspan>
+    </text>
+    <g fill="#404040" clipPath={`url(#${id}-d)`}>
+      <path fillRule="evenodd" d="M68.754 106.291a3.05 3.05 0 0 1 3.048 3.048c0 .541-.145 1.047-.39 1.486l-.003.042c0 .052.009.125.03.209.048.179.133.33.208.405a.533.533 0 0 1-.348.906 2.7 2.7 0 0 1-.874-.119 3 3 0 0 1-.42-.154 3 3 0 0 1-1.251.274 3.048 3.048 0 0 1-.028-6.095zm0 1.064a1.986 1.986 0 1 0 .365 3.937c.277-.053.49-.156.625-.233a.53.53 0 0 1 .554.014q.026.017.067.038a2 2 0 0 1-.018-.247c0-.153.025-.344.118-.519l.008-.015c.17-.293.267-.63.267-.991 0-1.092-.884-1.98-1.975-1.986z" clipRule="evenodd"/>
+      <path d="M65.594 102.845c1.433 0 2.698.705 3.476 1.781a.532.532 0 0 1-.861.622 3.22 3.22 0 0 0-2.615-1.341 3.23 3.23 0 0 0-2.895 4.66l.098.182.009.017c.111.209.144.446.144.652a2.6 2.6 0 0 1-.132.795 2.8 2.8 0 0 0 .61-.264l.064-.036a.53.53 0 0 1 .49.022c.173.099.425.224.745.314a.531.531 0 0 1-.287 1.023 4.3 4.3 0 0 1-.72-.277 4.5 4.5 0 0 1-.697.268c-.375.109-.814.188-1.22.166a.53.53 0 0 1-.347-.905c.154-.154.3-.426.378-.724.038-.144.055-.275.054-.38a.4.4 0 0 0-.02-.156 4.26 4.26 0 0 1-.567-2.126 4.293 4.293 0 0 1 4.293-4.293"/>
+    </g>
+    <text xmlSpace="preserve" fill="#404040" fontFamily="Inter" fontSize="9.912" fontWeight="500" letterSpacing="-.02em" style={{ "whiteSpace": "pre" }}>
+      <tspan x="80.709" y="110.795">Messages</tspan>
+    </text>
+    <path fill="#404040" d="M191.623 109.675a.531.531 0 0 1-1.062 0v-2.848l-3.223 3.224a.532.532 0 0 1-.751-.751l3.223-3.223h-2.847a.53.53 0 1 1 0-1.062h4.129a.53.53 0 0 1 .531.531z"/>
+    <text xmlSpace="preserve" fill="#737373" fontFamily="Inter" fontSize="9.912" fontWeight="500" letterSpacing="-.02em" style={{ "whiteSpace": "pre" }}>
+      <tspan x="60.887" y="152.277">Insights</tspan>
+    </text>
+    <g fill="#404040" clipPath={`url(#${id}-e)`}>
+      <path d="M66.55 170.379c.294 0 .531.238.531.531v.201c.412.111.851.383 1.102.978l-.49.206-.488.207a.6.6 0 0 0-.27-.317.8.8 0 0 0-.36-.079c-.11 0-.325.035-.48.128a.37.37 0 0 0-.138.13.3.3 0 0 0-.036.144l.002.081a.35.35 0 0 0 .174.277c.128.086.318.149.54.189.262.047.659.131 1 .339.371.226.689.611.703 1.2v.095c-.026.774-.6 1.272-1.259 1.441v.129a.531.531 0 0 1-1.062 0v-.123a1.61 1.61 0 0 1-1.236-1.145l.51-.154.507-.155c.054.177.138.274.235.334.107.067.278.119.54.119.436 0 .652-.219.695-.428l.008-.087c-.004-.156-.064-.241-.194-.32-.16-.097-.385-.156-.633-.2-.285-.051-.642-.148-.947-.353a1.4 1.4 0 0 1-.638-1.056l-.007-.117a1.4 1.4 0 0 1 .172-.732c.135-.239.328-.406.519-.52.153-.091.315-.154.47-.197v-.215c0-.293.237-.531.53-.531"/>
+      <path d="M65.137 174.329a.53.53 0 0 1 .663.353l-1.016.309a.53.53 0 0 1 .353-.662M68.183 172.089a.532.532 0 0 1-.978.413z"/>
+      <path fillRule="evenodd" d="M66.55 168.491a5.094 5.094 0 1 1 0 10.188 5.094 5.094 0 0 1 0-10.188m0 1.062a4.032 4.032 0 1 0 0 8.063 4.032 4.032 0 0 0 0-8.063" clipRule="evenodd"/>
+    </g>
+    <text xmlSpace="preserve" fill="#404040" fontFamily="Inter" fontSize="9.912" fontWeight="500" letterSpacing="-.02em" style={{ "whiteSpace": "pre" }}>
+      <tspan x="80.709" y="176.768">Earnings</tspan>
+    </text>
+    <path fill="#404040" d="M62.088 200.172v-7.867a.531.531 0 0 1 1.062 0v7.867a.531.531 0 0 1-1.062 0m2.674 0v-4.72a.531.531 0 0 1 1.062 0v4.72a.531.531 0 0 1-1.062 0m2.517 0v-2.203a.531.531 0 0 1 1.062 0v2.203a.531.531 0 0 1-1.062 0m2.675 0v-6.608a.531.531 0 0 1 1.062 0v6.608a.531.531 0 0 1-1.062 0"/>
+    <text xmlSpace="preserve" fill="#404040" fontFamily="Inter" fontSize="9.912" fontWeight="500" letterSpacing="-.02em" style={{ "whiteSpace": "pre" }}>
+      <tspan x="80.709" y="199.423">Analytics</tspan>
+    </text>
+    <g clipPath={`url(#${id}-f)`}>
+      <path fill="#404040" d="M65.279 218.497a.689.689 0 0 1 .874-.875l.007.003 4.596 1.577c.61.21.622 1.07.018 1.296v-.001l-1.359.511 2.069 2.069.037.04a.532.532 0 0 1-.748.747l-.04-.036-2.068-2.069-.511 1.359-.001.002c-.227.598-1.084.594-1.294-.02zm2.246 3.274.41-1.09.02-.044a.53.53 0 0 1 .338-.339l.046-.019 1.088-.41-2.895-.994zm-3.876-2.295a.531.531 0 0 1 .71.787l-.89.89a.531.531 0 0 1-.75-.751l.89-.89zm-.403-1.9a.531.531 0 0 1 0 1.062h-1.258a.53.53 0 1 1 0-1.062zm-.528-2.514a.53.53 0 0 1 .71-.037l.04.037.891.89.037.04a.531.531 0 0 1-.747.748l-.04-.037-.89-.89-.038-.04a.53.53 0 0 1 .037-.711m5.34 0a.532.532 0 0 1 .751.751l-.89.89-.04.037a.53.53 0 0 1-.711-.788zm-2.825.528v-1.258a.531.531 0 0 1 1.062 0v1.258a.531.531 0 0 1-1.062 0"/>
+    </g>
+    <text xmlSpace="preserve" fill="#404040" fontFamily="Inter" fontSize="9.912" fontWeight="500" letterSpacing="-.02em" style={{ "whiteSpace": "pre" }}>
+      <tspan x="80.709" y="222.078">Events</tspan>
+    </text>
+    <g clipPath={`url(#${id}-g)`}>
+      <path stroke="#404040" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.062" d="M66.55 240.448a1.73 1.73 0 1 0 .002-3.46 1.73 1.73 0 0 0-.001 3.46M66.81 242.034c-.086-.005-.171-.013-.258-.013a3.93 3.93 0 0 0-3.593 2.341.952.952 0 0 0 .596 1.288c.654.205 1.495.386 2.469.438"/>
+      <path fill="#404040" d="M69.697 242.179a2.52 2.52 0 0 0-2.517 2.517 2.52 2.52 0 0 0 2.517 2.517 2.52 2.52 0 0 0 2.517-2.517 2.52 2.52 0 0 0-2.517-2.517m1.452 2.046-1.416 1.573a.47.47 0 0 1-.339.156l-.012.001a.47.47 0 0 1-.334-.139l-.786-.786a.472.472 0 0 1 .667-.668l.435.435 1.083-1.203a.473.473 0 1 1 .702.631"/>
+    </g>
+    <text xmlSpace="preserve" fill="#404040" fontFamily="Inter" fontSize="9.912" fontWeight="500" letterSpacing="-.02em" style={{ "whiteSpace": "pre" }}>
+      <tspan x="80.709" y="244.733">Customers</tspan>
+    </text>
+    <text xmlSpace="preserve" fill="#737373" fontFamily="Inter" fontSize="9.912" fontWeight="500" letterSpacing="-.02em" style={{ "whiteSpace": "pre" }}>
+      <tspan x="60.887" y="286.215">Engage</tspan>
+    </text>
+    <g clipPath={`url(#${id}-h)`}>
+      <path fill="#404040" fillRule="evenodd" d="M69.933 302.918a.54.54 0 0 0-.338-.172l-.056-.003H63.56a.533.533 0 0 0-.528.584 14 14 0 0 0 .041.36h-1.086a.53.53 0 0 0-.53.503l-.004.169a6 6 0 0 0 .239 1.668c.143.462.382.967.79 1.361.42.404.988.662 1.72.664.37.704.846 1.249 1.442 1.531-.035.123-.087.27-.171.425-.228.421-.703.956-1.742 1.251a.532.532 0 0 0 .144 1.042h5.35a.532.532 0 0 0 .144-1.042c-1.04-.295-1.515-.83-1.743-1.251a2 2 0 0 1-.171-.425c.596-.281 1.071-.827 1.442-1.531.732-.002 1.3-.26 1.72-.664.408-.394.647-.899.79-1.361.145-.465.203-.923.225-1.257a6 6 0 0 0 .014-.411l-.004-.169a.53.53 0 0 0-.427-.493l-.103-.01h-1.086l.013-.111q.015-.123.028-.249a.53.53 0 0 0-.134-.409m-3.384 7.289q-.059.148-.142.306c-.13.241-.306.489-.538.726h1.361a3.3 3.3 0 0 1-.538-.726 3 3 0 0 1-.143-.306m-2.394-6.402c.192 1.546.499 2.736.892 3.566.438.923.925 1.291 1.388 1.35h.229c.463-.059.95-.427 1.388-1.35.393-.83.7-2.02.892-3.566zm-1.624.944c.021.277.07.624.175.964.113.363.28.684.514.91.133.129.298.235.51.3-.21-.63-.38-1.358-.512-2.174zm7.35 0a14 14 0 0 1-.512 2.174c.212-.065.377-.171.51-.3.235-.226.402-.547.514-.91.105-.34.154-.687.175-.964z" clipRule="evenodd"/>
+    </g>
+    <text xmlSpace="preserve" fill="#404040" fontFamily="Inter" fontSize="9.912" fontWeight="500" letterSpacing="-.02em" style={{ "whiteSpace": "pre" }}>
+      <tspan x="80.709" y="310.706">Bounties</tspan>
+    </text>
+    <path fill="#404040" d="M64.035 333.166a.472.472 0 1 0 0-.944.472.472 0 0 0 0 .944"/>
+    <path fill="#404040" fillRule="evenodd" d="M64.822 325.713c.64 0 1.16.52 1.16 1.16v5.126l2.795-2.795.021-.033a.1.1 0 0 0-.021-.106l-1.113-1.113a.097.097 0 0 0-.139 0l-.04.036a.532.532 0 0 1-.711-.786l.088-.08a1.16 1.16 0 0 1 1.553.079l1.112 1.112.08.089a1.16 1.16 0 0 1 0 1.465l-.08.087-3.624 3.625h3.953a.1.1 0 0 0 .098-.098v-1.573a.1.1 0 0 0-.06-.091l-.038-.008-.054-.002a.532.532 0 0 1 .054-1.06l.118.007a1.16 1.16 0 0 1 1.042 1.154v1.573c0 .641-.52 1.16-1.16 1.16h-5.821l-.056-.003a1.946 1.946 0 0 1-1.891-1.944v-5.821c0-.64.52-1.16 1.16-1.16zm-1.574 1.062a.1.1 0 0 0-.098.098v5.821a.885.885 0 0 0 1.77 0v-5.821a.1.1 0 0 0-.098-.098z" clipRule="evenodd"/>
+    <text xmlSpace="preserve" fill="#404040" fontFamily="Inter" fontSize="9.912" fontWeight="500" letterSpacing="-.02em" style={{ "whiteSpace": "pre" }}>
+      <tspan x="80.709" y="333.362">Resources</tspan>
+    </text>
+    <g filter={`url(#${id}-i)`}>
+      <g clipPath={`url(#${id}-j)`}>
+        <path fill="#fff" d="M215.221 14.16a8.495 8.495 0 0 1 8.495-8.496h962.124c4.69 0 8.5 3.804 8.5 8.496v661.239c0 4.692-3.81 8.495-8.5 8.495H223.716a8.495 8.495 0 0 1-8.495-8.495z"/>
+        <mask id={`${id}-k`} fill="#fff">
+          <path d="M215.221 5.664h979.119v45.31H215.221z"/>
         </mask>
-        <g mask={`url(#${id}-z)`}>
-          <path
-            fill="currentColor"
-            d="m1146.78 587.227-47.65 14.613-47.65 102.293-47.65-73.066-47.656 58.453-47.652-29.227-47.652-94.986-47.653 51.146-47.652 87.68h-47.652l-47.652-73.066-47.652-58.454L574.957 558l-47.653 43.84-47.652 29.227L432 777.2V832h1096V704.133h-47.65l-47.65-73.066-47.66 14.613-47.65-43.84-47.65 58.453-47.65 116.907-47.66 14.613z"
-            opacity="0.15"
+        <path fill="#e5e5e5" d="M1194.34 50.974v-.708H215.221v1.416h979.119z" mask={`url(#${id}-k)`}/>
+        <text xmlSpace="preserve" fill="#171717" fontFamily="Inter" fontSize="12.743" fontWeight="600" letterSpacing="-.02em" style={{ "whiteSpace": "pre" }}>
+          <tspan x="272.92" y="32.865">Overview</tspan>
+        </text>
+        <g clipPath={`url(#${id}-l)`}>
+          <path fill="#fafafa" d="M272.92 76.46a8.496 8.496 0 0 1 8.495-8.495h846.725c4.69 0 8.5 3.803 8.5 8.495v174.16c0 4.692-3.81 8.495-8.5 8.495H281.416a8.495 8.495 0 0 1-8.496-8.495z"/>
+          <rect x="569.912" y="50.266" width="566.898" height="227.08" fill={`url(#${id}-grid)`} opacity=".1"/>
+          <g filter={`url(#${id}-m)`} opacity=".3">
+            <ellipse cx="207.788" cy="166.09" fill={`url(#${id}-n)`} rx="207.788" ry="166.09" transform="matrix(1 0 0 -1 847.787 344.424)"/>
+            <ellipse cx="207.788" cy="166.09" fill={`url(#${id}-o)`} rx="207.788" ry="166.09" transform="matrix(1 0 0 -1 847.787 344.424)"/>
+            <ellipse cx="207.788" cy="166.09" fill={`url(#${id}-p)`} rx="207.788" ry="166.09" transform="matrix(1 0 0 -1 847.787 344.424)"/>
+            <ellipse cx="207.788" cy="166.09" fill={`url(#${id}-q)`} rx="207.788" ry="166.09" transform="matrix(1 0 0 -1 847.787 344.424)"/>
+            <ellipse cx="207.788" cy="166.09" fill={`url(#${id}-r)`} rx="207.788" ry="166.09" transform="matrix(1 0 0 -1 847.787 344.424)"/>
+            <ellipse cx="207.788" cy="166.09" fill={`url(#${id}-s)`} rx="207.788" ry="166.09" transform="matrix(1 0 0 -1 847.787 344.424)"/>
+          </g>
+          <g filter={`url(#${id}-t)`} opacity=".8" style={{ "mixBlendMode": "soft-light" }}>
+            <g clipPath={`url(#${id}-u)`} data-figma-skip-parse="true">
+              <foreignObject width="3984" height="3984" x="-1992" y="-1992" transform="matrix(-.12606 -.05853 .05541 -.13315 1055.57 165.665)">
+                <div style={{ "background": "conic-gradient(from 90deg,#ae3ba7 0deg,red 63deg,#eab308 158.4deg,#5cff80 240deg,#855afc 327.958deg,#ae3ba7 360deg)", "height": "100%", "width": "100%", "opacity": "1" }}/>
+              </foreignObject>
+            </g>
+            <ellipse cx="1055.57" cy="165.665" data-figma-gradient-fill="{&quot;type&quot;:&quot;GRADIENT_ANGULAR&quot;,&quot;stops&quot;:[{&quot;color&quot;:{&quot;r&quot;:1.0,&quot;g&quot;:0.0,&quot;b&quot;:0.0,&quot;a&quot;:1.0},&quot;position&quot;:0.17499999701976776},{&quot;color&quot;:{&quot;r&quot;:0.91764706373214722,&quot;g&quot;:0.70196080207824707,&quot;b&quot;:0.031372550874948502,&quot;a&quot;:1.0},&quot;position&quot;:0.43999999761581421},{&quot;color&quot;:{&quot;r&quot;:0.36233723163604736,&quot;g&quot;:1.0,&quot;b&quot;:0.50262302160263062,&quot;a&quot;:1.0},&quot;position&quot;:0.66666668653488159},{&quot;color&quot;:{&quot;r&quot;:0.52156865596771240,&quot;g&quot;:0.35294118523597717,&quot;b&quot;:0.98823529481887817,&quot;a&quot;:1.0},&quot;position&quot;:0.91099578142166138}],&quot;stopsVar&quot;:[],&quot;transform&quot;:{&quot;m00&quot;:-252.11561584472656,&quot;m01&quot;:110.82010650634766,&quot;m02&quot;:1126.2224121093750,&quot;m10&quot;:-117.05022430419922,&quot;m11&quot;:-266.28912353515625,&quot;m12&quot;:357.33502197265625},&quot;opacity&quot;:1.0,&quot;blendMode&quot;:&quot;NORMAL&quot;,&quot;visible&quot;:true}" rx="207.788" ry="219.469"/>
+          </g>
+          <g filter={`url(#${id}-v)`} opacity=".8" style={{ "mixBlendMode": "soft-light" }}>
+            <g clipPath={`url(#${id}-w)`} data-figma-skip-parse="true">
+              <foreignObject width="3984" height="3984" x="-1992" y="-1992" transform="matrix(-.12606 -.05853 .05541 -.13315 1055.57 165.665)">
+                <div style={{ "background": "conic-gradient(from 90deg,#ae3ba7 0deg,red 63deg,#eab308 158.4deg,#5cff80 240deg,#855afc 327.958deg,#ae3ba7 360deg)", "height": "100%", "width": "100%", "opacity": "1" }}/>
+              </foreignObject>
+            </g>
+            <ellipse cx="1055.57" cy="165.665" data-figma-gradient-fill="{&quot;type&quot;:&quot;GRADIENT_ANGULAR&quot;,&quot;stops&quot;:[{&quot;color&quot;:{&quot;r&quot;:1.0,&quot;g&quot;:0.0,&quot;b&quot;:0.0,&quot;a&quot;:1.0},&quot;position&quot;:0.17499999701976776},{&quot;color&quot;:{&quot;r&quot;:0.91764706373214722,&quot;g&quot;:0.70196080207824707,&quot;b&quot;:0.031372550874948502,&quot;a&quot;:1.0},&quot;position&quot;:0.43999999761581421},{&quot;color&quot;:{&quot;r&quot;:0.36233723163604736,&quot;g&quot;:1.0,&quot;b&quot;:0.50262302160263062,&quot;a&quot;:1.0},&quot;position&quot;:0.66666668653488159},{&quot;color&quot;:{&quot;r&quot;:0.52156865596771240,&quot;g&quot;:0.35294118523597717,&quot;b&quot;:0.98823529481887817,&quot;a&quot;:1.0},&quot;position&quot;:0.91099578142166138}],&quot;stopsVar&quot;:[],&quot;transform&quot;:{&quot;m00&quot;:-252.11561584472656,&quot;m01&quot;:110.82010650634766,&quot;m02&quot;:1126.2224121093750,&quot;m10&quot;:-117.05022430419922,&quot;m11&quot;:-266.28912353515625,&quot;m12&quot;:357.33502197265625},&quot;opacity&quot;:1.0,&quot;blendMode&quot;:&quot;NORMAL&quot;,&quot;visible&quot;:true}" rx="207.788" ry="219.469"/>
+          </g>
+          <path fill={`url(#${id}-x)`} d="M272.92 67.965h863.717v191.15H272.92z"/>
+          <g filter={`url(#${id}-y)`}>
+            <path fill={`url(#${id}-z)`} d="M966.727 118.231c0-6.256 5.071-11.328 11.327-11.328h90.616c6.26 0 11.33 5.072 11.33 11.328v90.619c0 6.256-5.07 11.328-11.33 11.328h-90.616c-6.256 0-11.327-5.072-11.327-11.328z"/>
+          </g>
+          <path stroke="#000" strokeOpacity=".06" strokeWidth=".531" d="M966.727 118.231c0-6.256 5.071-11.328 11.327-11.328h90.616c6.26 0 11.33 5.072 11.33 11.328v90.619c0 6.256-5.07 11.328-11.33 11.328h-90.616c-6.256 0-11.327-5.072-11.327-11.328z"/>
+          {/* Big overview logo */}
+          <image
+            x="995.045"
+            y="135.222"
+            href={program.logo || `${OG_AVATAR_URL}${program.name}`}
+            width="56.637"
+            height="56.637"
+            clipPath="circle(50%)"
           />
+          <g filter={`url(#${id}-A)`}/>
         </g>
-        <path
-          stroke="currentColor"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth="1.5"
-          d="m433 776.437 47.494-145.274c.074-.226.226-.419.429-.543l47.212-28.882q.082-.05.154-.116l47.116-43.235a1 1 0 0 1 .968-.22l46.772 14.307c.189.058.357.17.482.323l47.416 58.015 47.313 72.36a1 1 0 0 0 .837.453h46.474a1 1 0 0 0 .878-.522l47.264-86.742q.06-.111.147-.204l46.543-49.827a1 1 0 0 1 1.624.233l46.836 93.12a1 1 0 0 0 .371.403l46.622 28.521a1 1 0 0 0 1.296-.22l46.192-56.517a.998.998 0 0 1 1.61.085l45.88 70.167a.997.997 0 0 0 1.74-.124l46.66-99.908c.12-.256.35-.45.62-.533l46.16-14.119a.995.995 0 0 1 1.26.729l47.13 201.791c.13.564.71.898 1.26.729l46.13-14.111c.29-.088.52-.3.64-.578l47.37-115.922q.06-.139.15-.254l46.85-57.315a1 1 0 0 1 1.45-.104l46.4 42.585c.26.24.63.323.97.22l46.34-14.176c.43-.13.89.037 1.13.409l46.91 71.731c.18.283.49.453.83.453H1528"
-        />
+        <path stroke="#e5e5e5" strokeWidth=".708" d="M281.415 68.318h846.725c4.5 0 8.14 3.646 8.14 8.142v174.16a8.14 8.14 0 0 1-8.14 8.142H281.415a8.144 8.144 0 0 1-8.142-8.142V76.46a8.143 8.143 0 0 1 8.142-8.142Z"/>
+        <rect width="569.911" height="186.195" x="273.274" y="276.461" fill="#fff" rx="5.31"/>
+        <rect width="569.911" height="186.195" x="273.274" y="276.461" stroke="#e5e5e5" strokeWidth=".708" rx="5.31"/>
+        <path fill="#262626" fillRule="evenodd" d="M323.401 293.92q.543 0 .893.185.353.181.563.438.209.254.318.479h.08V294h1.437v6.279q0 .792-.379 1.311a2.27 2.27 0 0 1-1.034.777 4.1 4.1 0 0 1-1.488.257q-.784 0-1.347-.213a2.4 2.4 0 0 1-.906-.563 1.95 1.95 0 0 1-.474-.784l1.311-.318q.089.18.258.358.169.18.454.298.29.12.729.12.618 0 1.025-.301.406-.298.406-.982v-1.171h-.072a2 2 0 0 1-.33.463 1.7 1.7 0 0 1-.567.398q-.35.16-.881.161-.712 0-1.291-.334-.576-.337-.918-1.005-.337-.673-.337-1.681 0-1.018.337-1.719.343-.703.922-1.066a2.37 2.37 0 0 1 1.291-.365m.402 1.194q-.486 0-.812.253a1.54 1.54 0 0 0-.491.697q-.165.438-.165.997 0 .567.165.994.17.422.495.659.33.234.808.234.462 0 .788-.225.326-.227.495-.648.17-.423.169-1.014 0-.583-.169-1.022a1.45 1.45 0 0 0-.491-.679q-.321-.246-.792-.246M297.012 293.92q.447 0 .89.104.442.105.808.346.366.238.587.648.226.41.226 1.026v4.135h-1.4v-.849h-.049a1.8 1.8 0 0 1-.374.483 1.8 1.8 0 0 1-.599.357 2.4 2.4 0 0 1-.841.133q-.587 0-1.058-.209a1.7 1.7 0 0 1-.74-.628q-.27-.414-.269-1.021 0-.523.193-.865t.527-.547a2.7 2.7 0 0 1 .752-.31 6 6 0 0 1 .873-.157q.543-.056.881-.1.338-.048.491-.145.156-.101.157-.31v-.024q0-.455-.27-.704-.269-.249-.776-.249-.536 0-.849.233a1.16 1.16 0 0 0-.419.551l-1.359-.193q.161-.563.531-.941.37-.382.905-.571a3.5 3.5 0 0 1 1.182-.193m1.058 3.314a.7.7 0 0 1-.233.104 3 3 0 0 1-.362.085 10 10 0 0 1-.398.065l-.342.047q-.326.045-.583.146a.96.96 0 0 0-.407.281.7.7 0 0 0-.148.458q0 .403.293.608.294.205.748.206.439 0 .761-.173a1.3 1.3 0 0 0 .494-.467 1.2 1.2 0 0 0 .177-.632z" clipRule="evenodd"/>
+        <path fill="#262626" d="M330.355 293.92q1.086 0 1.709.462.628.462.777 1.251l-1.328.145a1.1 1.1 0 0 0-.197-.378 1 1 0 0 0-.37-.286 1.36 1.36 0 0 0-.571-.108q-.455 0-.764.197-.306.197-.302.511a.53.53 0 0 0 .197.438q.205.17.676.277l1.053.226q.877.19 1.304.599.43.411.434 1.074a1.68 1.68 0 0 1-.342 1.03q-.333.443-.929.692a3.5 3.5 0 0 1-1.367.25q-1.135 0-1.826-.475a1.9 1.9 0 0 1-.825-1.332l1.42-.137a1 1 0 0 0 .41.632q.313.213.816.213.52 0 .833-.213.318-.213.318-.527a.55.55 0 0 0-.206-.439q-.201-.173-.627-.265l-1.054-.222q-.888-.184-1.315-.622-.426-.443-.422-1.119-.004-.572.309-.989.318-.423.881-.652.567-.234 1.308-.233M293.251 293.192h-3.866v2.236h3.588v1.251h-3.588v2.249h3.898v1.251h-5.39v-8.239h5.358zM303.761 293.911q.12 0 .27.013.152.008.253.027v1.34a1.5 1.5 0 0 0-.294-.056 3 3 0 0 0-.382-.028q-.398 0-.716.173-.314.169-.494.471a1.3 1.3 0 0 0-.182.695v3.633h-1.456V294h1.412v1.03h.064a1.54 1.54 0 0 1 .58-.825q.414-.294.945-.294M308.332 293.92q.639 0 1.113.273.48.274.741.793.266.519.261 1.259v3.934h-1.456v-3.709q0-.62-.322-.97-.318-.35-.881-.35-.382 0-.679.17-.294.165-.463.478-.165.314-.165.761v3.62h-1.456V294h1.391v1.05h.073q.213-.519.68-.825.47-.306 1.163-.305M313.157 300.179h-1.456V294h1.456zM317.734 293.92q.64 0 1.115.273.479.274.74.793.265.519.262 1.259v3.934h-1.456v-3.709q0-.62-.323-.97-.317-.35-.88-.35-.383 0-.68.17-.294.165-.463.478-.165.314-.165.761v3.62h-1.456V294h1.392v1.05h.072q.214-.519.68-.825.47-.306 1.162-.305M312.433 291.542a.83.83 0 0 1 .595.234q.25.23.25.559a.74.74 0 0 1-.25.559.84.84 0 0 1-.595.229.85.85 0 0 1-.595-.229.74.74 0 0 1-.249-.559q0-.33.249-.559a.84.84 0 0 1 .595-.234"/>
+        <path fill="#525252" d="M302.861 318.519a8 8 0 0 1-.231 1.132q-.158.593-.33 1.099-.168.507-.276.806h-.96q.059-.28.163-.76.104-.475.204-1.063t.149-1.2l.046-.507h1.303z"/>
+        <path fill="#525252" fillRule="evenodd" d="M291.572 309.909q.755.046 1.353.32.725.33 1.141.91.416.575.434 1.321h-1.348a1.32 1.32 0 0 0-.598-.995 2.1 2.1 0 0 0-.982-.34v2.899l.39.102q.443.108.91.294.465.185.864.488.398.304.642.752.249.448.249 1.072 0 .788-.407 1.399-.403.61-1.172.964-.628.289-1.476.339v1.018h-.741v-1.017a4.2 4.2 0 0 1-1.435-.318q-.76-.33-1.191-.936-.429-.612-.475-1.449h1.403q.04.502.326.837.29.331.738.493.298.103.634.138v-3.072l-.439-.12q-1.114-.303-1.766-.891-.647-.589-.647-1.557 0-.801.435-1.398a2.85 2.85 0 0 1 1.176-.928 3.8 3.8 0 0 1 1.241-.316v-1.051h.741zm0 8.29a2.5 2.5 0 0 0 .67-.164q.466-.19.733-.524.267-.34.267-.793 0-.411-.235-.674a1.75 1.75 0 0 0-.629-.434 6 6 0 0 0-.806-.279zm-.741-7.067q-.322.043-.585.156a1.53 1.53 0 0 0-.647.489q-.226.308-.226.701 0 .33.154.571.159.239.412.403a3 3 0 0 0 .552.267q.174.06.34.108zM334.065 309.899q1.063 0 1.823.566.76.562 1.164 1.63.407 1.063.407 2.569 0 1.517-.403 2.589-.403 1.067-1.163 1.634-.76.561-1.828.561-1.072-.005-1.833-.566t-1.163-1.633-.403-2.585q0-1.506.403-2.574.407-1.068 1.167-1.629.765-.562 1.829-.562m0 1.186q-.937 0-1.471.923t-.539 2.656q0 1.16.24 1.96.244.797.693 1.208a1.54 1.54 0 0 0 1.077.407q.94 0 1.47-.918.534-.918.534-2.657 0-1.154-.244-1.95-.24-.8-.693-1.213a1.51 1.51 0 0 0-1.067-.416M342.036 309.899q1.064 0 1.823.566.761.562 1.164 1.63.407 1.063.407 2.569 0 1.517-.403 2.589-.402 1.067-1.163 1.634-.76.561-1.828.561-1.073-.005-1.832-.566t-1.163-1.633-.403-2.585q0-1.506.403-2.574.406-1.068 1.167-1.629.765-.562 1.828-.562m0 1.186q-.937 0-1.471.923t-.538 2.656q0 1.16.239 1.96.245.797.693 1.208.448.407 1.077.407.942 0 1.471-.918.534-.918.534-2.657 0-1.154-.244-1.95-.24-.8-.693-1.213a1.52 1.52 0 0 0-1.068-.416" clipRule="evenodd"/>
+        <path fill="#525252" d="M315.39 309.899q.891 0 1.538.349.652.344 1.005.919.357.575.353 1.257.004.779-.435 1.322a2.1 2.1 0 0 1-1.158.728v.073q.923.14 1.43.733.512.594.507 1.471.004.765-.425 1.371a2.9 2.9 0 0 1-1.163.955q-.738.344-1.688.344-.933 0-1.665-.322-.73-.321-1.154-.891a2.37 2.37 0 0 1-.453-1.331h1.421q.027.412.276.715.253.3.661.462.407.163.905.163.548 0 .968-.19.425-.19.665-.529.24-.345.24-.793 0-.465-.24-.818a1.56 1.56 0 0 0-.692-.562q-.452-.203-1.095-.204h-.783v-1.14h.783q.516 0 .905-.185.394-.186.615-.516.222-.336.222-.783 0-.43-.195-.747a1.3 1.3 0 0 0-.542-.502 1.8 1.8 0 0 0-.824-.181 2.15 2.15 0 0 0-.846.167 1.6 1.6 0 0 0-.634.471q-.244.303-.262.728h-1.354q.023-.75.444-1.321.426-.57 1.122-.891a3.7 3.7 0 0 1 1.548-.322M328.73 317.574q.37 0 .638.267a.86.86 0 0 1 .267.634.9.9 0 0 1-.127.457.93.93 0 0 1-.326.326.87.87 0 0 1-.452.122.88.88 0 0 1-.639-.263.88.88 0 0 1-.267-.642q0-.371.267-.634a.87.87 0 0 1 .639-.267M299.433 319.294h-1.402v-7.865h-.055l-2.217 1.448v-1.34l2.312-1.511h1.362zM307.558 309.899q.873 0 1.538.349.67.344 1.045.941.376.593.376 1.34 0 .516-.195 1.009-.19.493-.665 1.099-.474.603-1.322 1.462l-1.841 1.928v.068h4.172v1.199h-6.1v-1.014l3.136-3.249q.502-.529.828-.927.331-.404.493-.765.163-.362.163-.77a1.43 1.43 0 0 0-.217-.796 1.4 1.4 0 0 0-.593-.521 1.9 1.9 0 0 0-.846-.185q-.498 0-.868.203a1.4 1.4 0 0 0-.571.576 1.8 1.8 0 0 0-.199.868h-1.335q0-.846.389-1.48.39-.633 1.068-.981.679-.354 1.544-.354"/>
+        <path fill="#525252" fillRule="evenodd" d="M325.62 316.298h1.226v1.186h-1.226v1.81h-1.335v-1.81h-4.395v-1.131l4.005-6.327h1.725zm-4.263-.073v.073h2.937v-4.607h-.073z" clipRule="evenodd"/>
+        <path fill="#737373" fillRule="evenodd" d="M354.293 311.995q.585.035 1.052.249.563.256.887.708.324.447.338 1.027h-1.049a1.03 1.03 0 0 0-.464-.774 1.64 1.64 0 0 0-.764-.264v2.254l.303.08q.345.084.707.229.363.144.673.379t.499.584q.194.35.194.835 0 .613-.317 1.087-.313.476-.912.75-.489.225-1.147.265v.791h-.577v-.791a3.3 3.3 0 0 1-1.116-.247 2.15 2.15 0 0 1-.925-.729 2.1 2.1 0 0 1-.37-1.126h1.091q.032.39.253.651.226.256.574.384.232.08.493.106v-2.39l-.342-.092q-.866-.237-1.372-.694-.504-.457-.504-1.21 0-.624.338-1.088t.915-.722q.44-.198.965-.245v-.817h.577zm0 6.446q.282-.03.521-.126.362-.147.57-.408a.97.97 0 0 0 .208-.616.76.76 0 0 0-.183-.524 1.35 1.35 0 0 0-.49-.338 4.5 4.5 0 0 0-.626-.217zm-.577-5.493a1.7 1.7 0 0 0-.454.12 1.2 1.2 0 0 0-.503.379.9.9 0 0 0-.177.547.8.8 0 0 0 .12.443q.123.187.32.313.201.123.429.207.135.047.265.085zM374.598 311.987q.827 0 1.418.439.592.437.905 1.268.316.827.316 1.999 0 1.179-.313 2.013-.313.831-.904 1.271-.592.436-1.422.436-.834-.003-1.426-.44-.59-.436-.904-1.27-.313-.834-.313-2.01 0-1.172.313-2.003.317-.83.908-1.267.595-.436 1.422-.436m0 .922q-.729 0-1.144.717-.415.718-.419 2.067 0 .901.187 1.524.19.62.538.939.35.317.838.318.732 0 1.144-.715.415-.714.415-2.066 0-.897-.19-1.517-.186-.623-.538-.944a1.18 1.18 0 0 0-.831-.323" clipRule="evenodd"/>
+        <path fill="#737373" d="M368.436 311.987q.693 0 1.197.271.507.267.782.714.278.447.274.979.004.605-.338 1.027a1.63 1.63 0 0 1-.901.567v.056q.718.11 1.112.57.398.462.395 1.145.003.594-.331 1.066a2.25 2.25 0 0 1-.905.742 3.1 3.1 0 0 1-1.312.268q-.726 0-1.296-.25a2.2 2.2 0 0 1-.897-.693 1.83 1.83 0 0 1-.352-1.035h1.105a.95.95 0 0 0 .214.556q.198.233.514.359.317.127.705.127.425 0 .753-.148.33-.148.517-.412a1.05 1.05 0 0 0 .186-.616 1.1 1.1 0 0 0-.186-.637 1.2 1.2 0 0 0-.539-.436 2.1 2.1 0 0 0-.852-.159h-.608v-.887h.608q.402 0 .705-.144.306-.144.478-.401.172-.261.172-.609 0-.335-.15-.581a1 1 0 0 0-.423-.391 1.4 1.4 0 0 0-.641-.141q-.351 0-.658.131a1.2 1.2 0 0 0-.493.366.95.95 0 0 0-.204.567h-1.052a1.8 1.8 0 0 1 .345-1.028q.33-.444.873-.694a2.85 2.85 0 0 1 1.203-.249M395.737 311.987q.573 0 1.07.165.5.162.898.479.397.313.658.767.26.45.352 1.031h-1.099a1.67 1.67 0 0 0-.658-1.074 1.8 1.8 0 0 0-.559-.281 2.2 2.2 0 0 0-.652-.095q-.623 0-1.115.314-.49.312-.775.918-.28.605-.281 1.479 0 .879.281 1.485.286.605.778.915t1.109.31q.342 0 .648-.092.31-.096.559-.278a1.675 1.675 0 0 0 .665-1.059l1.099.003q-.089.531-.342.978a2.7 2.7 0 0 1-.644.768 2.9 2.9 0 0 1-.894.496 3.3 3.3 0 0 1-1.098.176q-.936 0-1.668-.443a3.1 3.1 0 0 1-1.155-1.278q-.419-.83-.419-1.981 0-1.155.423-1.983.422-.83 1.154-1.273a3.13 3.13 0 0 1 1.665-.447M364.258 317.956a.68.68 0 0 1 .497.207.67.67 0 0 1 .207.493.7.7 0 0 1-.098.356.7.7 0 0 1-.254.253.66.66 0 0 1-.352.095.68.68 0 0 1-.496-.204.68.68 0 0 1-.208-.5q0-.288.208-.493a.68.68 0 0 1 .496-.207M359.997 311.987q.68 0 1.197.271.52.267.813.732.293.46.293 1.042 0 .401-.152.784-.147.384-.518.856-.369.468-1.027 1.137l-1.433 1.499v.053h3.246v.933h-4.745v-.789l2.439-2.527q.39-.412.644-.722.258-.313.384-.595.127-.281.127-.598 0-.358-.169-.619a1.1 1.1 0 0 0-.461-.405 1.5 1.5 0 0 0-.658-.145q-.388 0-.677.159a1.1 1.1 0 0 0-.443.447 1.4 1.4 0 0 0-.155.676h-1.038q0-.658.303-1.151.303-.492.83-.764a2.56 2.56 0 0 1 1.2-.274M385.332 313.022H381.9v2.196h3.196v.933H381.9v2.207h3.474v.936h-4.562v-7.209h4.52z"/>
+        <path fill="#737373" fillRule="evenodd" d="M389.155 312.085q.84 0 1.393.307.554.306.828.838.274.527.274 1.189 0 .664-.278 1.197-.274.528-.831.838-.553.306-1.39.306h-1.478v2.534h-1.088v-7.209zm-1.482 3.753h1.38q.532-.001.862-.184.332-.186.486-.506a1.66 1.66 0 0 0 .155-.729q0-.408-.155-.725a1.1 1.1 0 0 0-.489-.496q-.331-.18-.874-.18h-1.365z" clipRule="evenodd"/>
+        <path fill={`url(#${id}-C)`} d="m825.818 391.593-18.497-1.449a4.25 4.25 0 0 1-2.93-1.514l-19.982-23.954a4.25 4.25 0 0 0-4.155-1.432l-20.502 4.406a4.25 4.25 0 0 1-3.446-.759l-18.34-13.794a4.25 4.25 0 0 0-5.491.326l-20.409 19.538a4.3 4.3 0 0 0-.783 1.018l-22.972 41.672a4.25 4.25 0 0 1-2.748 2.085l-17.109 4.021a4.25 4.25 0 0 1-5.02-2.846l-21.871-68.705a4.25 4.25 0 0 0-4.809-2.89l-18.033 3.288a4.25 4.25 0 0 0-2.776 1.827l-20.803 31.295c-1.559 2.345-4.926 2.552-6.76.416l-15.599-18.167a4.25 4.25 0 0 0-6.038-.413l-18.844 16.674a4.25 4.25 0 0 1-4.673.639l-20.623-10.037a4.26 4.26 0 0 1-1.662-1.442l-19.486-28.856a4.247 4.247 0 0 0-6.264-.865L476.42 357.56a4.3 4.3 0 0 0-.685.735l-21.914 29.969a4.25 4.25 0 0 1-3.429 1.74H430.17a4.25 4.25 0 0 1-3.073-1.316l-44.867-47.041a4.25 4.25 0 0 0-2.041-1.189l-20.326-5.096a4.25 4.25 0 0 0-3.587.726l-20.699 15.569a4.3 4.3 0 0 1-.982.552l-22.211 8.844a4.25 4.25 0 0 0-2.188 1.97l-23.691 45.078a4.25 4.25 0 0 0-.487 1.976v26.385a4.247 4.247 0 0 0 4.247 4.248h535.222a4.247 4.247 0 0 0 4.247-4.248v-40.634a4.247 4.247 0 0 0-3.916-4.235" opacity=".2"/>
+        <path fill={`url(#${id}-D)`} d="m825.818 391.593-18.497-1.449a4.25 4.25 0 0 1-2.93-1.514l-19.982-23.954a4.25 4.25 0 0 0-4.155-1.432l-20.502 4.406a4.25 4.25 0 0 1-3.446-.759l-18.34-13.794a4.25 4.25 0 0 0-5.491.326l-20.409 19.538a4.3 4.3 0 0 0-.783 1.018l-22.972 41.672a4.25 4.25 0 0 1-2.748 2.085l-17.109 4.021a4.25 4.25 0 0 1-5.02-2.846l-21.871-68.705a4.25 4.25 0 0 0-4.809-2.89l-18.033 3.288a4.25 4.25 0 0 0-2.776 1.827l-20.803 31.295c-1.559 2.345-4.926 2.552-6.76.416l-15.599-18.167a4.25 4.25 0 0 0-6.038-.413l-18.844 16.674a4.25 4.25 0 0 1-4.673.639l-20.623-10.037a4.26 4.26 0 0 1-1.662-1.442l-19.486-28.856a4.247 4.247 0 0 0-6.264-.865L476.42 357.56a4.3 4.3 0 0 0-.685.735l-21.914 29.969a4.25 4.25 0 0 1-3.429 1.74H430.17a4.25 4.25 0 0 1-3.073-1.316l-44.867-47.041a4.25 4.25 0 0 0-2.041-1.189l-20.326-5.096a4.25 4.25 0 0 0-3.587.726l-20.699 15.569a4.3 4.3 0 0 1-.982.552l-22.211 8.844a4.25 4.25 0 0 0-2.188 1.97l-23.691 45.078a4.25 4.25 0 0 0-.487 1.976v26.385a4.247 4.247 0 0 0 4.247 4.248h535.222a4.247 4.247 0 0 0 4.247-4.248v-40.634a4.247 4.247 0 0 0-3.916-4.235"/>
+        <path stroke={`url(#${id}-E)`} strokeLinejoin="round" strokeWidth="1.062" d="m286.018 409.029 24.178-46.006a4.25 4.25 0 0 1 2.188-1.97l22.211-8.844c.35-.14.681-.325.982-.552l20.699-15.569a4.25 4.25 0 0 1 3.587-.726l20.326 5.096a4.25 4.25 0 0 1 2.041 1.189l44.867 47.041a4.25 4.25 0 0 0 3.073 1.316h20.222a4.25 4.25 0 0 0 3.429-1.74l21.914-29.969a4.3 4.3 0 0 1 .685-.735l18.773-15.885a4.247 4.247 0 0 1 6.264.865l19.486 28.856a4.26 4.26 0 0 0 1.662 1.442l20.623 10.037a4.25 4.25 0 0 0 4.673-.639l18.844-16.674a4.25 4.25 0 0 1 6.038.413l15.599 18.167c1.834 2.136 5.201 1.929 6.76-.416l20.803-31.295a4.25 4.25 0 0 1 2.776-1.827l18.033-3.288a4.25 4.25 0 0 1 4.809 2.89l21.871 68.705a4.25 4.25 0 0 0 5.02 2.846l17.109-4.021a4.25 4.25 0 0 0 2.748-2.085l22.972-41.672a4.3 4.3 0 0 1 .783-1.018l20.409-19.538a4.25 4.25 0 0 1 5.491-.326l18.34 13.794a4.25 4.25 0 0 0 3.446.759l20.502-4.406a4.25 4.25 0 0 1 4.155 1.432l19.982 23.954a4.25 4.25 0 0 0 2.93 1.514l22.413 1.756"/>
+        <text xmlSpace="preserve" fill="#525252" fontFamily="Inter" fontSize="8.496" letterSpacing="0em" style={{ "whiteSpace": "pre" }}>
+          <tspan x="287.08" y="447.237">Dec 16</tspan>
+        </text>
+        <text xmlSpace="preserve" fill="#525252" fontFamily="Inter" fontSize="8.496" letterSpacing="0em" style={{ "whiteSpace": "pre" }}>
+          <tspan x="803.186" y="447.237">Jan 16</tspan>
+        </text>
+        <path fill="#fff" d="M728.088 290.621h97.398a3.894 3.894 0 0 1 3.894 3.895v11.327a3.893 3.893 0 0 1-3.894 3.893h-97.398a3.894 3.894 0 0 1-3.895-3.893v-11.327a3.895 3.895 0 0 1 3.895-3.895"/>
+        <path stroke="#e5e5e5" strokeWidth=".708" d="M728.088 290.621h97.398a3.894 3.894 0 0 1 3.894 3.895v11.327a3.893 3.893 0 0 1-3.894 3.893h-97.398a3.894 3.894 0 0 1-3.895-3.893v-11.327a3.895 3.895 0 0 1 3.895-3.895Z"/>
+        <path fill="#171717" fillRule="evenodd" d="M738.629 294.457a.53.53 0 0 1 .53.531v.727h.414a1.79 1.79 0 0 1 1.789 1.79v5.349a1.79 1.79 0 0 1-1.789 1.79h-5.979a1.79 1.79 0 0 1-1.789-1.79v-5.349c0-.989.801-1.79 1.789-1.79h.413v-.727a.531.531 0 0 1 1.062 0v.727h3.029v-.727a.53.53 0 0 1 .531-.531m-5.762 4.523v3.874c0 .401.325.728.727.728h5.979a.73.73 0 0 0 .727-.728v-3.874zm.727-2.203a.727.727 0 0 0-.727.728v.413h7.433v-.413a.727.727 0 0 0-.727-.728z" clipRule="evenodd"/>
+        <text xmlSpace="preserve" fill="#171717" fontFamily="Inter" fontSize="8.496" fontWeight="500" letterSpacing="0em" style={{ "whiteSpace": "pre" }}>
+          <tspan x="747.91" y="303.268">Last 12 months</tspan>
+        </text>
+        <g clipPath={`url(#${id}-F)`}>
+          <path fill="#737373" d="M821.195 298.821a.53.53 0 1 1 .751.75l-2.458 2.459a.533.533 0 0 1-.752 0l-2.457-2.459a.53.53 0 0 1 0-.75.53.53 0 0 1 .75 0l2.083 2.081z"/>
+        </g>
+        <path fill="#171717" d="M350.325 293.04q.048 0 .093.008l.012.002q.015.004.028.009.035.008.07.021.03.014.059.031.06.034.114.085a.5.5 0 0 1 .083.113q.018.028.031.059a.5.5 0 0 1 .032.109.5.5 0 0 1 .009.094v4.72a.531.531 0 0 1-1.062 0v-3.438l-3.813 3.813a.53.53 0 1 1-.751-.75l3.813-3.814h-3.438a.531.531 0 0 1 0-1.062z"/>
+        <rect width="275.398" height="186.195" x="860.885" y="276.461" fill="#fff" rx="5.31"/>
+        <rect width="275.398" height="186.195" x="860.885" y="276.461" stroke="#e5e5e5" strokeWidth=".708" rx="5.31"/>
+        <text xmlSpace="preserve" fill="#262626" fontFamily="Inter" fontSize="11.327" fontWeight="600" letterSpacing="0em" style={{ "whiteSpace": "pre" }}>
+          <tspan x="874.691" y="300.386">Payouts</tspan>
+        </text>
+        <text xmlSpace="preserve" fill="#737373" fontFamily="Inter" fontSize="9.912" fontWeight="500" letterSpacing="0em" style={{ "whiteSpace": "pre" }}>
+          <tspan x="1053.48" y="299.871">4</tspan>
+          <tspan x="1074.84" y="299.871">24 r</tspan>
+          <tspan x="1099.3" y="299.871">s</tspan>
+          <tspan x="1110.51" y="299.871">l</tspan>
+          <tspan x="1116.58" y="299.871">s</tspan>
+        </text>
+        <text xmlSpace="preserve" fill="#737373" fontFamily="Inter" fontSize="9.912" fontWeight="500" letterSpacing="0em" style={{ "whiteSpace": "pre" }}>
+          <tspan x="1059.96" y="299.871"> of </tspan>
+          <tspan x="1093.48" y="299.871">e</tspan>
+          <tspan x="1104.61" y="299.871">u</tspan>
+          <tspan x="1112.98" y="299.871">t</tspan>
+        </text>
+        <text xmlSpace="preserve" fill="#262626" fontFamily="Inter" fontSize="8.496" fontWeight="500" letterSpacing="0em" style={{ "whiteSpace": "pre" }}>
+          <tspan x="874.691" y="328.511">$78.34</tspan>
+        </text>
+        <text xmlSpace="preserve" fill="#737373" fontFamily="Inter" fontSize="7.788" letterSpacing="0em" style={{ "whiteSpace": "pre" }}>
+          <tspan x="874.691" y="340.086">Jan 12, 2026</tspan>
+        </text>
+        <path fill="#dbeafe" d="M1053.41 327.09c0-2.346 1.9-4.248 4.25-4.248h60.57c2.35 0 4.25 1.902 4.25 4.248v8.495c0 2.346-1.9 4.248-4.25 4.248h-60.57a4.247 4.247 0 0 1-4.25-4.248z"/>
+        <path fill="#155dfc" d="M1063.32 328.86c.29 0 .53.237.53.531v1.705l1.24 1.081.03.038c.19.197.2.505.02.711a.536.536 0 0 1-.71.084l-.04-.034-1.42-1.239a.55.55 0 0 1-.18-.399v-1.947c0-.294.24-.531.53-.531"/>
+        <path fill="#155dfc" fillRule="evenodd" d="M1063.32 327.09a4.247 4.247 0 1 1 0 8.495 4.247 4.247 0 1 1 0-8.495m0 1.062a3.19 3.19 0 0 0-3.19 3.186 3.19 3.19 0 0 0 3.19 3.185c1.76 0 3.19-1.426 3.19-3.185s-1.43-3.186-3.19-3.186" clipRule="evenodd"/>
+        <text xmlSpace="preserve" fill="#155dfc" fontFamily="Inter" fontSize="8.496" fontWeight="600" letterSpacing="-.02em" style={{ "whiteSpace": "pre" }}>
+          <tspan x="1071.81" y="334.09">Processing</tspan>
+        </text>
+        <path fill="#e5e5e5" d="M874.691 348.833h247.788v.708H874.691z"/>
+        <text xmlSpace="preserve" fill="#262626" fontFamily="Inter" fontSize="8.496" fontWeight="500" letterSpacing="0em" style={{ "whiteSpace": "pre" }}>
+          <tspan x="874.691" y="364.21">$56.89</tspan>
+        </text>
+        <text xmlSpace="preserve" fill="#737373" fontFamily="Inter" fontSize="7.788" letterSpacing="0em" style={{ "whiteSpace": "pre" }}>
+          <tspan x="874.691" y="375.784">Jan 5, 2026</tspan>
+        </text>
+        <path fill="#dbeafe" d="M1053.41 362.789c0-2.346 1.9-4.248 4.25-4.248h60.57c2.35 0 4.25 1.902 4.25 4.248v8.495c0 2.346-1.9 4.248-4.25 4.248h-60.57a4.247 4.247 0 0 1-4.25-4.248z"/>
+        <path fill="#155dfc" d="M1063.32 364.559c.29 0 .53.238.53.531v1.706l1.24 1.08.03.038c.19.197.2.505.02.712a.537.537 0 0 1-.71.083l-.04-.034-1.42-1.239a.55.55 0 0 1-.18-.399v-1.947c0-.293.24-.531.53-.531"/>
+        <path fill="#155dfc" fillRule="evenodd" d="M1063.32 362.789a4.247 4.247 0 1 1 0 8.496 4.247 4.247 0 1 1 0-8.496m0 1.062a3.19 3.19 0 0 0-3.19 3.186 3.19 3.19 0 0 0 6.38 0c0-1.76-1.43-3.186-3.19-3.186" clipRule="evenodd"/>
+        <text xmlSpace="preserve" fill="#155dfc" fontFamily="Inter" fontSize="8.496" fontWeight="600" letterSpacing="-.02em" style={{ "whiteSpace": "pre" }}>
+          <tspan x="1071.81" y="369.789">Processing</tspan>
+        </text>
+        <path fill="#e5e5e5" d="M874.691 384.532h247.788v.708H874.691z"/>
+        <text xmlSpace="preserve" fill="#262626" fontFamily="Inter" fontSize="8.496" fontWeight="500" letterSpacing="0em" style={{ "whiteSpace": "pre" }}>
+          <tspan x="874.691" y="399.909">$102.45</tspan>
+        </text>
+        <text xmlSpace="preserve" fill="#737373" fontFamily="Inter" fontSize="7.788" letterSpacing="0em" style={{ "whiteSpace": "pre" }}>
+          <tspan x="874.691" y="411.483">Dec 23, 2025</tspan>
+        </text>
+        <path fill="#dcfce7" d="M1054.41 398.488c0-2.346 1.9-4.248 4.25-4.248h59.57c2.35 0 4.25 1.902 4.25 4.248v8.496c0 2.346-1.9 4.247-4.25 4.247h-59.57a4.246 4.246 0 0 1-4.25-4.247z"/>
+        <path fill="#008236" fillRule="evenodd" d="M1064.32 399.55a3.19 3.19 0 0 0-3.19 3.186c0 1.76 1.43 3.186 3.19 3.186s3.19-1.426 3.19-3.186a3.19 3.19 0 0 0-3.19-3.186m-4.25 3.186c0-2.346 1.9-4.248 4.25-4.248a4.247 4.247 0 1 1 0 8.496 4.247 4.247 0 0 1-4.25-4.248m6.16-1.84c.24.176.29.508.11.743l-2.13 2.832a.52.52 0 0 1-.38.211.54.54 0 0 1-.42-.154l-1.06-1.062a.526.526 0 0 1 0-.751.53.53 0 0 1 .75-.001l.63.63 1.76-2.343a.527.527 0 0 1 .74-.105" clipRule="evenodd"/>
+        <text xmlSpace="preserve" fill="#008236" fontFamily="Inter" fontSize="8.496" fontWeight="600" letterSpacing="-.02em" style={{ "whiteSpace": "pre" }}>
+          <tspan x="1072.81" y="405.488">Completed</tspan>
+        </text>
+        <path fill="#e5e5e5" d="M874.691 420.231h247.788v.708H874.691z"/>
+        <text xmlSpace="preserve" fill="#262626" fontFamily="Inter" fontSize="8.496" fontWeight="500" letterSpacing="0em" style={{ "whiteSpace": "pre" }}>
+          <tspan x="874.691" y="435.608">$49.99</tspan>
+        </text>
+        <text xmlSpace="preserve" fill="#737373" fontFamily="Inter" fontSize="7.788" letterSpacing="0em" style={{ "whiteSpace": "pre" }}>
+          <tspan x="874.691" y="447.182">Dec 12, 2025</tspan>
+        </text>
+        <path fill="#dcfce7" d="M1054.41 434.187c0-2.346 1.9-4.248 4.25-4.248h59.57c2.35 0 4.25 1.902 4.25 4.248v8.496c0 2.346-1.9 4.248-4.25 4.248h-59.57a4.247 4.247 0 0 1-4.25-4.248z"/>
+        <path fill="#008236" fillRule="evenodd" d="M1064.32 435.249a3.19 3.19 0 0 0-3.19 3.186c0 1.76 1.43 3.186 3.19 3.186s3.19-1.426 3.19-3.186a3.19 3.19 0 0 0-3.19-3.186m-4.25 3.186c0-2.346 1.9-4.247 4.25-4.247s4.25 1.901 4.25 4.247-1.9 4.248-4.25 4.248a4.247 4.247 0 0 1-4.25-4.248m6.16-1.84c.24.176.29.509.11.743l-2.13 2.832a.52.52 0 0 1-.38.211.54.54 0 0 1-.42-.154l-1.06-1.062a.53.53 0 0 1 .75-.752l.63.631 1.76-2.343a.53.53 0 0 1 .74-.106" clipRule="evenodd"/>
+        <text xmlSpace="preserve" fill="#008236" fontFamily="Inter" fontSize="8.496" fontWeight="600" letterSpacing="-.02em" style={{ "whiteSpace": "pre" }}>
+          <tspan x="1072.81" y="441.188">Completed</tspan>
+        </text>
+        <rect width="275.87" height="186.195" x="273.274" y="480.354" stroke="#e5e5e5" strokeWidth=".708" rx="5.31"/>
+        <path fill="#262626" d="m319.42 500.374-1.327.145a1.1 1.1 0 0 0-.197-.378 1 1 0 0 0-.37-.286 1.4 1.4 0 0 0-.572-.108q-.454 0-.764.197-.305.196-.302.511a.54.54 0 0 0 .198.438q.205.169.675.278l1.054.225q.877.19 1.303.599.43.411.435 1.074a1.7 1.7 0 0 1-.342 1.03q-.334.443-.929.692t-1.368.249q-1.134 0-1.826-.474a1.91 1.91 0 0 1-.825-1.332l1.42-.137q.097.419.411.632t.816.213q.52 0 .833-.213.318-.213.318-.527a.55.55 0 0 0-.206-.439q-.201-.172-.627-.265l-1.054-.221q-.89-.185-1.315-.624-.427-.442-.423-1.118a1.6 1.6 0 0 1 .31-.99q.318-.422.881-.651.567-.234 1.307-.233 1.086 0 1.71.462.627.464.776 1.251M309.415 502.981l-.004-1.758h.233l2.221-2.482h1.701l-2.731 3.041h-.302zm-1.327 1.939v-8.239h1.456v8.239zm3.877 0-2.011-2.812.982-1.026 2.771 3.838zM304.245 505.04q-.925 0-1.589-.406a2.7 2.7 0 0 1-1.017-1.122q-.354-.72-.354-1.658 0-.94.362-1.661a2.7 2.7 0 0 1 1.021-1.126q.664-.406 1.569-.406.752 0 1.332.277.582.273.929.776.346.5.394 1.167H305.5a1.33 1.33 0 0 0-.402-.744q-.313-.302-.841-.302a1.32 1.32 0 0 0-.784.241 1.56 1.56 0 0 0-.527.684q-.185.447-.185 1.07 0 .632.185 1.086.185.451.519.696.338.242.792.242.323 0 .575-.121.258-.125.431-.358.173-.234.237-.567h1.392a2.43 2.43 0 0 1-.386 1.162 2.3 2.3 0 0 1-.909.789q-.576.28-1.352.281M298.597 504.92v-6.179h1.456v6.179zm.732-7.056a.85.85 0 0 1-.596-.229.74.74 0 0 1-.249-.559.73.73 0 0 1 .249-.559.84.84 0 0 1 .596-.234q.35 0 .595.234a.73.73 0 0 1 .249.559.74.74 0 0 1-.249.559.84.84 0 0 1-.595.229M297.099 496.681v8.239h-1.456v-8.239zM294.341 499.461h-1.505a1.9 1.9 0 0 0-.237-.656 1.76 1.76 0 0 0-1.018-.792 2.3 2.3 0 0 0-.704-.105q-.67 0-1.19.338-.519.334-.813.982-.294.643-.294 1.573 0 .945.294 1.592.298.644.813.974.519.326 1.186.326.37 0 .692-.097.326-.1.583-.293.262-.193.439-.475.182-.281.249-.644l1.505.008a3.3 3.3 0 0 1-.366 1.102 3.3 3.3 0 0 1-.728.91 3.4 3.4 0 0 1-1.054.611 3.9 3.9 0 0 1-1.34.217q-1.086 0-1.939-.503-.852-.502-1.343-1.452-.49-.95-.491-2.276 0-1.332.495-2.277.495-.95 1.347-1.452.854-.503 1.931-.503.688 0 1.279.193.592.194 1.054.567.463.37.761.909.301.535.394 1.223"/>
+        <path fill="#525252" d="M306.739 525.208q-1.073-.005-1.832-.566t-1.163-1.634q-.403-1.072-.403-2.584 0-1.507.403-2.575.407-1.068 1.167-1.629.765-.561 1.828-.561t1.824.566q.76.561 1.163 1.629.407 1.064.407 2.57 0 1.516-.402 2.589-.404 1.067-1.163 1.634-.76.561-1.829.561m0-1.209q.942 0 1.471-.918.534-.919.534-2.657 0-1.154-.244-1.95-.24-.8-.693-1.213a1.52 1.52 0 0 0-1.068-.416q-.936 0-1.47.923t-.539 2.656q0 1.16.24 1.96.245.797.692 1.208.448.408 1.077.407M298.526 525.18q-.933 0-1.665-.321-.73-.321-1.154-.891a2.36 2.36 0 0 1-.453-1.331h1.421q.027.412.276.715.253.298.661.462.407.163.905.163.548 0 .968-.19a1.6 1.6 0 0 0 .665-.53q.24-.344.24-.792 0-.465-.24-.819a1.56 1.56 0 0 0-.692-.561q-.453-.204-1.095-.204h-.783v-1.14h.783q.516 0 .905-.186.394-.185.615-.515.222-.336.222-.783 0-.43-.194-.747a1.3 1.3 0 0 0-.543-.502 1.76 1.76 0 0 0-.824-.181q-.453 0-.846.167-.39.163-.634.471-.244.303-.262.728h-1.353q.023-.75.443-1.321.426-.57 1.122-.892a3.7 3.7 0 0 1 1.548-.321q.891 0 1.539.349.651.343 1.004.918.358.575.353 1.258.005.779-.434 1.322-.435.543-1.159.728v.073q.923.14 1.43.733.512.592.507 1.471.004.764-.425 1.371a2.9 2.9 0 0 1-1.163.955q-.738.343-1.688.343M290.379 525.18q-.973 0-1.719-.334-.743-.335-1.164-.924a2.22 2.22 0 0 1-.416-1.339 2.36 2.36 0 0 1 .914-1.91 2.1 2.1 0 0 1 .951-.425v-.054a1.87 1.87 0 0 1-1.109-.743 2.17 2.17 0 0 1-.412-1.321 2.16 2.16 0 0 1 .376-1.267 2.63 2.63 0 0 1 1.054-.883q.67-.321 1.525-.321a3.4 3.4 0 0 1 1.512.326q.67.321 1.054.882a2.2 2.2 0 0 1 .389 1.263 2.2 2.2 0 0 1-.425 1.321 1.9 1.9 0 0 1-1.095.743v.054q.52.09.936.425.421.33.67.828.253.494.258 1.082a2.27 2.27 0 0 1-.425 1.339q-.421.589-1.168.924-.742.334-1.706.334m0-1.144q.574 0 .996-.19.42-.195.651-.539.231-.348.236-.815a1.53 1.53 0 0 0-.254-.855 1.7 1.7 0 0 0-.665-.584 2.1 2.1 0 0 0-.964-.212q-.547 0-.973.212a1.7 1.7 0 0 0-.67.584 1.5 1.5 0 0 0-.239.855q-.005.467.221.815.231.344.657.539.425.19 1.004.19m0-4.313q.462 0 .819-.186a1.4 1.4 0 0 0 .561-.515q.208-.332.213-.774a1.44 1.44 0 0 0-.208-.761 1.32 1.32 0 0 0-.557-.502 1.8 1.8 0 0 0-.828-.181q-.48 0-.842.181a1.33 1.33 0 0 0-.556.502 1.4 1.4 0 0 0-.195.761q-.004.442.199.774.204.33.561.515a1.8 1.8 0 0 0 .833.186"/>
+        <g opacity=".2">
+          <path fill={`url(#${id}-G)`} d="m504.148 556.259-28.541 38.92a4.25 4.25 0 0 1-5.063 1.407l-26.241-10.966a4.24 4.24 0 0 0-2.982-.111l-28.84 9.622a4.2 4.2 0 0 1-1.639.208l-29.763-2.066a4.25 4.25 0 0 1-1.699-.487l-27.715-14.721a4.25 4.25 0 0 0-4.848.606l-28.453 25.833a4.3 4.3 0 0 1-1.085.716l-30.552 14.012v6.608a4.247 4.247 0 0 0 4.247 4.248h240.708a4.25 4.25 0 0 0 4.248-4.248v-85.31l-30.186 14.407a4.25 4.25 0 0 0-1.596 1.322"/>
+          <path fill={`url(#${id}-H)`} d="m504.148 556.259-28.541 38.92a4.25 4.25 0 0 1-5.063 1.407l-26.241-10.966a4.24 4.24 0 0 0-2.982-.111l-28.84 9.622a4.2 4.2 0 0 1-1.639.208l-29.763-2.066a4.25 4.25 0 0 1-1.699-.487l-27.715-14.721a4.25 4.25 0 0 0-4.848.606l-28.453 25.833a4.3 4.3 0 0 1-1.085.716l-30.552 14.012v6.608a4.247 4.247 0 0 0 4.247 4.248h240.708a4.25 4.25 0 0 0 4.248-4.248v-85.31l-30.186 14.407a4.25 4.25 0 0 0-1.596 1.322"/>
+        </g>
+        <path stroke={`url(#${id}-I)`} strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.062" d="m287.434 619.469 30.972-15.249a.7.7 0 0 0 .163-.111l30.619-27.774a.71.71 0 0 1 .81-.1l30.492 16.324a.7.7 0 0 0 .276.081l30.772 2.542a.7.7 0 0 0 .28-.033l30.676-10.137a.7.7 0 0 1 .492.017l30.307 12.52a.71.71 0 0 0 .841-.235l30.631-41.653a.7.7 0 0 1 .257-.215l30.907-15.269"/>
+        <rect width="275.87" height="186.195" x="566.842" y="480.354" stroke="#e5e5e5" strokeWidth=".708" rx="5.31"/>
+        <path fill="#262626" d="m612.237 499.976-1.327.145a1.1 1.1 0 0 0-.197-.378 1 1 0 0 0-.37-.286 1.36 1.36 0 0 0-.571-.109q-.455 0-.765.197-.306.198-.301.511a.54.54 0 0 0 .197.439q.205.168.675.277l1.054.226q.877.188 1.304.599.43.41.434 1.074a1.7 1.7 0 0 1-.342 1.03q-.333.442-.929.692t-1.368.249q-1.134 0-1.826-.475a1.9 1.9 0 0 1-.825-1.331l1.42-.137q.098.419.411.632t.816.213q.52 0 .833-.213.318-.213.318-.527a.55.55 0 0 0-.205-.439q-.202-.173-.628-.265l-1.054-.221q-.888-.186-1.315-.624-.426-.443-.423-1.118a1.6 1.6 0 0 1 .31-.99q.318-.422.881-.651a3.4 3.4 0 0 1 1.307-.234q1.086 0 1.71.463.627.462.776 1.251M602.512 504.63q-.729 0-1.303-.374-.576-.375-.91-1.086-.333-.712-.333-1.73 0-1.03.338-1.738.341-.711.921-1.074a2.37 2.37 0 0 1 1.291-.366q.543 0 .893.185.35.181.555.439.206.253.318.478h.06v-3.081h1.46v8.238h-1.432v-.973h-.088a2.5 2.5 0 0 1-.326.479q-.213.249-.563.426t-.881.177m.406-1.195q.463 0 .789-.249.326-.254.494-.704.17-.45.169-1.05 0-.6-.169-1.042a1.5 1.5 0 0 0-.49-.688 1.27 1.27 0 0 0-.793-.245q-.486 0-.812.253a1.53 1.53 0 0 0-.491.7q-.165.447-.165 1.022 0 .58.165 1.034.168.45.495.712.33.257.808.257M595.493 504.646q-.588 0-1.058-.209a1.73 1.73 0 0 1-.741-.628q-.269-.414-.269-1.021 0-.523.193-.865t.527-.547.752-.31a6 6 0 0 1 .873-.157q.543-.056.881-.1.338-.05.491-.145.157-.101.157-.31v-.024q0-.455-.27-.704t-.776-.249q-.536 0-.849.233a1.15 1.15 0 0 0-.418.551l-1.36-.193a2.16 2.16 0 0 1 .531-.941q.37-.383.905-.572a3.5 3.5 0 0 1 1.183-.193q.446 0 .889.105.442.105.808.346.366.237.588.647.225.411.225 1.026v4.135h-1.4v-.848h-.048a1.8 1.8 0 0 1-.374.482 1.8 1.8 0 0 1-.6.358 2.4 2.4 0 0 1-.84.133m.378-1.07q.438 0 .76-.173.321-.177.495-.467.177-.29.177-.631v-.728a.7.7 0 0 1-.234.104 3 3 0 0 1-.362.085q-.2.036-.398.064l-.342.049a2.5 2.5 0 0 0-.583.144.96.96 0 0 0-.406.282.68.68 0 0 0-.149.458q0 .403.293.608.294.205.749.205M589.735 504.642q-.929 0-1.605-.386a2.6 2.6 0 0 1-1.033-1.102q-.362-.716-.362-1.686 0-.953.362-1.673a2.73 2.73 0 0 1 1.021-1.126q.656-.407 1.541-.407.571 0 1.078.185.511.182.901.563.394.383.619.974.226.587.226 1.4v.446h-5.065v-.981h3.669a1.6 1.6 0 0 0-.181-.744 1.3 1.3 0 0 0-.495-.519 1.4 1.4 0 0 0-.732-.189q-.447 0-.784.217-.338.213-.527.563a1.6 1.6 0 0 0-.189.76v.857q0 .539.197.925.197.382.551.588.354.201.828.201.318 0 .576-.089.257-.093.446-.269t.286-.439l1.359.153a2.1 2.1 0 0 1-.49.941 2.4 2.4 0 0 1-.918.62 3.5 3.5 0 0 1-1.279.217M580.648 504.521v-8.238h1.493v6.987h3.628v1.251z"/>
+        <path fill="#525252" d="M598.139 524.66a3.5 3.5 0 0 1-1.53-.326 2.8 2.8 0 0 1-1.077-.905 2.4 2.4 0 0 1-.43-1.312h1.358q.05.598.529.982.48.385 1.15.385.534 0 .946-.245.416-.249.651-.683.24-.435.24-.991 0-.566-.244-1.009a1.8 1.8 0 0 0-.674-.697 1.9 1.9 0 0 0-.978-.258q-.421 0-.846.145a2 2 0 0 0-.688.38l-1.281-.19.521-4.67h5.095v1.199h-3.932l-.294 2.593h.054a2.2 2.2 0 0 1 .719-.439q.453-.177.969-.177.846 0 1.507.403.665.403 1.045 1.1.385.692.38 1.593.005.9-.407 1.606a2.95 2.95 0 0 1-1.131 1.113q-.72.403-1.652.403M592.573 515.266v9.268h-1.403v-7.866h-.054l-2.218 1.449v-1.34l2.313-1.511zM580.648 522.723v-1.131l4.005-6.326h.892v1.665h-.566l-2.864 4.534v.073h5.489v1.185zm4.395 1.811v-2.155l.009-.515v-6.598h1.326v9.268z"/>
+        <g opacity=".2">
+          <path fill={`url(#${id}-J)`} d="m797.953 556.259-28.541 38.92a4.25 4.25 0 0 1-5.064 1.407l-26.24-10.966a4.24 4.24 0 0 0-2.982-.111l-28.84 9.622a4.2 4.2 0 0 1-1.639.208l-29.764-2.066a4.25 4.25 0 0 1-1.698-.487l-27.716-14.721a4.25 4.25 0 0 0-4.848.606l-28.452 25.833a4.3 4.3 0 0 1-1.085.716l-30.553 14.012v6.608a4.25 4.25 0 0 0 4.248 4.248h240.708a4.25 4.25 0 0 0 4.248-4.248v-85.31l-30.187 14.407a4.24 4.24 0 0 0-1.595 1.322"/>
+          <path fill={`url(#${id}-K)`} d="m797.953 556.259-28.541 38.92a4.25 4.25 0 0 1-5.064 1.407l-26.24-10.966a4.24 4.24 0 0 0-2.982-.111l-28.84 9.622a4.2 4.2 0 0 1-1.639.208l-29.764-2.066a4.25 4.25 0 0 1-1.698-.487l-27.716-14.721a4.25 4.25 0 0 0-4.848.606l-28.452 25.833a4.3 4.3 0 0 1-1.085.716l-30.553 14.012v6.608a4.25 4.25 0 0 0 4.248 4.248h240.708a4.25 4.25 0 0 0 4.248-4.248v-85.31l-30.187 14.407a4.24 4.24 0 0 0-1.595 1.322"/>
+        </g>
+        <path stroke={`url(#${id}-L)`} strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.062" d="m581.238 619.469 30.973-15.249a.7.7 0 0 0 .163-.111l30.618-27.774a.71.71 0 0 1 .81-.1l30.493 16.324a.7.7 0 0 0 .275.081l30.772 2.542a.7.7 0 0 0 .281-.033l30.675-10.137a.7.7 0 0 1 .493.017l30.307 12.52a.71.71 0 0 0 .84-.235l30.632-41.653a.7.7 0 0 1 .257-.215l30.907-15.269"/>
+        <rect width="275.87" height="186.195" x="860.413" y="480.354" stroke="#e5e5e5" strokeWidth=".708" rx="5.31"/>
+        <path fill="#262626" d="m902.864 500.089-1.327.144a1.1 1.1 0 0 0-.197-.378 1 1 0 0 0-.37-.285 1.34 1.34 0 0 0-.572-.109q-.454 0-.764.197-.305.198-.302.511a.54.54 0 0 0 .197.438q.206.17.676.278l1.054.225q.877.189 1.303.6.43.41.435 1.074a1.68 1.68 0 0 1-.342 1.029q-.334.443-.929.692-.596.25-1.368.25-1.134 0-1.826-.475a1.9 1.9 0 0 1-.825-1.331l1.42-.137q.097.418.411.631t.816.213q.52 0 .833-.213.318-.212.318-.527a.55.55 0 0 0-.206-.438q-.201-.173-.627-.266l-1.054-.221q-.89-.185-1.315-.623-.427-.442-.423-1.119-.003-.57.31-.989.317-.423.881-.652a3.4 3.4 0 0 1 1.307-.233q1.086 0 1.71.463.627.462.776 1.251M894.002 504.755q-.93 0-1.605-.387a2.6 2.6 0 0 1-1.034-1.102q-.362-.716-.362-1.685 0-.953.362-1.674a2.74 2.74 0 0 1 1.021-1.126q.656-.406 1.541-.406.571 0 1.078.185.511.181.901.563.394.382.62.974.225.587.225 1.399v.447h-5.064v-.982h3.668a1.6 1.6 0 0 0-.181-.744 1.3 1.3 0 0 0-.495-.519 1.4 1.4 0 0 0-.732-.189q-.446 0-.784.217-.338.214-.527.564-.185.346-.189.76v.857q0 .538.197.925.197.382.551.587.354.201.829.201.317 0 .575-.088.257-.093.446-.27a1.1 1.1 0 0 0 .286-.438l1.36.153q-.13.539-.491.941a2.4 2.4 0 0 1-.917.619 3.5 3.5 0 0 1-1.279.218M889.769 496.396v8.238h-1.456v-8.238zM883.586 504.759q-.587 0-1.058-.21a1.72 1.72 0 0 1-.74-.627q-.27-.414-.269-1.022 0-.522.193-.865.192-.342.527-.547.333-.205.752-.309.421-.11.873-.157.542-.057.881-.101.338-.048.49-.145.157-.1.157-.309v-.025q0-.454-.269-.703-.27-.25-.777-.25-.534 0-.848.233-.31.234-.419.552l-1.359-.194q.16-.563.531-.941.37-.382.905-.571a3.5 3.5 0 0 1 1.182-.193q.447 0 .889.105.443.104.809.345.366.238.587.648.225.411.225 1.026v4.135h-1.399v-.849h-.049a1.76 1.76 0 0 1-.973.841 2.4 2.4 0 0 1-.841.133m.378-1.07q.439 0 .761-.173a1.3 1.3 0 0 0 .494-.467q.177-.29.177-.631v-.729a.7.7 0 0 1-.233.105q-.16.048-.362.085-.201.036-.398.064l-.342.048q-.326.045-.583.145a1 1 0 0 0-.407.282.7.7 0 0 0-.149.458q0 .402.294.608t.748.205M878.993 498.661a1.1 1.1 0 0 0-.474-.821q-.414-.294-1.078-.294-.466 0-.801.141a1.2 1.2 0 0 0-.511.382.93.93 0 0 0-.181.551q0 .258.117.447.121.189.326.322.205.128.454.217.25.088.503.149l.773.193q.467.108.897.293.434.186.776.467.346.281.547.68.201.398.201.933 0 .725-.37 1.275-.37.547-1.07.857-.696.306-1.685.306-.962 0-1.67-.298a2.5 2.5 0 0 1-1.102-.869q-.394-.572-.426-1.392h1.468q.032.43.265.716t.608.427q.378.141.845.141.486 0 .852-.145.37-.15.58-.411a1 1 0 0 0 .213-.619.8.8 0 0 0-.189-.531 1.4 1.4 0 0 0-.519-.354 5 5 0 0 0-.772-.257l-.938-.242q-1.018-.261-1.609-.792-.587-.535-.587-1.42 0-.729.394-1.275a2.6 2.6 0 0 1 1.082-.849q.684-.306 1.549-.306.877 0 1.537.306a2.5 2.5 0 0 1 1.041.841q.378.534.391 1.231z"/>
+        <path fill="#525252" d="M893.496 524.926q-1.073-.004-1.833-.565t-1.163-1.634-.403-2.584q0-1.507.403-2.575.407-1.068 1.167-1.629.765-.561 1.829-.561 1.063 0 1.823.566.76.561 1.163 1.629.408 1.063.408 2.57 0 1.516-.403 2.589-.403 1.068-1.163 1.633-.76.561-1.828.561m0-1.208q.94 0 1.47-.919.534-.918.534-2.656 0-1.154-.244-1.95-.24-.802-.692-1.213a1.51 1.51 0 0 0-1.068-.416q-.937 0-1.471.923t-.539 2.656q0 1.159.24 1.96.245.796.693 1.208.447.407 1.077.407M885.27 524.926q-1.072-.004-1.833-.565t-1.163-1.634-.403-2.584q0-1.507.403-2.575.407-1.068 1.167-1.629.765-.561 1.829-.561t1.823.566q.76.561 1.163 1.629.408 1.063.408 2.57 0 1.516-.403 2.589-.403 1.068-1.163 1.633-.76.561-1.828.561m0-1.208q.94 0 1.47-.919.534-.918.534-2.656 0-1.154-.244-1.95-.24-.802-.692-1.213a1.51 1.51 0 0 0-1.068-.416q-.937 0-1.471.923t-.539 2.656q0 1.159.24 1.96.245.796.693 1.208.447.407 1.077.407M874.228 524.773v-1.014l3.136-3.249q.503-.53.828-.928a3.5 3.5 0 0 0 .493-.765q.163-.362.163-.769 0-.461-.217-.797a1.4 1.4 0 0 0-.593-.52 1.9 1.9 0 0 0-.846-.186q-.498 0-.869.204a1.4 1.4 0 0 0-.57.575 1.8 1.8 0 0 0-.199.869h-1.335q0-.846.389-1.48t1.068-.982q.678-.353 1.543-.353.873 0 1.539.348.67.344 1.045.942.375.592.376 1.339 0 .516-.195 1.009-.19.494-.665 1.1-.475.601-1.322 1.462l-1.841 1.927v.068h4.172v1.2z"/>
+        <g opacity=".2">
+          <path fill={`url(#${id}-M)`} d="m1091.05 556.259-28.54 38.92a4.244 4.244 0 0 1-5.06 1.407l-26.24-10.966a4.26 4.26 0 0 0-2.99-.111l-28.837 9.622a4.2 4.2 0 0 1-1.638.208l-29.764-2.066a4.25 4.25 0 0 1-1.698-.487l-27.716-14.721a4.25 4.25 0 0 0-4.848.606l-28.453 25.833a4.2 4.2 0 0 1-1.084.716l-30.553 14.012v6.608a4.25 4.25 0 0 0 4.248 4.248h240.703c2.35 0 4.25-1.902 4.25-4.248v-85.31l-30.18 14.407c-.64.302-1.19.756-1.6 1.322"/>
+          <path fill={`url(#${id}-N)`} d="m1091.05 556.259-28.54 38.92a4.244 4.244 0 0 1-5.06 1.407l-26.24-10.966a4.26 4.26 0 0 0-2.99-.111l-28.837 9.622a4.2 4.2 0 0 1-1.638.208l-29.764-2.066a4.25 4.25 0 0 1-1.698-.487l-27.716-14.721a4.25 4.25 0 0 0-4.848.606l-28.453 25.833a4.2 4.2 0 0 1-1.084.716l-30.553 14.012v6.608a4.25 4.25 0 0 0 4.248 4.248h240.703c2.35 0 4.25-1.902 4.25-4.248v-85.31l-30.18 14.407c-.64.302-1.19.756-1.6 1.322"/>
+        </g>
+        <path stroke={`url(#${id}-O)`} strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.062" d="m874.336 619.469 30.973-15.249a.7.7 0 0 0 .163-.111l30.618-27.774a.71.71 0 0 1 .81-.1l30.492 16.324q.13.068.276.081l30.772 2.542a.7.7 0 0 0 .281-.033l30.679-10.137a.7.7 0 0 1 .49.017l30.31 12.52c.3.124.64.027.84-.235l30.63-41.653a.65.65 0 0 1 .25-.215l30.91-15.269"/>
+        <text xmlSpace="preserve" fill="#262626" fontFamily="Inter" fontSize="11.327" fontWeight="600" letterSpacing="-.02em" style={{ "whiteSpace": "pre" }}>
+          <tspan x="286.727" y="96.154">Referral link</tspan>
+        </text>
+        <rect width="348.319" height="28.319" x="286.727" y="109.026" fill={`url(#${id}-P)`} rx="5.664"/>
+        <rect width="256.469" height="27.611" x="287.081" y="109.38" fill="#fff" rx="3.894"/>
+        <rect width="256.469" height="27.611" x="287.081" y="109.38" stroke="#d4d4d4" strokeWidth=".708" rx="3.894"/>
+        <text xmlSpace="preserve" fill="#262626" fontFamily="Inter" fontSize="9.912" fontWeight="500" letterSpacing="0em" style={{ "whiteSpace": "pre" }}>
+          <tspan x="295.223" y="126.79">refer.dub.co/steven</tspan>
+        </text>
+        <path fill="#171717" d="M552.398 114.69a5.664 5.664 0 0 1 5.664-5.664h71.319a5.663 5.663 0 0 1 5.663 5.664v16.991a5.663 5.663 0 0 1-5.663 5.664h-71.319a5.664 5.664 0 0 1-5.664-5.664z"/>
+        <g clipPath={`url(#${id}-Q)`}>
+          <path fill="#fff" d="M573.422 122.399a.727.727 0 0 0-.728-.727h-4.72a.726.726 0 0 0-.727.727v3.461c0 .402.325.728.727.728h4.72a.73.73 0 0 0 .728-.728zm-1.888-1.888a.727.727 0 0 0-.728-.727h-4.72a.726.726 0 0 0-.727.727v3.462c0 .402.325.727.727.727h.099v-2.301c0-.988.801-1.789 1.789-1.789h3.56zm1.062.099h.098c.989 0 1.79.801 1.79 1.789v3.461a1.79 1.79 0 0 1-1.79 1.79h-4.72a1.79 1.79 0 0 1-1.789-1.79v-.098h-.099a1.79 1.79 0 0 1-1.789-1.789v-3.462c0-.988.801-1.789 1.789-1.789h4.72c.989 0 1.79.8 1.79 1.789z"/>
+        </g>
+        <text xmlSpace="preserve" fill="#fff" fontFamily="Inter" fontSize="9.912" fontWeight="500" letterSpacing="-.02em" style={{ "whiteSpace": "pre" }}>
+          <tspan x="581.106" y="126.369">Copy link</tspan>
+        </text>
+        <text xmlSpace="preserve" fill="#262626" fontFamily="Inter" fontSize="11.327" fontWeight="600" letterSpacing="-.02em" style={{ "whiteSpace": "pre" }}>
+          <tspan x="286.727" y="172.615">Rewards</tspan>
+        </text>
+        <path fill="#fff" d="M290.975 183.018h339.822a3.895 3.895 0 0 1 3.894 3.894v55.486a3.894 3.894 0 0 1-3.894 3.894H290.975a3.894 3.894 0 0 1-3.895-3.894v-55.486a3.895 3.895 0 0 1 3.895-3.894"/>
+        <path stroke="#e5e5e5" strokeWidth=".708" d="M290.975 183.018h339.822a3.895 3.895 0 0 1 3.894 3.894v55.486a3.894 3.894 0 0 1-3.894 3.894H290.975a3.894 3.894 0 0 1-3.895-3.894v-55.486a3.895 3.895 0 0 1 3.895-3.894Z"/>
+        <g fill="#525252" clipPath={`url(#${id}-R)`}>
+          <path d="M304.426 197.95c.293 0 .531.238.531.531v.042c.438.111.91.395 1.179 1.03a.53.53 0 1 1-.979.413.67.67 0 0 0-.304-.357.9.9 0 0 0-.401-.087c-.122 0-.358.038-.531.141a.4.4 0 0 0-.159.151.43.43 0 0 0-.041.263c.014.144.079.238.202.322.143.096.35.164.59.207.278.049.697.139 1.055.357.388.237.718.637.733 1.251.021.875-.614 1.436-1.346 1.613a.531.531 0 0 1-1.058.005 1.684 1.684 0 0 1-1.322-1.205.532.532 0 0 1 1.017-.31c.059.197.154.308.266.377.122.076.31.132.594.132.545 0 .794-.315.787-.587-.004-.18-.077-.28-.224-.37-.176-.107-.424-.17-.689-.217-.302-.054-.677-.158-.997-.373a1.47 1.47 0 0 1-.665-1.101 1.5 1.5 0 0 1 .172-.885 1.5 1.5 0 0 1 .54-.542c.17-.101.35-.168.519-.213v-.057c0-.293.238-.531.531-.531"/>
+          <path fillRule="evenodd" d="M307.081 195.826c1.075 0 1.947.872 1.947 1.947v8.85a.53.53 0 0 1-.786.466l-1.703-.93-1.876.939a.53.53 0 0 1-.474 0l-1.877-.939-1.702.93a.533.533 0 0 1-.786-.466v-8.85c0-1.075.872-1.947 1.947-1.947zm-5.31 1.062a.885.885 0 0 0-.885.885v7.955l1.162-.633.058-.028a.53.53 0 0 1 .433.019l1.887.943 1.887-.943.059-.026a.53.53 0 0 1 .432.035l1.162.633v-7.955a.885.885 0 0 0-.885-.885z" clipRule="evenodd"/>
+        </g>
+        <text xmlSpace="preserve" fill="#525252" fontFamily="Inter" fontSize="9.912" fontWeight="500" letterSpacing="-.02em" style={{ "whiteSpace": "pre" }}>
+          <tspan x="316.957" y="204.675">30% per sale, and again every month for 12 months</tspan>
+        </text>
+        <path fill="#525252" fillRule="evenodd" d="M306.905 222.155a1.77 1.77 0 0 1 1.622 2.478h.325a1.24 1.24 0 0 1 1.239 1.239v.708a1.24 1.24 0 0 1-1.239 1.239h-.177v3.717a1.947 1.947 0 0 1-1.947 1.947h-4.601a1.947 1.947 0 0 1-1.947-1.947v-3.717h-.177a1.24 1.24 0 0 1-1.239-1.239v-.708c0-.684.554-1.239 1.239-1.239h.325a1.77 1.77 0 0 1 1.622-2.478c1.189 0 1.948.81 2.375 1.487q.054.088.102.174.048-.086.103-.174c.427-.677 1.186-1.487 2.375-1.487m-5.663 5.664v3.717c0 .489.395.885.885.885h1.769v-4.602zm3.716 0v4.602h1.77a.885.885 0 0 0 .885-.885v-3.717zm0-1.062h3.894a.177.177 0 0 0 .177-.177v-.708a.177.177 0 0 0-.177-.177h-3.894zm-4.955-1.062a.177.177 0 0 0-.177.177v.708c0 .098.079.177.177.177h3.893v-1.062zm1.947-2.478a.709.709 0 0 0 0 1.416h1.709a4 4 0 0 0-.233-.425c-.353-.561-.833-.991-1.476-.991m4.955 0c-.643 0-1.123.43-1.477.991-.09.144-.167.289-.232.425h1.709a.708.708 0 0 0 0-1.416" clipRule="evenodd"/>
+        <text xmlSpace="preserve" fill="#525252" fontFamily="Inter" fontSize="9.912" fontWeight="500" letterSpacing="-.02em" style={{ "whiteSpace": "pre" }}>
+          <tspan x="316.813" y="231.003">New users get 20% off for 3 months</tspan>
+        </text>
       </g>
-      <defs>
-        <pattern
-          xmlns="http://www.w3.org/2000/svg"
-          id={`${id}-smallGrid`}
-          width="20"
-          height="20"
-          patternUnits="userSpaceOnUse"
-        >
-          <path
-            d="M 20 0 L 0 0 0 20"
-            fill="none"
-            stroke="#0004"
-            strokeWidth="0.5"
-          />
-        </pattern>
-        <pattern
-          xmlns="http://www.w3.org/2000/svg"
-          id={`${id}-grid`}
-          width="80"
-          height="80"
-          patternUnits="userSpaceOnUse"
-        >
-          <rect width="80" height="80" fill={`url(#${id}-smallGrid)`} />
-          <path
-            d="M 80 0 L 0 0 0 80"
-            fill="none"
-            stroke="#0001"
-            strokeWidth="1"
-          />
-        </pattern>
-        <clipPath id={`${id}-a`}>
-          <path fill="#fff" d="M0 0h1695v940H0z" />
-        </clipPath>
-        <clipPath id={`${id}-b`}>
-          <path fill="#fff" d="M176 16h16v16h-16z" />
-        </clipPath>
-        <clipPath id={`${id}-e`}>
-          <path
-            fill="#fff"
-            d="M12 130a6 6 0 0 1 6-6h204a6 6 0 0 1 6 6v18a6 6 0 0 1-6 6H18a6 6 0 0 1-6-6z"
-          />
-        </clipPath>
-        <clipPath id={`${id}-f`}>
-          <path fill="#fff" d="M20 131h16v16H20z" />
-        </clipPath>
-        <clipPath id={`${id}-g`}>
-          <path fill="#fff" d="M20 191h16v16H20z" />
-        </clipPath>
-        <clipPath id={`${id}-h`}>
-          <rect
-            width="1200"
-            height="306"
-            x="367.5"
-            y="104"
-            fill="#fff"
-            rx="12"
-          />
-        </clipPath>
-        <clipPath id={`${id}-l`}>
-          <path fill="#fff" d="M1191.5 92h381v330h-381z" />
-        </clipPath>
-        <clipPath id={`${id}-v`}>
-          <path fill="#fff" d="M1516.5 346h22v22h-22z" />
-        </clipPath>
-        <clipPath id={`${id}-x`}>
-          <path fill="#fff" d="M1412.5 466h16v16h-16z" />
-        </clipPath>
-        <linearGradient
-          id={`${id}-i`}
-          x1="367"
-          x2="1330.65"
-          y1="410"
-          y2="25.44"
-          gradientUnits="userSpaceOnUse"
-        >
-          <stop stopColor="#FAFAFA" />
-          <stop offset="0.489" stopColor="#FAFAFA" />
-          <stop offset="1" stopColor="#fff" stopOpacity="0" />
-        </linearGradient>
-        <linearGradient
-          id={`${id}-m`}
-          x1="1407.5"
-          x2="1407.5"
-          y1="97.5"
-          y2="175.5"
-          gradientUnits="userSpaceOnUse"
-        >
-          <stop stopOpacity="0" />
-          <stop offset="1" />
-        </linearGradient>
-        <linearGradient
-          id={`${id}-n`}
-          x1="1567"
-          x2="1489"
-          y1="257"
-          y2="257"
-          gradientUnits="userSpaceOnUse"
-        >
-          <stop stopOpacity="0" />
-          <stop offset="1" />
-        </linearGradient>
-        <linearGradient
-          id={`${id}-o`}
-          x1="1447.5"
-          x2="1447.5"
-          y1="416.5"
-          y2="338.5"
-          gradientUnits="userSpaceOnUse"
-        >
-          <stop stopOpacity="0" />
-          <stop offset="1" />
-        </linearGradient>
-        <linearGradient
-          id={`${id}-p`}
-          x1="1210"
-          x2="1326"
-          y1="257"
-          y2="257"
-          gradientUnits="userSpaceOnUse"
-        >
-          <stop stopOpacity="0" />
-          <stop offset="1" />
-        </linearGradient>
-        <linearGradient
-          id={`${id}-q`}
-          x1="1367.5"
-          x2="1367.5"
-          y1="416.5"
-          y2="338.5"
-          gradientUnits="userSpaceOnUse"
-        >
-          <stop stopOpacity="0" />
-          <stop offset="1" />
-        </linearGradient>
-        <linearGradient
-          id={`${id}-s`}
-          x1="1407.5"
-          x2="1407.5"
-          y1="337"
-          y2="177"
-          gradientUnits="userSpaceOnUse"
-        >
-          <stop stopColor="#fff" stopOpacity="0.23" />
-          <stop offset="1" stopColor="#fff" stopOpacity="0.3" />
-        </linearGradient>
-        <linearGradient
-          id={`${id}-y`}
-          x1="989"
-          x2="989"
-          y1="539"
-          y2="832"
-          gradientUnits="userSpaceOnUse"
-        >
-          <stop />
-          <stop offset="1" stopOpacity="0" />
-        </linearGradient>
-        <filter
-          id={`${id}-c`}
-          width="763"
-          height="763"
-          x="-377"
-          y="461"
-          colorInterpolationFilters="sRGB"
-          filterUnits="userSpaceOnUse"
-        >
-          <feFlood floodOpacity="0" result="BackgroundImageFix" />
-          <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
-          <feGaussianBlur
-            result="effect1_foregroundBlur_0_1039"
-            stdDeviation="100"
-          />
-        </filter>
-        <filter
-          id={`${id}-j`}
-          width="1245"
-          height="806"
-          x="595"
-          y="-139"
-          colorInterpolationFilters="sRGB"
-          filterUnits="userSpaceOnUse"
-        >
-          <feFlood floodOpacity="0" result="BackgroundImageFix" />
-          <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
-          <feGaussianBlur
-            result="effect1_foregroundBlur_0_1039"
-            stdDeviation="80"
-          />
-        </filter>
-        <filter
-          id={`${id}-k`}
-          width="1440"
-          height="1440"
-          x="687.5"
-          y="-463"
-          colorInterpolationFilters="sRGB"
-          filterUnits="userSpaceOnUse"
-        >
-          <feFlood floodOpacity="0" result="BackgroundImageFix" />
-          <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
-          <feGaussianBlur
-            result="effect1_foregroundBlur_0_1039"
-            stdDeviation="60"
-          />
-        </filter>
-        <filter
-          id={`${id}-r`}
-          width="160.75"
-          height="160.75"
-          x="1327.12"
-          y="176.625"
-          colorInterpolationFilters="sRGB"
-          filterUnits="userSpaceOnUse"
-        >
-          <feFlood floodOpacity="0" result="BackgroundImageFix" />
-          <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
-          <feColorMatrix
-            in="SourceAlpha"
-            result="hardAlpha"
-            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
-          />
-          <feMorphology
-            in="SourceAlpha"
-            radius="6"
-            result="effect1_innerShadow_0_1039"
-          />
-          <feOffset />
-          <feGaussianBlur stdDeviation="6" />
-          <feComposite in2="hardAlpha" k2="-1" k3="1" operator="arithmetic" />
-          <feColorMatrix values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0" />
-          <feBlend in2="shape" result="effect1_innerShadow_0_1039" />
-        </filter>
-        <filter
-          id={`${id}-t`}
-          width="40.75"
-          height="40.75"
-          x="1227.12"
-          y="136.625"
-          colorInterpolationFilters="sRGB"
-          filterUnits="userSpaceOnUse"
-        >
-          <feFlood floodOpacity="0" result="BackgroundImageFix" />
-          <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
-          <feColorMatrix
-            in="SourceAlpha"
-            result="hardAlpha"
-            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
-          />
-          <feMorphology
-            in="SourceAlpha"
-            radius="6"
-            result="effect1_innerShadow_0_1039"
-          />
-          <feOffset />
-          <feGaussianBlur stdDeviation="6" />
-          <feComposite in2="hardAlpha" k2="-1" k3="1" operator="arithmetic" />
-          <feColorMatrix values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0" />
-          <feBlend in2="shape" result="effect1_innerShadow_0_1039" />
-        </filter>
-        <filter
-          id={`${id}-u`}
-          width="40.75"
-          height="40.75"
-          x="1507.12"
-          y="336.625"
-          colorInterpolationFilters="sRGB"
-          filterUnits="userSpaceOnUse"
-        >
-          <feFlood floodOpacity="0" result="BackgroundImageFix" />
-          <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
-          <feColorMatrix
-            in="SourceAlpha"
-            result="hardAlpha"
-            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
-          />
-          <feMorphology
-            in="SourceAlpha"
-            radius="6"
-            result="effect1_innerShadow_0_1039"
-          />
-          <feOffset />
-          <feGaussianBlur stdDeviation="6" />
-          <feComposite in2="hardAlpha" k2="-1" k3="1" operator="arithmetic" />
-          <feColorMatrix values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0" />
-          <feBlend in2="shape" result="effect1_innerShadow_0_1039" />
-        </filter>
-        <filter
-          id={`${id}-w`}
-          width="1600"
-          height="1600"
-          x="607.5"
-          y="-556"
-          colorInterpolationFilters="sRGB"
-          filterUnits="userSpaceOnUse"
-        >
-          <feFlood floodOpacity="0" result="BackgroundImageFix" />
-          <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
-          <feGaussianBlur
-            result="effect1_foregroundBlur_0_1039"
-            stdDeviation="100"
-          />
-        </filter>
-        <radialGradient
-          id={`${id}-d`}
-          cx="0"
-          cy="0"
-          r="1"
-          gradientTransform="rotate(-122.552 140.484 41.016)scale(147.858)"
-          gradientUnits="userSpaceOnUse"
-        >
-          <stop stopColor="red" />
-          <stop offset="0.275" stopColor="#EAB308" />
-          <stop offset="0.45" stopColor="#5CFF80" />
-          <stop offset="0.6" stopColor="#00FFF9" />
-          <stop offset="0.8" stopColor="#3A8BFD" />
-          <stop offset="1" stopColor="#855AFC" />
-        </radialGradient>
-      </defs>
+    </g>
+  </g>
+  <path stroke="#d4d4d4" strokeWidth=".708" d="M16 .354h1168c8.64 0 15.65 7.005 15.65 15.646v613.734H.354V16C.354 7.359 7.359.354 16 .354Z"/>
+  <defs>
+    <pattern id={`${id}-grid`} x="569.912" y="50.266" width="14.159" height="14.159" patternUnits="userSpaceOnUse">
+      <rect width="14.159" height=".531" fill="#000"/>
+      <rect width=".531" height="14.159" fill="#000"/>
+    </pattern>
+    <linearGradient id={`${id}-x`} x1="662.675" x2="980.059" y1="163.54" y2="-25.41" gradientUnits="userSpaceOnUse">
+      <stop stopColor="#fafafa"/>
+      <stop offset="1" stopColor="#fafafa" stopOpacity="0"/>
+    </linearGradient>
+    <linearGradient id={`${id}-z`} x1="1023.36" x2="1023.36" y1="220.178" y2="106.903" gradientUnits="userSpaceOnUse">
+      <stop stopColor="#fff" stopOpacity=".23"/>
+      <stop offset="1" stopColor="#fff" stopOpacity=".3"/>
+    </linearGradient>
+    <linearGradient id={`${id}-C`} x1="286.018" x2="829.734" y1="405.633" y2="405.633" gradientUnits="userSpaceOnUse">
+      <stop stopColor="#7d3aec"/>
+      <stop offset="1" stopColor="#da2778"/>
+    </linearGradient>
+    <linearGradient id={`${id}-D`} x1="557.876" x2="557.876" y1="334.869" y2="440.71" gradientUnits="userSpaceOnUse">
+      <stop stopColor="#fff" stopOpacity="0"/>
+      <stop offset="1" stopColor="#fff"/>
+    </linearGradient>
+    <linearGradient id={`${id}-E`} x1="286.018" x2="829.734" y1="381.575" y2="381.575" gradientUnits="userSpaceOnUse">
+      <stop stopColor="#7d3aec"/>
+      <stop offset="1" stopColor="#da2778"/>
+    </linearGradient>
+    <linearGradient id={`${id}-G`} x1="286.727" x2="535.93" y1="600.408" y2="600.408" gradientUnits="userSpaceOnUse">
+      <stop stopColor="#7d3aec"/>
+      <stop offset="1" stopColor="#da2778"/>
+    </linearGradient>
+    <linearGradient id={`${id}-H`} x1="411.328" x2="411.328" y1="540.53" y2="630.088" gradientUnits="userSpaceOnUse">
+      <stop stopColor="#fff" stopOpacity="0"/>
+      <stop offset="1" stopColor="#fff"/>
+    </linearGradient>
+    <linearGradient id={`${id}-I`} x1="287.434" x2="535.929" y1="582.363" y2="582.363" gradientUnits="userSpaceOnUse">
+      <stop stopColor="#7d3aec"/>
+      <stop offset="1" stopColor="#da2778"/>
+    </linearGradient>
+    <linearGradient id={`${id}-J`} x1="580.531" x2="829.735" y1="600.408" y2="600.408" gradientUnits="userSpaceOnUse">
+      <stop stopColor="#7d3aec"/>
+      <stop offset="1" stopColor="#da2778"/>
+    </linearGradient>
+    <linearGradient id={`${id}-K`} x1="705.133" x2="705.133" y1="540.53" y2="630.088" gradientUnits="userSpaceOnUse">
+      <stop stopColor="#fff" stopOpacity="0"/>
+      <stop offset="1" stopColor="#fff"/>
+    </linearGradient>
+    <linearGradient id={`${id}-L`} x1="581.238" x2="829.734" y1="582.363" y2="582.363" gradientUnits="userSpaceOnUse">
+      <stop stopColor="#7d3aec"/>
+      <stop offset="1" stopColor="#da2778"/>
+    </linearGradient>
+    <linearGradient id={`${id}-M`} x1="873.629" x2="1122.83" y1="600.408" y2="600.408" gradientUnits="userSpaceOnUse">
+      <stop stopColor="#7d3aec"/>
+      <stop offset="1" stopColor="#da2778"/>
+    </linearGradient>
+    <linearGradient id={`${id}-N`} x1="998.231" x2="998.231" y1="540.53" y2="630.088" gradientUnits="userSpaceOnUse">
+      <stop stopColor="#fff" stopOpacity="0"/>
+      <stop offset="1" stopColor="#fff"/>
+    </linearGradient>
+    <linearGradient id={`${id}-O`} x1="874.336" x2="1122.83" y1="582.363" y2="582.363" gradientUnits="userSpaceOnUse">
+      <stop stopColor="#7d3aec"/>
+      <stop offset="1" stopColor="#da2778"/>
+    </linearGradient>
+    <linearGradient id={`${id}-P`} x1="286.727" x2="635.045" y1="123.186" y2="123.186" gradientUnits="userSpaceOnUse">
+      <stop stopColor="#f5f5f5"/>
+      <stop offset="1" stopColor="#f5f5f5" stopOpacity="0"/>
+    </linearGradient>
+    <clipPath id={`${id}-u`}>
+      <ellipse cx="1055.57" cy="165.665" rx="207.788" ry="219.469"/>
+    </clipPath>
+    <clipPath id={`${id}-w`}>
+      <ellipse cx="1055.57" cy="165.665" rx="207.788" ry="219.469"/>
+    </clipPath>
+    <clipPath id={`${id}-a`}>
+      <path fill="#fff" d="M0 16C0 7.163 7.163 0 16 0h1168c8.84 0 16 7.163 16 16v614.089H0z"/>
+    </clipPath>
+    <clipPath id={`${id}-c`}>
+      <path fill="#fff" d="M60.887 56.638h11.327v11.327H60.887z"/>
+    </clipPath>
+    <clipPath id={`${id}-d`}>
+      <path fill="#fff" d="M60.887 101.947h11.327v11.327H60.887z"/>
+    </clipPath>
+    <clipPath id={`${id}-e`}>
+      <path fill="#fff" d="M60.887 167.921h11.327v11.327H60.887z"/>
+    </clipPath>
+    <clipPath id={`${id}-f`}>
+      <path fill="#fff" d="M60.887 213.23h11.327v11.327H60.887z"/>
+    </clipPath>
+    <clipPath id={`${id}-g`}>
+      <path fill="#fff" d="M60.887 235.886h11.327v11.327H60.887z"/>
+    </clipPath>
+    <clipPath id={`${id}-h`}>
+      <path fill="#fff" d="M60.887 301.858h11.327v11.327H60.887z"/>
+    </clipPath>
+    <clipPath id={`${id}-j`}>
+      <path fill="#fff" d="M215.221 14.16a8.495 8.495 0 0 1 8.495-8.496h962.124c4.69 0 8.5 3.804 8.5 8.496v661.239c0 4.692-3.81 8.495-8.5 8.495H223.716a8.495 8.495 0 0 1-8.495-8.495z"/>
+    </clipPath>
+    <clipPath id={`${id}-l`}>
+      <path fill="#fff" d="M272.92 76.46a8.496 8.496 0 0 1 8.495-8.495h846.725c4.69 0 8.5 3.803 8.5 8.495v174.16c0 4.692-3.81 8.495-8.5 8.495H281.416a8.495 8.495 0 0 1-8.496-8.495z"/>
+    </clipPath>
+    <clipPath id={`${id}-F`}>
+      <path fill="#fff" d="M815.574 296.64h7.08v7.08h-7.08z"/>
+    </clipPath>
+    <clipPath id={`${id}-Q`}>
+      <path fill="#fff" d="M563.727 117.521h11.327v11.327h-11.327z"/>
+    </clipPath>
+    <clipPath id={`${id}-R`}>
+      <path fill="#fff" d="M298.055 195.119h12.743v12.743h-12.743z"/>
+    </clipPath>
+    <radialGradient id={`${id}-n`} cx="0" cy="0" r="1" gradientTransform="matrix(318.59 234.736 -193.862 385.761 153.291 221.716)" gradientUnits="userSpaceOnUse">
+      <stop stopColor="#eea5ba"/>
+      <stop offset=".5" stopColor="#eea5ba" stopOpacity="0"/>
+    </radialGradient>
+    <radialGradient id={`${id}-o`} cx="0" cy="0" r="1" gradientTransform="matrix(231.637 195.038 -161.077 280.475 142.6 186.333)" gradientUnits="userSpaceOnUse">
+      <stop stopColor="#3a8bfd"/>
+      <stop offset=".5" stopColor="#3a8bfd" stopOpacity="0"/>
+    </radialGradient>
+    <radialGradient id={`${id}-p`} cx="0" cy="0" r="1" gradientTransform="matrix(-348.524 0 0 -422.007 415.575 332.18)" gradientUnits="userSpaceOnUse">
+      <stop stopColor="#e4c795"/>
+      <stop offset=".5" stopColor="#e4c795" stopOpacity="0"/>
+    </radialGradient>
+    <radialGradient id={`${id}-q`} cx="0" cy="0" r="1" gradientTransform="matrix(338.702 358.775 -299.056 406.678 10.59 96.815)" gradientUnits="userSpaceOnUse">
+      <stop stopColor="#855afc"/>
+      <stop offset=".5" stopColor="#855afc" stopOpacity="0"/>
+    </radialGradient>
+    <radialGradient id={`${id}-r`} cx="0" cy="0" r="1" gradientTransform="matrix(372.135 0 0 452.009 217.345 332.18)" gradientUnits="userSpaceOnUse">
+      <stop stopColor="#fd3a4e"/>
+      <stop offset=".5" stopColor="#fd3a4e" stopOpacity="0"/>
+    </radialGradient>
+    <radialGradient id={`${id}-s`} cx="0" cy="0" r="1" gradientTransform="matrix(287.132 475.513 -423.459 374.889 384.313 22.364)" gradientUnits="userSpaceOnUse">
+      <stop stopColor="#72fe7d"/>
+      <stop offset=".5" stopColor="#72fe7d" stopOpacity="0"/>
+    </radialGradient>
+    <filter id={`${id}-i`} width="983.363" height="682.478" x="213.097" y="4.956" colorInterpolationFilters="sRGB" filterUnits="userSpaceOnUse">
+      <feFlood floodOpacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" result="hardAlpha" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+      <feOffset dy="1.416"/>
+      <feGaussianBlur stdDeviation="1.062"/>
+      <feComposite in2="hardAlpha" operator="out"/>
+      <feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.04 0"/>
+      <feBlend in2="BackgroundImageFix" result="effect1_dropShadow_45986_79663"/>
+      <feBlend in="SourceGraphic" in2="effect1_dropShadow_45986_79663" result="shape"/>
+    </filter>
+    <filter id={`${id}-m`} width="585.486" height="502.092" x="762.831" y="-72.713" colorInterpolationFilters="sRGB" filterUnits="userSpaceOnUse">
+      <feFlood floodOpacity="0" result="BackgroundImageFix"/>
+      <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+      <feGaussianBlur result="effect1_foregroundBlur_45986_79663" stdDeviation="42.478"/>
+    </filter>
+    <filter id={`${id}-t`} width="557.167" height="580.531" x="776.991" y="-124.6" colorInterpolationFilters="sRGB" filterUnits="userSpaceOnUse">
+      <feFlood floodOpacity="0" result="BackgroundImageFix"/>
+      <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+      <feGaussianBlur result="effect1_foregroundBlur_45986_79663" stdDeviation="35.398"/>
+    </filter>
+    <filter id={`${id}-v`} width="557.167" height="580.531" x="776.991" y="-124.6" colorInterpolationFilters="sRGB" filterUnits="userSpaceOnUse">
+      <feFlood floodOpacity="0" result="BackgroundImageFix"/>
+      <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+      <feGaussianBlur result="effect1_foregroundBlur_45986_79663" stdDeviation="35.398"/>
+    </filter>
+    <filter id={`${id}-y`} width="113.805" height="113.806" x="966.461" y="106.638" colorInterpolationFilters="sRGB" filterUnits="userSpaceOnUse">
+      <feFlood floodOpacity="0" result="BackgroundImageFix"/>
+      <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+      <feColorMatrix in="SourceAlpha" result="hardAlpha" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+      <feOffset/>
+      <feGaussianBlur stdDeviation="4.248"/>
+      <feComposite in2="hardAlpha" k2="-1" k3="1" operator="arithmetic"/>
+      <feColorMatrix values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="shape" result="effect1_innerShadow_45986_79663"/>
+    </filter>
+    <filter id={`${id}-A`} width="70.796" height="70.796" x="987.965" y="128.142" colorInterpolationFilters="sRGB" filterUnits="userSpaceOnUse">
+      <feFlood floodOpacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" result="hardAlpha" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+      <feOffset/>
+      <feGaussianBlur stdDeviation="3.54"/>
+      <feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+      <feBlend in2="BackgroundImageFix" result="effect1_dropShadow_45986_79663"/>
+      <feBlend in="SourceGraphic" in2="effect1_dropShadow_45986_79663" result="shape"/>
+    </filter>
+  </defs>
+
     </svg>
   );
 }


### PR DESCRIPTION
Updated the svg to reflect the current layout.
- Uses the program logo and name like the current instance
- Example link and rewards show for /steven and link to dub. Then we don't have to blur anything since it doesn't make mention of the person applying.

<img width="1209" height="1027" alt="CleanShot 2026-02-04 at 11 23 37@2x" src="https://github.com/user-attachments/assets/676dfb94-ecf9-41b8-82bb-5074cb4ed4bd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed border and rounded corners from the screenshot on the partner application success page for a cleaner, streamlined appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->