### PR TITLE
Add custom domain landing pages

### DIFF
--- a/apps/web/app/[domain]/landing-page.tsx
+++ b/apps/web/app/[domain]/landing-page.tsx
@@ -1,0 +1,163 @@
+import { ButtonLink } from "@/ui/placeholders/button-link";
+import { Hero } from "@/ui/placeholders/hero";
+import { Logo } from "@dub/ui";
+import { cn, createHref, getApexDomain } from "@dub/utils";
+import { ArrowRight } from "lucide-react";
+import { BubbleIcon } from "../../ui/placeholders/bubble-icon";
+import { BrowserGraphic } from "./browser-graphic";
+
+const UTM_PARAMS = {
+  utm_source: "Custom Domain",
+  utm_medium: "Landing Page",
+};
+
+type LandingPageLink = {
+  id: string;
+  shortLink: string;
+  url: string;
+  title: string | null;
+  description: string | null;
+  clicks: number;
+};
+
+export function LandingPage({
+  domain,
+  title,
+  description,
+  featuredLinks,
+}: {
+  domain: string;
+  title: string;
+  description: string;
+  featuredLinks: LandingPageLink[];
+}) {
+  return (
+    <div>
+      <Hero>
+        <div className="relative mx-auto flex w-full max-w-4xl flex-col items-center">
+          <BubbleIcon>
+            <Logo className="size-10" />
+          </BubbleIcon>
+          <div className="mt-16 w-full max-w-xl">
+            <BrowserGraphic domain={domain} />
+          </div>
+          <h1
+            className={cn(
+              "font-display mt-2 text-center text-4xl font-medium text-neutral-900 sm:text-5xl sm:leading-[1.15]",
+              "animate-slide-up-fade motion-reduce:animate-fade-in [--offset:20px] [animation-duration:1s] [animation-fill-mode:both]",
+            )}
+          >
+            {title}
+          </h1>
+          <p
+            className={cn(
+              "mt-5 max-w-2xl text-balance text-center text-base text-neutral-700 sm:text-xl",
+              "animate-slide-up-fade motion-reduce:animate-fade-in [--offset:10px] [animation-delay:200ms] [animation-duration:1s] [animation-fill-mode:both]",
+            )}
+          >
+            {description}
+          </p>
+
+          <div
+            className={cn(
+              "xs:flex-row relative mx-auto mt-8 flex max-w-fit flex-col items-center gap-4",
+              "animate-slide-up-fade motion-reduce:animate-fade-in [--offset:5px] [animation-delay:300ms] [animation-duration:1s] [animation-fill-mode:both]",
+            )}
+          >
+            {featuredLinks[0] && (
+              <ButtonLink variant="primary" href={featuredLinks[0].shortLink}>
+                Open featured link
+              </ButtonLink>
+            )}
+            <ButtonLink
+              variant="secondary"
+              href={createHref("/links", domain, {
+                ...UTM_PARAMS,
+                utm_campaign: domain,
+                utm_content: "Powered by Dub",
+              })}
+            >
+              Powered by Dub
+            </ButtonLink>
+          </div>
+        </div>
+      </Hero>
+
+      <section className="mx-auto mt-20 max-w-6xl px-4 pb-24 sm:px-6">
+        {featuredLinks.length > 0 ? (
+          <>
+            <div className="flex items-end justify-between gap-4">
+              <div>
+                <p className="text-sm font-medium uppercase tracking-[0.18em] text-neutral-500">
+                  Featured Links
+                </p>
+                <h2 className="mt-2 text-2xl font-semibold text-neutral-900 sm:text-3xl">
+                  Explore what&apos;s available on {domain}
+                </h2>
+              </div>
+              <p className="hidden text-sm text-neutral-500 sm:block">
+                {featuredLinks.length} public link
+                {featuredLinks.length === 1 ? "" : "s"}
+              </p>
+            </div>
+
+            <div className="mt-8 grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+              {featuredLinks.map((link) => {
+                const hostname = getApexDomain(link.url);
+                const pathname = new URL(link.shortLink).pathname || "/";
+
+                return (
+                  <a
+                    key={link.id}
+                    href={link.shortLink}
+                    className="group rounded-2xl border border-neutral-200 bg-white p-5 transition-all hover:-translate-y-0.5 hover:border-neutral-300 hover:shadow-lg"
+                  >
+                    <div className="flex items-center justify-between gap-4">
+                      <span className="rounded-full border border-neutral-200 bg-neutral-50 px-3 py-1 text-xs font-medium text-neutral-600">
+                        {pathname}
+                      </span>
+                      <span className="text-xs text-neutral-400">
+                        {link.clicks} click{link.clicks === 1 ? "" : "s"}
+                      </span>
+                    </div>
+
+                    <h3 className="mt-4 text-lg font-semibold text-neutral-900 transition-colors group-hover:text-black">
+                      {link.title || pathname.slice(1) || domain}
+                    </h3>
+
+                    <p className="mt-2 line-clamp-3 text-sm text-neutral-600">
+                      {link.description || `Redirects to ${hostname}.`}
+                    </p>
+
+                    <div className="mt-6 flex items-center justify-between gap-4 text-sm">
+                      <span className="truncate text-neutral-500">
+                        {hostname}
+                      </span>
+                      <span className="flex items-center gap-1 font-medium text-neutral-900">
+                        Visit
+                        <ArrowRight className="size-4 transition-transform group-hover:translate-x-0.5" />
+                      </span>
+                    </div>
+                  </a>
+                );
+              })}
+            </div>
+          </>
+        ) : (
+          <div className="rounded-3xl border border-dashed border-neutral-300 bg-neutral-50 px-6 py-12 text-center">
+            <p className="text-sm font-medium uppercase tracking-[0.18em] text-neutral-500">
+              Landing Page Ready
+            </p>
+            <h2 className="mt-3 text-2xl font-semibold text-neutral-900">
+              Add cloaked links to showcase them here
+            </h2>
+            <p className="mx-auto mt-3 max-w-2xl text-balance text-sm text-neutral-600 sm:text-base">
+              This landing page is live. As soon as this domain has active
+              cloaked links, they&apos;ll appear here automatically.
+            </p>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/web/app/[domain]/page.tsx
+++ b/apps/web/app/[domain]/page.tsx
@@ -1,25 +1,57 @@
+import {
+  getCustomDomainLandingPageData,
+  getLandingPageCopy,
+} from "@/lib/custom-domain-landing-page";
 import { constructMetadata } from "@dub/utils";
+import { LandingPage } from "./landing-page";
 import PlaceholderContent from "./placeholder";
 
-export const revalidate = false; // cache indefinitely
+export const revalidate = 300;
 
 export async function generateMetadata(props: {
   params: Promise<{ domain: string }>;
 }) {
   const params = await props.params;
-  const title = `${params.domain.toUpperCase()} - A ${
-    process.env.NEXT_PUBLIC_APP_NAME
-  } Custom Domain`;
-  const description = `${params.domain.toUpperCase()} is a custom domain on ${
-    process.env.NEXT_PUBLIC_APP_NAME
-  } - an open-source link management tool for modern marketing teams to create, share, and track short links.`;
+  const { rootLink, featuredLinks } = await getCustomDomainLandingPageData(
+    params.domain,
+  );
+  const landingPageCopy = getLandingPageCopy({
+    domain: params.domain,
+    rootLink,
+    featuredLinks,
+  });
 
   return constructMetadata({
-    title,
-    description,
+    title: landingPageCopy.title,
+    description: landingPageCopy.description,
+    image: landingPageCopy.image,
+    video: landingPageCopy.video,
+    url: `https://${params.domain}`,
   });
 }
 
-export default function CustomDomainPage() {
-  return <PlaceholderContent />;
+export default async function CustomDomainPage(props: {
+  params: Promise<{ domain: string }>;
+}) {
+  const { domain } = await props.params;
+  const { rootLink, featuredLinks } =
+    await getCustomDomainLandingPageData(domain);
+  const landingPageCopy = getLandingPageCopy({
+    domain,
+    rootLink,
+    featuredLinks,
+  });
+
+  if (!landingPageCopy.hasCustomContent) {
+    return <PlaceholderContent domain={domain} />;
+  }
+
+  return (
+    <LandingPage
+      domain={domain}
+      title={landingPageCopy.title}
+      description={landingPageCopy.description}
+      featuredLinks={featuredLinks}
+    />
+  );
 }

--- a/apps/web/app/[domain]/placeholder.tsx
+++ b/apps/web/app/[domain]/placeholder.tsx
@@ -1,12 +1,9 @@
-"use client";
-
 import { ButtonLink } from "@/ui/placeholders/button-link";
 import { CTA } from "@/ui/placeholders/cta";
 import { FeaturesSection } from "@/ui/placeholders/features-section";
 import { Hero } from "@/ui/placeholders/hero";
 import { Logo } from "@dub/ui";
 import { cn, createHref } from "@dub/utils";
-import { useParams } from "next/navigation";
 import { BubbleIcon } from "../../ui/placeholders/bubble-icon";
 import { BrowserGraphic } from "./browser-graphic";
 
@@ -15,9 +12,7 @@ const UTM_PARAMS = {
   utm_medium: "Welcome Page",
 };
 
-export default function PlaceholderContent() {
-  const { domain } = useParams() as { domain: string };
-
+export default function PlaceholderContent({ domain }: { domain: string }) {
   return (
     <div>
       <Hero>

--- a/apps/web/lib/custom-domain-landing-page.ts
+++ b/apps/web/lib/custom-domain-landing-page.ts
@@ -1,0 +1,137 @@
+import { prisma } from "@dub/prisma";
+import { Link } from "@dub/prisma/client";
+import { cache } from "react";
+import { encodeKeyIfCaseSensitive } from "./api/links/case-sensitivity";
+
+const FEATURED_LINK_LIMIT = 12;
+
+type LandingPageRootLink = Pick<
+  Link,
+  "title" | "description" | "image" | "video"
+>;
+type LandingPageLink = Pick<
+  Link,
+  | "id"
+  | "domain"
+  | "key"
+  | "url"
+  | "shortLink"
+  | "title"
+  | "description"
+  | "image"
+  | "clicks"
+  | "createdAt"
+  | "archived"
+  | "rewrite"
+  | "expiresAt"
+  | "disabledAt"
+  | "password"
+>;
+
+export function filterLandingPageLinks(
+  links: LandingPageLink[],
+  now: Date = new Date(),
+) {
+  return links
+    .filter(
+      (link) =>
+        link.rewrite &&
+        !link.archived &&
+        !link.disabledAt &&
+        !link.password &&
+        link.url.length > 0 &&
+        (!link.expiresAt || link.expiresAt > now),
+    )
+    .sort(
+      (a, b) =>
+        b.clicks - a.clicks || b.createdAt.getTime() - a.createdAt.getTime(),
+    )
+    .slice(0, FEATURED_LINK_LIMIT);
+}
+
+export function getLandingPageCopy({
+  domain,
+  rootLink,
+  featuredLinks,
+}: {
+  domain: string;
+  rootLink: LandingPageRootLink | null;
+  featuredLinks: LandingPageLink[];
+}) {
+  const title =
+    rootLink?.title ||
+    (featuredLinks.length > 0 ? `Explore ${domain}` : `Welcome to ${domain}`);
+  const description =
+    rootLink?.description ||
+    (featuredLinks.length > 0
+      ? `Browse the featured links available on ${domain}.`
+      : `${domain} is a branded short link domain powered by Dub.`);
+
+  return {
+    title,
+    description,
+    image: rootLink?.image || null,
+    video: rootLink?.video || null,
+    hasCustomContent: Boolean(
+      rootLink?.title ||
+        rootLink?.description ||
+        rootLink?.image ||
+        rootLink?.video ||
+        featuredLinks.length,
+    ),
+  };
+}
+
+export const getCustomDomainLandingPageData = cache(async (domain: string) => {
+  const rootKey = encodeKeyIfCaseSensitive({
+    domain,
+    key: "_root",
+  });
+
+  const [rootLink, links] = await Promise.all([
+    prisma.link.findUnique({
+      where: {
+        domain_key: {
+          domain,
+          key: rootKey,
+        },
+      },
+      select: {
+        title: true,
+        description: true,
+        image: true,
+        video: true,
+      },
+    }),
+    prisma.link.findMany({
+      where: {
+        domain,
+        key: {
+          not: rootKey,
+        },
+      },
+      select: {
+        id: true,
+        domain: true,
+        key: true,
+        url: true,
+        shortLink: true,
+        title: true,
+        description: true,
+        image: true,
+        clicks: true,
+        createdAt: true,
+        archived: true,
+        rewrite: true,
+        expiresAt: true,
+        disabledAt: true,
+        password: true,
+      },
+    }),
+  ]);
+
+  return {
+    rootLink: rootLink as LandingPageRootLink | null,
+    featuredLinks: filterLandingPageLinks(links as LandingPageLink[]),
+  };
+});

--- a/apps/web/tests/domains/custom-domain-landing-page.test.ts
+++ b/apps/web/tests/domains/custom-domain-landing-page.test.ts
@@ -1,0 +1,124 @@
+import {
+  filterLandingPageLinks,
+  getLandingPageCopy,
+} from "@/lib/custom-domain-landing-page";
+import { describe, expect, test } from "vitest";
+
+describe("custom-domain landing page helpers", () => {
+  test("filters landing page links to active cloaked links only", () => {
+    const now = new Date("2026-03-18T00:00:00.000Z");
+
+    const links = [
+      {
+        id: "link_1",
+        domain: "go.acme.com",
+        key: "summer",
+        url: "https://acme.com/summer",
+        shortLink: "https://go.acme.com/summer",
+        title: "Summer Launch",
+        description: null,
+        image: null,
+        clicks: 10,
+        createdAt: new Date("2026-03-10T00:00:00.000Z"),
+        archived: false,
+        rewrite: true,
+        expiresAt: null,
+        disabledAt: null,
+        password: null,
+      },
+      {
+        id: "link_2",
+        domain: "go.acme.com",
+        key: "private",
+        url: "https://acme.com/private",
+        shortLink: "https://go.acme.com/private",
+        title: null,
+        description: null,
+        image: null,
+        clicks: 99,
+        createdAt: new Date("2026-03-11T00:00:00.000Z"),
+        archived: false,
+        rewrite: true,
+        expiresAt: null,
+        disabledAt: null,
+        password: "secret",
+      },
+      {
+        id: "link_3",
+        domain: "go.acme.com",
+        key: "expired",
+        url: "https://acme.com/expired",
+        shortLink: "https://go.acme.com/expired",
+        title: null,
+        description: null,
+        image: null,
+        clicks: 5,
+        createdAt: new Date("2026-03-12T00:00:00.000Z"),
+        archived: false,
+        rewrite: true,
+        expiresAt: new Date("2026-03-17T00:00:00.000Z"),
+        disabledAt: null,
+        password: null,
+      },
+      {
+        id: "link_4",
+        domain: "go.acme.com",
+        key: "visible",
+        url: "https://acme.com/visible",
+        shortLink: "https://go.acme.com/visible",
+        title: "Visible",
+        description: null,
+        image: null,
+        clicks: 50,
+        createdAt: new Date("2026-03-09T00:00:00.000Z"),
+        archived: false,
+        rewrite: true,
+        expiresAt: null,
+        disabledAt: null,
+        password: null,
+      },
+      {
+        id: "link_5",
+        domain: "go.acme.com",
+        key: "not-cloaked",
+        url: "https://acme.com/plain",
+        shortLink: "https://go.acme.com/plain",
+        title: null,
+        description: null,
+        image: null,
+        clicks: 60,
+        createdAt: new Date("2026-03-08T00:00:00.000Z"),
+        archived: false,
+        rewrite: false,
+        expiresAt: null,
+        disabledAt: null,
+        password: null,
+      },
+    ];
+
+    expect(filterLandingPageLinks(links, now).map((link) => link.id)).toEqual([
+      "link_4",
+      "link_1",
+    ]);
+  });
+
+  test("uses root link copy when available", () => {
+    expect(
+      getLandingPageCopy({
+        domain: "go.acme.com",
+        rootLink: {
+          title: "Acme Resources",
+          description: "Browse the latest campaign links.",
+          image: "https://assets.example.com/cover.png",
+          video: null,
+        },
+        featuredLinks: [],
+      }),
+    ).toMatchObject({
+      title: "Acme Resources",
+      description: "Browse the latest campaign links.",
+      image: "https://assets.example.com/cover.png",
+      hasCustomContent: true,
+    });
+  });
+});

--- a/apps/web/ui/domains/domain-card.tsx
+++ b/apps/web/ui/domains/domain-card.tsx
@@ -449,7 +449,11 @@ function DomainCardMenu({
                   Link Settings
                 </p>
                 <Button
-                  text="Edit Link"
+                  text={
+                    linkProps?.key === "_root"
+                      ? "Edit Landing Page"
+                      : "Edit Link"
+                  }
                   variant="outline"
                   onClick={() => {
                     setOpenPopover(false);


### PR DESCRIPTION
## Feature Proposal: Template-Based Landing Page for Custom Domains

Currently, all custom domains display the same default landing page. This PR proposes adding a **template-based landing page** system for custom domains, with the following improvements:

- Use a predefined template for the root page of a custom domain.
- Automatically display links where **Link Cloaking** is enabled, so visitors see available links instead of a blank page.

This enhancement aligns with related discussions (#293, #319) and would allow custom domains to act as lightweight destination hubs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added custom domain landing pages with hero sections and featured link displays
  * Landing pages now show click statistics for links and support custom titles and descriptions
  * Implemented caching strategy to improve page load performance

* **Chores**
  * Added test coverage for landing page functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->