### PR TITLE
Fix dark mode colors in referral embed Combobox and links table

### DIFF
--- a/apps/web/app/(ee)/app.dub.co/embed/referrals/links-list.tsx
+++ b/apps/web/app/(ee)/app.dub.co/embed/referrals/links-list.tsx
@@ -95,15 +95,15 @@ export function ReferralsEmbedLinksList({
 
               <div className="flex min-w-0 flex-col">
                 <span
-                  className="min-w-0 truncate text-xs font-medium text-neutral-900"
+                  className="text-content-emphasis min-w-0 truncate text-xs font-medium"
                   title={partnerLink}
                 >
                   {getPrettyUrl(partnerLink)}
                 </span>
                 <div className="flex min-w-0 max-w-[300px] items-center gap-1">
-                  <ArrowTurnRight2 className="size-3 shrink-0 text-neutral-400" />
+                  <ArrowTurnRight2 className="text-content-muted size-3 shrink-0" />
                   <a
-                    className="min-w-0 cursor-alias truncate text-xs font-normal text-neutral-600 decoration-dotted underline-offset-2 hover:underline"
+                    className="text-content-subtle min-w-0 cursor-alias truncate text-xs font-normal decoration-dotted underline-offset-2 hover:underline"
                     href={destinationUrl}
                     target="_blank"
                     rel="noopener noreferrer"

--- a/apps/web/app/(ee)/app.dub.co/embed/referrals/page-client.tsx
+++ b/apps/web/app/(ee)/app.dub.co/embed/referrals/page-client.tsx
@@ -377,14 +377,14 @@ function ReferralLinkDisplay({
               inputClassName="text-sm h-10"
               optionDescription={(option) => (
                 <span className="flex min-w-0 items-center gap-1">
-                  <ArrowTurnRight2 className="size-3 shrink-0 text-neutral-400" />
-                  <span className="min-w-0 truncate text-xs text-neutral-600">
+                  <ArrowTurnRight2 className="text-content-muted size-3 shrink-0" />
+                  <span className="text-content-subtle min-w-0 truncate text-xs">
                     {option.meta.destination}
                   </span>
                 </span>
               )}
               popoverProps={{
-                contentClassName: "rounded-lg border border-neutral-200 p-1",
+                contentClassName: "rounded-lg border border-border-subtle p-1",
               }}
               trigger={
                 <button
@@ -396,7 +396,7 @@ function ReferralLinkDisplay({
                       ? getPrettyUrl(partnerLink)
                       : "No referral link"}
                   </span>
-                  <ChevronDown className="size-4 shrink-0 text-neutral-400" />
+                  <ChevronDown className="text-content-muted size-4 shrink-0" />
                 </button>
               }
             />

--- a/packages/ui/src/combobox/index.tsx
+++ b/packages/ui/src/combobox/index.tsx
@@ -213,8 +213,8 @@ export function Combobox({
   const createOptionItem = (
     <Command.Item
       className={cn(
-        "flex cursor-pointer items-center gap-3 whitespace-nowrap rounded-md px-3 py-2 text-left text-sm text-neutral-700",
-        "data-[selected=true]:bg-neutral-100",
+        "text-content-default flex cursor-pointer items-center gap-3 whitespace-nowrap rounded-md px-3 py-2 text-left text-sm",
+        "data-[selected=true]:bg-bg-subtle",
         optionClassName,
       )}
       onSelect={async () => {
@@ -264,13 +264,13 @@ export function Combobox({
         >
           <Command loop shouldFilter={shouldFilter}>
             {!hideSearch && (
-              <div className="flex items-center overflow-hidden rounded-t-lg border-b border-neutral-200">
+              <div className="border-border-subtle flex items-center overflow-hidden rounded-t-lg border-b">
                 <Command.Input
                   placeholder={searchPlaceholder}
                   value={search}
                   onValueChange={setSearch}
                   className={cn(
-                    "grow border-0 py-3 pl-4 pr-2 outline-none placeholder:text-neutral-400 focus:ring-0 sm:text-sm",
+                    "text-content-emphasis placeholder:text-content-muted grow border-0 bg-transparent py-3 pl-4 pr-2 outline-none focus:ring-0 sm:text-sm",
                     inputClassName,
                   )}
                   onKeyDown={(e) => {
@@ -286,7 +286,7 @@ export function Combobox({
                 />
                 {inputRight && <div className="mr-2">{inputRight}</div>}
                 {shortcutHint && (
-                  <kbd className="mr-2 hidden shrink-0 rounded border border-neutral-200 bg-neutral-100 px-2 py-0.5 text-xs font-light text-neutral-500 md:block">
+                  <kbd className="border-border-subtle bg-bg-subtle text-content-subtle mr-2 hidden shrink-0 rounded border px-2 py-0.5 text-xs font-light md:block">
                     {shortcutHint}
                   </kbd>
                 )}
@@ -331,11 +331,11 @@ export function Combobox({
                       search.length > 0 &&
                       createOptionItem}
                     {shouldFilter ? (
-                      <Empty className="flex min-h-12 items-center justify-center text-sm text-neutral-500">
+                      <Empty className="text-content-subtle flex min-h-12 items-center justify-center text-sm">
                         {emptyState ? emptyState : "No matches"}
                       </Empty>
                     ) : sortedOptions.length === 0 ? (
-                      <div className="flex min-h-12 items-center justify-center text-sm text-neutral-500">
+                      <div className="text-content-subtle flex min-h-12 items-center justify-center text-sm">
                         {emptyState ? emptyState : "No matches"}
                       </div>
                     ) : null}
@@ -352,7 +352,7 @@ export function Combobox({
             </ScrollContainer>
             {/* for single selection, the create option item is shown as a sticky item outside of the scroll container */}
             {onCreate && !multiple && (
-              <div className="rounded-b-lg border-t border-neutral-200 bg-white p-1">
+              <div className="border-border-subtle bg-bg-default rounded-b-lg border-t p-1">
                 {createOptionItem}
               </div>
             )}
@@ -384,7 +384,7 @@ export function Combobox({
               {caret &&
                 (caret === true ? (
                   <ChevronDown
-                    className={`ml-1 size-4 shrink-0 text-neutral-400 transition-transform duration-75 group-data-[state=open]:rotate-180`}
+                    className={`text-content-muted ml-1 size-4 shrink-0 transition-transform duration-75 group-data-[state=open]:rotate-180`}
                   />
                 ) : (
                   caret
@@ -433,7 +433,7 @@ function Option({
           className={cn(
             "flex cursor-pointer items-center gap-3 rounded-md px-3 py-2 text-left text-sm",
             hasDescription ? "whitespace-normal py-2.5" : "whitespace-nowrap",
-            "data-[selected=true]:bg-neutral-100",
+            "data-[selected=true]:bg-bg-subtle",
             Boolean(disabled || option.disabledTooltip) &&
               "cursor-not-allowed opacity-50",
             className,
@@ -443,11 +443,11 @@ function Option({
           value={option.label + option?.value}
         >
           {multiple && (
-            <div className="shrink-0 text-neutral-600">
+            <div className="text-content-default shrink-0">
               {selected ? (
-                <CheckboxCheckedFill className="size-4 text-neutral-600" />
+                <CheckboxCheckedFill className="text-content-default size-4" />
               ) : (
-                <CheckboxUnchecked className="size-4 text-neutral-400" />
+                <CheckboxUnchecked className="text-content-muted size-4" />
               )}
             </div>
           )}
@@ -458,7 +458,7 @@ function Option({
             )}
           >
             {option.icon && (
-              <span className="shrink-0 text-neutral-600">
+              <span className="text-content-default shrink-0">
                 {isReactNode(option.icon) ? (
                   option.icon
                 ) : (
@@ -470,24 +470,24 @@ function Option({
               className={cn(
                 "grow",
                 hasDescription
-                  ? "text-neutral-900"
-                  : "truncate text-neutral-700",
+                  ? "text-content-emphasis"
+                  : "text-content-default truncate",
               )}
             >
               {option.label}
             </span>
             {hasDescription && (
-              <span className="text-sm text-neutral-500">{description}</span>
+              <span className="text-content-subtle text-sm">{description}</span>
             )}
           </div>
           {right}
           {!multiple && selected && (
-            <Check2 className="size-4 shrink-0 text-neutral-600" />
+            <Check2 className="text-content-default size-4 shrink-0" />
           )}
         </Command.Item>
       </DisabledTooltip>
       {option.separatorAfter && (
-        <Command.Separator className="-mx-1 my-1 h-px bg-neutral-200" />
+        <Command.Separator className="bg-border-subtle -mx-1 my-1 h-px" />
       )}
     </>
   );


### PR DESCRIPTION
<img width="2578" height="812" alt="CleanShot 2026-03-05 at 8  40 18" src="https://github.com/user-attachments/assets/c192d8f6-a9e8-49e7-9884-7fea65622aba" />

<img width="2582" height="601" alt="CleanShot 2026-03-05 at 8  40 28" src="https://github.com/user-attachments/assets/ddca6fc2-d132-434e-a3c8-b6024549ed24" />

<img width="2577" height="737" alt="CleanShot 2026-03-05 at 8  40 39" src="https://github.com/user-attachments/assets/e89cf53b-77bb-4d4c-9772-c18ae4c1e81d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated color tokens and visual styling across referral link displays, dropdown selectors, and combobox components to align with the design system standards. These styling refinements enhance visual consistency, improve hierarchy and appearance of interface elements, and ensure a cohesive experience throughout the application while maintaining all existing functionality and interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->