### PR TITLE
Replace marketplace category underscore with space

### DIFF
--- a/apps/web/app/(ee)/partners.dub.co/(dashboard)/programs/marketplace/use-program-network-filters.tsx
+++ b/apps/web/app/(ee)/partners.dub.co/(dashboard)/programs/marketplace/use-program-network-filters.tsx
@@ -101,7 +101,7 @@ export function useProgramNetworkFilters() {
         options:
           categoriesCount?.map(({ category, _count }) => ({
             value: category,
-            label: category,
+            label: category.replaceAll("_", " "),
             right: nFormatter(_count, { full: true }),
           })) ?? [],
       },


### PR DESCRIPTION

<img width="769" height="615" alt="CleanShot 2026-03-17 at 11 17 00@2x" src="https://github.com/user-attachments/assets/901239dc-ba14-45d9-b488-23a73051828c" />

<img width="753" height="391" alt="CleanShot 2026-03-17 at 11 20 03@2x" src="https://github.com/user-attachments/assets/931c55ba-b16b-440f-b22a-89b5252a1222" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved category label formatting in program marketplace filters. Category option labels now display with spaces instead of underscores for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->