### PR TITLE
Reject 'is not' link filter on partner analytics/events

### DIFF
--- a/apps/web/app/(ee)/api/partner-profile/programs/[programId]/analytics/export/route.ts
+++ b/apps/web/app/(ee)/api/partner-profile/programs/[programId]/analytics/export/route.ts
@@ -53,6 +53,14 @@ export const GET = withPartnerProfile(
 
     const { linkId, domain, key } = parsedParams;
 
+     if (linkId?.sqlOperator === "NOT IN") {
+      throw new DubApiError({
+        code: "bad_request",
+        message:
+          "The 'is not' filter is not supported for partner analytics export.",
+      });
+    }
+
     if (linkId) {
       // check to make sure all of the linkId.values are in the links
       if (

--- a/apps/web/app/(ee)/api/partner-profile/programs/[programId]/analytics/route.ts
+++ b/apps/web/app/(ee)/api/partner-profile/programs/[programId]/analytics/route.ts
@@ -34,6 +34,13 @@ export const GET = withPartnerProfile(
 
     const { linkId, domain, key } = parsedParams;
 
+     if (linkId?.sqlOperator === "NOT IN") {
+      throw new DubApiError({
+        code: "bad_request",
+        message: "The 'is not' filter is not supported for partner analytics.",
+      });
+    }
+
     if (linkId) {
       // check to make sure all of the linkId.values are in the links
       if (

--- a/apps/web/app/(ee)/api/partner-profile/programs/[programId]/events/export/route.ts
+++ b/apps/web/app/(ee)/api/partner-profile/programs/[programId]/events/export/route.ts
@@ -96,6 +96,14 @@ export const GET = withPartnerProfile(
 
     const { linkId, domain, key } = parsedParams;
 
+    if (linkId?.sqlOperator === "NOT IN") {
+      throw new DubApiError({
+        code: "bad_request",
+        message:
+          "The 'is not' filter is not supported for partner events export.",
+      });
+    }
+
     if (linkId) {
       // check to make sure all of the linkId.values are in the links
       if (

--- a/apps/web/app/(ee)/api/partner-profile/programs/[programId]/events/route.ts
+++ b/apps/web/app/(ee)/api/partner-profile/programs/[programId]/events/route.ts
@@ -48,6 +48,13 @@ export const GET = withPartnerProfile(
     const parsedParams = partnerProfileEventsQuerySchema.parse(searchParams);
     const { linkId, domain, key } = parsedParams;
 
+    if (linkId?.sqlOperator === "NOT IN") {
+      throw new DubApiError({
+        code: "bad_request",
+        message: "The 'is not' filter is not supported for partner events.",
+      });
+    }
+
     if (linkId) {
       // check to make sure all of the linkId.values are in the links
       if (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unsupported "is not" filters on links in partner analytics and partner events endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->