### PR TITLE
Update partner reward UI with descriptions and helper blocks

### DIFF
--- a/apps/web/app/(ee)/app.dub.co/(new-program)/[slug]/program/new/rewards/form.tsx
+++ b/apps/web/app/(ee)/app.dub.co/(new-program)/[slug]/program/new/rewards/form.tsx
@@ -18,12 +18,34 @@ const DEFAULT_REWARD_TYPES = [
   {
     key: "sale",
     label: "Sale",
-    description: "For sales and subscriptions",
+    description: "When revenue is generated",
+    mostCommon: true,
   },
   {
     key: "lead",
     label: "Lead",
-    description: "For sign ups and leads",
+    description: "For sign ups and demos",
+    mostCommon: false,
+  },
+] as const;
+
+const COMMISSION_STRUCTURE_DESCRIPTIONS: Record<string, string> = {
+  "one-off": "For referrals and fixed payouts",
+  recurring: "For ongoing revenue share",
+};
+
+const PAYOUT_MODELS = [
+  {
+    key: "percentage",
+    label: "Percentage",
+    description: "Share of the revenue",
+    mostCommon: true,
+  },
+  {
+    key: "flat",
+    label: "Flat",
+    description: "Fixed amount per conversion",
+    mostCommon: false,
   },
 ] as const;
 
