### PR TITLE
Fraud email layout fix

### DIFF
--- a/packages/email/src/templates/unresolved-fraud-events-summary.tsx
+++ b/packages/email/src/templates/unresolved-fraud-events-summary.tsx
@@ -32,7 +32,7 @@ export default function UnresolvedFraudEventsSummary({
       count: 2,
       partner: {
         name: "Lauren Anderson",
-        image: `${OG_AVATAR_URL}/Lauren Anderson`,
+        image: `${OG_AVATAR_URL}Lauren Anderson`,
       },
     },
     {
@@ -41,7 +41,7 @@ export default function UnresolvedFraudEventsSummary({
       count: 1,
       partner: {
         name: "Charlie Anderson",
-        image: `${OG_AVATAR_URL}/Charlie Anderson`,
+        image: `${OG_AVATAR_URL}Charlie Anderson`,
       },
     },
   ],
@@ -113,7 +113,7 @@ export default function UnresolvedFraudEventsSummary({
                             <Img
                               src={
                                 group.partner.image ||
-                                `${OG_AVATAR_URL}/${group.partner.name}`
+                                `${OG_AVATAR_URL}${group.partner.name}`
                               }
                               width={32}
                               height={32}


### PR DESCRIPTION
Adjusted the layout to work better for all email sizes

<img width="1517" height="897" alt="CleanShot 2026-03-06 at 13 39 19@2x" src="https://github.com/user-attachments/assets/fdd392d6-4395-4a54-bcc0-7a761de9c0bd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Simplified rows into a compact per-group layout and removed the table header for cleaner reading.
  * Increased avatar size, made them circular, and fixed avatar URL formatting so images load correctly.
  * Tightened partner name typography/spacing; added inline group label with a count badge.
  * Refined row borders, right-column alignment/padding, and updated inline "View" link styling and color.
  * Updated CTA from "Review events" to "Review all events".

* **Bug Fixes**
  * Improved hidden-items summary so the "Plus N more" display and counts are accurate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->