### PR TITLE
Update the partner website to avoid linking to 404 page

### DIFF
--- a/apps/web/lib/partners/partner-platforms.ts
+++ b/apps/web/lib/partners/partner-platforms.ts
@@ -7,7 +7,7 @@ import {
   Twitter,
   YouTube,
 } from "@dub/ui/icons";
-import { getPrettyUrl, getUrlFromString, nFormatter } from "@dub/utils";
+import { getPrettyUrl, getUrlFromStringIfValid, nFormatter } from "@dub/utils";
 import { PartnerPlatformProps } from "../types";
 
 export const PARTNER_PLATFORM_FIELDS: {
@@ -30,7 +30,7 @@ export const PARTNER_PLATFORM_FIELDS: {
         value: website ? getPrettyUrl(website.identifier) : null,
         verified: !!website?.verifiedAt,
         href: website?.identifier
-          ? getUrlFromString(website.identifier)
+          ? getUrlFromStringIfValid(website.identifier)
           : null,
       };
     },


### PR DESCRIPTION
Some partner website identifiers stored without a protocol (e.g., `example.com` instead of `https://example.com`) were rendered as relative links, causing them to navigate to `app.dub.co/.../example.com` instead of the actual website.

Uses `getUrlFromString` to ensure the href always has a protocol prefix before rendering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Website links in partner platforms now validate and normalize URLs before use, and will be omitted when no identifier is provided, preventing invalid raw identifiers from becoming clickable links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->