### PR TITLE
Fix workspace slug prefix overflow on mobile

### DIFF
--- a/apps/web/ui/workspaces/create-workspace-form.tsx
+++ b/apps/web/ui/workspaces/create-workspace-form.tsx
@@ -139,7 +139,7 @@ export function CreateWorkspaceForm({
           </p>
         </label>
         <div className="relative mt-2 flex rounded-md shadow-sm">
-          <span className="inline-flex items-center rounded-l-md border border-r-0 border-neutral-300 bg-neutral-50 px-5 text-neutral-500 sm:text-sm">
+          <span className="inline-flex max-w-[140px] items-center truncate rounded-l-md border border-r-0 border-neutral-300 bg-neutral-50 px-3 text-neutral-500 sm:max-w-none sm:px-5 sm:text-sm">
             app.{process.env.NEXT_PUBLIC_APP_DOMAIN}
           </span>
           <input


### PR DESCRIPTION
This PR fixes a mobile UI issue where the workspace slug prefix on the Create Workspace page overlaps or pushes the input out of bounds on smaller screens. 

I've added max-width and truncate utilities to the prefix span to ensure it appropriately scales and truncates, allowing the user to view and edit the slug without the input breaking flex layout on mobile.

Closes #3431.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved the workspace creation form's slug prefix badge so it better adapts to different screen sizes for a more consistent layout.
  * Enhanced badge appearance by adding text truncation and adjusted padding/width for cleaner, more readable presentation on mobile and desktop.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->