### PR TITLE
perf: reduce not-found page response size

### DIFF
--- a/apps/web/app/[domain]/not-found/page.tsx
+++ b/apps/web/app/[domain]/not-found/page.tsx
@@ -1,7 +1,5 @@
 import { BubbleIcon } from "@/ui/placeholders/bubble-icon";
 import { ButtonLink } from "@/ui/placeholders/button-link";
-import { CTA } from "@/ui/placeholders/cta";
-import { FeaturesSection } from "@/ui/placeholders/features-section";
 import { Hero } from "@/ui/placeholders/hero";
 import { GlobeSearch } from "@dub/ui";
 import { cn, constructMetadata, createHref } from "@dub/utils";
@@ -15,11 +13,6 @@ export const metadata = constructMetadata({
   image: "https://assets.dub.co/misc/notfoundlink.jpg",
   noIndex: true,
 });
-
-const UTM_PARAMS = {
-  utm_source: "Link Not Found",
-  utm_medium: "Link Not Found Page",
-};
 
 export default async function NotFoundLinkPage(props: {
   params: Promise<{ domain: string }>;
@@ -62,7 +55,8 @@ export default async function NotFoundLinkPage(props: {
           <ButtonLink
             variant="secondary"
             href={createHref("/", params.domain, {
-              ...UTM_PARAMS,
+              utm_source: "Link Not Found",
+              utm_medium: "Link Not Found Page",
               utm_campaign: params.domain,
               utm_content: "Learn more",
             })}
@@ -71,12 +65,6 @@ export default async function NotFoundLinkPage(props: {
           </ButtonLink>
         </div>
       </Hero>
-      <div className="mt-20">
-        <FeaturesSection domain={params.domain} utmParams={UTM_PARAMS} />
-      </div>
-      <div className="mt-32">
-        <CTA domain={params.domain} utmParams={UTM_PARAMS} />
-      </div>
     </main>
   );
 }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Streamlined the 404 error page by removing unnecessary sections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Summary
Remove `FeaturesSection` and `CTA` from `/[domain]/not-found` to reduce response size.

## Problem
Not-found page serves heavy marketing components (feature cards, SVGs, ratings, logos) to high-volume bot/crawler traffic. Response size multiplied by request volume = significant Fast Data Transfer.

## Changes
- Remove `FeaturesSection` and `CTA`
- Keep Hero: "Link not found" message + CTA buttons

## Impact
~80-90% response size reduction for this high-volume route.