### PR TITLE
Add AppsFlyer integration

### DIFF
--- a/apps/web/app/(ee)/api/appsflyer/webhook/route.ts
+++ b/apps/web/app/(ee)/api/appsflyer/webhook/route.ts
@@ -1,0 +1,70 @@
+import { DubApiError, handleAndReturnErrorResponse } from "@/lib/api/errors";
+import { withAxiom } from "@/lib/axiom/server";
+import { trackAppsFlyerLeadEvent } from "@/lib/integrations/appsflyer/track-lead";
+import { trackAppsFlyerSaleEvent } from "@/lib/integrations/appsflyer/track-sale";
+import { prisma } from "@dub/prisma";
+import { getSearchParams } from "@dub/utils";
+import { NextResponse } from "next/server";
+import * as z from "zod/v4";
+
+const querySchema = z.object({
+  publishable_key: z
+    .string()
+    .min(1, "publishable_key is required")
+    .startsWith("dub_pk_", "Invalid publishable key format.")
+    .describe("The workspace's publishable key on Dub."),
+  event_type: z.enum(["lead", "sale"]),
+});
+
+// GET /api/appsflyer/webhook – listen to Postback events from AppsFlyer
+export const GET = withAxiom(async (req) => {
+  try {
+    const queryParams = getSearchParams(req.url);
+
+    const { publishable_key: publishableKey, event_type: eventType } =
+      querySchema.parse(queryParams);
+
+    const workspace = await prisma.project.findUnique({
+      where: {
+        publishableKey,
+      },
+      select: {
+        id: true,
+        stripeConnectId: true,
+        webhookEnabled: true,
+      },
+    });
+
+    if (!workspace) {
+      throw new DubApiError({
+        code: "unauthorized",
+        message: "Invalid publishable key.",
+        docUrl:
+          "https://dub.co/docs/api-reference/authentication#create-a-publishable-key",
+      });
+    }
+
+    delete queryParams.publishable_key;
+    delete queryParams.event_type;
+
+    if (eventType === "lead") {
+      await trackAppsFlyerLeadEvent({
+        queryParams,
+        workspace,
+      });
+    } else if (eventType === "sale") {
+      await trackAppsFlyerSaleEvent({
+        queryParams,
+        workspace,
+      });
+    }
+
+    return NextResponse.json("OK");
+  } catch (error) {
+    return handleAndReturnErrorResponse(error);
+  }
+});
+
+export const HEAD = () => {
+  return new Response("OK");
+};

--- a/apps/web/lib/integrations/appsflyer/track-lead.ts
+++ b/apps/web/lib/integrations/appsflyer/track-lead.ts
@@ -1,0 +1,44 @@
+import { trackLead } from "@/lib/api/conversions/track-lead";
+import { WorkspaceProps } from "@/lib/types";
+import { trackLeadRequestSchema } from "@/lib/zod/schemas/leads";
+import * as z from "zod/v4";
+
+const appsFlyerLeadEventSchema = z.object({
+  clickId: z.string().min(1),
+  event_name: z.string().min(1),
+  customer_external_id: trackLeadRequestSchema.shape.customerExternalId,
+  customer_name: trackLeadRequestSchema.shape.customerName,
+  customer_email: trackLeadRequestSchema.shape.customerEmail,
+  customer_avatar: trackLeadRequestSchema.shape.customerAvatar,
+});
+
+export const trackAppsFlyerLeadEvent = async ({
+  queryParams,
+  workspace,
+}: {
+  queryParams: Record<string, string>;
+  workspace: Pick<WorkspaceProps, "id" | "stripeConnectId" | "webhookEnabled">;
+}) => {
+  const {
+    clickId,
+    event_name: eventName,
+    customer_external_id: customerExternalId,
+    customer_name: customerName,
+    customer_email: customerEmail,
+    customer_avatar: customerAvatar,
+  } = appsFlyerLeadEventSchema.parse(queryParams);
+
+  return await trackLead({
+    clickId,
+    eventName,
+    customerExternalId,
+    customerName,
+    customerEmail,
+    customerAvatar,
+    eventQuantity: undefined,
+    mode: undefined,
+    metadata: null,
+    workspace,
+    rawBody: queryParams,
+  });
+};

--- a/apps/web/lib/integrations/appsflyer/track-sale.ts
+++ b/apps/web/lib/integrations/appsflyer/track-sale.ts
@@ -1,0 +1,44 @@
+import { trackSale } from "@/lib/api/conversions/track-sale";
+import { WorkspaceProps } from "@/lib/types";
+import { trackSaleRequestSchema } from "@/lib/zod/schemas/sales";
+import * as z from "zod/v4";
+
+const appsFlyerSaleEventSchema = z.object({
+  event_name: z.string().min(1),
+  customer_external_id: trackSaleRequestSchema.shape.customerExternalId,
+  amount: z
+    .string()
+    .min(1)
+    .transform((val) => Number(val)),
+  invoice_id: trackSaleRequestSchema.shape.invoiceId,
+  currency: trackSaleRequestSchema.shape.currency,
+});
+
+export const trackAppsFlyerSaleEvent = async ({
+  queryParams,
+  workspace,
+}: {
+  queryParams: Record<string, string>;
+  workspace: Pick<WorkspaceProps, "id" | "stripeConnectId" | "webhookEnabled">;
+}) => {
+  const {
+    event_name: eventName,
+    customer_external_id: customerExternalId,
+    amount,
+    currency,
+    invoice_id: invoiceId,
+  } = appsFlyerSaleEventSchema.parse(queryParams);
+
+  return await trackSale({
+    customerExternalId,
+    amount,
+    currency,
+    eventName,
+    paymentProcessor: undefined,
+    invoiceId,
+    leadEventName: undefined,
+    metadata: null,
+    workspace,
+    rawBody: queryParams,
+  });
+};

