### PR TITLE
Display the pending referral count only on `/customers/referrals` page

### DIFF
--- a/apps/web/ui/layout/sidebar/app-sidebar-nav.tsx
+++ b/apps/web/ui/layout/sidebar/app-sidebar-nav.tsx
@@ -191,6 +191,7 @@ const NAV_AREAS: SidebarNavAreas<SidebarNavData> = {
   // Program
   program: ({
     slug,
+    pathname,
     showNews,
     pendingPayoutsCount,
     applicationsCount,
@@ -284,11 +285,13 @@ const NAV_AREAS: SidebarNavAreas<SidebarNavData> = {
             name: "Customers",
             icon: User,
             href: `/${slug}/program/customers`,
-            badge: pendingReferralsCount
-              ? pendingReferralsCount > 99
-                ? "99+"
-                : pendingReferralsCount
-              : undefined,
+            badge:
+              pathname?.includes("/customers/referrals") &&
+              pendingReferralsCount
+                ? pendingReferralsCount > 99
+                  ? "99+"
+                  : pendingReferralsCount
+                : undefined,
           },
           {
             name: "Commissions",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pending referrals badge visibility in the navigation menu. The Customers notification badge now appears only when viewing the referrals section and there are pending referrals to review, ensuring relevant notifications at the right time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->