### PR TITLE
Exclude imported commissions from getCustomerStripeInvoices

### DIFF
--- a/apps/web/app/(ee)/api/customers/[id]/stripe-invoices/route.ts
+++ b/apps/web/app/(ee)/api/customers/[id]/stripe-invoices/route.ts
@@ -1,8 +1,10 @@
 import { getCustomerOrThrow } from "@/lib/api/customers/get-customer-or-throw";
 import { getCustomerStripeInvoices } from "@/lib/api/customers/get-customer-stripe-invoices";
 import { DubApiError } from "@/lib/api/errors";
+import { getDefaultProgramIdOrThrow } from "@/lib/api/programs/get-default-program-id-or-throw";
 import { withWorkspace } from "@/lib/auth";
 import { NextResponse } from "next/server";
+
 export const GET = withWorkspace(async ({ workspace, params }) => {
   const { id: customerId } = params;
 
@@ -30,6 +32,7 @@ export const GET = withWorkspace(async ({ workspace, params }) => {
   const stripeCustomerInvoices = await getCustomerStripeInvoices({
     stripeCustomerId: customer.stripeCustomerId,
     stripeConnectId: workspace.stripeConnectId,
+    programId: getDefaultProgramIdOrThrow(workspace),
   });
 
   return NextResponse.json(stripeCustomerInvoices);

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/commissions/create-commission-sheet.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/commissions/create-commission-sheet.tsx
@@ -178,6 +178,9 @@ function CreateCommissionSheetContent({
   );
 
   const stripeInvoices = stripeInvoicesData?.invoices ?? [];
+  const unimportedStripeInvoices = stripeInvoices.filter(
+    (inv) => !inv.dubCommissionId,
+  );
   const noStripeCustomerId = stripeInvoicesData?.noStripeCustomerId ?? false;
   const noStripeCustomerMessage = stripeInvoicesData?.message;
 
@@ -279,8 +282,8 @@ function CreateCommissionSheetContent({
           return "This customer doesn't have a Stripe customer ID. Add one in the customer profile before proceeding.";
         }
 
-        if (stripeInvoices.length === 0) {
-          return "No paid Stripe invoices found for this customer.";
+        if (unimportedStripeInvoices.length === 0) {
+          return "No unimported Stripe invoices found for this customer.";
         }
       } else {
         if (!saleAmount) {
@@ -299,7 +302,7 @@ function CreateCommissionSheetContent({
     saleAmount, // sale commission amount
     useExistingEvents,
     noStripeCustomerId,
-    stripeInvoices.length,
+    unimportedStripeInvoices.length,
     isStripeInvoicesLoading,
   ]);
 
@@ -652,22 +655,47 @@ function CreateCommissionSheetContent({
                                 {stripeInvoices.map((inv) => (
                                   <div
                                     key={inv.id}
-                                    className="flex items-center justify-between gap-3 rounded-md px-3 py-2.5"
+                                    className={cn(
+                                      "flex items-center justify-between gap-3 rounded-md px-3 py-2.5",
+                                      inv.dubCommissionId &&
+                                        "bg-neutral-50/80 opacity-75",
+                                    )}
                                   >
                                     <div className="min-w-0 flex-1">
                                       <a
                                         href={`https://dashboard.stripe.com/invoices/${inv.id}`}
                                         target="_blank"
                                         rel="noopener noreferrer"
-                                        className="cursor-alias font-mono text-sm font-medium text-neutral-800 decoration-dotted underline-offset-2 hover:underline"
+                                        className={cn(
+                                          "cursor-alias font-mono text-sm font-medium decoration-dotted underline-offset-2 hover:underline",
+                                          inv.dubCommissionId
+                                            ? "text-neutral-500"
+                                            : "text-neutral-800",
+                                        )}
                                       >
                                         {inv.id}
                                       </a>
-                                      <p className="mt-0.5 text-xs text-neutral-500">
+                                      <p className="mt-0.5 flex flex-wrap items-center gap-x-2 text-xs text-neutral-500">
                                         {formatDate(inv.createdAt)}
+                                        {inv.dubCommissionId && (
+                                          <a
+                                            href={`/${slug}/program/commissions?partnerId=${partnerId}&customerId=${customerId}`}
+                                            target="_blank"
+                                            className="rounded bg-neutral-200/80 px-1.5 py-0.5 text-neutral-500 hover:bg-neutral-200 hover:text-neutral-900"
+                                          >
+                                            Already imported
+                                          </a>
+                                        )}
                                       </p>
                                     </div>
-                                    <span className="shrink-0 text-sm font-medium text-neutral-700">
+                                    <span
+                                      className={cn(
+                                        "shrink-0 text-sm font-medium",
+                                        inv.dubCommissionId
+                                          ? "text-neutral-500"
+                                          : "text-neutral-700",
+                                      )}
+                                    >
                                       {currencyFormatter(inv.amount)}
                                     </span>
                                   </div>
@@ -978,7 +1006,7 @@ function CreateCommissionSheetContent({
           <Button
             type="submit"
             variant="primary"
-            text={`Create commission${stripeInvoices.length > 0 ? "s" : ""}`}
+            text={`Create commission${unimportedStripeInvoices.length > 0 ? "s" : ""}`}
             className="w-fit"
             loading={isPending}
             disabledTooltip={submitDisabledMessage}

--- a/apps/web/lib/actions/partners/create-manual-commission.ts
+++ b/apps/web/lib/actions/partners/create-manual-commission.ts
@@ -177,18 +177,18 @@ export const createManualCommissionAction = authActionClient
       const stripeCustomerInvoices = await getCustomerStripeInvoices({
         stripeCustomerId: customer.stripeCustomerId,
         stripeConnectId: workspace.stripeConnectId,
-      }).then(
-        (
-          invoices, // sort invoices by created date ascending
-        ) =>
-          invoices.sort(
-            (a, b) => a.createdAt.getTime() - b.createdAt.getTime(),
-          ),
+        programId,
+      }).then((invoices) =>
+        invoices
+          // filter out invoices that are already associated with a commission on Dub
+          .filter((invoice) => !invoice.dubCommissionId)
+          // sort invoices by created date ascending
+          .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime()),
       );
 
       if (stripeCustomerInvoices.length === 0) {
         throw new Error(
-          `No paid Stripe invoices found for customer ${customer.email} (${customer.stripeCustomerId}).`,
+          `No unimported Stripe invoices found for customer ${customer.email} (${customer.stripeCustomerId}).`,
         );
       }
 

--- a/apps/web/lib/zod/schemas/customers.ts
+++ b/apps/web/lib/zod/schemas/customers.ts
@@ -200,4 +200,5 @@ export const StripeCustomerInvoiceSchema = z.object({
   amount: z.number(),
   createdAt: z.date(),
   metadata: z.any(),
+  dubCommissionId: z.string().nullable(),
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stripe invoices now include visual indicators distinguishing between already imported and unimported invoices in the commission creation interface
  * The commission workflow clearly shows which invoices have previously been associated with existing commissions

* **Improvements**
  * Enhanced styling and messaging throughout the interface to clarify the import status of Stripe invoices
  * Refined error messages when no unimported Stripe invoices are available for commission creation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->