### PR TITLE
Fix: overlaping of "Sign in as a different user" button for small and medium devices

### DIFF
--- a/apps/web/app/app.dub.co/(onboarding)/onboarding/(steps)/layout.tsx
+++ b/apps/web/app/app.dub.co/(onboarding)/onboarding/(steps)/layout.tsx
@@ -52,7 +52,7 @@ export default function Layout({ children }: PropsWithChildren) {
           </div>
         </div>
 
-        <div className="w-full py-16">{children}</div>
+        <div className="w-full pt-16 pb-0 lg:pb-16">{children}</div>
 
         {/* Empty div to center main content */}
         <div className="grow basis-0" />

--- a/apps/web/app/app.dub.co/(onboarding)/signed-in-hint.tsx
+++ b/apps/web/app/app.dub.co/(onboarding)/signed-in-hint.tsx
@@ -9,7 +9,7 @@ export function SignedInHint() {
   const [isLoading, setIsLoading] = useState(false);
 
   return (
-    <div className="fixed bottom-0 left-0 z-40 m-5 flex flex-col gap-2">
+    <div className="static mt-1 m-5 flex flex-col gap-2 items-center lg:mt-0 lg:fixed lg:bottom-0 lg:left-0 lg:z-40 lg:items-start">
       <div className="flex items-center gap-1 text-xs text-neutral-600">
         You're signed in as{" "}
         {session ? (

--- a/packages/ui/src/rich-text-area/rich-text-provider.tsx
+++ b/packages/ui/src/rich-text-area/rich-text-provider.tsx
@@ -209,7 +209,7 @@ export const RichTextProvider = forwardRef<
               }),
             ]
           : []),
-      ],
+      ] as any,
       editorProps: {
         attributes: {
           ...editorProps?.attributes,

--- a/packages/ui/src/rich-text-area/rich-text-provider.tsx
+++ b/packages/ui/src/rich-text-area/rich-text-provider.tsx
@@ -209,7 +209,7 @@ export const RichTextProvider = forwardRef<
               }),
             ]
           : []),
-      ] as any,
+      ],
       editorProps: {
         attributes: {
           ...editorProps?.attributes,


### PR DESCRIPTION
Fixes: #3431

**Description:**
On small and medium screen sizes, the component was overlapping with buttons and text due to position: fixed.
To fix this, I removed position: fixed specifically for small and medium devices and centered the component instead.

Before:
<img width="908" height="931" alt="Screenshot 2026-02-08 190913" src="https://github.com/user-attachments/assets/676a8cb0-52f0-46c0-97e8-6b59860c46d9" />


This ensures:

- No overlapping of buttons or text
- Better alignment on small and medium screens
- No changes to large screen behavior

Only small and medium device styles were updated; desktop layout remains unchanged.

After: 
<img width="936" height="937" alt="image" src="https://github.com/user-attachments/assets/cc1c1b02-addf-45d9-9482-aef0c7cc7c58" />
I think it looks better in the center and just below of the "Create Workspace" button.
Just let me know if i can make it better.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enhanced responsive layout adjustments in the onboarding experience. Small screens now display with optimized top spacing, while large screens receive additional bottom spacing and improved positioning for better visual balance across devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->