### PR TITLE
Cache 404s in scrape-creators to avoid repeated failed requests

### DIFF
--- a/apps/web/lib/api/scrape-creators/client.ts
+++ b/apps/web/lib/api/scrape-creators/client.ts
@@ -7,7 +7,7 @@ export const scrapeCreatorsFetch = createFetch({
   baseURL: "https://api.scrapecreators.com",
   retry: {
     type: "linear",
-    attempts: 2,
+    attempts: 1,
     delay: 3000,
   },
   headers: {

--- a/apps/web/lib/api/scrape-creators/get-social-content.ts
+++ b/apps/web/lib/api/scrape-creators/get-social-content.ts
@@ -76,6 +76,17 @@ export async function getSocialContent({
   );
 
   if (error) {
+    // Post not found
+    // Cache empty result, so that we don't keep trying to scrape the same post.
+    if (error.status === 404) {
+      waitUntil(
+        redis.set(cacheKey, EMPTY_SOCIAL_CONTENT, {
+          ex: CACHE_TTL * 24 * 30,
+        }),
+      );
+    }
+
+    // We don't cache other errors because they are likely to be transient.
     return EMPTY_SOCIAL_CONTENT;
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized caching behavior for unavailable content and adjusted retry configuration to improve request efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->