### PR TITLE
Fix race condition in partner upsert causing unique constraint violation

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -29,7 +29,7 @@ jobs:
       NEXTAUTH_URL: "http://partners.localhost:8888"
 
       NEXT_PUBLIC_APP_NAME: "Dub"
-      NEXT_PUBLIC_APP_DOMAIN: "localhost:8888"
+      NEXT_PUBLIC_APP_DOMAIN: "dub.co"
       NEXT_PUBLIC_APP_SHORT_DOMAIN: "dub.sh"
 
       E2E_PARTNER_EMAIL: "partner1@dub-internal-test.com"

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -29,7 +29,7 @@ jobs:
       NEXTAUTH_URL: "http://partners.localhost:8888"
 
       NEXT_PUBLIC_APP_NAME: "Dub"
-      NEXT_PUBLIC_APP_DOMAIN: "dub.co"
+      NEXT_PUBLIC_APP_DOMAIN: "localhost:8888"
       NEXT_PUBLIC_APP_SHORT_DOMAIN: "dub.sh"
 
       E2E_PARTNER_EMAIL: "partner1@dub-internal-test.com"

--- a/apps/web/lib/api/partners/create-and-enroll-partner.ts
+++ b/apps/web/lib/api/partners/create-and-enroll-partner.ts
@@ -1,5 +1,3 @@
-"use server";
-
 import { createId } from "@/lib/api/create-id";
 import { polyfillSocialMediaFields } from "@/lib/social-utils";
 import { isStored, storage } from "@/lib/storage";
@@ -160,29 +158,73 @@ export const createAndEnrollPartner = async ({
     },
   };
 
-  const upsertedPartner = await prisma.partner.upsert({
-    where: {
-      email: partner.email,
-    },
-    update: payload,
-    create: {
-      ...payload,
-      id: createId({ prefix: "pn_" }),
-      name: partner.name || partner.email,
-      email: partner.email,
-      image: partner.image && !isStored(partner.image) ? null : partner.image,
-      country: partner.country,
-      description: partner.description,
-    },
+  let upsertedPartner: Prisma.PartnerGetPayload<{
     include: {
-      platforms: true,
-      programs: {
-        where: {
-          programId: program.id,
+      platforms: true;
+      programs: true;
+    };
+  }>;
+
+  try {
+    upsertedPartner = await prisma.partner.upsert({
+      where: {
+        email: partner.email,
+      },
+      update: payload,
+      create: {
+        ...payload,
+        id: createId({ prefix: "pn_" }),
+        name: partner.name || partner.email,
+        email: partner.email,
+        image: partner.image && !isStored(partner.image) ? null : partner.image,
+        country: partner.country,
+        description: partner.description,
+      },
+      include: {
+        platforms: true,
+        programs: {
+          where: {
+            programId: program.id,
+          },
         },
       },
-    },
-  });
+    });
+  } catch (error: any) {
+    // Handle race condition: another request created the enrollment between
+    // our check and the upsert, violating the unique constraint
+    if (error.code === "P2002") {
+      const existingEnrollment = await prisma.programEnrollment.findFirst({
+        where: {
+          programId: program.id,
+          partner: {
+            email: partner.email,
+          },
+        },
+        include: {
+          partner: {
+            include: {
+              platforms: true,
+            },
+          },
+          links: true,
+        },
+      });
+
+      if (existingEnrollment) {
+        return EnrolledPartnerSchema.parse({
+          ...existingEnrollment.partner,
+          ...existingEnrollment,
+          id: existingEnrollment.partner.id,
+          links: existingEnrollment.links,
+          ...polyfillSocialMediaFields(existingEnrollment.partner.platforms),
+        });
+      }
+
+      throw error;
+    }
+
+    throw error;
+  }
 
   // Create the partner links based on group defaults
   const links = await createPartnerDefaultLinks({

--- a/apps/web/lib/api/partners/create-and-enroll-partner.ts
+++ b/apps/web/lib/api/partners/create-and-enroll-partner.ts
@@ -211,6 +211,43 @@ export const createAndEnrollPartner = async ({
       });
 
       if (existingEnrollment) {
+        if (
+          partner.tenantId &&
+          partner.tenantId !== existingEnrollment.tenantId
+        ) {
+          await throwIfExistingTenantEnrollmentExists({
+            tenantId: partner.tenantId,
+            programId: program.id,
+          });
+
+          const updatedEnrollment = await prisma.programEnrollment.update({
+            where: {
+              id: existingEnrollment.id,
+            },
+            data: {
+              tenantId: partner.tenantId,
+            },
+            include: {
+              partner: {
+                include: {
+                  platforms: true,
+                },
+              },
+              links: true,
+            },
+          });
+
+          return EnrolledPartnerSchema.parse({
+            ...updatedEnrollment.partner,
+            ...updatedEnrollment,
+            id: updatedEnrollment.partner.id,
+            links: updatedEnrollment.links,
+            ...polyfillSocialMediaFields(
+              updatedEnrollment.partner.platforms,
+            ),
+          });
+        }
+
         return EnrolledPartnerSchema.parse({
           ...existingEnrollment.partner,
           ...existingEnrollment,


### PR DESCRIPTION
When concurrent requests hit `/api/tokens/embed/referrals` with the same partner email, the nested ProgramEnrollment is created inside `partner.upsert` could violate the `unique(partnerId, programId)` constraint. Handle P2002 errors by falling back to returning the existing enrollment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of partner enrollment when concurrent requests occur by adding a safe fallback to detect and return existing enrollments.
  * Ensures returned partner data is more consistent and updates tenant association when appropriate, reducing duplicate enrollments and race-condition failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->