### PR TITLE
fix chat bubble border

### DIFF
--- a/apps/web/ui/support/chat-bubble.tsx
+++ b/apps/web/ui/support/chat-bubble.tsx
@@ -40,8 +40,7 @@ export function SupportChatBubble() {
             animate={{ opacity: 1, y: 0, scale: 1 }}
             exit={{ opacity: 0, y: 16, scale: 0.97 }}
             transition={{ duration: 0.2, ease: [0.16, 1, 0.3, 1] }}
-            className="pointer-events-auto mb-4 flex h-[660px] max-h-[calc(100vh-6rem)] w-[calc(100vw-2rem)] flex-col overflow-hidden rounded-2xl border sm:w-[560px]"
-            style={{ borderColor: "rgba(0,0,0,0.07)" }}
+            className="pointer-events-auto mb-4 flex h-[660px] max-h-[calc(100vh-6rem)] w-[calc(100vw-2rem)] flex-col overflow-hidden rounded-2xl bg-white shadow-xl shadow-neutral-900/15 sm:w-[560px]"
           >
             <div className="flex shrink-0 items-center justify-between bg-neutral-900 px-4 py-3">
               <div className="flex items-center gap-2.5">
@@ -75,13 +74,11 @@ export function SupportChatBubble() {
               </div>
             </div>
 
-            <div className="flex-1 overflow-hidden bg-white">
-              <ChatInterface
-                key={resetKey}
-                onReset={handleReset}
-                className="h-full overflow-hidden"
-              />
-            </div>
+            <ChatInterface
+              key={resetKey}
+              onReset={handleReset}
+              className="h-full overflow-hidden"
+            />
           </motion.div>
         )}
       </AnimatePresence>


### PR DESCRIPTION
<img width="611" height="784" alt="image" src="https://github.com/user-attachments/assets/7624907f-6a08-45e9-b708-34bdd1cb6a1d" />
<img width="606" height="779" alt="image" src="https://github.com/user-attachments/assets/5472a97e-baa3-4e08-8334-25ebdb0c4cca" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Chat bubbles refreshed: removed inset border shadow, now use a white background with a larger drop shadow for a cleaner, more modern look.
  * Visual polish applied without changing layout or runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->