### PR TITLE
Fix/otp double submit

### DIFF
--- a/apps/web/ui/auth/register/verify-email-form.tsx
+++ b/apps/web/ui/auth/register/verify-email-form.tsx
@@ -51,12 +51,19 @@ export const VerifyEmailForm = () => {
     return;
   }
 
+  const handleVerify = (completedCode?: string) => {
+  if (isPending || isRedirecting) return;
+  const finalCode = (completedCode ?? code).trim();
+  if (!finalCode || finalCode.length < 6) return;
+  executeAsync({ email, password, code: finalCode });
+};
+
   return (
     <div className="flex flex-col gap-3">
       <form
         onSubmit={(e) => {
           e.preventDefault();
-          executeAsync({ email, password, code });
+          handleVerify();
         }}
       >
         <div>
@@ -65,7 +72,7 @@ export const VerifyEmailForm = () => {
             value={code}
             onChange={(code) => {
               setIsInvalidCode(false);
-              setCode(code);
+              setCode(code.trim());
             }}
             autoFocus={!isMobile}
             render={({ slots }) => (
@@ -85,14 +92,14 @@ export const VerifyEmailForm = () => {
                     {hasFakeCaret && (
                       <div className="animate-caret-blink pointer-events-none absolute inset-0 flex items-center justify-center">
                         <div className="h-5 w-px bg-black" />
-                      </div>
+                       </div>
                     )}
                   </div>
                 ))}
               </div>
             )}
-            onComplete={() => {
-              executeAsync({ email, password, code });
+            onComplete={(completedCode) => {
+              handleVerify(completedCode);
             }}
           />
           <AnimatedSizeContainer height>
@@ -108,7 +115,7 @@ export const VerifyEmailForm = () => {
             text={isPending ? "Verifying..." : "Continue"}
             type="submit"
             loading={isPending || isRedirecting}
-            disabled={!code || code.length < 6}
+            disabled={isPending || isRedirecting || code.length < 6}
           />
         </div>
       </form>


### PR DESCRIPTION
This PR fixes a small issue in the OTP verification flow.

### What was happening

`VerifyEmailForm` could call `executeAsync` twice:

- once when the form is submitted
- again when the OTP input completes

This could lead to duplicate verification/account creation attempts.

### What changed

Added a simple `handleVerify` guard to make sure the request only runs once while pending or redirecting.

### Result

OTP verification now triggers only a single request, making the signup flow more stable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Email verification form now includes stricter OTP code validation with a minimum length requirement.
  * Added safeguards to prevent accidental repeated submission attempts during the verification process.
  * Form submission button is now disabled appropriately based on code validation status and pending operations.
  * Improved overall reliability of the email verification workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->