### PR TITLE
Fixing the squished logo in the email preview

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/invite-partner-sheet.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/invite-partner-sheet.tsx
@@ -635,7 +635,7 @@ function EmailPreview({
               <BlurImage
                 src={program?.logo || "https://assets.dub.co/wordmark.png"}
                 alt={program?.name || "Dub"}
-                className="my-1 h-8 rounded-full"
+                className="my-1 size-8 rounded-full object-contain"
                 width={48}
                 height={48}
               />


### PR DESCRIPTION
Setting the size instead of just the height.

<img width="2012" height="2302" alt="CleanShot 2026-03-19 at 11 24 26@2x" src="https://github.com/user-attachments/assets/436ef057-e26b-4dd2-bfce-c0578e40e68e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved email preview program logo display with better image sizing and containment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->