### PR TITLE
fix: open Stripe Express payout management in new tab

### DIFF
--- a/apps/web/ui/partners/payout-methods-dropdown.tsx
+++ b/apps/web/ui/partners/payout-methods-dropdown.tsx
@@ -46,7 +46,7 @@ export function PayoutMethodsDropdown() {
           toast.error("Unable to create account link. Please contact support.");
           return;
         }
-        router.push(data.url);
+        window.open(data.url, "_blank", "noopener,noreferrer");
       },
       onError: ({ error }) => {
         toast.error(error.serverError);


### PR DESCRIPTION
This updates the Stripe payout account “Manage” action to open Stripe Express in a new tab instead of navigating away from the Dub dashboard.

Since Stripe Express is an external dashboard, opening it in a new tab preserves user context and improves the payout management experience.

Closes #3290


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stripe payout method page now opens in a new browser tab instead of navigating within the app, preserving your current session and navigation context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->