### PR TITLE
Redirect paywalls to the correct upgrade plan

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/bounties/confirm-create-bounty-modal.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/bounties/confirm-create-bounty-modal.tsx
@@ -1,3 +1,4 @@
+import { buildUpgradeUrl } from "@/lib/billing/upgrade-intent";
 import { getBountyRewardDescription } from "@/lib/partners/get-bounty-reward-description";
 import { getPlanCapabilities } from "@/lib/plan-capabilities";
 import useGroups from "@/lib/swr/use-groups";
@@ -176,7 +177,12 @@ function ConfirmCreateBountyModal({
                     <TooltipContent
                       title="New bounty notifications are only available on Advanced plans and above."
                       cta="Upgrade to Advanced"
-                      href={`/${workspaceSlug}/upgrade?showPartnersUpgradeModal=true`}
+                      href={buildUpgradeUrl({
+                        slug: workspaceSlug,
+                        upgradePlan: "advanced",
+                        upgradeSource: "partners_bounties_notification",
+                        showPartnersUpgradeModal: true,
+                      })}
                       target="_blank"
                     />
                   ),

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners-upgrade-cta.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners-upgrade-cta.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { buildUpgradeUrl } from "@/lib/billing/upgrade-intent";
 import { getPlanCapabilities } from "@/lib/plan-capabilities";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { buttonVariants } from "@dub/ui";
@@ -22,7 +23,11 @@ export function PartnersUpgradeCTA({
     if (!canManageProgram || isLegacyBusinessPlan({ plan, payoutsLimit })) {
       return {
         cta: "Upgrade plan",
-        href: `/${slug}/upgrade`,
+        href: buildUpgradeUrl({
+          slug,
+          upgradePlan: "advanced",
+          upgradeSource: "partners_overview",
+        }),
       };
     } else {
       return {

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/analytics/conversion-tracking-toggle.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/analytics/conversion-tracking-toggle.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { buildUpgradeUrl } from "@/lib/billing/upgrade-intent";
 import { clientAccessCheck } from "@/lib/client-access-check";
 import { getPlanCapabilities } from "@/lib/plan-capabilities";
 import useWorkspace from "@/lib/swr/use-workspace";
@@ -81,12 +82,16 @@ export function ConversionTrackingToggle() {
     <Tooltip
       content={
         !canTrackConversions ? (
-          <TooltipContent
-            title="You can only enable conversion tracking on Business plans and above."
-            cta="Upgrade to Business"
-            href={`/${workspaceSlug}/upgrade`}
-          />
-        ) : (
+            <TooltipContent
+              title="You can only enable conversion tracking on Business plans and above."
+              cta="Upgrade to Business"
+              href={buildUpgradeUrl({
+                slug: workspaceSlug,
+                upgradePlan: "business",
+                upgradeSource: "settings_conversion_tracking",
+              })}
+            />
+          ) : (
           permissionsError || (
             <p className="text-content-default max-w-xs p-3 text-xs">
               <strong className="font-semibold">

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/billing/plan-usage.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/billing/plan-usage.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { buildUpgradeUrl } from "@/lib/billing/upgrade-intent";
 import { MEGA_WORKSPACE_LINKS_LIMIT } from "@/lib/constants/misc";
 import useGroupsCount from "@/lib/swr/use-groups-count";
 import usePartnersCount from "@/lib/swr/use-partners-count";
@@ -174,7 +175,12 @@ export default function PlanUsage() {
         </div>
         <div className="flex items-center gap-2">
           {plan !== "enterprise" && (
-            <Link href={`/${slug}/settings/billing/upgrade`}>
+            <Link
+              href={buildUpgradeUrl({
+                slug,
+                upgradeSource: "settings_billing_plan_usage",
+              })}
+            >
               <Button
                 text={plan === "free" ? "Upgrade" : "Manage plan"}
                 variant="primary"
@@ -362,7 +368,11 @@ function UsageTabCard({
                 <div className="max-w-xs px-4 py-2 text-center text-sm text-neutral-600">
                   Upgrade to Business to unlock conversion tracking.{" "}
                   <Link
-                    href={`/${slug}/upgrade`}
+                    href={buildUpgradeUrl({
+                      slug,
+                      upgradePlan: "business",
+                      upgradeSource: "settings_billing_conversion_tooltip",
+                    })}
                     className="underline underline-offset-2 hover:text-neutral-800"
                   >
                     View pricing plans

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/domains/default/page-client.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/domains/default/page-client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { buildUpgradeUrl } from "@/lib/billing/upgrade-intent";
 import { clientAccessCheck } from "@/lib/client-access-check";
 import useDefaultDomains from "@/lib/swr/use-default-domains";
 import useWorkspace from "@/lib/swr/use-workspace";
@@ -97,7 +98,11 @@ export function DefaultDomains() {
                     <TooltipContent
                       title="You can only use dub.link on a Pro plan and above. Upgrade to Pro to use this domain."
                       cta="Upgrade to Pro"
-                      href={`/${slug}/upgrade`}
+                      href={buildUpgradeUrl({
+                        slug,
+                        upgradePlan: "pro",
+                        upgradeSource: "settings_default_domain_dub_link",
+                      })}
                     />
                   ) : undefined)
                 }

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/domains/email/page-client.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/domains/email/page-client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { buildUpgradeUrl } from "@/lib/billing/upgrade-intent";
 import { getPlanCapabilities } from "@/lib/plan-capabilities";
 import { useEmailDomains } from "@/lib/swr/use-email-domains";
 import useWorkspace from "@/lib/swr/use-workspace";
@@ -41,7 +42,11 @@ export function EmailDomains() {
             }
             addButton={
               <Link
-                href={`/${slug}/upgrade`}
+                href={buildUpgradeUrl({
+                  slug,
+                  upgradePlan: "advanced",
+                  upgradeSource: "settings_email_domains",
+                })}
                 className={cn(
                   buttonVariants({ variant: "primary" }),
                   "flex h-9 items-center justify-center whitespace-nowrap rounded-lg border px-4 text-sm",

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/integrations/[integrationSlug]/page-client.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/integrations/[integrationSlug]/page-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { getIntegrationInstallUrl } from "@/lib/actions/get-integration-install-url";
+import { buildUpgradeUrl } from "@/lib/billing/upgrade-intent";
 import { clientAccessCheck } from "@/lib/client-access-check";
 import { HubSpotSettings } from "@/lib/integrations/hubspot/ui/settings";
 import { SegmentSettings } from "@/lib/integrations/segment/ui/settings";
@@ -288,7 +289,11 @@ export default function IntegrationPageClient({
                     <TooltipContent
                       title="Hubspot integration is only available on Business plans and above. Upgrade to get started."
                       cta="Upgrade to Business"
-                      href={`/${slug}/settings/billing/upgrade`}
+                      href={buildUpgradeUrl({
+                        slug,
+                        upgradePlan: "business",
+                        upgradeSource: "integration_hubspot_gate",
+                      })}
                     />
                   ) : null
                 }

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/security/audit-logs.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/security/audit-logs.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { buildUpgradeUrl } from "@/lib/billing/upgrade-intent";
 import { getPlanCapabilities } from "@/lib/plan-capabilities";
 import useWorkspace from "@/lib/swr/use-workspace";
 import SimpleDateRangePicker from "@/ui/shared/simple-date-range-picker";
@@ -120,7 +121,11 @@ export function AuditLogs() {
             className="h-8 w-auto px-5"
             onClick={() =>
               window.open(
-                slug ? `/${slug}/upgrade` : "https://dub.co/enterprise",
+                buildUpgradeUrl({
+                  slug,
+                  upgradePlan: "enterprise",
+                  upgradeSource: "settings_audit_logs",
+                }),
                 "_blank",
               )
             }

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/webhooks/page-client.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/webhooks/page-client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { buildUpgradeUrl } from "@/lib/billing/upgrade-intent";
 import useWebhooks from "@/lib/swr/use-webhooks";
 import useWorkspace from "@/lib/swr/use-workspace";
 import EmptyState from "@/ui/shared/empty-state";
@@ -23,7 +24,11 @@ export default function WebhooksPageClient() {
           description="Webhooks allow you to receive HTTP requests whenever a specific event (eg: someone clicked your link) occurs in Dub."
           learnMore="https://d.to/webhooks"
           buttonText="Upgrade to Business"
-          buttonLink={`/${slug}/upgrade`}
+          buttonLink={buildUpgradeUrl({
+            slug,
+            upgradePlan: "business",
+            upgradeSource: "settings_webhooks",
+          })}
         />
       </div>
     );

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/links/page-client.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/links/page-client.tsx
@@ -1,5 +1,9 @@
 "use client";
 
+import {
+  buildUpgradeUrl,
+  parseUpgradePlan,
+} from "@/lib/billing/upgrade-intent";
 import useCurrentFolderId from "@/lib/swr/use-current-folder-id";
 import {
   useCheckFolderPermission,
@@ -413,7 +417,11 @@ function ImportOption({
         <TooltipContent
           title="Your workspace has exceeded its monthly links limit. We're still collecting data on your existing links, but you need to upgrade to create more links."
           cta={nextPlan ? `Upgrade to ${nextPlan.name}` : "Contact support"}
-          href={`/${slug}/upgrade`}
+          href={buildUpgradeUrl({
+            slug,
+            upgradePlan: parseUpgradePlan(nextPlan?.name.toLowerCase()),
+            upgradeSource: "links_import_option",
+          })}
         />
       }
     >

--- a/apps/web/lib/billing/upgrade-intent.ts
+++ b/apps/web/lib/billing/upgrade-intent.ts
@@ -1,0 +1,59 @@
+export const UPGRADE_PLANS = [
+  "pro",
+  "business",
+  "advanced",
+  "enterprise",
+] as const;
+
+export type UpgradePlan = (typeof UPGRADE_PLANS)[number];
+
+type SearchParamGetter = {
+  get: (key: string) => string | null;
+};
+
+export function parseUpgradePlan(plan: string | null | undefined) {
+  if (!plan) return undefined;
+  return UPGRADE_PLANS.includes(plan as UpgradePlan)
+    ? (plan as UpgradePlan)
+    : undefined;
+}
+
+export function parseUpgradeIntent(searchParams: SearchParamGetter) {
+  return {
+    upgradePlan: parseUpgradePlan(searchParams.get("upgrade_plan")),
+    upgradeSource: searchParams.get("upgrade_source") ?? undefined,
+    showPartnersUpgradeModal:
+      searchParams.get("showPartnersUpgradeModal") === "true",
+  };
+}
+
+export function buildUpgradeUrl({
+  slug,
+  upgradePlan,
+  upgradeSource,
+  showPartnersUpgradeModal,
+}: {
+  slug?: string | null;
+  upgradePlan?: UpgradePlan;
+  upgradeSource?: string;
+  showPartnersUpgradeModal?: boolean;
+}) {
+  if (!slug) return "https://dub.co/pricing";
+
+  const params = new URLSearchParams();
+
+  if (upgradePlan) {
+    params.set("upgrade_plan", upgradePlan);
+  }
+
+  if (upgradeSource) {
+    params.set("upgrade_source", upgradeSource);
+  }
+
+  if (showPartnersUpgradeModal) {
+    params.set("showPartnersUpgradeModal", "true");
+  }
+
+  const query = params.toString();
+  return query ? `/${slug}/upgrade?${query}` : `/${slug}/upgrade`;
+}

--- a/apps/web/tests/misc/upgrade-intent.test.ts
+++ b/apps/web/tests/misc/upgrade-intent.test.ts
@@ -1,0 +1,57 @@
+import {
+  buildUpgradeUrl,
+  parseUpgradeIntent,
+  parseUpgradePlan,
+} from "@/lib/billing/upgrade-intent";
+import { describe, expect, it } from "vitest";
+
+describe("upgrade-intent helpers", () => {
+  it("parses valid upgrade plans", () => {
+    expect(parseUpgradePlan("pro")).toBe("pro");
+    expect(parseUpgradePlan("business")).toBe("business");
+    expect(parseUpgradePlan("advanced")).toBe("advanced");
+    expect(parseUpgradePlan("enterprise")).toBe("enterprise");
+  });
+
+  it("rejects invalid upgrade plans", () => {
+    expect(parseUpgradePlan("free")).toBeUndefined();
+    expect(parseUpgradePlan("")).toBeUndefined();
+    expect(parseUpgradePlan(null)).toBeUndefined();
+  });
+
+  it("builds upgrade URLs with all intent params", () => {
+    expect(
+      buildUpgradeUrl({
+        slug: "acme",
+        upgradePlan: "advanced",
+        upgradeSource: "partners_overview",
+        showPartnersUpgradeModal: true,
+      }),
+    ).toBe(
+      "/acme/upgrade?upgrade_plan=advanced&upgrade_source=partners_overview&showPartnersUpgradeModal=true",
+    );
+  });
+
+  it("returns pricing URL when slug is missing", () => {
+    expect(
+      buildUpgradeUrl({
+        slug: undefined,
+        upgradePlan: "business",
+      }),
+    ).toBe("https://dub.co/pricing");
+  });
+
+  it("parses upgrade intent from search params", () => {
+    const searchParams = new URLSearchParams({
+      upgrade_plan: "advanced",
+      upgrade_source: "partners_overview",
+      showPartnersUpgradeModal: "true",
+    });
+
+    expect(parseUpgradeIntent(searchParams)).toEqual({
+      upgradePlan: "advanced",
+      upgradeSource: "partners_overview",
+      showPartnersUpgradeModal: true,
+    });
+  });
+});

--- a/apps/web/ui/analytics/analytics-loading-spinner.tsx
+++ b/apps/web/ui/analytics/analytics-loading-spinner.tsx
@@ -1,3 +1,7 @@
+import {
+  buildUpgradeUrl,
+  parseUpgradePlan,
+} from "@/lib/billing/upgrade-intent";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { LoadingSpinner } from "@dub/ui";
 import { Lock } from "lucide-react";
@@ -18,7 +22,11 @@ export function AnalyticsLoadingSpinner() {
         {nextPlan.name} plan required to view more analytics
       </p>
       <Link
-        href={slug ? `/${slug}/upgrade` : "https://dub.co/pricing"}
+        href={buildUpgradeUrl({
+          slug,
+          upgradePlan: parseUpgradePlan(nextPlan?.name.toLowerCase()),
+          upgradeSource: "analytics_loading_spinner",
+        })}
         {...(slug ? {} : { target: "_blank" })}
         className="w-full rounded-md border border-black bg-black px-3 py-1.5 text-center text-sm text-white transition-all hover:bg-neutral-800 hover:ring-4 hover:ring-neutral-200"
       >

--- a/apps/web/ui/analytics/chart-section.tsx
+++ b/apps/web/ui/analytics/chart-section.tsx
@@ -1,4 +1,5 @@
 import { EventType } from "@/lib/analytics/types";
+import { buildUpgradeUrl } from "@/lib/billing/upgrade-intent";
 import useWorkspace from "@/lib/swr/use-workspace";
 import {
   BlurImage,
@@ -182,7 +183,11 @@ function ConversionTrackingPaywall() {
           </Link>
         </p>
         <Link
-          href={`/${slug}/upgrade`}
+          href={buildUpgradeUrl({
+            slug,
+            upgradePlan: "business",
+            upgradeSource: "analytics_chart_conversion_tracking",
+          })}
           className={cn(
             buttonVariants({ variant: "primary" }),
             "mt-4 flex h-8 items-center justify-center whitespace-nowrap rounded-lg border px-3 text-sm",

--- a/apps/web/ui/analytics/events/events-export-button.tsx
+++ b/apps/web/ui/analytics/events/events-export-button.tsx
@@ -1,3 +1,4 @@
+import { buildUpgradeUrl } from "@/lib/billing/upgrade-intent";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { Button, Download, TooltipContent } from "@dub/ui";
 import { useSession } from "next-auth/react";
@@ -65,7 +66,11 @@ export function EventsExportButton({
           <TooltipContent
             title="Upgrade to our Business Plan to enable CSV downloads for events in your workspace."
             cta="Upgrade to Business"
-            href={`/${slug}/upgrade`}
+            href={buildUpgradeUrl({
+              slug,
+              upgradePlan: "business",
+              upgradeSource: "analytics_events_export",
+            })}
           />
         )
       }

--- a/apps/web/ui/analytics/events/index.tsx
+++ b/apps/web/ui/analytics/events/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { buildUpgradeUrl } from "@/lib/billing/upgrade-intent";
 import useWorkspace from "@/lib/swr/use-workspace";
 import EmptyState from "@/ui/shared/empty-state";
 import { Menu3 } from "@dub/ui/icons";
@@ -59,7 +60,11 @@ function EventsTableContainer() {
           description={`Want more data on your link ${selectedTab === "clicks" ? "clicks & QR code scans" : selectedTab}? Upgrade to our Business Plan to get a detailed, real-time stream of events in your workspace.`}
           learnMore="https://d.to/events"
           buttonText="Upgrade to Business"
-          buttonLink={`/${slug}/upgrade`}
+          buttonLink={buildUpgradeUrl({
+            slug,
+            upgradePlan: "business",
+            upgradeSource: "analytics_events_stream",
+          })}
         />
       }
     />

--- a/apps/web/ui/analytics/toggle.tsx
+++ b/apps/web/ui/analytics/toggle.tsx
@@ -4,6 +4,7 @@ import {
 } from "@/lib/analytics/constants";
 import { validDateRangeForPlan } from "@/lib/analytics/utils";
 import { getStartEndDates } from "@/lib/analytics/utils/get-start-end-dates";
+import { buildUpgradeUrl, parseUpgradePlan } from "@/lib/billing/upgrade-intent";
 import useWorkspace from "@/lib/swr/use-workspace";
 import {
   BlurImage,
@@ -316,7 +317,17 @@ function UpgradeTooltip({
     <TooltipContent
       title={`${rangeLabel} can only be viewed on a ${isAllTime ? "Business" : getNextPlan(plan).name} plan or higher. Upgrade now to view more stats.`}
       cta={`Upgrade to ${isAllTime ? "Business" : getNextPlan(plan).name}`}
-      href={slug ? `/${slug}/upgrade` : APP_DOMAIN}
+      href={
+        slug
+          ? buildUpgradeUrl({
+              slug,
+              upgradePlan: isAllTime
+                ? "business"
+                : parseUpgradePlan(getNextPlan(plan).name.toLowerCase()),
+              upgradeSource: "analytics_toggle_date_range",
+            })
+          : APP_DOMAIN
+      }
     />
   );
 }

--- a/apps/web/ui/customers/customers-table/customers-table.tsx
+++ b/apps/web/ui/customers/customers-table/customers-table.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { buildUpgradeUrl } from "@/lib/billing/upgrade-intent";
 import { getPlanCapabilities } from "@/lib/plan-capabilities";
 import useCustomersCount from "@/lib/swr/use-customers-count";
 import useWorkspace from "@/lib/swr/use-workspace";
@@ -485,7 +486,11 @@ export function CustomersTable({
                   </p>
                   <div className="mt-4">
                     <Link
-                      href={`/${workspaceSlug}/upgrade`}
+                      href={buildUpgradeUrl({
+                        slug: workspaceSlug,
+                        upgradePlan: "business",
+                        upgradeSource: "customers_insights_gate",
+                      })}
                       className={cn(
                         buttonVariants({ variant: "secondary" }),
                         "flex h-8 items-center justify-center gap-2 rounded-md border px-4 text-sm",

--- a/apps/web/ui/domains/register-domain-form.tsx
+++ b/apps/web/ui/domains/register-domain-form.tsx
@@ -1,3 +1,4 @@
+import { buildUpgradeUrl } from "@/lib/billing/upgrade-intent";
 import { mutatePrefix } from "@/lib/swr/mutate";
 import useWorkspace from "@/lib/swr/use-workspace";
 import {
@@ -373,7 +374,15 @@ function UpgradeTooltipContent() {
     <TooltipContent
       title="You can only claim a free `.link` domain on a Pro plan and above."
       cta="Upgrade to Pro"
-      onClick={() => window.open(`/${slug}/upgrade`)}
+      onClick={() =>
+        window.open(
+          buildUpgradeUrl({
+            slug,
+            upgradePlan: "pro",
+            upgradeSource: "domains_register_free_dot_link",
+          }),
+        )
+      }
     />
   );
 }

--- a/apps/web/ui/folders/add-folder-form.tsx
+++ b/apps/web/ui/folders/add-folder-form.tsx
@@ -1,3 +1,4 @@
+import { buildUpgradeUrl } from "@/lib/billing/upgrade-intent";
 import { FOLDER_WORKSPACE_ACCESS } from "@/lib/folder/constants";
 import { getPlanCapabilities } from "@/lib/plan-capabilities";
 import useWorkspace from "@/lib/swr/use-workspace";
@@ -173,7 +174,11 @@ export const AddFolderForm = ({ onSuccess, onCancel }: AddFolderFormProps) => {
                         <TooltipContent
                           title="You can only set custom folder permissions on a Business plan and above."
                           cta="Upgrade to Business"
-                          href={`/${workspace.slug}/upgrade`}
+                          href={buildUpgradeUrl({
+                            slug: workspace.slug,
+                            upgradePlan: "business",
+                            upgradeSource: "folders_add_permissions",
+                          })}
                           target="_blank"
                         />
                       }

--- a/apps/web/ui/folders/edit-folder-sheet.tsx
+++ b/apps/web/ui/folders/edit-folder-sheet.tsx
@@ -1,3 +1,4 @@
+import { buildUpgradeUrl } from "@/lib/billing/upgrade-intent";
 import { updateUserRoleInFolder } from "@/lib/actions/folders/update-folder-user-role";
 import {
   FOLDER_USER_ROLE,
@@ -164,7 +165,11 @@ const EditFolderSheetContent = ({
                     <TooltipContent
                       title="You can only set custom folder permissions on a Business plan and above."
                       cta="Upgrade to Business"
-                      href={`/${slug}/upgrade`}
+                      href={buildUpgradeUrl({
+                        slug,
+                        upgradePlan: "business",
+                        upgradeSource: "folders_edit_permissions",
+                      })}
                       target="_blank"
                     />
                   }
@@ -192,7 +197,11 @@ const EditFolderSheetContent = ({
                   </>
                 }
                 className="border-none"
-                learnMoreHref={`/${slug}/upgrade`}
+                learnMoreHref={buildUpgradeUrl({
+                  slug,
+                  upgradePlan: "business",
+                  upgradeSource: "folders_edit_users",
+                })}
                 learnMoreText="Upgrade to Business"
               />
             ) : (

--- a/apps/web/ui/folders/folder-dropdown.tsx
+++ b/apps/web/ui/folders/folder-dropdown.tsx
@@ -4,6 +4,7 @@ import { unsortedLinks } from "@/lib/folder/constants";
 import { getPlanCapabilities } from "@/lib/plan-capabilities";
 import useCurrentFolderId from "@/lib/swr/use-current-folder-id";
 import useFolder from "@/lib/swr/use-folder";
+import { buildUpgradeUrl } from "@/lib/billing/upgrade-intent";
 import useFolders from "@/lib/swr/use-folders";
 import useLinksCount from "@/lib/swr/use-links-count";
 import useWorkspace from "@/lib/swr/use-workspace";
@@ -158,7 +159,11 @@ export const FolderDropdown = ({
           <TooltipContent
             title="You can only use Link Folders on a Pro plan and above. Upgrade to Pro to continue."
             cta="Upgrade to Pro"
-            href={`/${slug}/upgrade`}
+            href={buildUpgradeUrl({
+              slug,
+              upgradePlan: "pro",
+              upgradeSource: "folders_dropdown_create",
+            })}
           />
         ) : undefined,
       },
@@ -269,7 +274,11 @@ export const FolderDropdown = ({
                   <TooltipContent
                     title="You can only use Link Folders on a Pro plan and above. Upgrade to Pro to continue."
                     cta="Upgrade to Pro"
-                    href={`/${slug}/upgrade`}
+                    href={buildUpgradeUrl({
+                      slug,
+                      upgradePlan: "pro",
+                      upgradeSource: "folders_dropdown_empty_state",
+                    })}
                   />
                 ) : undefined
               }

--- a/apps/web/ui/layout/sidebar/sidebar-usage.tsx
+++ b/apps/web/ui/layout/sidebar/sidebar-usage.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { buildUpgradeUrl } from "@/lib/billing/upgrade-intent";
 import useWorkspace from "@/lib/swr/use-workspace";
 import ManageSubscriptionButton from "@/ui/workspaces/manage-subscription-button";
 import { AnimatedSizeContainer, buttonVariants, Icon } from "@dub/ui";
@@ -136,7 +137,11 @@ function UsageInner() {
             />
           ) : (warning || plan === "free") && plan !== "enterprise" ? (
             <Link
-              href={`/${slug}/upgrade`}
+              href={buildUpgradeUrl({
+                slug,
+                upgradePlan: plan === "free" ? "pro" : undefined,
+                upgradeSource: "sidebar_usage",
+              })}
               className={cn(
                 buttonVariants(),
                 "mt-4 flex h-9 items-center justify-center rounded-md border px-4 text-sm",

--- a/apps/web/ui/layout/upgrade-banner.tsx
+++ b/apps/web/ui/layout/upgrade-banner.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { buildUpgradeUrl } from "@/lib/billing/upgrade-intent";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { Crown } from "@dub/ui";
 import { cn } from "@dub/utils";
@@ -54,7 +55,10 @@ export function UpgradeBanner() {
       </p>
       {needsUpgrade ? (
         <Link
-          href={`/${slug}/settings/billing/upgrade`}
+          href={buildUpgradeUrl({
+            slug,
+            upgradeSource: "upgrade_banner",
+          })}
           className={cn(
             "bg-bg-default text-content-emphasis border-border-subtle ml-4 flex h-7 items-center justify-center rounded-lg border px-2.5 text-sm font-medium",
             "hover:bg-bg-subtle transition-colors duration-150",

--- a/apps/web/ui/links/link-builder/conversion-tracking-toggle.tsx
+++ b/apps/web/ui/links/link-builder/conversion-tracking-toggle.tsx
@@ -1,3 +1,4 @@
+import { buildUpgradeUrl } from "@/lib/billing/upgrade-intent";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { LinkFormData } from "@/ui/links/link-builder/link-builder-provider";
 import {
@@ -63,7 +64,11 @@ export const ConversionTrackingToggle = memo(() => {
             <TooltipContent
               title="Conversion tracking is only available on Business plans and above."
               cta="Upgrade to Business"
-              href={slug ? `/${slug}/upgrade` : "https://dub.co/pricing"}
+              href={buildUpgradeUrl({
+                slug,
+                upgradePlan: "business",
+                upgradeSource: "link_builder_conversion_toggle",
+              })}
               target="_blank"
             />
           )

--- a/apps/web/ui/links/link-builder/link-preview.tsx
+++ b/apps/web/ui/links/link-builder/link-preview.tsx
@@ -1,3 +1,4 @@
+import { buildUpgradeUrl } from "@/lib/billing/upgrade-intent";
 import useWorkspace from "@/lib/swr/use-workspace";
 import {
   LinkFormData,
@@ -120,7 +121,11 @@ export const LinkPreview = memo(() => {
               <TooltipContent
                 title="Custom Link Previews are only available on the Pro plan and above."
                 cta="Upgrade to Pro"
-                href={slug ? `/${slug}/upgrade` : "https://dub.co/pricing"}
+                href={buildUpgradeUrl({
+                  slug,
+                  upgradePlan: "pro",
+                  upgradeSource: "link_preview_custom_og",
+                })}
                 target="_blank"
               />
             ) : undefined

--- a/apps/web/ui/links/links-toolbar.tsx
+++ b/apps/web/ui/links/links-toolbar.tsx
@@ -1,3 +1,4 @@
+import { buildUpgradeUrl } from "@/lib/billing/upgrade-intent";
 import { getPlanCapabilities } from "@/lib/plan-capabilities";
 import { useFolderPermissions } from "@/lib/swr/use-folder-permissions";
 import useWorkspace from "@/lib/swr/use-workspace";
@@ -123,7 +124,11 @@ export const LinksToolbar = memo(
               <TooltipContent
                 title="You can only use Link Folders on a Pro plan and above. Upgrade to Pro to continue."
                 cta="Upgrade to Pro"
-                href={`/${slug}/upgrade`}
+                href={buildUpgradeUrl({
+                  slug,
+                  upgradePlan: "pro",
+                  upgradeSource: "links_toolbar_folder",
+                })}
               />
             ) : undefined,
           keyboardShortcut: "m",
@@ -136,7 +141,11 @@ export const LinksToolbar = memo(
             <TooltipContent
               title="Conversion tracking is only available on Business plans and above."
               cta="Upgrade to Business"
-              href={slug ? `/${slug}/upgrade` : "https://dub.co/pricing"}
+              href={buildUpgradeUrl({
+                slug,
+                upgradePlan: "business",
+                upgradeSource: "links_toolbar_conversion",
+              })}
               target="_blank"
             />
           ),

--- a/apps/web/ui/links/short-link-input.tsx
+++ b/apps/web/ui/links/short-link-input.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { buildUpgradeUrl, parseUpgradePlan } from "@/lib/billing/upgrade-intent";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { LinkProps } from "@/lib/types";
 import { DOMAINS_MAX_PAGE_SIZE } from "@/lib/zod/schemas/domains";
@@ -365,7 +366,11 @@ export const ShortLinkInput = forwardRef<HTMLInputElement, ShortLinkInputProps>(
               {error.split(`Upgrade to ${nextPlan.name}`)[0]}
               <a
                 className="cursor-pointer underline"
-                href={`/${slug}/upgrade`}
+                href={buildUpgradeUrl({
+                  slug,
+                  upgradePlan: parseUpgradePlan(nextPlan?.name.toLowerCase()),
+                  upgradeSource: "short_link_input_error",
+                })}
                 target="_blank"
               >
                 Upgrade to {nextPlan.name}

--- a/apps/web/ui/modals/add-edit-domain-modal.tsx
+++ b/apps/web/ui/modals/add-edit-domain-modal.tsx
@@ -1,3 +1,4 @@
+import { buildUpgradeUrl } from "@/lib/billing/upgrade-intent";
 import { clientAccessCheck } from "@/lib/client-access-check";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { DomainProps } from "@/lib/types";
@@ -69,7 +70,10 @@ function AddDomainButton({
             <TooltipContent
               title={`You can only add up to ${domainsLimit} ${pluralize("domain", domainsLimit || 0)} on the ${capitalize(plan)} plan. Upgrade to add more domains`}
               cta="Upgrade"
-              href={`/${slug}/upgrade`}
+              href={buildUpgradeUrl({
+                slug,
+                upgradeSource: "domains_limit",
+              })}
             />
           ) : (
             permissionsError || undefined

--- a/apps/web/ui/modals/add-edit-tag-modal.tsx
+++ b/apps/web/ui/modals/add-edit-tag-modal.tsx
@@ -1,3 +1,4 @@
+import { buildUpgradeUrl } from "@/lib/billing/upgrade-intent";
 import { clientAccessCheck } from "@/lib/client-access-check";
 import { mutatePrefix } from "@/lib/swr/mutate";
 import useTags from "@/lib/swr/use-tags";
@@ -231,7 +232,10 @@ function AddTagButton({
             <TooltipContent
               title={`You can only add up to ${tagsLimit} ${pluralize("tag", tagsLimit || 0)} on the ${capitalize(plan)} plan. Upgrade to add more tags`}
               cta="Upgrade"
-              href={`/${slug}/upgrade`}
+              href={buildUpgradeUrl({
+                slug,
+                upgradeSource: "tags_limit",
+              })}
             />
           ) : (
             permissionsError || undefined

--- a/apps/web/ui/modals/add-folder-modal.tsx
+++ b/apps/web/ui/modals/add-folder-modal.tsx
@@ -1,3 +1,4 @@
+import { buildUpgradeUrl } from "@/lib/billing/upgrade-intent";
 import { clientAccessCheck } from "@/lib/client-access-check";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { FolderSummary } from "@/lib/types";
@@ -62,7 +63,11 @@ function AddFolderButton({
           <TooltipContent
             title="You can only use Link Folders on a Pro plan and above. Upgrade to Pro to continue."
             cta="Upgrade to Pro"
-            href={`/${slug}/upgrade`}
+            href={buildUpgradeUrl({
+              slug,
+              upgradePlan: "pro",
+              upgradeSource: "folders_add_modal",
+            })}
           />
         ) : (
           permissionsError || undefined

--- a/apps/web/ui/modals/link-builder/index.tsx
+++ b/apps/web/ui/modals/link-builder/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { buildUpgradeUrl } from "@/lib/billing/upgrade-intent";
 import { clientAccessCheck } from "@/lib/client-access-check";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { ExpandedLinkProps } from "@/lib/types";
@@ -312,7 +313,10 @@ export function CreateLinkButton({
           <TooltipContent
             title="Your workspace has exceeded its monthly links limit. We're still collecting data on your existing links, but you need to upgrade to create more links."
             cta="Upgrade plan"
-            href={`/${slug}/upgrade`}
+            href={buildUpgradeUrl({
+              slug,
+              upgradeSource: "link_builder_exceeded_links",
+            })}
           />
         ) : (
           permissionsError || undefined

--- a/apps/web/ui/modals/link-qr-modal.tsx
+++ b/apps/web/ui/modals/link-qr-modal.tsx
@@ -1,3 +1,4 @@
+import { buildUpgradeUrl } from "@/lib/billing/upgrade-intent";
 import { getQRAsCanvas, getQRAsSVGDataUri, getQRData } from "@/lib/qr";
 import useDomain from "@/lib/swr/use-domain";
 import useWorkspace from "@/lib/swr/use-workspace";
@@ -256,7 +257,11 @@ function LinkQRModalInner({
               <TooltipContent
                 title="You need to be on the Pro plan and above to customize your QR Code logo."
                 cta="Upgrade to Pro"
-                href={slug ? `/${slug}/upgrade` : "https://dub.co/pricing"}
+                href={buildUpgradeUrl({
+                  slug,
+                  upgradePlan: "pro",
+                  upgradeSource: "qr_logo_customization",
+                })}
                 target="_blank"
               />
             ) : undefined

--- a/apps/web/ui/modals/manage-usage-modal.tsx
+++ b/apps/web/ui/modals/manage-usage-modal.tsx
@@ -1,3 +1,7 @@
+import {
+  buildUpgradeUrl,
+  parseUpgradePlan,
+} from "@/lib/billing/upgrade-intent";
 import { clientAccessCheck } from "@/lib/client-access-check";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { CursorRays, Hyperlink, Modal, Slider, ToggleGroup } from "@dub/ui";
@@ -242,7 +246,11 @@ function ManageUsageModalContent({ type }: ManageUsageModalProps) {
 
           <div className="mt-4 flex justify-center">
             <Link
-              href={`/${slug}/settings/billing/upgrade`}
+              href={buildUpgradeUrl({
+                slug,
+                upgradePlan: parseUpgradePlan(suggestedPlan.name.toLowerCase()),
+                upgradeSource: `manage_usage_modal_${type}`,
+              })}
               className="text-content-subtle hover:text-content-default block text-xs font-medium underline underline-offset-2"
             >
               View all plans

--- a/apps/web/ui/partners/confirm-payouts-sheet.tsx
+++ b/apps/web/ui/partners/confirm-payouts-sheet.tsx
@@ -1,3 +1,4 @@
+import { buildUpgradeUrl } from "@/lib/billing/upgrade-intent";
 import { confirmPayoutsAction } from "@/lib/actions/partners/confirm-payouts";
 import { clientAccessCheck } from "@/lib/client-access-check";
 import {
@@ -777,7 +778,11 @@ function ConfirmPayoutsSheetContent() {
                   type: "payouts",
                 })}
                 cta="Upgrade"
-                href={`/${slug}/settings/billing/upgrade`}
+                href={buildUpgradeUrl({
+                  slug,
+                  upgradePlan: "advanced",
+                  upgradeSource: "partners_confirm_payouts_limit",
+                })}
               />
             ) : amount && amount < INVOICE_MIN_PAYOUT_AMOUNT_CENTS ? (
               "Your payout total is less than the minimum invoice amount of $10."

--- a/apps/web/ui/partners/rewards/add-edit-reward-sheet.tsx
+++ b/apps/web/ui/partners/rewards/add-edit-reward-sheet.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { buildUpgradeUrl } from "@/lib/billing/upgrade-intent";
 import { parseActionError } from "@/lib/actions/parse-action-errors";
 import { createRewardAction } from "@/lib/actions/partners/create-reward";
 import { deleteRewardAction } from "@/lib/actions/partners/delete-reward";
@@ -601,7 +602,12 @@ function RewardSheetContent({
                   <TooltipContent
                     title="Advanced reward structures are only available on the Advanced plan and above."
                     cta="Upgrade to Advanced"
-                    href={`/${workspaceSlug}/upgrade?showPartnersUpgradeModal=true`}
+                    href={buildUpgradeUrl({
+                      slug: workspaceSlug,
+                      upgradePlan: "advanced",
+                      upgradeSource: "partners_rewards_advanced",
+                      showPartnersUpgradeModal: true,
+                    })}
                     target="_blank"
                   />
                 ) : undefined

--- a/apps/web/ui/shared/upgrade-required-toast.tsx
+++ b/apps/web/ui/shared/upgrade-required-toast.tsx
@@ -1,5 +1,10 @@
 "use client";
 
+import {
+  buildUpgradeUrl,
+  parseUpgradePlan,
+  UpgradePlan,
+} from "@/lib/billing/upgrade-intent";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { capitalize } from "@dub/utils";
 import { Crown } from "lucide-react";
@@ -11,12 +16,16 @@ export const UpgradeRequiredToast = ({
   message,
   ctaLabel,
   ctaUrl,
+  upgradePlan,
+  upgradeSource,
 }: {
   title?: string;
   planToUpgradeTo?: string;
   message: string;
   ctaLabel?: string;
   ctaUrl?: string;
+  upgradePlan?: UpgradePlan;
+  upgradeSource?: string;
 }) => {
   const { slug, nextPlan } = useWorkspace();
   planToUpgradeTo = planToUpgradeTo || nextPlan?.name;
@@ -26,7 +35,11 @@ export const UpgradeRequiredToast = ({
     ? `Upgrade to ${capitalize(planToUpgradeTo)}`
     : "Contact support";
 
-  const defaultCtaUrl = slug ? `/${slug}/upgrade` : "https://dub.co/pricing";
+  const defaultCtaUrl = buildUpgradeUrl({
+    slug,
+    upgradePlan: upgradePlan ?? parseUpgradePlan(planToUpgradeTo?.toLowerCase()),
+    upgradeSource,
+  });
 
   return (
     <div className="flex flex-col space-y-3 rounded-lg bg-white p-6 shadow-lg">

--- a/apps/web/ui/workspaces/create-workspace-button.tsx
+++ b/apps/web/ui/workspaces/create-workspace-button.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { buildUpgradeUrl } from "@/lib/billing/upgrade-intent";
 import useWorkspaces from "@/lib/swr/use-workspaces";
 import { ModalContext } from "@/ui/modals/modal-provider";
 import { Button, TooltipContent } from "@dub/ui";
@@ -21,7 +22,11 @@ export default function CreateWorkspaceButton() {
               cta="Upgrade to Pro"
               href={
                 freeWorkspaces
-                  ? `/${freeWorkspaces[0].slug}/upgrade`
+                  ? buildUpgradeUrl({
+                      slug: freeWorkspaces[0].slug,
+                      upgradePlan: "pro",
+                      upgradeSource: "create_workspace_limit",
+                    })
                   : "https://dub.co/pricing"
               }
             />


### PR DESCRIPTION
This looks to fix the issue in which users looking to upgrade aren't shown the correct plan to upgrade to based on the paywall they're clicking from.

This create a link type of upgrade_plan={planRecommended}&upgrade_source={sourceLocation} and maps it to the correct version.

<img width="806" height="62" alt="CleanShot 2026-02-09 at 15 52 23@2x" src="https://github.com/user-attachments/assets/490be324-5aee-4290-bd23-cf7e06845c81" />
