### PR TITLE
call sync-embeddings with qstash delay

### DIFF
--- a/apps/web/app/api/ai/sync-embeddings/route.ts
+++ b/apps/web/app/api/ai/sync-embeddings/route.ts
@@ -1,6 +1,27 @@
 import { upsertDocsEmbeddings } from "@/lib/ai/upsert-docs-embedding";
+import { DubApiError, handleAndReturnErrorResponse } from "@/lib/api/errors";
 import { qstash } from "@/lib/cron";
 import { APP_DOMAIN_WITH_NGROK } from "@dub/utils";
+import * as z from "zod/v4";
+
+const schema = z.object({
+  url: z.url().refine(
+    (val) => {
+      try {
+        const { protocol, hostname, pathname } = new URL(val);
+        return (
+          protocol === "https:" &&
+          ["dub.co", "www.dub.co"].includes(hostname) &&
+          ["/docs/", "/help/"].some((p) => pathname.startsWith(p))
+        );
+      } catch {
+        return false;
+      }
+    },
+    { message: "URL must be a dub.co/docs or dub.co/help URL" },
+  ),
+  delay: z.number().positive().optional(),
+});
 
 // POST /api/ai/sync-embeddings
 // Triggers re-embedding of a single docs/help article.
@@ -16,74 +37,37 @@ export const POST = async (req: Request) => {
     return new Response("Unauthorized", { status: 401 });
   }
 
-  let url: string;
-  let delay: number | undefined;
   try {
-    ({ url, delay } = await req.json());
-  } catch {
-    return new Response("Invalid JSON body", { status: 400 });
-  }
-
-  if (!url || typeof url !== "string") {
-    return new Response("Missing or invalid `url` field", { status: 400 });
-  }
-
-  if (delay !== undefined && (typeof delay !== "number" || delay <= 0)) {
-    return new Response("`delay` must be a positive number (seconds)", {
-      status: 400,
+    const body = await req.json().catch(() => {
+      throw new DubApiError({ code: "bad_request", message: "Invalid JSON body." });
     });
-  }
+    const { url, delay } = schema.parse(body);
+    const normalizedUrl = new URL(url).toString();
 
-  let parsedUrl: URL;
-  try {
-    parsedUrl = new URL(url);
-  } catch {
-    return new Response("Invalid URL", { status: 400 });
-  }
+    if (delay !== undefined) {
+      const response = await qstash.publishJSON({
+        url: `${APP_DOMAIN_WITH_NGROK}/api/ai/sync-embeddings`,
+        method: "POST",
+        delay,
+        headers: { Authorization: `Bearer ${secret}` },
+        body: { url: normalizedUrl },
+      });
 
-  const allowedHostnames = ["dub.co", "www.dub.co"];
-  const allowedPathPrefixes = ["/docs/", "/help/"];
-  if (
-    parsedUrl.protocol !== "https:" ||
-    !allowedHostnames.includes(parsedUrl.hostname) ||
-    !allowedPathPrefixes.some((p) => parsedUrl.pathname.startsWith(p))
-  ) {
-    return new Response("URL must be a dub.co/docs or dub.co/help URL", {
-      status: 400,
-    });
-  }
+      return Response.json({
+        scheduled: true,
+        url: normalizedUrl,
+        delay,
+        messageId: response.messageId,
+      });
+    }
 
-  const normalizedUrl = parsedUrl.toString();
-
-  if (delay !== undefined) {
-    const response = await qstash.publishJSON({
-      delay,
-      url: `${APP_DOMAIN_WITH_NGROK}/api/ai/sync-embeddings`,
-      method: "POST",
-      headers: { Authorization: `Bearer ${secret}` },
-      body: { url: normalizedUrl },
-    });
-
-    return Response.json({
-      delay,
-      scheduled: true,
-      url: normalizedUrl,
-      messageId: response.messageId,
-    });
-  }
-
-  try {
     // const pageviewsMap = await fetchPlausiblePageviews();
     const result = await upsertDocsEmbeddings(
       normalizedUrl,
       // pageviewsMap // TODO: add pageviewsMap back in once we support it
     );
     return Response.json({ success: true, url: normalizedUrl, ...result });
-  } catch (err) {
-    console.error("Failed to seed URL:", normalizedUrl, err);
-    return Response.json(
-      { success: false, url: normalizedUrl, error: "Failed to seed embedding" },
-      { status: 500 },
-    );
+  } catch (error) {
+    return handleAndReturnErrorResponse(error);
   }
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Embedding synchronization requests can be scheduled with an optional delay; scheduled requests return confirmation including delay and message ID.
  * Requests now accept and normalize supported doc/help URLs, improving reliability.

* **Bug Fixes**
  * Added strict request validation: rejects invalid JSON, enforces allowed URL patterns, and requires a positive delay when provided.
  * Improved error handling to return consistent error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->