### PR TITLE
Update to the partner connect payout button

### DIFF
--- a/apps/web/ui/partners/payouts/connect-payout-button.tsx
+++ b/apps/web/ui/partners/payouts/connect-payout-button.tsx
@@ -72,7 +72,11 @@ export function ConnectPayoutButton({
       <Button
         onClick={handleClick}
         text={
-          connected ? "Manage" : payoutMethod ? "Connect" : "Connect payout"
+          connected
+            ? "Manage"
+            : payoutMethod
+              ? "Connect"
+              : "Connect payout method"
         }
         loading={isPending}
         disabledTooltip={


### PR DESCRIPTION
Small language change to read better.

**Before:** Connect payout
**After:** Connect payout method

<img width="483" height="452" alt="CleanShot 2026-03-04 at 11 42 05@2x" src="https://github.com/user-attachments/assets/731ce537-0025-4f68-80c3-efe37ae3b8e8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated payout button label text to be more descriptive, changing the default fallback text from "Connect payout" to "Connect payout method" for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->