### PR TITLE
fix: resolve client-side error when re-selecting newly created tag

### DIFF
--- a/apps/web/ui/links/link-builder/tag-select.tsx
+++ b/apps/web/ui/links/link-builder/tag-select.tsx
@@ -77,7 +77,17 @@ export const TagSelect = memo(() => {
       setValue("tags", [...tags, newTag], { shouldDirty: true });
       toast.success(`Successfully created tag!`);
       setIsOpen(false);
-      await mutate(`/api/tags?workspaceId=${workspaceId}`);
+      await mutate(
+        (key) => {
+          if (typeof key !== "string") return false;
+          if (!key.startsWith(`/api/tags?workspaceId=${workspaceId}`)) return false;
+          if (!key.includes("search=")) return true;
+          return key.includes("search=") && key.includes("search=&"); // Only base query
+        },
+        (data) => (data ? [newTag, ...data] : [newTag]),
+        false
+      );
+
       return true;
     } else {
       const { error } = await res.json();


### PR DESCRIPTION
## Fix: Client-side error when re-selecting newly created tag

### Summary

Fixes a client-side error that occurs when a newly created tag is unselected and then selected again.

---

### Root Cause

* State mismatch between `tag-select` and `@dub/ui` ComboBox
* `useTags` mutation was updating both base and search queries, leading to inconsistent data

---

### Changes

* Updated mutation logic to only append the new tag to the **base query (no search)**
* Prevented mutation of search-based queries to avoid stale or invalid state

```js
await mutate(
  (key) => {
    if (typeof key !== "string") return false;
    if (!key.startsWith(`/api/tags?workspaceId=${workspaceId}`)) return false;
    if (!key.includes("search=")) return true;
    return key.includes("search=") && key.includes("search=&");
  },
  (data) => (data ? [newTag, ...data] : [newTag]),
  false
);
```

---

### Behavior

* Works correctly for **local search (cached tags)**
* Works correctly for **API search (after exceeding `TAGS_MAX_PAGE_SIZE`)**

---

### Result

Tags can now be re-selected without client-side errors.

---

### Issue

Closes #3685


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tag creation responsiveness by ensuring newly created tags display immediately in the selector.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->