### PR TITLE
Handle `redisWithTimeout`

### DIFF
--- a/apps/web/lib/api/links/cache.ts
+++ b/apps/web/lib/api/links/cache.ts
@@ -1,5 +1,9 @@
 import { LinkProps, RedisLinkProps } from "@/lib/types";
-import { formatRedisLink, redisGlobal } from "@/lib/upstash";
+import {
+  formatRedisLink,
+  redisGlobal,
+  redisGlobalWithTimeout,
+} from "@/lib/upstash";
 import { LRUCache } from "lru-cache";
 import { decodeKey, isCaseSensitiveDomain } from "./case-sensitivity";
 import { ExpandedLink } from "./utils/transform-link";
@@ -62,17 +66,23 @@ class LinkCache {
 
     console.log(`[LRU Cache MISS] ${cacheKey} - Checking redisGlobal...`);
 
-    // Fallback to redisGlobal if LRU cache miss
-    cachedLink = await redisGlobal.get<RedisLinkProps>(cacheKey);
+    try {
+      // Fallback to redisGlobal if LRU cache miss
+      cachedLink = await redisGlobalWithTimeout.get<RedisLinkProps>(cacheKey);
 
-    if (cachedLink) {
-      console.log(`[Redis Cache HIT] ${cacheKey} - Populating LRU Cache...`);
-      linkLRUCache.set(cacheKey, cachedLink); // persist to LRU cache
-      return cachedLink;
-    } else {
-      console.log(
-        `[Redis Cache MISS] ${cacheKey} - Not found in LRU or Redis, falling back to MySQL...`,
-      );
+      if (cachedLink) {
+        console.log(`[Redis Cache HIT] ${cacheKey} - Populating LRU Cache...`);
+        linkLRUCache.set(cacheKey, cachedLink); // persist to LRU cache
+        return cachedLink;
+      } else {
+        console.log(
+          `[Redis Cache MISS] ${cacheKey} - Not found in LRU or Redis, falling back to MySQL...`,
+        );
+        return null;
+      }
+    } catch (error) {
+      console.error(`[Redis Cache Error] ${cacheKey} - ${error}`);
+      throw new Error(`[Redis Cache Error] ${cacheKey} - ${error}`);
     }
   }
 

--- a/apps/web/lib/upstash/redis.ts
+++ b/apps/web/lib/upstash/redis.ts
@@ -13,36 +13,18 @@ const hasGlobalRedisConfig =
   !!process.env.UPSTASH_GLOBAL_REDIS_REST_URL &&
   !!process.env.UPSTASH_GLOBAL_REDIS_REST_TOKEN;
 
-const redisGlobalBase = new Redis({
+const redisConfig = {
   url: hasGlobalRedisConfig
     ? process.env.UPSTASH_GLOBAL_REDIS_REST_URL
     : process.env.UPSTASH_REDIS_REST_URL || "",
   token: hasGlobalRedisConfig
     ? process.env.UPSTASH_GLOBAL_REDIS_REST_TOKEN
     : process.env.UPSTASH_REDIS_REST_TOKEN || "",
-  signal: () => AbortSignal.timeout(1000),
-});
+};
 
-// On timeout (or other errors), get() method calls return null instead of throwing
-export const redisGlobal = new Proxy(redisGlobalBase, {
-  get(target, prop) {
-    const value = target[prop as keyof Redis];
-    if (prop === "get" && typeof value === "function") {
-      return async (...args: unknown[]) => {
-        try {
-          return await (value as (...args: unknown[]) => unknown).apply(
-            target,
-            args,
-          );
-        } catch (error) {
-          console.error(
-            "[redisGlobal] – Timeout getting value from Redis, returning null...",
-            error,
-          );
-          return null;
-        }
-      };
-    }
-    return value;
-  },
+export const redisGlobal = new Redis(redisConfig);
+
+export const redisGlobalWithTimeout = new Redis({
+  ...redisConfig,
+  signal: () => AbortSignal.timeout(1000),
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added timeout protection (1 second) to cache operations to prevent application hang on slow connections.
  * Improved error handling and logging for cache operation failures.

* **Refactor**
  * Restructured cache configuration for better timeout management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->