### PR TITLE
Fix mobile nav contrast on Brand page

### DIFF
--- a/packages/ui/src/nav/nav-mobile.tsx
+++ b/packages/ui/src/nav/nav-mobile.tsx
@@ -105,7 +105,7 @@ export function NavMobile({
       </button>
       <nav
         className={cn(
-          "fixed inset-0 z-20 hidden max-h-screen w-full overflow-y-auto bg-white px-5 py-16 lg:hidden dark:bg-black dark:text-white/70",
+          "fixed inset-0 z-20 hidden max-h-screen w-full overflow-y-auto bg-white px-5 py-16 lg:hidden dark:bg-black dark:text-white/90",
           open && "block",
         )}
       >


### PR DESCRIPTION
## Summary

This PR improves the readability of the mobile navigation menu on the `/brand` page (and other pages using the dark navigation variant) by increasing text contrast in dark mode.

---

## Background

On mobile, when visiting `/brand` in dark mode and opening the navigation menu, the menu items appear noticeably dim against the dark background. This reduces readability, especially when expanding sections like **“Product”** or **“Resources”**.

The rest of the navigation in dark mode uses higher-contrast colors, so the mobile menu items feel slightly inconsistent with the rest of the UI.

---

## Changes

- **Mobile nav dark-mode text color**
  - In `NavMobile`, increased the dark-mode text color from `dark:text-white/70` to `dark:text-white/90` on the full-screen mobile navigation container.
  - This affects the mobile nav overlay used on `/brand` and other marketing pages that rely on the dark navigation theme.

---

## Rationale

- **Accessibility & readability**  
  The previous `white/70` on a black background is relatively low contrast for primary navigation items. Increasing to `white/90` makes the menu items easier to read on a wider range of displays and lighting conditions.

- **Design consistency**  
  The new value better matches the contrast level used elsewhere in the dark navigation. The change keeps the existing visual style but brings the mobile menu in line with the rest of the dark theme.

- **Scoped impact**  
  The change is limited to the mobile navigation overlay:
  - Light mode behavior is unchanged.
  - No structural or interaction changes were made.

---

## Testing

- Ran the app locally and navigated to `/brand` on a small (mobile) viewport.
- Opened the mobile navigation and expanded sections such as **“Product”** and **“Resources”**.
- Verified that:
  - In **light mode**, the appearance and behavior of the mobile nav are unchanged.
  - In **dark mode**, menu items now have higher contrast and are clearly readable against the black background.
  - The change does not affect layout, animations, or navigation behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved dark mode text visibility in mobile navigation by increasing text opacity for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->