### PR TITLE
Touch device filtering fix

### DIFF
--- a/packages/ui/src/filter/filter-select.tsx
+++ b/packages/ui/src/filter/filter-select.tsx
@@ -419,8 +419,6 @@ function FilterButton({
   isChecked?: boolean;
   onSelect: () => void;
 }) {
-  const { isMobile } = useMediaQuery();
-
   const Icon = option
     ? option.icon ??
       filter.getOptionIcon?.(option.value, { key: filter.key, option }) ??
@@ -438,15 +436,6 @@ function FilterButton({
         "flex cursor-pointer items-center gap-3 whitespace-nowrap rounded-md px-3 py-2 text-left text-sm",
         "data-[selected=true]:bg-neutral-100",
       )}
-      onPointerDown={(e) => {
-        e.preventDefault();
-      }}
-      onPointerUp={(e) => {
-        e.preventDefault();
-        // Mobile touches have some sort of delay that can cause the next page's option's
-        // onClick / onSelect to be triggered so we delay this by 100ms to account for it
-        isMobile ? setTimeout(onSelect, 100) : onSelect();
-      }}
       onSelect={onSelect}
       value={label + option?.value}
     >


### PR DESCRIPTION
On touch devices there was mobile query patch that prevented pointer actions and had a delay. This should fix it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified filter button interaction handling on mobile devices by removing delayed response behavior and unnecessary gesture-prevention logic, allowing pointer interactions to trigger immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->