### PR TITLE
Consistent filters layout

### DIFF
--- a/apps/web/app/(ee)/partners.dub.co/(dashboard)/programs/[programSlug]/(enrolled)/earnings/earnings-composite-chart.tsx
+++ b/apps/web/app/(ee)/partners.dub.co/(dashboard)/programs/[programSlug]/(enrolled)/earnings/earnings-composite-chart.tsx
@@ -365,7 +365,7 @@ function EarningsTableControls() {
 
   return (
     <div>
-      <div className="flex flex-col gap-3 md:flex-row">
+      <div className="flex flex-col gap-2 md:flex-row md:items-center">
         <Filter.Select
           filters={filters}
           activeFilters={activeFilters}
@@ -373,10 +373,7 @@ function EarningsTableControls() {
           onRemove={onRemove}
           onSelectedFilterChange={setSelectedFilter}
         />
-        <SimpleDateRangePicker
-          className="w-full sm:min-w-[200px] md:w-fit"
-          align="start"
-        />
+        <SimpleDateRangePicker className="w-full md:w-fit" align="start" />
       </div>
 
       <div

--- a/apps/web/ui/analytics/toggle.tsx
+++ b/apps/web/ui/analytics/toggle.tsx
@@ -90,7 +90,7 @@ export function AnalyticsToggle({
 
   const dateRangePicker = (
     <DateRangePicker
-      className="w-full sm:min-w-[160px] md:w-fit lg:min-w-[200px]"
+      className="w-full md:w-fit"
       align={dashboardProps ? "end" : "center"}
       value={
         start && end


### PR DESCRIPTION
This inconsistency was only happening on the partner pages for Events, Analytics, and Earnings for the program pages. 

Now each group has consistent gap and width, and matches the workspace versions.

<img width="1276" height="1056" alt="CleanShot 2026-03-04 at 17 17 36@2x" src="https://github.com/user-attachments/assets/55c6c85c-71dd-49bf-964b-5336c5b28010" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Optimized responsive design and spacing for analytics interface components. Refined vertical spacing and responsive width handling to improve layout consistency across mobile, tablet, and desktop screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->