### PR TITLE
Fix brand mobile nav contrast

### DIFF
--- a/packages/ui/src/nav/nav-mobile.tsx
+++ b/packages/ui/src/nav/nav-mobile.tsx
@@ -105,7 +105,7 @@ export function NavMobile({
       </button>
       <nav
         className={cn(
-          "fixed inset-0 z-20 hidden max-h-screen w-full overflow-y-auto bg-white px-5 py-16 lg:hidden dark:bg-black dark:text-white/90",
+          "fixed inset-0 z-20 hidden max-h-screen w-full overflow-y-auto bg-white px-5 py-16 lg:hidden dark:bg-black dark:text-white/70",
           open && "block",
         )}
       >
@@ -277,10 +277,10 @@ const ChildItem = ({
       </div>
       <div>
         <div className="flex items-center gap-2">
-          <h2 className="text-sm font-medium text-neutral-900">{title}</h2>
+          <h2 className="text-sm font-medium text-neutral-900 dark:text-white/90">{title}</h2>
         </div>
         {description && (
-          <p className="text-sm text-neutral-500">{description}</p>
+          <p className="text-sm text-neutral-500 dark:text-white/70">{description}</p>
         )}
       </div>
     </Link>

--- a/packages/ui/src/nav/nav-mobile.tsx
+++ b/packages/ui/src/nav/nav-mobile.tsx
@@ -105,7 +105,7 @@ export function NavMobile({
       </button>
       <nav
         className={cn(
-          "fixed inset-0 z-20 hidden max-h-screen w-full overflow-y-auto bg-white px-5 py-16 lg:hidden dark:bg-black dark:text-white/70",
+          "fixed inset-0 z-20 hidden max-h-screen w-full overflow-y-auto bg-white px-5 py-16 lg:hidden dark:bg-black dark:text-white/90",
           open && "block",
         )}
       >


### PR DESCRIPTION
### Update: Improve dark-mode contrast for submenu items

Thanks for the review!

This update applies dark-mode text styles to the submenu rows as well, ensuring that the expanded navigation items maintain proper contrast within the dark mobile navigation overlay.

#### Changes
- Added `dark:text-white/90` to submenu titles
- Added `dark:text-white/70` to submenu descriptions

#### Result
- Submenu items such as **Product** and **Resources** now have improved readability in dark mode.
- Light mode behavior remains unchanged.
- The change is limited to styling and does not affect layout or navigation behavior.

#### Testing
- Ran the app locally
- Verified behavior on `/brand` with a mobile viewport
- Confirmed improved readability in dark mode
- Confirmed light mode remains unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved dark mode appearance in mobile navigation with enhanced text visibility and contrast for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->