### PR TITLE
Updated the character counter direction

### DIFF
--- a/apps/web/ui/partners/bounties/claim-bounty-modal.tsx
+++ b/apps/web/ui/partners/bounties/claim-bounty-modal.tsx
@@ -626,8 +626,7 @@ function ClaimBountyModalContent({ bounty }: ClaimBountyModalProps) {
                       />
                       <div className="mt-1 text-left">
                         <span className="text-xs text-neutral-500">
-                          {BOUNTY_MAX_SUBMISSION_DESCRIPTION_LENGTH -
-                            description.length}{" "}
+                          {description.length}{" "}
                           / {BOUNTY_MAX_SUBMISSION_DESCRIPTION_LENGTH}
                         </span>
                       </div>


### PR DESCRIPTION
For some reason it was counting down, but it should be counting up to the limit.

| Current | Updated |
| -- | -- |
| <img width="567" height="292" alt="CleanShot 2026-02-06 at 15 32 29@2x" src="https://github.com/user-attachments/assets/d97cb225-8417-48a1-90bc-2b0c82704128" /> | <img width="1250" height="814" alt="CleanShot 2026-02-06 at 15 30 40@2x" src="https://github.com/user-attachments/assets/8ff3d905-7319-40d5-83ad-b95d6762fa85" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the description length indicator in the bounty claim modal to display the current character count instead of remaining characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->