### PR TITLE
Send rejection emails when bulk rejecting partner applications

### DIFF
--- a/apps/web/lib/actions/partners/bulk-reject-partner-applications.ts
+++ b/apps/web/lib/actions/partners/bulk-reject-partner-applications.ts
@@ -26,17 +26,6 @@ export const bulkRejectPartnerApplicationsAction = authActionClient
 
     const programId = getDefaultProgramIdOrThrow(workspace);
 
-    const program = await prisma.program.findUniqueOrThrow({
-      where: {
-        id: programId,
-      },
-      select: {
-        name: true,
-        slug: true,
-        supportEmail: true,
-      },
-    });
-
     const programEnrollments = await prisma.programEnrollment.findMany({
       where: {
         programId,
@@ -129,40 +118,44 @@ export const bulkRejectPartnerApplicationsAction = authActionClient
           }),
         ]);
 
+        const program = await prisma.program.findUniqueOrThrow({
+          where: {
+            id: programId,
+          },
+          select: {
+            name: true,
+            slug: true,
+            supportEmail: true,
+          },
+        });
+
         const partnersWithEmail = programEnrollments
           .filter(({ partner }) => partner.email)
           .map(({ partner }) => partner);
 
         if (partnersWithEmail.length > 0) {
-          try {
-            await sendBatchEmail(
-              partnersWithEmail.map((partner) => ({
-                to: partner.email!,
-                subject: `Your application to ${program.name} was not approved`,
-                variant: "notifications" as const,
-                replyTo: program.supportEmail || "noreply",
-                react: PartnerApplicationRejected({
-                  partner: {
-                    name: partner.name ?? "there",
-                    email: partner.email!,
-                  },
-                  program: {
-                    name: program.name,
-                    slug: program.slug,
-                    supportEmail: program.supportEmail ?? undefined,
-                  },
-                  rejectionReason: undefined,
-                  additionalNotes: undefined,
-                  canReapplyImmediately: false,
-                }),
-              })),
-            );
-          } catch (error) {
-            console.error("Failed to send bulk rejection emails", {
-              error,
-              programId,
-            });
-          }
+          await sendBatchEmail(
+            partnersWithEmail.map((partner) => ({
+              to: partner.email!,
+              subject: `Your application to ${program.name} was not approved`,
+              variant: "notifications",
+              replyTo: program.supportEmail || "noreply",
+              react: PartnerApplicationRejected({
+                partner: {
+                  name: partner.name ?? "there",
+                  email: partner.email!,
+                },
+                program: {
+                  name: program.name,
+                  slug: program.slug,
+                  supportEmail: program.supportEmail ?? undefined,
+                },
+                rejectionReason: undefined,
+                additionalNotes: undefined,
+                canReapplyImmediately: false,
+              }),
+            })),
+          );
         }
       })(),
     );


### PR DESCRIPTION
 Added email notification functionality to bulk partner application rejection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Partners now receive batch email notifications when their applications are bulk-rejected; emails include program name and support contact.

* **Improvements**
  * Emails are sent only after audit logging and fraud checks complete.
  * Emails are sent only to partners with valid emails; send failures are caught and logged without interrupting processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->