### PR TITLE
Feat: added timestamp for Youtube URL while creating link

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/links/[...link]/page-client.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/links/[...link]/page-client.tsx
@@ -8,6 +8,7 @@ import { LinkAnalyticsBadge } from "@/ui/links/link-analytics-badge";
 import { LinkBuilderDestinationUrlInput } from "@/ui/links/link-builder/controls/link-builder-destination-url-input";
 import { LinkBuilderFolderSelector } from "@/ui/links/link-builder/controls/link-builder-folder-selector";
 import { LinkBuilderShortLinkInput } from "@/ui/links/link-builder/controls/link-builder-short-link-input";
+import { VideoTimestampInput } from "@/ui/links/link-builder/controls/video-timestamp-input";
 import { LinkCommentsInput } from "@/ui/links/link-builder/controls/link-comments-input";
 import { ConversionTrackingToggle } from "@/ui/links/link-builder/conversion-tracking-toggle";
 import {
@@ -220,6 +221,8 @@ function LinkBuilder({ link }: { link: ExpandedLinkProps }) {
         <div className="relative flex min-h-full flex-col px-4 md:px-6">
           <div className="relative mx-auto flex w-full max-w-xl flex-col gap-7 pb-4 pt-10 lg:pb-10">
             <LinkBuilderDestinationUrlInput />
+
+            <VideoTimestampInput />
 
             <LinkBuilderShortLinkInput />
 

--- a/apps/web/ui/links/link-builder/controls/video-timestamp-input.tsx
+++ b/apps/web/ui/links/link-builder/controls/video-timestamp-input.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { LinkFormData } from "@/ui/links/link-builder/link-builder-provider";
+import { Tooltip } from "@dub/ui";
+import {
+  getYouTubeTimestampFromUrl,
+  isYouTubeUrl,
+  setYouTubeTimestampInUrl,
+} from "@dub/utils";
+import { useCallback, useEffect, useId, useState } from "react";
+import { useFormContext, useWatch } from "react-hook-form";
+
+export function VideoTimestampInput() {
+  const id = useId();
+  const { setValue } = useFormContext<LinkFormData>();
+  const url = useWatch({ name: "url" }) as string | undefined;
+
+  const isYouTube = Boolean(url && isYouTubeUrl(url));
+  const initialSeconds =
+    url && isYouTube ? getYouTubeTimestampFromUrl(url) : null;
+
+  const [minutes, setMinutes] = useState<number>(
+    initialSeconds != null ? Math.floor(initialSeconds / 60) : 0,
+  );
+  const [seconds, setSeconds] = useState<number>(
+    initialSeconds != null ? initialSeconds % 60 : 0,
+  );
+
+  const totalSeconds = minutes * 60 + seconds;
+  const hasTimestamp = totalSeconds > 0;
+
+  useEffect(() => {
+    if (!isYouTube || !url) return;
+    const t = getYouTubeTimestampFromUrl(url);
+    if (t != null) {
+      setMinutes(Math.floor(t / 60));
+      setSeconds(t % 60);
+    } else {
+      setMinutes(0);
+      setSeconds(0);
+    }
+  }, [url, isYouTube]);
+
+  const applyTimestamp = useCallback(
+    (newMinutes: number, newSeconds: number) => {
+      if (!url || !isYouTubeUrl(url)) return;
+      const total = newMinutes * 60 + newSeconds;
+      const newUrl =
+        total <= 0
+          ? setYouTubeTimestampInUrl(url, null)
+          : setYouTubeTimestampInUrl(url, total);
+      setValue("url", newUrl, { shouldDirty: true });
+    },
+    [url, setValue],
+  );
+
+  const handleMinutesChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const v = Math.max(0, parseInt(e.target.value, 10) || 0);
+    setMinutes(v);
+    applyTimestamp(v, seconds);
+  };
+
+  const handleSecondsChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const v = Math.max(0, Math.min(59, parseInt(e.target.value, 10) || 0));
+    setSeconds(v);
+    applyTimestamp(minutes, v);
+  };
+
+  const handleClear = () => {
+    setMinutes(0);
+    setSeconds(0);
+    if (url && isYouTubeUrl(url)) {
+      setValue("url", setYouTubeTimestampInUrl(url, null), {
+        shouldDirty: true,
+      });
+    }
+  };
+
+  if (!isYouTube) return null;
+
+  return (
+    <div className="grid gap-y-1">
+      <div className="flex items-center gap-2">
+        <Tooltip
+          content={
+            <div className="p-3 text-center text-xs">
+              <p className="text-neutral-600">
+                Start the video at this time. Stored as <code>?t=</code>{" "}
+                (seconds) so the link jumps to this point.
+              </p>
+            </div>
+          }
+          sideOffset={4}
+          disableHoverableContent
+        >
+          <label
+            htmlFor={`${id}-video-ts`}
+            className="cursor-default text-sm font-medium text-neutral-700"
+          >
+            Video timestamp
+          </label>
+        </Tooltip>
+      </div>
+      <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1 rounded-md border border-neutral-300 bg-white focus-within:ring-2 focus-within:ring-neutral-500 focus-within:ring-offset-0">
+          <input
+            id={`${id}-video-ts`}
+            type="number"
+            min={0}
+            max={599}
+            placeholder="0"
+            className="w-14 border-0 bg-transparent py-2 pl-3 pr-1 text-sm tabular-nums focus:ring-0"
+            value={minutes === 0 ? "" : minutes}
+            onChange={handleMinutesChange}
+            aria-label="Minutes"
+          />
+          <span className="text-neutral-400">m</span>
+          <input
+            type="number"
+            min={0}
+            max={59}
+            placeholder="0"
+            className="w-12 border-0 border-l border-neutral-200 bg-transparent py-2 pl-2 pr-2 text-sm tabular-nums focus:ring-0"
+            value={seconds === 0 ? "" : seconds}
+            onChange={handleSecondsChange}
+            aria-label="Seconds"
+          />
+          <span className="pr-3 text-neutral-400">s</span>
+        </div>
+        {hasTimestamp && (
+          <button
+            type="button"
+            onClick={handleClear}
+            className="text-xs text-neutral-500 underline hover:text-neutral-700"
+          >
+            Clear
+          </button>
+        )}
+      </div>
+      {hasTimestamp && (
+        <p className="text-xs text-neutral-500">
+          Link will open at {minutes > 0 ? `${minutes}m ` : ""}
+          {seconds}s (
+          <code className="rounded bg-neutral-100 px-0.5">?t={totalSeconds}</code>
+          )
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/ui/modals/link-builder/index.tsx
+++ b/apps/web/ui/modals/link-builder/index.tsx
@@ -7,6 +7,7 @@ import { LinkBuilderDestinationUrlInput } from "@/ui/links/link-builder/controls
 import { LinkBuilderFolderSelector } from "@/ui/links/link-builder/controls/link-builder-folder-selector";
 import { LinkBuilderShortLinkInput } from "@/ui/links/link-builder/controls/link-builder-short-link-input";
 import { LinkCommentsInput } from "@/ui/links/link-builder/controls/link-comments-input";
+import { VideoTimestampInput } from "@/ui/links/link-builder/controls/video-timestamp-input";
 import { ConversionTrackingToggle } from "@/ui/links/link-builder/conversion-tracking-toggle";
 import {
   DraftControls,
@@ -199,6 +200,8 @@ function LinkBuilderInner({
             <div className="scrollbar-hide px-6 md:overflow-auto">
               <div className="flex min-h-full flex-col gap-6 py-4">
                 <LinkBuilderDestinationUrlInput />
+
+                <VideoTimestampInput />
 
                 <LinkBuilderShortLinkInput />
 

--- a/packages/utils/src/functions/urls.ts
+++ b/packages/utils/src/functions/urls.ts
@@ -218,3 +218,62 @@ export const getFileExtension = (url: string): string | null => {
     return extension ? extension.toUpperCase() : null;
   }
 };
+
+const YOUTUBE_HOSTS = [
+  "youtube.com",
+  "www.youtube.com",
+  "m.youtube.com",
+  "youtu.be",
+];
+
+// Returns true if the URL is a YouTube video URL
+export const isYouTubeUrl = (url: string): boolean => {
+  if (!url) return false;
+  try {
+    const u = new URL(url.startsWith("http") ? url : `https://${url}`);
+    return YOUTUBE_HOSTS.some(
+      (h) => u.hostname === h || u.hostname.endsWith(`.${h}`),
+    );
+  } catch {
+    return false;
+  }
+};
+
+/// Parses YouTube `t` param from a URL
+export const getYouTubeTimestampFromUrl = (url: string): number | null => {
+  if (!url) return null;
+  try {
+    const t = new URL(url).searchParams.get("t");
+    if (!t) return null;
+    const trimmed = t.trim();
+    if (/^\d+$/.test(trimmed)) return parseInt(trimmed, 10);
+    // e.g. 1m30s, 1m, 30s
+    let total = 0;
+    const m = trimmed.match(/(\d+)m/);
+    const s = trimmed.match(/(\d+)s/);
+    if (m) total += parseInt(m[1], 10) * 60;
+    if (s) total += parseInt(s[1], 10);
+    return total > 0 ? total : null;
+  } catch {
+    return null;
+  }
+};
+
+///Sets or removes the YouTube `t` (timestamp) param in a URL
+export const setYouTubeTimestampInUrl = (
+  url: string,
+  seconds: number | null,
+): string => {
+  if (!url) return url;
+  try {
+    const u = new URL(url);
+    if (seconds == null || seconds < 0) {
+      u.searchParams.delete("t");
+    } else {
+      u.searchParams.set("t", String(seconds));
+    }
+    return u.toString();
+  } catch {
+    return url;
+  }
+};


### PR DESCRIPTION
Fixes: #496

Summary
When the destination URL is a YouTube video, the link builder now shows a Video timestamp control so users can set a start time (minutes/seconds) without editing the URL. The time is stored as ?t= on the destination URL and passed through by the short link.

Changes
packages/utils – URL helpers: isYouTubeUrl(), getYouTubeTimestampFromUrl(), setYouTubeTimestampInUrl() (detect YouTube URLs, read/write t in seconds; support 90, 1m30s, etc.).

VideoTimestampInput – New control shown only for YouTube destination URLs: minutes/seconds inputs, Clear button, helper text with ?t=..., tooltip. Kept in sync with the destination URL.
Placement – Rendered between Destination URL and Short link in the create/edit link modal and on the link detail page.

Testing

- Set a YouTube URL as destination → Video timestamp row appears; set minutes/seconds → URL gets ?t=<seconds>; Clear removes it.
- Non-YouTube URL → Video timestamp row is hidden.
- Short link with ?t= opens the video at the given time.

After changes : [Loom video](https://www.loom.com/share/82ebd7708b5b4e0cb7835a424625f466)

- I've made these changes—please review and say if anything (including UI) should be updated.
- Changes are in; feedback welcome on whether the UI or anything else needs tweaks.
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added timestamp control for YouTube video links. Users can now specify a start time (minutes and seconds) when creating shortened links to YouTube videos. The timestamp is automatically included in the resulting link and can be cleared as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->