--- a/apps/web/lib/middleware/link.ts
+++ b/apps/web/lib/middleware/link.ts
@@ -30,6 +30,7 @@ import { detectBot } from "./utils/detect-bot";
 import { getFinalUrl } from "./utils/get-final-url";
 import { getIdentityHash } from "./utils/get-identity-hash";
 import { handleNotFoundLink } from "./utils/handle-not-found-link";
+import { isAppsFlyerTrackingUrl } from "./utils/is-appsflyer-tracking-url";
 import { isIosAppStoreUrl } from "./utils/is-ios-app-store-url";
 import { isSingularTrackingUrl } from "./utils/is-singular-tracking-url";
 import { isSupportedCustomURIScheme } from "./utils/is-supported-custom-uri-scheme";
@@ -147,9 +148,12 @@ export async function LinkMiddleware(req: NextRequest, ev: NextFetchEvent) {
   // if the following is true, we need to cache the clickId data (so it's available for subsequent /track/lead requests):
   // - trackConversion is enabled
   // - it's a partner link
-  // - it's a Singular tracking URL
+  // - it's a Singular or AppsFlyer tracking URL
   const shouldCacheClickId =
-    trackConversion || isPartnerLink || isSingularTrackingUrl(url);
+    trackConversion ||
+    isPartnerLink ||
+    isSingularTrackingUrl(url) ||
+    isAppsFlyerTrackingUrl(url);
 
   // by default, we only index default dub domain links (e.g. dub.sh)
   // everything else is not indexed by default, unless the user has explicitly set it to be indexed

--- a/apps/web/lib/middleware/utils/get-final-url.ts
+++ b/apps/web/lib/middleware/utils/get-final-url.ts
@@ -5,6 +5,7 @@ import {
 import { getUrlFromStringIfValid } from "@dub/utils/src/functions";
 import { ipAddress } from "@vercel/functions";
 import { NextRequest, userAgent } from "next/server";
+import { isAppsFlyerTrackingUrl } from "./is-appsflyer-tracking-url";
 import { isGooglePlayStoreUrl } from "./is-google-play-store-url";
 import { isSingularTrackingUrl } from "./is-singular-tracking-url";
 import { parse } from "./parse";
@@ -62,6 +63,16 @@ export const getFinalUrl = (
     urlObj.searchParams.set("cl", clickId ?? "");
     urlObj.searchParams.set("ua", ua?.ua ?? "");
     urlObj.searchParams.set("ip", ip ?? "");
+  }
+
+  // for AppsFlyer tracking links
+  if (isAppsFlyerTrackingUrl(url)) {
+    const ua = userAgent(req);
+    const ip = process.env.VERCEL === "1" ? ipAddress(req) : LOCALHOST_IP;
+    urlObj.searchParams.set("clickid", clickId ?? "");
+    urlObj.searchParams.set("af_siteid", via ?? "");
+    urlObj.searchParams.set("af_ua", ua?.ua ?? "");
+    urlObj.searchParams.set("af_ip", ip ?? "");
   }
 
   // Polyfill wpcn & wpcl params for Singular integration

--- a/apps/web/lib/middleware/utils/is-appsflyer-tracking-url.ts
+++ b/apps/web/lib/middleware/utils/is-appsflyer-tracking-url.ts
@@ -1,0 +1,12 @@
+export const isAppsFlyerTrackingUrl = (url: string | null | undefined) => {
+  if (!url) {
+    return false;
+  }
+
+  try {
+    const parsedUrl = new URL(url);
+    return parsedUrl.hostname.endsWith(".onelink.me");
+  } catch (error) {
+    return false;
+  }
+};

--- a/apps/web/tests/redirects/index.test.ts
+++ b/apps/web/tests/redirects/index.test.ts
@@ -143,6 +143,18 @@ describe.runIf(env.CI)("Link Redirects", async () => {
     expect(response.status).toBe(302);
   });
 
+  test("appsflyer tracking url", async () => {
+    const response = await fetch(`${h.baseUrl}/appsflyer`, fetchOptions);
+
+    // location to include clickid, af_siteid, af_ip, af_ua query params
+    expect(response.headers.get("location")).toMatch(/clickid=[a-zA-Z0-9]+/);
+    expect(response.headers.get("location")).toMatch(/af_siteid=/);
+    expect(response.headers.get("location")).toMatch(/af_ip=[a-zA-Z0-9.]+/);
+    expect(response.headers.get("location")).toMatch(/af_ua=.+/);
+    expect(response.headers.get("x-powered-by")).toBe(poweredBy);
+    expect(response.status).toBe(302);
+  });
+
   test("google play store url", async () => {
     const response = await fetch(`${h.baseUrl}/gps`, fetchOptions);
     const location = response.headers.get("location");


### PR DESCRIPTION
## Summary
- Detect AppsFlyer OneLink URLs (`*.onelink.me`) and inject `clickid`, `af_siteid`, `af_ip`, `af_ua` params on redirect (same pattern as Singular)
- Cache clickId for AppsFlyer tracking URLs to support conversion matching via postbacks
- Add webhook endpoint (`GET /api/appsflyer/webhook`) authenticated via `publishable_key` query param, supporting `lead` and `sale` event types
- Add redirect test for AppsFlyer parameter injection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AppsFlyer integration with webhook support for processing lead and sale conversion events
  * Implemented AppsFlyer tracking URL detection and automatic parameter injection (clickid, af_siteid, af_ua, af_ip)
  * Extended tracking support with AppsFlyer Onelink compatibility

* **Tests**
  * Added test coverage for AppsFlyer tracking redirects

<!-- end of auto-generated comment: release notes by coderabbit.ai -->