### PR TITLE
Limit bounties shown on the move email

### DIFF
--- a/packages/email/src/templates/partner-group-changed.tsx
+++ b/packages/email/src/templates/partner-group-changed.tsx
@@ -60,7 +60,7 @@ export default function PartnerGroupChanged({
   rewards?: { icon: string; label: string }[] | null;
   bounties?: { icon: string; label: string }[] | null;
 }) {
-  const shouldCollapseBounties = (bounties?.length ?? 0) > 2;
+  const shouldCollapseBounties = (bounties?.length ?? 0) > 3;
   const visibleBounties = shouldCollapseBounties
     ? bounties!.slice(0, 2)
     : bounties;


### PR DESCRIPTION
Currently there's not limit, and some programs may have many.

- If the program group has 3 bounties, show the full list
- If the program group has more than 3 bounties, cap at 2 and show `Plus X more`

<img width="890" height="1029" alt="CleanShot 2026-03-13 at 08 41 42@2x" src="https://github.com/user-attachments/assets/af0aa58a-af97-41bd-a535-22fcd75b6dea" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated partner group notification emails to collapse bounty lists when exceeding 3 items, displaying a "Plus X more" indicator for hidden bounties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->