### PR TITLE
Refactor PayPal certificate caching

### DIFF
--- a/apps/web/app/(ee)/api/paypal/webhook/verify-signature.ts
+++ b/apps/web/app/(ee)/api/paypal/webhook/verify-signature.ts
@@ -19,6 +19,13 @@ async function downloadAndCache(url: string) {
   }
 
   const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(
+      `[PayPal] Failed to download certificate ${response.status}`,
+    );
+  }
+
   const certPem = await response.text();
 
   waitUntil(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved PayPal webhook certificate caching to use per-endpoint keys with a 7-day expiry, reducing remote fetches and improving verification reliability and performance.
* **Bug Fixes**
  * Added error handling for failed certificate downloads to avoid silent failures.
* **Chores**
  * Added logging around cache usage and download events to improve operational visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->