### PR TITLE
Paywall redirect to recommended plan

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/bounties/confirm-create-bounty-modal.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/bounties/confirm-create-bounty-modal.tsx
@@ -1,4 +1,5 @@
 import { getBountyRewardDescription } from "@/lib/partners/get-bounty-reward-description";
+import { getBillingUpgradePathForFeature } from "@/lib/billing/upgrade-url";
 import { getPlanCapabilities } from "@/lib/plan-capabilities";
 import useGroups from "@/lib/swr/use-groups";
 import { usePartnersCountByGroupIds } from "@/lib/swr/use-partners-count-by-groupids";
@@ -176,7 +177,11 @@ function ConfirmCreateBountyModal({
                     <TooltipContent
                       title="New bounty notifications are only available on Advanced plans and above."
                       cta="Upgrade to Advanced"
-                      href={`/${workspaceSlug}/upgrade?showPartnersUpgradeModal=true`}
+                      href={getBillingUpgradePathForFeature({
+                        slug: workspaceSlug,
+                        feature: "partners",
+                        showPartnersUpgradeModal: true,
+                      })}
                       target="_blank"
                     />
                   ),

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners-upgrade-cta.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners-upgrade-cta.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { getBillingUpgradePathForFeature } from "@/lib/billing/upgrade-url";
 import { getPlanCapabilities } from "@/lib/plan-capabilities";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { buttonVariants } from "@dub/ui";
@@ -22,7 +23,10 @@ export function PartnersUpgradeCTA({
     if (!canManageProgram || isLegacyBusinessPlan({ plan, payoutsLimit })) {
       return {
         cta: "Upgrade plan",
-        href: `/${slug}/upgrade`,
+        href: getBillingUpgradePathForFeature({
+          slug,
+          feature: "partners",
+        }),
       };
     } else {
       return {

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/analytics/conversion-tracking-toggle.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/analytics/conversion-tracking-toggle.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { clientAccessCheck } from "@/lib/client-access-check";
+import { getBillingUpgradePathForFeature } from "@/lib/billing/upgrade-url";
 import { getPlanCapabilities } from "@/lib/plan-capabilities";
 import useWorkspace from "@/lib/swr/use-workspace";
 import {
@@ -84,7 +85,10 @@ export function ConversionTrackingToggle() {
           <TooltipContent
             title="You can only enable conversion tracking on Business plans and above."
             cta="Upgrade to Business"
-            href={`/${workspaceSlug}/upgrade`}
+            href={getBillingUpgradePathForFeature({
+              slug: workspaceSlug,
+              feature: "business",
+            })}
           />
         ) : (
           permissionsError || (

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/billing/plan-usage.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/billing/plan-usage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { MEGA_WORKSPACE_LINKS_LIMIT } from "@/lib/constants/misc";
+import { getBillingUpgradePath, getBillingUpgradePathForFeature } from "@/lib/billing/upgrade-url";
 import useGroupsCount from "@/lib/swr/use-groups-count";
 import usePartnersCount from "@/lib/swr/use-partners-count";
 import useTagsCount from "@/lib/swr/use-tags-count";
@@ -32,6 +33,7 @@ import {
   capitalize,
   cn,
   getFirstAndLastDay,
+  getNextPlan,
   INFINITY_NUMBER,
   isLegacyBusinessPlan,
   nFormatter,
@@ -66,6 +68,7 @@ export default function PlanUsage() {
     usersLimit,
     billingCycleStart,
   } = useWorkspace();
+  const nextPlan = getNextPlan(plan);
 
   const { data: tags } = useTagsCount();
   const { users } = useWorkspaceUsers();
@@ -174,7 +177,16 @@ export default function PlanUsage() {
         </div>
         <div className="flex items-center gap-2">
           {plan !== "enterprise" && (
-            <Link href={`/${slug}/settings/billing/upgrade`}>
+            <Link
+              href={getBillingUpgradePath({
+                slug,
+                recommendation: nextPlan
+                  ? {
+                      plan: nextPlan.name.toLowerCase(),
+                    }
+                  : undefined,
+              })}
+            >
               <Button
                 text={plan === "free" ? "Upgrade" : "Manage plan"}
                 variant="primary"
@@ -362,7 +374,10 @@ function UsageTabCard({
                 <div className="max-w-xs px-4 py-2 text-center text-sm text-neutral-600">
                   Upgrade to Business to unlock conversion tracking.{" "}
                   <Link
-                    href={`/${slug}/upgrade`}
+                    href={getBillingUpgradePathForFeature({
+                      slug,
+                      feature: "business",
+                    })}
                     className="underline underline-offset-2 hover:text-neutral-800"
                   >
                     View pricing plans

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/domains/default/page-client.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/domains/default/page-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { clientAccessCheck } from "@/lib/client-access-check";
+import { getBillingUpgradePathForFeature } from "@/lib/billing/upgrade-url";
 import useDefaultDomains from "@/lib/swr/use-default-domains";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { DomainCardTitleColumn } from "@/ui/domains/domain-card-title-column";
@@ -42,7 +43,7 @@ function DubDomainsIcon(domain: string) {
 }
 
 export function DefaultDomains() {
-  const { id, plan, role, flags } = useWorkspace();
+  const { id, slug: workspaceSlug, plan, role, flags } = useWorkspace();
   const [submitting, setSubmitting] = useState(false);
   const [defaultDomains, setDefaultDomains] = useState<string[]>([]);
   const { defaultDomains: initialDefaultDomains, mutate } = useDefaultDomains();
@@ -97,7 +98,10 @@ export function DefaultDomains() {
                     <TooltipContent
                       title="You can only use dub.link on a Pro plan and above. Upgrade to Pro to use this domain."
                       cta="Upgrade to Pro"
-                      href={`/${slug}/upgrade`}
+                      href={getBillingUpgradePathForFeature({
+                        slug: workspaceSlug,
+                        feature: "pro",
+                      })}
                     />
                   ) : undefined)
                 }

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/domains/email/page-client.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/domains/email/page-client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { getBillingUpgradePathForFeature } from "@/lib/billing/upgrade-url";
 import { getPlanCapabilities } from "@/lib/plan-capabilities";
 import { useEmailDomains } from "@/lib/swr/use-email-domains";
 import useWorkspace from "@/lib/swr/use-workspace";
@@ -41,7 +42,10 @@ export function EmailDomains() {
             }
             addButton={
               <Link
-                href={`/${slug}/upgrade`}
+                href={getBillingUpgradePathForFeature({
+                  slug,
+                  feature: "advanced",
+                })}
                 className={cn(
                   buttonVariants({ variant: "primary" }),
                   "flex h-9 items-center justify-center whitespace-nowrap rounded-lg border px-4 text-sm",

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/integrations/[integrationSlug]/page-client.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/integrations/[integrationSlug]/page-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { getIntegrationInstallUrl } from "@/lib/actions/get-integration-install-url";
+import { getBillingUpgradePathForFeature } from "@/lib/billing/upgrade-url";
 import { clientAccessCheck } from "@/lib/client-access-check";
 import { HubSpotSettings } from "@/lib/integrations/hubspot/ui/settings";
 import { SegmentSettings } from "@/lib/integrations/segment/ui/settings";
@@ -288,7 +289,10 @@ export default function IntegrationPageClient({
                     <TooltipContent
                       title="Hubspot integration is only available on Business plans and above. Upgrade to get started."
                       cta="Upgrade to Business"
-                      href={`/${slug}/settings/billing/upgrade`}
+                      href={getBillingUpgradePathForFeature({
+                        slug,
+                        feature: "business",
+                      })}
                     />
                   ) : null
                 }

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/webhooks/page-client.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/webhooks/page-client.tsx
@@ -2,6 +2,7 @@
 
 import useWebhooks from "@/lib/swr/use-webhooks";
 import useWorkspace from "@/lib/swr/use-workspace";
+import { getBillingUpgradePathForFeature } from "@/lib/billing/upgrade-url";
 import EmptyState from "@/ui/shared/empty-state";
 import WebhookCard from "@/ui/webhooks/webhook-card";
 import WebhookPlaceholder from "@/ui/webhooks/webhook-placeholder";
@@ -23,7 +24,10 @@ export default function WebhooksPageClient() {
           description="Webhooks allow you to receive HTTP requests whenever a specific event (eg: someone clicked your link) occurs in Dub."
           learnMore="https://d.to/webhooks"
           buttonText="Upgrade to Business"
-          buttonLink={`/${slug}/upgrade`}
+          buttonLink={getBillingUpgradePathForFeature({
+            slug,
+            feature: "business",
+          })}
         />
       </div>
     );

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/links/page-client.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/links/page-client.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/lib/swr/use-folder-permissions";
 import useLinks from "@/lib/swr/use-links";
 import useWorkspace from "@/lib/swr/use-workspace";
+import { getBillingUpgradePath } from "@/lib/billing/upgrade-url";
 import { useWorkspaceStore } from "@/lib/swr/use-workspace-store";
 import { FolderDropdown } from "@/ui/folders/folder-dropdown";
 import {
@@ -412,7 +413,14 @@ function ImportOption({
         <TooltipContent
           title="Your workspace has exceeded its monthly links limit. We're still collecting data on your existing links, but you need to upgrade to create more links."
           cta={nextPlan ? `Upgrade to ${nextPlan.name}` : "Contact support"}
-          href={`/${slug}/upgrade`}
+          href={getBillingUpgradePath({
+            slug,
+            recommendation: nextPlan
+              ? {
+                  plan: nextPlan.name.toLowerCase(),
+                }
+              : undefined,
+          })}
         />
       }
     >

--- a/apps/web/lib/billing/upgrade-url.ts
+++ b/apps/web/lib/billing/upgrade-url.ts
@@ -1,0 +1,66 @@
+type UpgradeRecommendation = {
+  plan: string;
+  planTier?: number;
+};
+
+const FEATURE_RECOMMENDATIONS: Record<string, UpgradeRecommendation> = {
+  pro: {
+    plan: "pro",
+  },
+  business: {
+    plan: "business",
+  },
+  advanced: {
+    plan: "advanced",
+  },
+  partners: {
+    plan: "advanced",
+    planTier: 2,
+  },
+};
+
+export function getBillingUpgradePath({
+  slug,
+  recommendation,
+  showPartnersUpgradeModal,
+}: {
+  slug?: string;
+  recommendation?: UpgradeRecommendation;
+  showPartnersUpgradeModal?: boolean;
+}) {
+  if (!slug) {
+    return "https://dub.co/pricing";
+  }
+
+  const queryParams = new URLSearchParams();
+
+  if (recommendation) {
+    queryParams.set("plan", recommendation.plan);
+    if (recommendation.planTier && recommendation.planTier > 1) {
+      queryParams.set("planTier", recommendation.planTier.toString());
+    }
+  }
+
+  if (showPartnersUpgradeModal) {
+    queryParams.set("showPartnersUpgradeModal", "true");
+  }
+
+  const query = queryParams.toString();
+  return `/${slug}/settings/billing/upgrade${query ? `?${query}` : ""}`;
+}
+
+export function getBillingUpgradePathForFeature({
+  slug,
+  feature,
+  showPartnersUpgradeModal,
+}: {
+  slug?: string;
+  feature: keyof typeof FEATURE_RECOMMENDATIONS;
+  showPartnersUpgradeModal?: boolean;
+}) {
+  return getBillingUpgradePath({
+    slug,
+    recommendation: FEATURE_RECOMMENDATIONS[feature],
+    showPartnersUpgradeModal,
+  });
+}

--- a/apps/web/lib/integrations/segment/ui/set-write-key.tsx
+++ b/apps/web/lib/integrations/segment/ui/set-write-key.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import useWorkspace from "@/lib/swr/use-workspace";
+import { getBillingUpgradePathForFeature } from "@/lib/billing/upgrade-url";
 import { SegmentIntegrationCredentials } from "@/lib/types";
 import { Lock } from "@/ui/shared/icons";
 import { Button, Tooltip, TooltipContent } from "@dub/ui";
@@ -50,7 +51,10 @@ export function SetWriteKey({
     <TooltipContent
       title="You can only install the Segment integration on the Business plan and above."
       cta="Upgrade to Business"
-      href={`/${slug}/upgrade`}
+      href={getBillingUpgradePathForFeature({
+        slug,
+        feature: "business",
+      })}
     />
   );
 

--- a/apps/web/ui/analytics/analytics-loading-spinner.tsx
+++ b/apps/web/ui/analytics/analytics-loading-spinner.tsx
@@ -1,4 +1,5 @@
 import useWorkspace from "@/lib/swr/use-workspace";
+import { getBillingUpgradePath } from "@/lib/billing/upgrade-url";
 import { LoadingSpinner } from "@dub/ui";
 import { Lock } from "lucide-react";
 import Link from "next/link";
@@ -18,7 +19,12 @@ export function AnalyticsLoadingSpinner() {
         {nextPlan.name} plan required to view more analytics
       </p>
       <Link
-        href={slug ? `/${slug}/upgrade` : "https://dub.co/pricing"}
+        href={getBillingUpgradePath({
+          slug,
+          recommendation: {
+            plan: nextPlan.name.toLowerCase(),
+          },
+        })}
         {...(slug ? {} : { target: "_blank" })}
         className="w-full rounded-md border border-black bg-black px-3 py-1.5 text-center text-sm text-white transition-all hover:bg-neutral-800 hover:ring-4 hover:ring-neutral-200"
       >

--- a/apps/web/ui/analytics/chart-section.tsx
+++ b/apps/web/ui/analytics/chart-section.tsx
@@ -1,5 +1,6 @@
 import { EventType } from "@/lib/analytics/types";
 import useWorkspace from "@/lib/swr/use-workspace";
+import { getBillingUpgradePathForFeature } from "@/lib/billing/upgrade-url";
 import {
   BlurImage,
   buttonVariants,
@@ -182,7 +183,10 @@ function ConversionTrackingPaywall() {
           </Link>
         </p>
         <Link
-          href={`/${slug}/upgrade`}
+          href={getBillingUpgradePathForFeature({
+            slug,
+            feature: "business",
+          })}
           className={cn(
             buttonVariants({ variant: "primary" }),
             "mt-4 flex h-8 items-center justify-center whitespace-nowrap rounded-lg border px-3 text-sm",

--- a/apps/web/ui/analytics/events/events-export-button.tsx
+++ b/apps/web/ui/analytics/events/events-export-button.tsx
@@ -1,4 +1,5 @@
 import useWorkspace from "@/lib/swr/use-workspace";
+import { getBillingUpgradePathForFeature } from "@/lib/billing/upgrade-url";
 import { Button, Download, TooltipContent } from "@dub/ui";
 import { useSession } from "next-auth/react";
 import { Dispatch, SetStateAction, useContext } from "react";
@@ -65,7 +66,10 @@ export function EventsExportButton({
           <TooltipContent
             title="Upgrade to our Business Plan to enable CSV downloads for events in your workspace."
             cta="Upgrade to Business"
-            href={`/${slug}/upgrade`}
+            href={getBillingUpgradePathForFeature({
+              slug,
+              feature: "business",
+            })}
           />
         )
       }

--- a/apps/web/ui/analytics/events/index.tsx
+++ b/apps/web/ui/analytics/events/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import useWorkspace from "@/lib/swr/use-workspace";
+import { getBillingUpgradePathForFeature } from "@/lib/billing/upgrade-url";
 import EmptyState from "@/ui/shared/empty-state";
 import { Menu3 } from "@dub/ui/icons";
 import { cn } from "@dub/utils";
@@ -59,7 +60,10 @@ function EventsTableContainer() {
           description={`Want more data on your link ${selectedTab === "clicks" ? "clicks & QR code scans" : selectedTab}? Upgrade to our Business Plan to get a detailed, real-time stream of events in your workspace.`}
           learnMore="https://d.to/events"
           buttonText="Upgrade to Business"
-          buttonLink={`/${slug}/upgrade`}
+          buttonLink={getBillingUpgradePathForFeature({
+            slug,
+            feature: "business",
+          })}
         />
       }
     />

--- a/apps/web/ui/analytics/toggle.tsx
+++ b/apps/web/ui/analytics/toggle.tsx
@@ -5,6 +5,7 @@ import {
 import { validDateRangeForPlan } from "@/lib/analytics/utils";
 import { getStartEndDates } from "@/lib/analytics/utils/get-start-end-dates";
 import useWorkspace from "@/lib/swr/use-workspace";
+import { getBillingUpgradePath } from "@/lib/billing/upgrade-url";
 import {
   BlurImage,
   Button,
@@ -322,7 +323,12 @@ function UpgradeTooltip({
     <TooltipContent
       title={`${rangeLabel} can only be viewed on a ${isAllTime ? "Business" : getNextPlan(plan).name} plan or higher. Upgrade now to view more stats.`}
       cta={`Upgrade to ${isAllTime ? "Business" : getNextPlan(plan).name}`}
-      href={slug ? `/${slug}/upgrade` : APP_DOMAIN}
+      href={getBillingUpgradePath({
+        slug,
+        recommendation: {
+          plan: (isAllTime ? "Business" : getNextPlan(plan).name).toLowerCase(),
+        },
+      })}
     />
   );
 }

--- a/apps/web/ui/customers/customers-table/customers-table.tsx
+++ b/apps/web/ui/customers/customers-table/customers-table.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { getPlanCapabilities } from "@/lib/plan-capabilities";
+import { getBillingUpgradePathForFeature } from "@/lib/billing/upgrade-url";
 import useCustomersCount from "@/lib/swr/use-customers-count";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { CustomerProps } from "@/lib/types";
@@ -482,7 +483,10 @@ export function CustomersTable({
                   </p>
                   <div className="mt-4">
                     <Link
-                      href={`/${workspaceSlug}/upgrade`}
+                      href={getBillingUpgradePathForFeature({
+                        slug: workspaceSlug,
+                        feature: "business",
+                      })}
                       className={cn(
                         buttonVariants({ variant: "secondary" }),
                         "flex h-8 items-center justify-center gap-2 rounded-md border px-4 text-sm",

--- a/apps/web/ui/domains/register-domain-form.tsx
+++ b/apps/web/ui/domains/register-domain-form.tsx
@@ -1,4 +1,5 @@
 import { mutatePrefix } from "@/lib/swr/mutate";
+import { getBillingUpgradePathForFeature } from "@/lib/billing/upgrade-url";
 import useWorkspace from "@/lib/swr/use-workspace";
 import {
   AnimatedSizeContainer,
@@ -373,7 +374,14 @@ function UpgradeTooltipContent() {
     <TooltipContent
       title="You can only claim a free `.link` domain on a Pro plan and above."
       cta="Upgrade to Pro"
-      onClick={() => window.open(`/${slug}/upgrade`)}
+      onClick={() =>
+        window.open(
+          getBillingUpgradePathForFeature({
+            slug,
+            feature: "pro",
+          }),
+        )
+      }
     />
   );
 }

--- a/apps/web/ui/folders/add-folder-form.tsx
+++ b/apps/web/ui/folders/add-folder-form.tsx
@@ -1,4 +1,5 @@
 import { FOLDER_WORKSPACE_ACCESS } from "@/lib/folder/constants";
+import { getBillingUpgradePathForFeature } from "@/lib/billing/upgrade-url";
 import { getPlanCapabilities } from "@/lib/plan-capabilities";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { FolderAccessLevel, FolderSummary } from "@/lib/types";
@@ -173,7 +174,10 @@ export const AddFolderForm = ({ onSuccess, onCancel }: AddFolderFormProps) => {
                         <TooltipContent
                           title="You can only set custom folder permissions on a Business plan and above."
                           cta="Upgrade to Business"
-                          href={`/${workspace.slug}/upgrade`}
+                          href={getBillingUpgradePathForFeature({
+                            slug: workspace.slug,
+                            feature: "business",
+                          })}
                           target="_blank"
                         />
                       }

--- a/apps/web/ui/folders/edit-folder-sheet.tsx
+++ b/apps/web/ui/folders/edit-folder-sheet.tsx
@@ -3,6 +3,7 @@ import {
   FOLDER_USER_ROLE,
   FOLDER_WORKSPACE_ACCESS,
 } from "@/lib/folder/constants";
+import { getBillingUpgradePathForFeature } from "@/lib/billing/upgrade-url";
 import { getPlanCapabilities } from "@/lib/plan-capabilities";
 import {
   useCheckFolderPermission,
@@ -164,7 +165,10 @@ const EditFolderSheetContent = ({
                     <TooltipContent
                       title="You can only set custom folder permissions on a Business plan and above."
                       cta="Upgrade to Business"
-                      href={`/${slug}/upgrade`}
+                      href={getBillingUpgradePathForFeature({
+                        slug,
+                        feature: "business",
+                      })}
                       target="_blank"
                     />
                   }
@@ -192,7 +196,10 @@ const EditFolderSheetContent = ({
                   </>
                 }
                 className="border-none"
-                learnMoreHref={`/${slug}/upgrade`}
+                learnMoreHref={getBillingUpgradePathForFeature({
+                  slug,
+                  feature: "business",
+                })}
                 learnMoreText="Upgrade to Business"
               />
             ) : (

--- a/apps/web/ui/folders/folder-dropdown.tsx
+++ b/apps/web/ui/folders/folder-dropdown.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { unsortedLinks } from "@/lib/folder/constants";
+import { getBillingUpgradePathForFeature } from "@/lib/billing/upgrade-url";
 import { getPlanCapabilities } from "@/lib/plan-capabilities";
 import useCurrentFolderId from "@/lib/swr/use-current-folder-id";
 import useFolder from "@/lib/swr/use-folder";
@@ -158,7 +159,10 @@ export const FolderDropdown = ({
           <TooltipContent
             title="You can only use Link Folders on a Pro plan and above. Upgrade to Pro to continue."
             cta="Upgrade to Pro"
-            href={`/${slug}/upgrade`}
+            href={getBillingUpgradePathForFeature({
+              slug,
+              feature: "pro",
+            })}
           />
         ) : undefined,
       },
@@ -269,7 +273,10 @@ export const FolderDropdown = ({
                   <TooltipContent
                     title="You can only use Link Folders on a Pro plan and above. Upgrade to Pro to continue."
                     cta="Upgrade to Pro"
-                    href={`/${slug}/upgrade`}
+                    href={getBillingUpgradePathForFeature({
+                      slug,
+                      feature: "pro",
+                    })}
                   />
                 ) : undefined
               }

--- a/apps/web/ui/layout/sidebar/sidebar-usage.tsx
+++ b/apps/web/ui/layout/sidebar/sidebar-usage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import useWorkspace from "@/lib/swr/use-workspace";
+import { getBillingUpgradePath } from "@/lib/billing/upgrade-url";
 import ManageSubscriptionButton from "@/ui/workspaces/manage-subscription-button";
 import { AnimatedSizeContainer, buttonVariants, Icon } from "@dub/ui";
 import { CursorRays, Hyperlink } from "@dub/ui/icons";
@@ -136,7 +137,14 @@ function UsageInner() {
             />
           ) : (warning || plan === "free") && plan !== "enterprise" ? (
             <Link
-              href={`/${slug}/upgrade`}
+              href={getBillingUpgradePath({
+                slug,
+                recommendation: nextPlan
+                  ? {
+                      plan: nextPlan.name.toLowerCase(),
+                    }
+                  : undefined,
+              })}
               className={cn(
                 buttonVariants(),
                 "mt-4 flex h-9 items-center justify-center rounded-md border px-4 text-sm",

--- a/apps/web/ui/layout/upgrade-banner.tsx
+++ b/apps/web/ui/layout/upgrade-banner.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import useWorkspace from "@/lib/swr/use-workspace";
+import { getBillingUpgradePath } from "@/lib/billing/upgrade-url";
 import { Crown } from "@dub/ui";
 import { cn } from "@dub/utils";
 import { motion } from "motion/react";
@@ -16,7 +17,7 @@ export function useUpgradeBannerVisible() {
 }
 
 export function UpgradeBanner() {
-  const { slug, exceededEvents, exceededLinks, exceededPayouts } =
+  const { slug, nextPlan, exceededEvents, exceededLinks, exceededPayouts } =
     useWorkspace();
 
   const needsUpgrade = exceededEvents || exceededLinks || exceededPayouts;
@@ -54,7 +55,14 @@ export function UpgradeBanner() {
       </p>
       {needsUpgrade ? (
         <Link
-          href={`/${slug}/settings/billing/upgrade`}
+          href={getBillingUpgradePath({
+            slug,
+            recommendation: nextPlan
+              ? {
+                  plan: nextPlan.name.toLowerCase(),
+                }
+              : undefined,
+          })}
           className={cn(
             "bg-bg-default text-content-emphasis border-border-subtle ml-4 flex h-7 items-center justify-center rounded-lg border px-2.5 text-sm font-medium",
             "hover:bg-bg-subtle transition-colors duration-150",

--- a/apps/web/ui/links/link-builder/conversion-tracking-toggle.tsx
+++ b/apps/web/ui/links/link-builder/conversion-tracking-toggle.tsx
@@ -1,4 +1,5 @@
 import useWorkspace from "@/lib/swr/use-workspace";
+import { getBillingUpgradePathForFeature } from "@/lib/billing/upgrade-url";
 import { LinkFormData } from "@/ui/links/link-builder/link-builder-provider";
 import {
   CrownSmall,
@@ -63,7 +64,10 @@ export const ConversionTrackingToggle = memo(() => {
             <TooltipContent
               title="Conversion tracking is only available on Business plans and above."
               cta="Upgrade to Business"
-              href={slug ? `/${slug}/upgrade` : "https://dub.co/pricing"}
+              href={getBillingUpgradePathForFeature({
+                slug,
+                feature: "business",
+              })}
               target="_blank"
             />
           )

--- a/apps/web/ui/links/link-builder/link-preview.tsx
+++ b/apps/web/ui/links/link-builder/link-preview.tsx
@@ -1,4 +1,5 @@
 import useWorkspace from "@/lib/swr/use-workspace";
+import { getBillingUpgradePathForFeature } from "@/lib/billing/upgrade-url";
 import {
   LinkFormData,
   useLinkBuilderContext,
@@ -120,7 +121,10 @@ export const LinkPreview = memo(() => {
               <TooltipContent
                 title="Custom Link Previews are only available on the Pro plan and above."
                 cta="Upgrade to Pro"
-                href={slug ? `/${slug}/upgrade` : "https://dub.co/pricing"}
+                href={getBillingUpgradePathForFeature({
+                  slug,
+                  feature: "pro",
+                })}
                 target="_blank"
               />
             ) : undefined

--- a/apps/web/ui/links/links-toolbar.tsx
+++ b/apps/web/ui/links/links-toolbar.tsx
@@ -1,4 +1,5 @@
 import { getPlanCapabilities } from "@/lib/plan-capabilities";
+import { getBillingUpgradePathForFeature } from "@/lib/billing/upgrade-url";
 import { useFolderPermissions } from "@/lib/swr/use-folder-permissions";
 import useWorkspace from "@/lib/swr/use-workspace";
 import {
@@ -123,7 +124,10 @@ export const LinksToolbar = memo(
               <TooltipContent
                 title="You can only use Link Folders on a Pro plan and above. Upgrade to Pro to continue."
                 cta="Upgrade to Pro"
-                href={`/${slug}/upgrade`}
+                href={getBillingUpgradePathForFeature({
+                  slug,
+                  feature: "pro",
+                })}
               />
             ) : undefined,
           keyboardShortcut: "m",
@@ -136,7 +140,10 @@ export const LinksToolbar = memo(
             <TooltipContent
               title="Conversion tracking is only available on Business plans and above."
               cta="Upgrade to Business"
-              href={slug ? `/${slug}/upgrade` : "https://dub.co/pricing"}
+              href={getBillingUpgradePathForFeature({
+                slug,
+                feature: "business",
+              })}
               target="_blank"
             />
           ),

--- a/apps/web/ui/links/short-link-input.tsx
+++ b/apps/web/ui/links/short-link-input.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { getBillingUpgradePath } from "@/lib/billing/upgrade-url";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { LinkProps } from "@/lib/types";
 import { DOMAINS_MAX_PAGE_SIZE } from "@/lib/zod/schemas/domains";
@@ -365,7 +366,12 @@ export const ShortLinkInput = forwardRef<HTMLInputElement, ShortLinkInputProps>(
               {error.split(`Upgrade to ${nextPlan.name}`)[0]}
               <a
                 className="cursor-pointer underline"
-                href={`/${slug}/upgrade`}
+                href={getBillingUpgradePath({
+                  slug,
+                  recommendation: {
+                    plan: nextPlan.name.toLowerCase(),
+                  },
+                })}
                 target="_blank"
               >
                 Upgrade to {nextPlan.name}

--- a/apps/web/ui/modals/add-edit-domain-modal.tsx
+++ b/apps/web/ui/modals/add-edit-domain-modal.tsx
@@ -1,9 +1,10 @@
 import { clientAccessCheck } from "@/lib/client-access-check";
+import { getBillingUpgradePath } from "@/lib/billing/upgrade-url";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { DomainProps } from "@/lib/types";
 import { AddEditDomainForm } from "@/ui/domains/add-edit-domain-form";
 import { Button, ButtonProps, Modal, TooltipContent } from "@dub/ui";
-import { capitalize, pluralize } from "@dub/utils";
+import { capitalize, getNextPlan, pluralize } from "@dub/utils";
 import {
   Dispatch,
   SetStateAction,
@@ -54,6 +55,7 @@ function AddDomainButton({
   buttonProps?: Partial<ButtonProps>;
 }) {
   const { slug, plan, role, domainsLimit, exceededDomains } = useWorkspace();
+  const nextPlan = getNextPlan(plan);
 
   const permissionsError = clientAccessCheck({
     action: "domains.write",
@@ -69,7 +71,14 @@ function AddDomainButton({
             <TooltipContent
               title={`You can only add up to ${domainsLimit} ${pluralize("domain", domainsLimit || 0)} on the ${capitalize(plan)} plan. Upgrade to add more domains`}
               cta="Upgrade"
-              href={`/${slug}/upgrade`}
+              href={getBillingUpgradePath({
+                slug,
+                recommendation: nextPlan
+                  ? {
+                      plan: nextPlan.name.toLowerCase(),
+                    }
+                  : undefined,
+              })}
             />
           ) : (
             permissionsError || undefined

--- a/apps/web/ui/modals/add-edit-tag-modal.tsx
+++ b/apps/web/ui/modals/add-edit-tag-modal.tsx
@@ -1,4 +1,5 @@
 import { clientAccessCheck } from "@/lib/client-access-check";
+import { getBillingUpgradePath } from "@/lib/billing/upgrade-url";
 import { mutatePrefix } from "@/lib/swr/mutate";
 import useTags from "@/lib/swr/use-tags";
 import useWorkspace from "@/lib/swr/use-workspace";
@@ -16,7 +17,7 @@ import {
   useKeyboardShortcut,
   useMediaQuery,
 } from "@dub/ui";
-import { capitalize, cn, pluralize } from "@dub/utils";
+import { capitalize, cn, getNextPlan, pluralize } from "@dub/utils";
 import {
   Dispatch,
   FormEvent,
@@ -207,6 +208,7 @@ function AddTagButton({
   setShowAddEditTagModal: Dispatch<SetStateAction<boolean>>;
 }) {
   const { slug, plan, tagsLimit, role } = useWorkspace();
+  const nextPlan = getNextPlan(plan);
   const { tags } = useTags();
   const exceededTags = tags && tagsLimit && tags.length >= tagsLimit;
 
@@ -231,7 +233,14 @@ function AddTagButton({
             <TooltipContent
               title={`You can only add up to ${tagsLimit} ${pluralize("tag", tagsLimit || 0)} on the ${capitalize(plan)} plan. Upgrade to add more tags`}
               cta="Upgrade"
-              href={`/${slug}/upgrade`}
+              href={getBillingUpgradePath({
+                slug,
+                recommendation: nextPlan
+                  ? {
+                      plan: nextPlan.name.toLowerCase(),
+                    }
+                  : undefined,
+              })}
             />
           ) : (
             permissionsError || undefined

--- a/apps/web/ui/modals/add-folder-modal.tsx
+++ b/apps/web/ui/modals/add-folder-modal.tsx
@@ -1,4 +1,5 @@
 import { clientAccessCheck } from "@/lib/client-access-check";
+import { getBillingUpgradePathForFeature } from "@/lib/billing/upgrade-url";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { FolderSummary } from "@/lib/types";
 import { Button, Modal, TooltipContent, useKeyboardShortcut } from "@dub/ui";
@@ -62,7 +63,10 @@ function AddFolderButton({
           <TooltipContent
             title="You can only use Link Folders on a Pro plan and above. Upgrade to Pro to continue."
             cta="Upgrade to Pro"
-            href={`/${slug}/upgrade`}
+            href={getBillingUpgradePathForFeature({
+              slug,
+              feature: "pro",
+            })}
           />
         ) : (
           permissionsError || undefined

--- a/apps/web/ui/modals/link-builder/index.tsx
+++ b/apps/web/ui/modals/link-builder/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { clientAccessCheck } from "@/lib/client-access-check";
+import { getBillingUpgradePath } from "@/lib/billing/upgrade-url";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { ExpandedLinkProps } from "@/lib/types";
 import { LinkBuilderDestinationUrlInput } from "@/ui/links/link-builder/controls/link-builder-destination-url-input";
@@ -263,7 +264,7 @@ export function CreateLinkButton({
 }: {
   setShowLinkBuilder: Dispatch<SetStateAction<boolean>>;
 } & CreateLinkButtonProps) {
-  const { slug, role, exceededLinks } = useWorkspace();
+  const { slug, role, exceededLinks, nextPlan } = useWorkspace();
 
   const permissionsError = clientAccessCheck({
     action: "links.write",
@@ -312,7 +313,14 @@ export function CreateLinkButton({
           <TooltipContent
             title="Your workspace has exceeded its monthly links limit. We're still collecting data on your existing links, but you need to upgrade to create more links."
             cta="Upgrade plan"
-            href={`/${slug}/upgrade`}
+            href={getBillingUpgradePath({
+              slug,
+              recommendation: nextPlan
+                ? {
+                    plan: nextPlan.name.toLowerCase(),
+                  }
+                : undefined,
+            })}
           />
         ) : (
           permissionsError || undefined

--- a/apps/web/ui/modals/link-qr-modal.tsx
+++ b/apps/web/ui/modals/link-qr-modal.tsx
@@ -1,4 +1,5 @@
 import { getQRAsCanvas, getQRAsSVGDataUri, getQRData } from "@/lib/qr";
+import { getBillingUpgradePathForFeature } from "@/lib/billing/upgrade-url";
 import useDomain from "@/lib/swr/use-domain";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { QRLinkProps } from "@/lib/types";
@@ -256,7 +257,10 @@ function LinkQRModalInner({
               <TooltipContent
                 title="You need to be on the Pro plan and above to customize your QR Code logo."
                 cta="Upgrade to Pro"
-                href={slug ? `/${slug}/upgrade` : "https://dub.co/pricing"}
+                href={getBillingUpgradePathForFeature({
+                  slug,
+                  feature: "pro",
+                })}
                 target="_blank"
               />
             ) : undefined

--- a/apps/web/ui/modals/manage-usage-modal.tsx
+++ b/apps/web/ui/modals/manage-usage-modal.tsx
@@ -1,4 +1,5 @@
 import { clientAccessCheck } from "@/lib/client-access-check";
+import { getBillingUpgradePath } from "@/lib/billing/upgrade-url";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { CursorRays, Hyperlink, Modal, Slider, ToggleGroup } from "@dub/ui";
 import {
@@ -242,7 +243,13 @@ function ManageUsageModalContent({ type }: ManageUsageModalProps) {
 
           <div className="mt-4 flex justify-center">
             <Link
-              href={`/${slug}/settings/billing/upgrade`}
+              href={getBillingUpgradePath({
+                slug,
+                recommendation: {
+                  plan: suggestedPlan.name.toLowerCase(),
+                  planTier: suggestedPlanTier > 1 ? suggestedPlanTier : undefined,
+                },
+              })}
               className="text-content-subtle hover:text-content-default block text-xs font-medium underline underline-offset-2"
             >
               View all plans

--- a/apps/web/ui/partners/confirm-payouts-sheet.tsx
+++ b/apps/web/ui/partners/confirm-payouts-sheet.tsx
@@ -8,6 +8,7 @@ import {
   INVOICE_MIN_PAYOUT_AMOUNT_CENTS,
 } from "@/lib/constants/payouts";
 import { exceededLimitError } from "@/lib/exceeded-limit-error";
+import { getBillingUpgradePathForFeature } from "@/lib/billing/upgrade-url";
 import { calculatePayoutFeeWithWaiver } from "@/lib/partners/calculate-payout-fee-with-waiver";
 import {
   CUTOFF_PERIOD,
@@ -806,7 +807,10 @@ function ConfirmPayoutsSheetContent() {
                   type: "payouts",
                 })}
                 cta="Upgrade"
-                href={`/${slug}/settings/billing/upgrade`}
+                href={getBillingUpgradePathForFeature({
+                  slug,
+                  feature: "partners",
+                })}
               />
             ) : amount && amount < INVOICE_MIN_PAYOUT_AMOUNT_CENTS ? (
               "Your payout total is less than the minimum invoice amount of $10."

--- a/apps/web/ui/partners/rewards/add-edit-reward-sheet.tsx
+++ b/apps/web/ui/partners/rewards/add-edit-reward-sheet.tsx
@@ -5,6 +5,7 @@ import { createRewardAction } from "@/lib/actions/partners/create-reward";
 import { deleteRewardAction } from "@/lib/actions/partners/delete-reward";
 import { updateRewardAction } from "@/lib/actions/partners/update-reward";
 import { constructRewardAmount } from "@/lib/api/sales/construct-reward-amount";
+import { getBillingUpgradePathForFeature } from "@/lib/billing/upgrade-url";
 import { handleMoneyInputChange, handleMoneyKeyDown } from "@/lib/form-utils";
 import { getPlanCapabilities } from "@/lib/plan-capabilities";
 import useGroup from "@/lib/swr/use-group";
@@ -604,7 +605,11 @@ function RewardSheetContent({
                   <TooltipContent
                     title="Advanced reward structures are only available on the Advanced plan and above."
                     cta="Upgrade to Advanced"
-                    href={`/${workspaceSlug}/upgrade?showPartnersUpgradeModal=true`}
+                    href={getBillingUpgradePathForFeature({
+                      slug: workspaceSlug,
+                      feature: "partners",
+                      showPartnersUpgradeModal: true,
+                    })}
                     target="_blank"
                   />
                 ) : undefined

--- a/apps/web/ui/shared/upgrade-required-toast.tsx
+++ b/apps/web/ui/shared/upgrade-required-toast.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { getBillingUpgradePath } from "@/lib/billing/upgrade-url";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { capitalize } from "@dub/utils";
 import { Crown } from "lucide-react";
@@ -26,7 +27,14 @@ export const UpgradeRequiredToast = ({
     ? `Upgrade to ${capitalize(planToUpgradeTo)}`
     : "Contact support";
 
-  const defaultCtaUrl = slug ? `/${slug}/upgrade` : "https://dub.co/pricing";
+  const defaultCtaUrl = getBillingUpgradePath({
+    slug,
+    recommendation: planToUpgradeTo
+      ? {
+          plan: planToUpgradeTo.toLowerCase(),
+        }
+      : undefined,
+  });
 
   return (
     <div className="flex flex-col space-y-3 rounded-lg bg-white p-6 shadow-lg">

--- a/apps/web/ui/workspaces/create-workspace-button.tsx
+++ b/apps/web/ui/workspaces/create-workspace-button.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { getBillingUpgradePathForFeature } from "@/lib/billing/upgrade-url";
 import useWorkspaces from "@/lib/swr/use-workspaces";
 import { ModalContext } from "@/ui/modals/modal-provider";
 import { Button, TooltipContent } from "@dub/ui";
@@ -21,7 +22,10 @@ export default function CreateWorkspaceButton() {
               cta="Upgrade to Pro"
               href={
                 freeWorkspaces
-                  ? `/${freeWorkspaces[0].slug}/upgrade`
+                  ? getBillingUpgradePathForFeature({
+                      slug: freeWorkspaces[0].slug,
+                      feature: "pro",
+                    })
                   : "https://dub.co/pricing"
               }
             />


### PR DESCRIPTION
Standardized upgrade/paywall CTAs across the app to route through a shared billing upgrade URL helper, fixing cases where Billing Upgrade defaulted to the next plan instead of the feature-required plan.

`upgrade-url.ts` is the central URL builder:

- `getBillingUpgradePath(...)` creates `/${slug}/settings/billing/upgrade` and appends optional `plan`, `planTier`, and modal params.
- `getBillingUpgradePathForFeature(...)` maps gated features (e.g. partners/business/pro/advanced) to their recommended upgrade target so call sites can use a single feature key instead of hardcoded links/query strings.

This makes upgrade routing consistent and easier to maintain as paywalls grow.

**Eg.**
`dub.co/acme/settings/billing/upgrade?plan=pro`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Billing upgrade flows now intelligently route users to appropriate plan recommendations based on the specific feature they're trying to access
  * Consistent upgrade experience across all dashboard sections, settings pages, and feature areas
  * Smart plan recommendations that automatically match to feature requirements for better upgrade guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->