### PR TITLE
Sort partners with unread messages first in message list

### DIFF
--- a/apps/web/app/(ee)/api/messages/route.ts
+++ b/apps/web/app/(ee)/api/messages/route.ts
@@ -61,14 +61,25 @@ export const GET = withWorkspace(
     return NextResponse.json(
       PartnerMessagesSchema.parse(
         partners
-          // Sort by most recent message
-          .sort((a, b) =>
-            sortOrder === "desc"
+          // Sort by unread first, then by most recent message
+          .sort((a, b) => {
+            const aUnread = a.messages.some(
+              (m) => m.senderPartnerId && !m.readInApp,
+            );
+            const bUnread = b.messages.some(
+              (m) => m.senderPartnerId && !m.readInApp,
+            );
+
+            if (aUnread !== bUnread) {
+              return aUnread ? -1 : 1;
+            }
+
+            return sortOrder === "desc"
               ? (b.messages?.[0]?.[sortBy]?.getTime() ?? 0) -
-                (a.messages?.[0]?.[sortBy]?.getTime() ?? 0)
+                  (a.messages?.[0]?.[sortBy]?.getTime() ?? 0)
               : (a.messages?.[0]?.[sortBy]?.getTime() ?? 0) -
-                (b.messages?.[0]?.[sortBy]?.getTime() ?? 0),
-          )
+                  (b.messages?.[0]?.[sortBy]?.getTime() ?? 0);
+          })
           // Map to {partner, messages}
           .map(({ messages, ...partner }) => ({
             partner,

--- a/apps/web/app/(ee)/api/partner-profile/messages/route.ts
+++ b/apps/web/app/(ee)/api/partner-profile/messages/route.ts
@@ -97,14 +97,25 @@ export const GET = withPartnerProfile(async ({ partner, searchParams }) => {
   return NextResponse.json(
     ProgramMessagesSchema.parse(
       programs
-        // Sort by most recent message
-        .sort((a, b) =>
-          sortOrder === "desc"
+        // Sort by unread first, then by most recent message
+        .sort((a, b) => {
+          const aUnread = a.messages.some(
+            (m) => !m.senderPartnerId && !m.readInApp,
+          );
+          const bUnread = b.messages.some(
+            (m) => !m.senderPartnerId && !m.readInApp,
+          );
+
+          if (aUnread !== bUnread) {
+            return aUnread ? -1 : 1;
+          }
+
+          return sortOrder === "desc"
             ? (b.messages?.[0]?.[sortBy]?.getTime() ?? 0) -
-              (a.messages?.[0]?.[sortBy]?.getTime() ?? 0)
+                (a.messages?.[0]?.[sortBy]?.getTime() ?? 0)
             : (a.messages?.[0]?.[sortBy]?.getTime() ?? 0) -
-              (b.messages?.[0]?.[sortBy]?.getTime() ?? 0),
-        )
+                (b.messages?.[0]?.[sortBy]?.getTime() ?? 0);
+        })
         // Map to {program, messages}
         .map(({ messages, ...program }) => ({
           program,


### PR DESCRIPTION
Update both program-side and partner-side message endpoints to prioritize conversations with unread messages at the top, with timestamp-based sorting as secondary ordering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Message conversations now prioritize unread items, displaying unread conversations first before sorting by most recent messages. This improves visibility and conversation management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->