### PR TITLE
Account for custom createdAt in subscriptionDurationMonths calculation

### DIFF
--- a/apps/web/lib/partners/create-partner-commission.ts
+++ b/apps/web/lib/partners/create-partner-commission.ts
@@ -118,7 +118,10 @@ export const createPartnerCommission = async ({
       });
 
       const subscriptionDurationMonths = firstCommission
-        ? differenceInMonths(new Date(), firstCommission.createdAt)
+        ? differenceInMonths(
+            createdAt ?? new Date(), // account for custom commission creation date
+            firstCommission.createdAt,
+          )
         : 0;
 
       context = {
@@ -233,13 +236,13 @@ export const createPartnerCommission = async ({
             // Recurring sale reward (maxDuration > 0)
             else {
               const subscriptionDurationMonths = differenceInMonths(
-                new Date(),
+                createdAt ?? new Date(), // account for custom commission creation date
                 firstCommission.createdAt,
               );
 
               if (subscriptionDurationMonths >= reward.maxDuration) {
                 console.log(
-                  `Partner ${partnerId} has reached max duration for ${event} event, skipping commission creation...`,
+                  `Partner ${partnerId} has reached max duration for ${event} event (subscription duration: ${subscriptionDurationMonths} months, max duration: ${reward.maxDuration} months), skipping commission creation...`,
                 );
 
                 return {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Partner commission calculations now use the creation date instead of the current date when computing subscription duration, ensuring more accurate commission amounts.
  * Enhanced logging for commission calculations to include additional details about subscription duration and maximum duration thresholds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->