### PR TITLE
iPad onboarding height fix

### DIFF
--- a/apps/web/app/(ee)/partners.dub.co/(auth-login-register)/(generic)/layout.tsx
+++ b/apps/web/app/(ee)/partners.dub.co/(auth-login-register)/(generic)/layout.tsx
@@ -64,7 +64,7 @@ export default async function PartnerAuthLayout(props: {
     redirect("/register");
   }
   return (
-    <div className="relative grid grid-cols-1 min-[900px]:grid-cols-[440px_minmax(0,1fr)] lg:grid-cols-[595px_minmax(0,1fr)]">
+    <div className="relative grid min-h-screen min-h-[100dvh] grid-cols-1 min-[900px]:grid-cols-[440px_minmax(0,1fr)] lg:grid-cols-[595px_minmax(0,1fr)]">
       <PartnerBanner program={program} />
       <SidePanel program={program} />
 
@@ -105,7 +105,7 @@ export default async function PartnerAuthLayout(props: {
             </div>
           ))}
         </div>
-        <div className="relative flex h-screen w-full justify-center">
+        <div className="relative flex min-h-screen min-h-[100dvh] w-full justify-center">
           <Logo className="min-[900px]:hidden" />
           {props.children}
         </div>

--- a/apps/web/app/(ee)/partners.dub.co/(auth-other)/layout.tsx
+++ b/apps/web/app/(ee)/partners.dub.co/(auth-other)/layout.tsx
@@ -45,7 +45,7 @@ export default function PartnerAuthLayout({
           </div>
         ))}
       </div>
-      <div className="relative flex h-screen w-full justify-center">
+      <div className="relative flex min-h-screen min-h-[100dvh] w-full justify-center">
         <Logo />
         {children}
       </div>

--- a/apps/web/app/(ee)/partners.dub.co/(onboarding)/layout.tsx
+++ b/apps/web/app/(ee)/partners.dub.co/(onboarding)/layout.tsx
@@ -48,7 +48,7 @@ export default function PartnerOnboardingLayout({
         ))}
       </div>
 
-      <div className="relative flex min-h-screen w-full flex-col items-center justify-between">
+      <div className="relative flex min-h-screen min-h-[100dvh] w-full flex-col items-center justify-between">
         <div className="grow basis-0">
           <div className="pt-4">
             <Link href="https://dub.co/home" target="_blank" className="block">

--- a/apps/web/app/app.dub.co/(auth)/layout.tsx
+++ b/apps/web/app/app.dub.co/(auth)/layout.tsx
@@ -9,7 +9,7 @@ export default function AuthLayout({ children }: { children: ReactNode }) {
     <>
       <Toolbar />
 
-      <div className="relative grid h-screen grid-cols-1 min-[900px]:grid-cols-[minmax(0,1fr)_440px] lg:grid-cols-[minmax(0,1fr)_595px]">
+      <div className="relative grid min-h-screen min-h-[100dvh] grid-cols-1 min-[900px]:grid-cols-[minmax(0,1fr)_440px] lg:grid-cols-[minmax(0,1fr)_595px]">
         {/* Left: Main auth content */}
         <div className="relative">
           <div className="absolute inset-0 isolate overflow-hidden bg-white">
@@ -49,7 +49,7 @@ export default function AuthLayout({ children }: { children: ReactNode }) {
             ))}
           </div>
 
-          <div className="relative flex min-h-screen w-full justify-center">
+          <div className="relative flex min-h-screen min-h-[100dvh] w-full justify-center">
             <a
               href="https://dub.co"
               target="_blank"

--- a/apps/web/app/app.dub.co/(onboarding)/onboarding/(steps)/layout.tsx
+++ b/apps/web/app/app.dub.co/(onboarding)/onboarding/(steps)/layout.tsx
@@ -43,7 +43,7 @@ export default function Layout({ children }: PropsWithChildren) {
         ))}
       </div>
 
-      <div className="relative flex min-h-screen w-full flex-col items-center justify-between">
+      <div className="relative flex min-h-screen min-h-[100dvh] w-full flex-col items-center justify-between">
         <div className="grow basis-0">
           <div className="pt-4">
             <Link href="https://dub.co/home" target="_blank" className="block">

--- a/apps/web/app/app.dub.co/(onboarding)/onboarding/welcome/page.tsx
+++ b/apps/web/app/app.dub.co/(onboarding)/onboarding/welcome/page.tsx
@@ -9,7 +9,7 @@ export default function Welcome() {
     <>
       <TrackSignup />
       <NewBackground showAnimation showGradient={false} />
-      <div className="relative flex min-h-screen flex-col items-center justify-center">
+      <div className="relative flex min-h-screen min-h-[100dvh] flex-col items-center justify-center">
         <div className="flex max-w-sm flex-col items-center px-4 py-16 text-center">
           <div className="animate-slide-up-fade relative flex w-auto items-center justify-center px-6 py-2 [--offset:20px] [animation-duration:1.3s] [animation-fill-mode:both]">
             <Gradient className="opacity-10 mix-blend-overlay" />

--- a/apps/web/ui/layout/auth-layout.tsx
+++ b/apps/web/ui/layout/auth-layout.tsx
@@ -13,7 +13,7 @@ export const AuthLayout = ({
   return (
     <div
       className={cn(
-        "flex min-h-screen w-full flex-col items-center justify-between",
+        "flex min-h-screen min-h-[100dvh] w-full flex-col items-center justify-between",
         className,
       )}
     >


### PR DESCRIPTION
The fixes an issue in which on ipads, the onboarding pages don't play well with the current `min-h-screen`, so changing to `min-h-[100dvh]` to accommodate all device types.

This fixes the logos being cut off on the workspace sign up page too.

### Current
Can scroll
<img width="1366" height="1024" alt="Dub Partners  Earn by partnering with world-class companies 2" src="https://github.com/user-attachments/assets/ead0e0ae-a4ce-482c-9b50-f3f8897745b1" />

### Updated
Fits within the screen height
<img width="1366" height="1024" alt="Dub Partners  Earn by partnering with world-class companies" src="https://github.com/user-attachments/assets/34963928-04e9-4947-a7ec-ee382991ca8b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced viewport height handling across all authentication and onboarding interface screens. Layout constraints now adapt more effectively to different device displays, particularly mobile devices where browser interface elements dynamically expand and collapse. This ensures consistent full-screen visual presentation and better responsive layout behavior across all supported platforms and screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->