### PR TITLE
Hide events metadata from partner

### DIFF
--- a/apps/web/app/(ee)/api/cron/export/events/partner/route.ts
+++ b/apps/web/app/(ee)/api/cron/export/events/partner/route.ts
@@ -113,7 +113,7 @@ export async function POST(req: Request) {
     const eventsFilters = {
       ...parsedParams,
       workspaceId: program.workspaceId,
-      hideMetadata: true,
+      includeMetadata: false,
       ...(parsedParams.linkId
         ? { linkId: parsedParams.linkId }
         : links.length > MAX_PARTNER_LINKS_FOR_LOCAL_FILTERING

--- a/apps/web/app/(ee)/api/partner-profile/programs/[programId]/customers/[customerId]/route.ts
+++ b/apps/web/app/(ee)/api/partner-profile/programs/[programId]/customers/[customerId]/route.ts
@@ -69,7 +69,7 @@ export const GET = withPartnerProfile(async ({ partner, params }) => {
   const events = await getCustomerEvents({
     customerId: customer.id,
     linkIds: links.map((link) => link.id),
-    hideMetadata: true,
+    includeMetadata: false,
   });
 
   if (events.length === 0) {

--- a/apps/web/app/(ee)/api/partner-profile/programs/[programId]/events/export/route.ts
+++ b/apps/web/app/(ee)/api/partner-profile/programs/[programId]/events/export/route.ts
@@ -192,7 +192,7 @@ export const GET = withPartnerProfile(
     const events = await getEvents({
       ...parsedParams,
       workspaceId: program.workspaceId,
-      hideMetadata: true,
+      includeMetadata: false,
       ...(parsedParams.linkId
         ? { linkId: parsedParams.linkId }
         : links.length > MAX_PARTNER_LINKS_FOR_LOCAL_FILTERING

--- a/apps/web/app/(ee)/api/partner-profile/programs/[programId]/events/route.ts
+++ b/apps/web/app/(ee)/api/partner-profile/programs/[programId]/events/route.ts
@@ -100,7 +100,7 @@ export const GET = withPartnerProfile(
     const events = await getEvents({
       ...parsedParams,
       workspaceId: program.workspaceId,
-      hideMetadata: true,
+      includeMetadata: false,
       ...(parsedParams.linkId
         ? { linkId: parsedParams.linkId }
         : links.length > MAX_PARTNER_LINKS_FOR_LOCAL_FILTERING

--- a/apps/web/lib/analytics/get-customer-events.ts
+++ b/apps/web/lib/analytics/get-customer-events.ts
@@ -13,11 +13,11 @@ import { saleEventResponseSchema } from "../zod/schemas/sales";
 export const getCustomerEvents = async ({
   customerId,
   linkIds,
-  hideMetadata = false,
+  includeMetadata = true,
 }: {
   customerId: string;
   linkIds?: string[];
-  hideMetadata?: boolean;
+  includeMetadata?: boolean;
 }) => {
   const response = await getCustomerEventsTB({
     customerId,
@@ -56,7 +56,7 @@ export const getCustomerEvents = async ({
               eventId: evt.event_id,
               eventName: evt.event_name,
               metadata:
-                hideMetadata || !evt.metadata
+                !includeMetadata || !evt.metadata
                   ? undefined
                   : JSON.parse(evt.metadata),
               ...(evt.event === "sale"

--- a/apps/web/lib/analytics/get-events.ts
+++ b/apps/web/lib/analytics/get-events.ts
@@ -48,7 +48,7 @@ export const getEvents = async (params: EventsFilters) => {
     sortOrder,
     dataAvailableFrom,
     query,
-    hideMetadata = false,
+    includeMetadata = true,
   } = params;
 
   const { startDate, endDate } = getStartEndDates({
@@ -211,7 +211,7 @@ export const getEvents = async (params: EventsFilters) => {
               eventId: evt.event_id,
               eventName: evt.event_name,
               metadata:
-                hideMetadata || !evt.metadata
+                !includeMetadata || !evt.metadata
                   ? undefined
                   : JSON.parse(evt.metadata),
               customer: customersMap[evt.customer_id] ?? {

--- a/apps/web/lib/analytics/types.ts
+++ b/apps/web/lib/analytics/types.ts
@@ -75,7 +75,7 @@ export type EventsFilters = Partial<
     // Accept plain string (from partner-profile/cron routes) or ParsedFilter (from API schema)
     partnerId?: string | ParsedFilter;
     linkId?: string | ParsedFilter;
-    hideMetadata?: boolean;
+    includeMetadata?: boolean;
   };
 
 const partnerAnalyticsSchema = analyticsQuerySchema


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Event metadata is now excluded from partner event exports and customer event API responses for optimized data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->