### PR TITLE
Bug: Single link pages with extra height

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/links/[...link]/page-client.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/links/[...link]/page-client.tsx
@@ -139,7 +139,7 @@ function LinkBuilder({ link }: { link: ExpandedLinkProps }) {
   const [isChangingLink, setIsChangingLink] = useState(false);
 
   return (
-    <div className="flex min-h-[calc(100vh-8px)] flex-col rounded-t-[inherit] bg-white">
+    <div className="flex min-h-[calc(100dvh-var(--page-top-margin)-var(--page-bottom-margin)-1px)] flex-col rounded-t-[inherit] bg-white">
       <div className="py-2 pl-4 pr-5">
         <LinkBuilderHeader
           onSelectLink={(selectedLink) => {
@@ -308,7 +308,7 @@ const Controls = memo(({ link }: { link: ExpandedLinkProps }) => {
 
 function LoadingSkeleton() {
   return (
-    <div className="flex min-h-[calc(100vh-8px)] flex-col rounded-t-[inherit] bg-white">
+    <div className="flex min-h-[calc(100dvh-var(--page-top-margin)-var(--page-bottom-margin)-1px)] flex-col rounded-t-[inherit] bg-white">
       <div className="flex items-center justify-between gap-4 py-2.5 pl-4 pr-5">
         <div className="h-8 w-64 max-w-full animate-pulse rounded-md bg-neutral-100" />
         <div className="h-7 w-32 max-w-full animate-pulse rounded-md bg-neutral-100" />

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/links/[...link]/page.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/links/[...link]/page.tsx
@@ -4,8 +4,8 @@ import { LinkPageClient } from "./page-client";
 export default function LinkPage() {
   return (
     <PageContentOld
-      className="md:mt-0 md:bg-transparent md:py-0"
-      contentWrapperClassName="pt-0 md:rounded-tl-2xl"
+      className="h-full min-h-full md:mt-0 md:flex md:flex-col md:bg-transparent md:py-0"
+      contentWrapperClassName="h-full grow pt-0 md:rounded-tl-2xl"
     >
       <LinkPageClient />
     </PageContentOld>

--- a/apps/web/ui/links/link-builder/link-action-bar.tsx
+++ b/apps/web/ui/links/link-builder/link-action-bar.tsx
@@ -23,7 +23,7 @@ export function LinkActionBar({ children }: PropsWithChildren) {
   return (
     <div
       className={cn(
-        "sticky bottom-0 w-full overflow-hidden lg:bottom-4 lg:[filter:drop-shadow(0_5px_8px_#222A351d)]",
+        "sticky bottom-0 z-10 w-full overflow-hidden lg:bottom-4 lg:[filter:drop-shadow(0_5px_8px_#222A351d)]",
       )}
     >
       <div


### PR DESCRIPTION
Noticed that the single link pages had extra height on all of them which caused scrolling so this fixes that.

https://github.com/user-attachments/assets/6fff2c65-5018-44a9-992b-9fe3f9497168



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved dynamic height calculations to better account for page margins across dashboard components
  * Enhanced responsive layout behavior for improved visual consistency
  * Refined visual stacking order of action elements for better UI presentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->