### PR TITLE
Improve `/track/click` to handle full URL `domain`

### DIFF
--- a/apps/web/app/(ee)/api/track/click/route.ts
+++ b/apps/web/app/(ee)/api/track/click/route.ts
@@ -17,13 +17,16 @@ import { RedisLinkProps } from "@/lib/types";
 import { formatRedisLink, redis, redisGlobalWithTimeout } from "@/lib/upstash";
 import { DiscountSchema } from "@/lib/zod/schemas/discount";
 import { PartnerSchema } from "@/lib/zod/schemas/partners";
-import { isValidUrl, nanoid } from "@dub/utils";
+import { getDomainWithoutWWW, isValidUrl, nanoid } from "@dub/utils";
 import { waitUntil } from "@vercel/functions";
 import { NextResponse } from "next/server";
 import * as z from "zod/v4";
 
 const trackClickSchema = z.object({
-  domain: z.string({ error: "domain is required." }),
+  domain: z.preprocess(
+    (val) => getDomainWithoutWWW(val as string),
+    z.string({ error: "domain is required." }),
+  ),
   key: z.string({ error: "key is required." }),
   url: z.string().nullish(),
   referrer: z.string().nullish(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Domain values in click tracking are now normalized (strip "www") before validation and lookup, leading to consistent cache keys and link/hostname matching across requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->