### PR TITLE
Include current program in partner ban summary

### DIFF
--- a/apps/web/app/(ee)/api/partners/[partnerId]/cross-program-summary/route.ts
+++ b/apps/web/app/(ee)/api/partners/[partnerId]/cross-program-summary/route.ts
@@ -24,9 +24,6 @@ export const GET = withWorkspace(
       by: ["status"],
       where: {
         partnerId,
-        programId: {
-          not: programId,
-        },
       },
       _count: true,
     });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cross-program summary calculations for partner data. The aggregation now properly includes enrollment information from the current program when computing statistics. This update ensures total programs, active programs, and banned programs counts reflect a comprehensive dataset for more accurate reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->