### PR TITLE
Show the program destination URL in the marketplace

### DIFF
--- a/apps/web/app/(ee)/partners.dub.co/(dashboard)/programs/marketplace/[programSlug]/page.tsx
+++ b/apps/web/app/(ee)/partners.dub.co/(dashboard)/programs/marketplace/[programSlug]/page.tsx
@@ -9,7 +9,7 @@ import { ProgramRewardsDisplay } from "@/ui/partners/program-marketplace/program
 import { prisma } from "@dub/prisma";
 import { ChevronRight, Shop, Tooltip } from "@dub/ui";
 import { Hyperlink } from "@dub/ui/icons";
-import { OG_AVATAR_URL, cn, getDomainWithoutWWW, getPrettyUrl } from "@dub/utils";
+import { OG_AVATAR_URL, cn, getDomainWithoutWWW } from "@dub/utils";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { ProgramStatusBadge } from "../program-status-badge";
@@ -49,9 +49,6 @@ export default async function MarketplaceProgramPage(props: {
   }
 
   const isDarkImage = program.marketplaceHeaderImage?.includes("dark");
-  const website =
-    program.url &&
-    (getDomainWithoutWWW(program.url) ?? getPrettyUrl(program.url));
 
   return (
     <PageContent
@@ -132,7 +129,9 @@ export default async function MarketplaceProgramPage(props: {
                   <span
                     className={cn(
                       "block text-xs font-medium",
-                      isDarkImage ? "text-content-inverted" : "text-neutral-400",
+                      isDarkImage
+                        ? "text-content-inverted"
+                        : "text-neutral-400",
                     )}
                   >
                     Rewards
@@ -151,7 +150,9 @@ export default async function MarketplaceProgramPage(props: {
                   <span
                     className={cn(
                       "block text-xs font-medium",
-                      isDarkImage ? "text-content-inverted" : "text-neutral-400",
+                      isDarkImage
+                        ? "text-content-inverted"
+                        : "text-neutral-400",
                     )}
                   >
                     Category
@@ -195,17 +196,13 @@ export default async function MarketplaceProgramPage(props: {
                   </div>
                 </div>
               )}
-              {website && (
+              {program.url && (
                 <div className="min-w-0">
                   <span className="block text-xs font-medium text-neutral-400">
                     Website
                   </span>
                   <Link
-                    href={
-                      program.url!.startsWith("http")
-                        ? program.url!
-                        : `https://${program.url}`
-                    }
+                    href={program.url}
                     target="_blank"
                     rel="noopener noreferrer"
                     className={cn(
@@ -216,7 +213,9 @@ export default async function MarketplaceProgramPage(props: {
                     )}
                   >
                     <Hyperlink className="size-4 shrink-0" />
-                    <span className="truncate">{website} ↗</span>
+                    <span className="truncate">
+                      {getDomainWithoutWWW(program.url)} ↗
+                    </span>
                   </Link>
                 </div>
               )}


### PR DESCRIPTION
Instead of the partner searching the web for the company, we'll show the domain of the group destination URL from the default link settings. Also strips additional paths if any are added to keep things simple.

| Featured | Default |
| --- | --- |
| <img width="1343" height="986" alt="CleanShot 2026-02-10 at 17 24 17@2x" src="https://github.com/user-attachments/assets/9aaa03ba-94a9-48eb-9638-1e0981b58a16" /> | <img width="1360" height="994" alt="CleanShot 2026-02-10 at 17 24 12@2x" src="https://github.com/user-attachments/assets/934dbfbe-7d21-4102-b988-7b6191ce12c7" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Website section to program marketplace pages that displays normalized links (http/https), opens in a new tab, shows a link icon, and truncates long domains for readability.

* **UI Improvements**
  * Rewards and Category labels now toggle between inverted or neutral text colors based on image darkness for more consistent contrast.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->