### PR TITLE
Copy partner ID added

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/[partnerId]/layout.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/[partnerId]/layout.tsx
@@ -291,136 +291,145 @@ function PageControls({ partner }: { partner: EnrolledPartnerProps }) {
         openPopover={isOpen}
         setOpenPopover={setIsOpen}
         content={
-          <div className="grid w-full grid-cols-1 gap-px p-2 md:w-48">
+          <div className="w-full md:w-48">
             {partner.status === "invited" ? (
-              <MenuItem
-                icon={isDeletingInvite ? LoadingSpinner : Trash}
-                onClick={async () => {
-                  if (partner.status !== "invited" || !workspaceId) {
-                    return;
-                  }
-                  if (
-                    !window.confirm(
-                      "Are you sure you want to delete this invite? This action cannot be undone.",
-                    )
-                  ) {
-                    return;
-                  }
+              <div className="grid gap-px p-2">
+                <MenuItem
+                  icon={isDeletingInvite ? LoadingSpinner : Trash}
+                  onClick={async () => {
+                    if (partner.status !== "invited" || !workspaceId) {
+                      return;
+                    }
+                    if (
+                      !window.confirm(
+                        "Are you sure you want to delete this invite? This action cannot be undone.",
+                      )
+                    ) {
+                      return;
+                    }
 
-                  await deleteInvite({
-                    workspaceId,
-                    partnerId: partner.id,
-                  });
-                }}
-                variant="danger"
-              >
-                Delete invite
-              </MenuItem>
+                    await deleteInvite({
+                      workspaceId,
+                      partnerId: partner.id,
+                    });
+                  }}
+                  variant="danger"
+                >
+                  Delete invite
+                </MenuItem>
+              </div>
             ) : (
               <>
-                <MenuItem
-                  as={Link}
-                  href={`/${workspaceSlug}/program/messages/${partner.id}`}
-                  target="_blank"
-                  icon={Msgs}
-                  onClick={() => setIsOpen(false)}
-                  className="md:hidden"
-                >
-                  Message
-                </MenuItem>
-                <MenuItem
-                  icon={InvoiceDollar}
-                  onClick={() => {
-                    setCreateCommissionSheetOpen(true);
-                    setIsOpen(false);
-                  }}
-                  className="md:hidden"
-                >
-                  Create commission
-                </MenuItem>
-                <MenuItem
-                  icon={Refresh2}
-                  onClick={() => {
-                    setClawbackSheetOpen(true);
-                    setIsOpen(false);
-                  }}
-                >
-                  Create clawback
-                </MenuItem>
-                <MenuItem
-                  icon={PenWriting}
-                  onClick={() => {
-                    setShowPartnerAdvancedSettingsModal(true);
-                    setIsOpen(false);
-                  }}
-                >
-                  Advanced settings
-                </MenuItem>
-                <MenuItem
-                  icon={Copy}
-                  onClick={() => {
-                    navigator.clipboard.writeText(partner.id);
-                    toast.success("Partner ID copied!");
-                    setIsOpen(false);
-                  }}
-                >
-                  Copy Partner ID
-                </MenuItem>
-                {!["banned", "deactivated"].includes(partner.status) && (
+                <div className="grid gap-px p-2">
                   <MenuItem
-                    icon={BoxArchive}
+                    as={Link}
+                    href={`/${workspaceSlug}/program/messages/${partner.id}`}
+                    target="_blank"
+                    icon={Msgs}
+                    onClick={() => setIsOpen(false)}
+                    className="md:hidden"
+                  >
+                    Message
+                  </MenuItem>
+                  <MenuItem
+                    icon={InvoiceDollar}
                     onClick={() => {
-                      setShowArchivePartnerModal(true);
+                      setCreateCommissionSheetOpen(true);
+                      setIsOpen(false);
+                    }}
+                    className="md:hidden"
+                  >
+                    Create commission
+                  </MenuItem>
+                  <MenuItem
+                    icon={Refresh2}
+                    onClick={() => {
+                      setClawbackSheetOpen(true);
                       setIsOpen(false);
                     }}
                   >
-                    {partner.status === "archived" ? "Unarchive" : "Archive"}{" "}
-                    partner
+                    Create clawback
                   </MenuItem>
-                )}
-                {partner.status === "deactivated" ? (
                   <MenuItem
-                    icon={LockOpen}
+                    icon={PenWriting}
                     onClick={() => {
-                      setShowReactivatePartnerModal(true);
+                      setShowPartnerAdvancedSettingsModal(true);
                       setIsOpen(false);
                     }}
                   >
-                    Reactivate partner
+                    Advanced settings
                   </MenuItem>
-                ) : partner.status !== "banned" ? (
                   <MenuItem
-                    icon={CircleXmark}
+                    icon={Copy}
                     onClick={() => {
-                      setShowDeactivatePartnerModal(true);
+                      navigator.clipboard.writeText(partner.id);
+                      toast.success("Partner ID copied!");
                       setIsOpen(false);
                     }}
                   >
-                    Deactivate partner
+                    Copy Partner ID
                   </MenuItem>
-                ) : null}
-                {partner.status === "banned" ? (
-                  <MenuItem
-                    icon={UserCheck}
-                    onClick={() => {
-                      setShowUnbanPartnerModal(true);
-                      setIsOpen(false);
-                    }}
-                  >
-                    Unban partner
-                  </MenuItem>
-                ) : (
-                  <MenuItem
-                    icon={UserDelete}
-                    variant="danger"
-                    onClick={() => {
-                      setShowBanPartnerModal(true);
-                      setIsOpen(false);
-                    }}
-                  >
-                    Ban partner
-                  </MenuItem>
-                )}
+                </div>
+                <div className="border-t border-neutral-200" />
+                <div className="grid gap-px p-2">
+                  {!["banned", "deactivated"].includes(partner.status) && (
+                    <MenuItem
+                      icon={BoxArchive}
+                      onClick={() => {
+                        setShowArchivePartnerModal(true);
+                        setIsOpen(false);
+                      }}
+                    >
+                      {partner.status === "archived"
+                        ? "Unarchive"
+                        : "Archive"}{" "}
+                      partner
+                    </MenuItem>
+                  )}
+                  {partner.status === "deactivated" ? (
+                    <MenuItem
+                      icon={LockOpen}
+                      onClick={() => {
+                        setShowReactivatePartnerModal(true);
+                        setIsOpen(false);
+                      }}
+                    >
+                      Reactivate partner
+                    </MenuItem>
+                  ) : partner.status !== "banned" ? (
+                    <MenuItem
+                      icon={CircleXmark}
+                      onClick={() => {
+                        setShowDeactivatePartnerModal(true);
+                        setIsOpen(false);
+                      }}
+                    >
+                      Deactivate partner
+                    </MenuItem>
+                  ) : null}
+                  {partner.status === "banned" ? (
+                    <MenuItem
+                      icon={UserCheck}
+                      onClick={() => {
+                        setShowUnbanPartnerModal(true);
+                        setIsOpen(false);
+                      }}
+                    >
+                      Unban partner
+                    </MenuItem>
+                  ) : (
+                    <MenuItem
+                      icon={UserDelete}
+                      variant="danger"
+                      onClick={() => {
+                        setShowBanPartnerModal(true);
+                        setIsOpen(false);
+                      }}
+                    >
+                      Ban partner
+                    </MenuItem>
+                  )}
+                </div>
               </>
             )}
           </div>


### PR DESCRIPTION
Adding dropdown functionality to the partner profile to allow for copying partner ID. Split by actions/settings and status changes (destructive).

<img width="441" height="356" alt="CleanShot 2026-02-05 at 16 22 03@2x" src="https://github.com/user-attachments/assets/c5f1f424-4895-412b-a66f-0b6ab5f47f2d" />


https://github.com/user-attachments/assets/17467eec-b6ac-483b-9c8c-52cf97977e18



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Copy Partner ID: Users can now quickly copy partner identifiers to clipboard from the partner actions menu for seamless sharing and collaboration
  * Improved Partner Actions Menu: Reorganized with better visual grouping and structure, making it easier to locate and execute specific partner management actions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->