@@ -111,50 +133,60 @@ export function Form() {
           </div>
 
           <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
-            {DEFAULT_REWARD_TYPES.map(({ key, label, description }) => {
-              const isSelected = key === defaultRewardType;
+            {DEFAULT_REWARD_TYPES.map(
+              ({ key, label, description, mostCommon }) => {
+                const isSelected = key === defaultRewardType;
 
-              return (
-                <label
-                  key={key}
-                  className={cn(
-                    "relative flex w-full cursor-pointer items-start gap-0.5 rounded-md border border-neutral-200 bg-white p-3 text-neutral-600 hover:bg-neutral-50",
-                    "transition-all duration-150",
-                    isSelected &&
-                      "border-black bg-neutral-50 text-neutral-900 ring-1 ring-black",
-                  )}
-                >
-                  <input
-                    type="radio"
-                    value={key}
-                    className="hidden"
-                    checked={isSelected}
-                    onChange={() => {
-                      setValue("defaultRewardType", key, { shouldDirty: true });
+                return (
+                  <div key={key} className="flex flex-col items-center">
+                    <label
+                      className={cn(
+                        "relative flex w-full cursor-pointer items-start gap-0.5 rounded-md border border-neutral-200 bg-white p-3 text-neutral-600 hover:bg-neutral-50",
+                        "transition-all duration-150",
+                        isSelected &&
+                          "border-black bg-neutral-50 text-neutral-900 ring-1 ring-black",
+                      )}
+                    >
+                      <input
+                        type="radio"
+                        value={key}
+                        className="hidden"
+                        checked={isSelected}
+                        onChange={() => {
+                          setValue("defaultRewardType", key, {
+                            shouldDirty: true,
+                          });
 
-                      if (key === "lead") {
-                        setValue("type", "flat", { shouldDirty: true });
-                        setValue("maxDuration", 0, { shouldDirty: true });
-                      }
-                    }}
-                  />
-                  <div className="flex grow flex-col text-sm">
-                    <span className="text-sm font-semibold text-neutral-900">
-                      {label}
-                    </span>
-                    <span className="text-sm font-normal text-neutral-600">
-                      {description}
-                    </span>
-                  </div>
-                  <CircleCheckFill
-                    className={cn(
-                      "-mr-px -mt-px flex size-4 scale-75 items-center justify-center rounded-full opacity-0 transition-[transform,opacity] duration-150",
-                      isSelected && "scale-100 opacity-100",
+                          if (key === "lead") {
+                            setValue("type", "flat", { shouldDirty: true });
+                            setValue("maxDuration", 0, { shouldDirty: true });
+                          }
+                        }}
+                      />
+                      <div className="flex grow flex-col text-sm">
+                        <span className="text-sm font-semibold text-neutral-900">
+                          {label}
+                        </span>
+                        <span className="text-sm font-normal text-neutral-600">
+                          {description}
+                        </span>
+                      </div>
+                      <CircleCheckFill
+                        className={cn(
+                          "-mr-px -mt-px flex size-4 scale-75 items-center justify-center rounded-full opacity-0 transition-[transform,opacity] duration-150",
+                          isSelected && "scale-100 opacity-100",
+                        )}
+                      />
+                    </label>
+                    {mostCommon && (
+                      <span className="mt-1.5 text-xs text-neutral-400">
+                        Most common
+                      </span>
                     )}
-                  />
-                </label>
-              );
-            })}
+                  </div>
+                );
+              },
+            )}
           </div>
         </div>
 
@@ -170,53 +202,61 @@ export function Form() {
             </div>
 
             <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
-              {COMMISSION_TYPES.map(({ value, label, description }) => {
+              {COMMISSION_TYPES.map(({ value, label }) => {
                 const isSelected = value === commissionStructure;
 
                 return (
-                  <label
-                    key={value}
-                    className={cn(
-                      "relative flex w-full cursor-pointer items-start gap-0.5 rounded-md border border-neutral-200 bg-white p-3 text-neutral-600 hover:bg-neutral-50",
-                      "transition-all duration-150",
-                      isSelected &&
-                        "border-black bg-neutral-50 text-neutral-900 ring-1 ring-black",
-                    )}
-                  >
-                    <input
-                      type="radio"
-                      value={value}
-                      className="hidden"
-                      checked={isSelected}
-                      onChange={(e) => {
-                        if (value === "one-off") {
-                          setCommissionStructure("one-off");
-                          setValue("maxDuration", 0, { shouldValidate: true });
-                        }
-
-                        if (value === "recurring") {
-                          setCommissionStructure("recurring");
-                          setValue("maxDuration", 12, {
-                            shouldValidate: true,
-                          });
-                        }
-                      }}
-                    />
-                    <div className="flex grow flex-col text-sm">
-                      <span className="text-sm font-semibold text-neutral-900">
-                        {label}
-                      </span>
-                      <span className="text-sm font-normal text-neutral-600">
-                        {description}
-                      </span>
-                    </div>
-                    <CircleCheckFill
+                  <div key={value} className="flex flex-col items-center">
+                    <label
                       className={cn(
-                        "-mr-px -mt-px flex size-4 scale-75 items-center justify-center rounded-full opacity-0 transition-[transform,opacity] duration-150",
-                        isSelected && "scale-100 opacity-100",
+                        "relative flex w-full cursor-pointer items-start gap-0.5 rounded-md border border-neutral-200 bg-white p-3 text-neutral-600 hover:bg-neutral-50",
+                        "transition-all duration-150",
+                        isSelected &&
+                          "border-black bg-neutral-50 text-neutral-900 ring-1 ring-black",
                       )}
-                    />
-                  </label>
+                    >
+                      <input
+                        type="radio"
+                        value={value}
+                        className="hidden"
+                        checked={isSelected}
+                        onChange={() => {
+                          if (value === "one-off") {
+                            setCommissionStructure("one-off");
+                            setValue("maxDuration", 0, {
+                              shouldValidate: true,
+                            });
+                          }
+
+                          if (value === "recurring") {
+                            setCommissionStructure("recurring");
+                            setValue("maxDuration", 12, {
+                              shouldValidate: true,
+                            });
+                          }
+                        }}
+                      />
+                      <div className="flex grow flex-col text-sm">
+                        <span className="text-sm font-semibold text-neutral-900">
+                          {label}
+                        </span>
+                        <span className="text-sm font-normal text-neutral-600">
+                          {COMMISSION_STRUCTURE_DESCRIPTIONS[value]}
+                        </span>
+                      </div>
+                      <CircleCheckFill
+                        className={cn(
+                          "-mr-px -mt-px flex size-4 scale-75 items-center justify-center rounded-full opacity-0 transition-[transform,opacity] duration-150",
+                          isSelected && "scale-100 opacity-100",
+                        )}
+                      />
+                    </label>
+                    {value === "one-off" && (
+                      <span className="mt-1.5 text-xs text-neutral-400">
+                        Most common
+                      </span>
+                    )}
+                  </div>
                 );
               })}
             </div>
@@ -267,23 +307,61 @@ export function Form() {
           </div>
 
           {defaultRewardType === "sale" && (
-            <div>
-              <label className="text-sm font-medium text-neutral-800">
-                Reward structure
-              </label>
-              <select
-                {...register("type")}
-                className="mt-2 block w-full rounded-md border border-neutral-300 bg-white py-2 pl-3 pr-10 text-sm text-neutral-900 focus:border-neutral-500 focus:outline-none focus:ring-neutral-500"
-              >
-                <option value="flat">Flat</option>
-                <option value="percentage">Percentage</option>
-              </select>
+            <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+              {PAYOUT_MODELS.map(
+                ({ key, label, description, mostCommon }) => {
+                  const isSelected = key === type;
+
+                  return (
+                    <div key={key} className="flex flex-col items-center">
+                      <label
+                        className={cn(
+                          "relative flex w-full cursor-pointer items-start gap-0.5 rounded-md border border-neutral-200 bg-white p-3 text-neutral-600 hover:bg-neutral-50",
+                          "transition-all duration-150",
+                          isSelected &&
+                            "border-black bg-neutral-50 text-neutral-900 ring-1 ring-black",
+                        )}
+                      >
+                        <input
+                          type="radio"
+                          value={key}
+                          className="hidden"
+                          checked={isSelected}
+                          onChange={() =>
+                            setValue("type", key, { shouldDirty: true })
+                          }
+                        />
+                        <div className="flex grow flex-col text-sm">
+                          <span className="text-sm font-semibold text-neutral-900">
+                            {label}
+                          </span>
+                          <span className="text-sm font-normal text-neutral-600">
+                            {description}
+                          </span>
+                        </div>
+                        <CircleCheckFill
+                          className={cn(
+                            "-mr-px -mt-px flex size-4 scale-75 items-center justify-center rounded-full opacity-0 transition-[transform,opacity] duration-150",
+                            isSelected && "scale-100 opacity-100",
+                          )}
+                        />
+                      </label>
+                      {mostCommon && (
+                        <span className="mt-1.5 text-xs text-neutral-400">
+                          Most common
+                        </span>
+                      )}
+                    </div>
+                  );
+                },
+              )}
             </div>
           )}
 
           <div>
             <label className="text-sm font-medium text-neutral-800">
-              Reward amount {defaultRewardType != "sale" ? "per lead" : ""}
+              {type === "percentage" ? "Percentage" : "Amount"} per{" "}
+              {defaultRewardType}
             </label>
             <div className="relative mt-2 rounded-md shadow-sm">
               <span className="absolute inset-y-0 left-0 flex items-center pl-3 text-sm text-neutral-400">

--- a/apps/web/app/(ee)/app.dub.co/(new-program)/[slug]/program/new/rewards/page.tsx
+++ b/apps/web/app/(ee)/app.dub.co/(new-program)/[slug]/program/new/rewards/page.tsx
@@ -3,7 +3,7 @@ import { Form } from "./form";
 
 export default async function ProgramOnboardingRewardsPage() {
   return (
-    <StepPage title="Configure rewards">
+    <StepPage title="Create default reward">
       <Form />
     </StepPage>
   );

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/groups/[groupSlug]/rewards/group-rewards.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/groups/[groupSlug]/rewards/group-rewards.tsx
@@ -25,6 +25,24 @@ import Link from "next/link";
 import { useParams } from "next/navigation";
 import { useEffect, useState } from "react";
 
+const REWARD_EVENT_DESCRIPTIONS: Record<
+  EventType,
+  { title: string; description: string }
+> = {
+  sale: {
+    title: "Sale reward",
+    description: "Reward when revenue is generated.",
+  },
+  lead: {
+    title: "Lead reward",
+    description: "Reward for sign ups or demos.",
+  },
+  click: {
+    title: "Click reward",
+    description: "Reward for traffic and reach.",
+  },
+};
+
 export function GroupRewards() {
   const { group, loading } = useGroup();
   const { searchParams } = useRouterStuff();
@@ -157,18 +175,23 @@ const RewardItem = ({
         </div>
         <div className="flex flex-1 flex-col justify-between gap-y-4 md:flex-row md:items-center">
           <div className="flex items-center gap-2">
-            <span className="text-sm font-normal">
-              {reward ? (
+            {reward ? (
+              <span className="text-sm font-normal">
                 <ProgramRewardDescription
                   reward={reward}
                   amountClassName="text-blue-600"
                 />
-              ) : (
-                <span className="text-sm font-normal text-neutral-600">
-                  No {event} reward configured
+              </span>
+            ) : (
+              <div className="flex flex-col">
+                <span className="text-sm font-medium text-neutral-900">
+                  {REWARD_EVENT_DESCRIPTIONS[event].title}
                 </span>
-              )}
-            </span>
+                <span className="text-sm font-normal text-neutral-500">
+                  {REWARD_EVENT_DESCRIPTIONS[event].description}
+                </span>
+              </div>
+            )}
           </div>
 
           {reward ? (

--- a/apps/web/app/app.dub.co/(onboarding)/onboarding/(steps)/program/reward/form.tsx
+++ b/apps/web/app/app.dub.co/(onboarding)/onboarding/(steps)/program/reward/form.tsx
@@ -18,12 +18,29 @@ const DEFAULT_REWARD_TYPES = [
   {
     key: "sale",
     label: "Sale",
-    description: "For purchases",
+    description: "Paid revenue",
+    mostCommon: true,
   },
   {
     key: "lead",
     label: "Lead",
-    description: "For sign ups",
+    description: "Sign ups and demos",
+    mostCommon: false,
+  },
+] as const;
+
+const PAYOUT_MODELS = [
+  {
+    key: "percentage",
+    label: "Percentage",
+    description: "Revenue based",
+    mostCommon: true,
+  },
+  {
+    key: "flat",
+    label: "Flat",
+    description: "Fixed amount",
+    mostCommon: false,
   },
 ] as const;
 
@@ -99,52 +116,60 @@ export function Form() {
         </h2>
 
         <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
-          {DEFAULT_REWARD_TYPES.map(({ key, label, description }) => {
-            const isSelected = key === defaultRewardType;
+          {DEFAULT_REWARD_TYPES.map(
+            ({ key, label, description, mostCommon }) => {
+              const isSelected = key === defaultRewardType;
 
-            return (
-              <label
-                key={key}
-                className={cn(
-                  "relative flex w-full cursor-pointer items-start gap-0.5 rounded-md border border-neutral-200 bg-white p-3 text-neutral-600 hover:bg-neutral-50",
-                  "transition-all duration-150",
-                  isSelected &&
-                    "border-black bg-neutral-50 text-neutral-900 ring-1 ring-black",
-                )}
-              >
-                <input
-                  type="radio"
-                  value={key}
-                  className="hidden"
-                  checked={isSelected}
-                  onChange={() => {
-                    setValue("defaultRewardType", key, {
-                      shouldDirty: true,
-                    });
+              return (
+                <div key={key} className="flex flex-col items-center">
+                  <label
+                    className={cn(
+                      "relative flex w-full cursor-pointer items-start gap-0.5 rounded-md border border-neutral-200 bg-white p-3 text-neutral-600 hover:bg-neutral-50",
+                      "transition-all duration-150",
+                      isSelected &&
+                        "border-black bg-neutral-50 text-neutral-900 ring-1 ring-black",
+                    )}
+                  >
+                    <input
+                      type="radio"
+                      value={key}
+                      className="hidden"
+                      checked={isSelected}
+                      onChange={() => {
+                        setValue("defaultRewardType", key, {
+                          shouldDirty: true,
+                        });
 
-                    if (key === "lead") {
-                      setValue("type", "flat", { shouldDirty: true });
-                      setValue("maxDuration", 0, { shouldDirty: true });
-                    }
-                  }}
-                />
-                <div className="flex grow flex-col text-sm">
-                  <span className="text-sm font-semibold text-neutral-900">
-                    {label}
-                  </span>
-                  <span className="text-sm font-normal text-neutral-600">
-                    {description}
-                  </span>
-                </div>
-                <CircleCheckFill
-                  className={cn(
-                    "-mr-px -mt-px flex size-4 scale-75 items-center justify-center rounded-full opacity-0 transition-[transform,opacity] duration-150",
-                    isSelected && "scale-100 opacity-100",
+                        if (key === "lead") {
+                          setValue("type", "flat", { shouldDirty: true });
+                          setValue("maxDuration", 0, { shouldDirty: true });
+                        }
+                      }}
+                    />
+                    <div className="flex grow flex-col text-sm">
+                      <span className="text-sm font-semibold text-neutral-900">
+                        {label}
+                      </span>
+                      <span className="text-sm font-normal text-neutral-600">
+                        {description}
+                      </span>
+                    </div>
+                    <CircleCheckFill
+                      className={cn(
+                        "-mr-px -mt-px flex size-4 scale-75 items-center justify-center rounded-full opacity-0 transition-[transform,opacity] duration-150",
+                        isSelected && "scale-100 opacity-100",
+                      )}
+                    />
+                  </label>
+                  {mostCommon && (
+                    <span className="mt-1.5 text-xs text-neutral-400">
+                      Most common
+                    </span>
                   )}
-                />
-              </label>
-            );
-          })}
+                </div>
+              );
+            },
+          )}
         </div>
       </div>
 
@@ -166,51 +191,60 @@ export function Form() {
                       const isSelected = value === commissionStructure;
 
                       return (
-                        <label
+                        <div
                           key={value}
-                          className={cn(
-                            "relative flex w-full cursor-pointer items-start gap-0.5 rounded-md border border-neutral-200 bg-white p-3 text-neutral-600 hover:bg-neutral-50",
-                            "transition-all duration-150",
-                            isSelected &&
-                              "border-black bg-neutral-50 text-neutral-900 ring-1 ring-black",
-                          )}
+                          className="flex flex-col items-center"
                         >
-                          <input
-                            type="radio"
-                            value={value}
-                            className="hidden"
-                            checked={isSelected}
-                            onChange={(e) => {
-                              if (value === "one-off") {
-                                setCommissionStructure("one-off");
-                                setValue("maxDuration", 0, {
-                                  shouldValidate: true,
-                                });
-                              }
-
-                              if (value === "recurring") {
-                                setCommissionStructure("recurring");
-                                setValue("maxDuration", 12, {
-                                  shouldValidate: true,
-                                });
-                              }
-                            }}
-                          />
-                          <div className="flex grow flex-col text-sm">
-                            <span className="text-sm font-semibold text-neutral-900">
-                              {label}
-                            </span>
-                            <span className="text-sm font-normal text-neutral-600">
-                              {shortDescription}
-                            </span>
-                          </div>
-                          <CircleCheckFill
+                          <label
                             className={cn(
-                              "-mr-px -mt-px flex size-4 scale-75 items-center justify-center rounded-full opacity-0 transition-[transform,opacity] duration-150",
-                              isSelected && "scale-100 opacity-100",
+                              "relative flex w-full cursor-pointer items-start gap-0.5 rounded-md border border-neutral-200 bg-white p-3 text-neutral-600 hover:bg-neutral-50",
+                              "transition-all duration-150",
+                              isSelected &&
+                                "border-black bg-neutral-50 text-neutral-900 ring-1 ring-black",
                             )}
-                          />
-                        </label>
+                          >
+                            <input
+                              type="radio"
+                              value={value}
+                              className="hidden"
+                              checked={isSelected}
+                              onChange={() => {
+                                if (value === "one-off") {
+                                  setCommissionStructure("one-off");
+                                  setValue("maxDuration", 0, {
+                                    shouldValidate: true,
+                                  });
+                                }
+
+                                if (value === "recurring") {
+                                  setCommissionStructure("recurring");
+                                  setValue("maxDuration", 12, {
+                                    shouldValidate: true,
+                                  });
+                                }
+                              }}
+                            />
+                            <div className="flex grow flex-col text-sm">
+                              <span className="text-sm font-semibold text-neutral-900">
+                                {label}
+                              </span>
+                              <span className="text-sm font-normal text-neutral-600">
+                                {shortDescription}
+                              </span>
+                            </div>
+                            <CircleCheckFill
+                              className={cn(
+                                "-mr-px -mt-px flex size-4 scale-75 items-center justify-center rounded-full opacity-0 transition-[transform,opacity] duration-150",
+                                isSelected && "scale-100 opacity-100",
+                              )}
+                            />
+                          </label>
+                          {value === "one-off" && (
+                            <span className="mt-1.5 text-xs text-neutral-400">
+                              Most common
+                            </span>
+                          )}
+                        </div>
                       );
                     },
                   )}
@@ -249,23 +283,69 @@ export function Form() {
               )}
 
             {defaultRewardType === "sale" && (
-              <label className="space-y-2">
-                <span className="text-content-emphasis block text-sm font-semibold">
+              <div className="space-y-2">
+                <h2 className="text-content-emphasis text-sm font-semibold">
                   Payout model
-                </span>
-                <select
-                  {...register("type")}
-                  className="block w-full rounded-md border border-neutral-300 bg-white py-2 pl-3 pr-10 text-sm text-neutral-900 focus:border-neutral-500 focus:outline-none focus:ring-neutral-500"
-                >
-                  <option value="flat">Flat</option>
-                  <option value="percentage">Percentage</option>
-                </select>
-              </label>
+                </h2>
+                <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+                  {PAYOUT_MODELS.map(
+                    ({ key, label, description, mostCommon }) => {
+                      const isSelected = key === type;
+
+                      return (
+                        <div
+                          key={key}
+                          className="flex flex-col items-center"
+                        >
+                          <label
+                            className={cn(
+                              "relative flex w-full cursor-pointer items-start gap-0.5 rounded-md border border-neutral-200 bg-white p-3 text-neutral-600 hover:bg-neutral-50",
+                              "transition-all duration-150",
+                              isSelected &&
+                                "border-black bg-neutral-50 text-neutral-900 ring-1 ring-black",
+                            )}
+                          >
+                            <input
+                              type="radio"
+                              value={key}
+                              className="hidden"
+                              checked={isSelected}
+                              onChange={() =>
+                                setValue("type", key, { shouldDirty: true })
+                              }
+                            />
+                            <div className="flex grow flex-col text-sm">
+                              <span className="text-sm font-semibold text-neutral-900">
+                                {label}
+                              </span>
+                              <span className="text-sm font-normal text-neutral-600">
+                                {description}
+                              </span>
+                            </div>
+                            <CircleCheckFill
+                              className={cn(
+                                "-mr-px -mt-px flex size-4 scale-75 items-center justify-center rounded-full opacity-0 transition-[transform,opacity] duration-150",
+                                isSelected && "scale-100 opacity-100",
+                              )}
+                            />
+                          </label>
+                          {mostCommon && (
+                            <span className="mt-1.5 text-xs text-neutral-400">
+                              Most common
+                            </span>
+                          )}
+                        </div>
+                      );
+                    },
+                  )}
+                </div>
+              </div>
             )}
 
             <label className="space-y-2">
               <span className="text-content-emphasis block text-sm font-semibold">
-                Amount per {defaultRewardType}
+                {type === "percentage" ? "Percentage" : "Amount"} per{" "}
+                {defaultRewardType}
               </span>
               <div className="relative rounded-md shadow-sm">
                 <span className="absolute inset-y-0 left-0 flex items-center pl-3 text-sm text-neutral-400">

--- a/apps/web/ui/partners/rewards/add-edit-reward-sheet.tsx
+++ b/apps/web/ui/partners/rewards/add-edit-reward-sheet.tsx
@@ -31,8 +31,10 @@ import {
   Sheet,
   Tooltip,
   TooltipContent,
+  useLocalStorage,
   useRouterStuff,
 } from "@dub/ui";
+import { CursorRays, InvoiceDollar, UserPlus } from "@dub/ui/icons";
 import { capitalize, cn, pluralize } from "@dub/utils";
 import { motion } from "motion/react";
 import { useAction } from "next-safe-action/hooks";
@@ -367,6 +369,7 @@ function RewardSheetContent({
         </div>
 
         <div className="flex flex-1 flex-col overflow-y-auto p-6">
+          {!reward && <RewardHelperBlock event={event} />}
           <RewardSheetCard
             title={
               <div className="w-full">
@@ -607,6 +610,78 @@ function RewardSheetContent({
         </div>
       </form>
     </FormProvider>
+  );
+}
+
+const REWARD_HELPER_CONTENT: Record<
+  EventType,
+  {
+    icon: typeof InvoiceDollar;
+    title: string;
+    description: string;
+  }
+> = {
+  sale: {
+    icon: InvoiceDollar,
+    title: "Sale rewards",
+    description:
+      "Reward when revenue is generated. Best for partners, creators, and long term partnerships.",
+  },
+  lead: {
+    icon: UserPlus,
+    title: "Lead rewards",
+    description:
+      "Reward for sign ups or demos. Best for B2B, demos, waitlists, or longer sales cycles.",
+  },
+  click: {
+    icon: CursorRays,
+    title: "Click rewards",
+    description:
+      "Reward for traffic and reach. Best for publishers and trusted partners only.",
+  },
+};
+
+function RewardHelperBlock({ event }: { event: EventType }) {
+  const [dismissed, setDismissed] = useLocalStorage<boolean>(
+    `reward-helper-${event}-dismissed`,
+    false,
+  );
+
+  const content = REWARD_HELPER_CONTENT[event];
+  const Icon = content.icon;
+
+  return (
+    <motion.div
+      animate={
+        dismissed
+          ? { opacity: 0, height: 0, marginBottom: 0 }
+          : { opacity: 1, height: "auto", marginBottom: 16 }
+      }
+      initial={false}
+      className="overflow-hidden"
+      inert={dismissed}
+    >
+      <div className="relative flex items-start gap-3 rounded-lg border border-neutral-200 bg-neutral-50 p-4">
+        <div className="flex size-8 shrink-0 items-center justify-center rounded-md border border-neutral-200 bg-white">
+          <Icon className="size-4 text-neutral-600" />
+        </div>
+        <div className="flex flex-1 flex-col gap-1 pr-6">
+          <span className="text-sm font-medium text-neutral-900">
+            {content.title}
+          </span>
+          <span className="text-sm text-neutral-500">
+            {content.description}
+          </span>
+        </div>
+        <button
+          type="button"
+          className="absolute right-3 top-3 flex size-6 shrink-0 items-center justify-center rounded-md transition-colors hover:bg-neutral-200"
+          onClick={() => setDismissed(true)}
+        >
+          <X className="size-3.5 text-neutral-400" />
+        </button>
+      </div>
+    </motion.div>
   );
 }
 


### PR DESCRIPTION
## Summary
Updated partner program reward UI across 4 flows to improve user education and guidance:
- Onboarding and new program creation: Added "Most common" tags, converted payout model to radio cards, dynamic labels
- Group reward empty states: Replaced generic text with descriptive titles
- Reward creation: Added per-event-type dismissible helper blocks with independent persistence

## Changes
1. **Onboarding reward form**: Updated descriptions, "Most common" tags, payout model radio cards
2. **New program reward form**: Similar updates with custom commission descriptions and page title
3. **Group reward empty states**: Structured title + description for sale, lead, click rewards
4. **Reward creation helper**: Per-event-type info blocks with independent localStorage dismissal

All changes are type-safe and follow existing patterns in the codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Most common" indicators to guide users toward recommended reward configuration options
  * Introduced helpful guidance blocks when creating new rewards

* **Style**
  * Improved layout and visual organization of reward configuration forms
  * Enhanced descriptions for reward types, commission structures, and payout models
  * Dynamic field labels that update based on selected reward type
  * Updated page title for clarity in reward setup flow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->