### PR TITLE
perf: add CDN cache headers to metatags endpoint

### DIFF
--- a/apps/web/app/api/links/metatags/route.ts
+++ b/apps/web/app/api/links/metatags/route.ts
@@ -37,7 +37,12 @@ export async function GET(req: NextRequest) {
         poweredBy: "Dub - The Modern Link Attribution Platform",
       },
       {
-        headers: corsHeaders,
+        headers: {
+          ...corsHeaders,
+          "Cache-Control": "public, max-age=300",
+          "Vercel-CDN-Cache-Control":
+            "s-maxage=3600, stale-while-revalidate=86400",
+        },
       },
     );
   } catch (error) {


### PR DESCRIPTION
## Problem
`GET /api/links/metatags` has zero `Cache-Control` headers. Every request invokes the edge function, fetches the target URL's HTML, and parses metatags — even for repeated requests with the same URL. This is the last remaining public cacheable GET endpoint without CDN caching (avatar + QR were addressed in #3619).

## Changes
Add cache headers to the metatags response, matching the pattern from #3619:
- `Cache-Control: public, max-age=300` (5min browser cache)
- `Vercel-CDN-Cache-Control: s-maxage=3600, stale-while-revalidate=86400` (1h CDN, 1d stale)

Metatags are deterministic per URL but external content can change when the target site updates, so the TTL is shorter than avatar/QR.

## User-facing changes
Metatags for a given URL may be up to 1 hour stale. If a target site changes its `og:title` or `og:image`, it takes up to 1h for the change to propagate through the CDN. `stale-while-revalidate` ensures the CDN refreshes in the background without blocking the response.