### PR TITLE
Format amount and earnings in commissions export

### DIFF
--- a/apps/web/lib/analytics/events-export-helpers.ts
+++ b/apps/web/lib/analytics/events-export-helpers.ts
@@ -1,3 +1,4 @@
+import { formatMoneyCentsForExport } from "@/lib/api/utils/format-money-cents-for-export";
 import { ClickEvent, LeadEvent, SaleEvent } from "@/lib/types";
 import { COUNTRIES } from "@dub/utils";
 
@@ -28,6 +29,12 @@ export const eventsExportColumnAccessors = {
     r.customer.name + (r.customer.email ? ` <${r.customer.email}>` : ""),
   invoiceId: (r: Row) => ("sale" in r ? r.sale.invoiceId : ""),
   saleAmount: (r: Row) =>
-    "sale" in r ? "$" + (r.sale.amount / 100).toFixed(2) : "",
+    "sale" in r
+      ? formatMoneyCentsForExport(
+          r.sale.amount,
+          r.sale.currency,
+          `event ${r.eventId}`,
+        )
+      : "",
   clickId: (r: ClickEvent) => r.click.id,
 };

--- a/apps/web/lib/analytics/get-events.ts
+++ b/apps/web/lib/analytics/get-events.ts
@@ -227,6 +227,7 @@ export const getEvents = async (params: EventsFilters) => {
                       amount: evt.saleAmount,
                       invoiceId: evt.invoice_id,
                       paymentProcessor: evt.payment_processor,
+                      currency: evt.currency,
                     },
                   }
                 : {}),

--- a/apps/web/lib/api/commissions/format-commissions-for-export.ts
+++ b/apps/web/lib/api/commissions/format-commissions-for-export.ts
@@ -1,5 +1,5 @@
+import { formatMoneyCentsForExport } from "@/lib/api/utils/format-money-cents-for-export";
 import { COMMISSION_EXPORT_COLUMNS } from "@/lib/zod/schemas/commissions";
-import { currencyFormatter } from "@dub/utils";
 import * as z from "zod/v4";
 import { getCommissions } from "./get-commissions";
 
@@ -37,30 +37,6 @@ const COLUMN_TYPE_SCHEMAS = {
     .transform((value) => value || ""),
 };
 
-/** Intl.NumberFormat throws RangeError for invalid ISO currency codes; DB allows free-form strings. */
-function formatMoneyCentsForExport(
-  cents: number,
-  currency: string | null | undefined,
-  commissionId: string,
-): string {
-  const code = (currency ?? "").trim() || "USD";
-  try {
-    return currencyFormatter(cents, { currency: code });
-  } catch (error) {
-    const isRangeError = error instanceof RangeError;
-    console.warn(
-      `[formatCommissionsForExport] currency format failed for commission ${commissionId} (currency=${JSON.stringify(currency)}, isRangeError=${isRangeError}); falling back.`,
-      error,
-    );
-    try {
-      return currencyFormatter(cents, { currency: "USD" });
-    } catch {
-      const safe = Number.isFinite(cents) ? cents : 0;
-      return (safe / 100).toFixed(2);
-    }
-  }
-}
-
 // Formats commissions for CSV export with proper column ordering and type coercion
 export function formatCommissionsForExport(
   commissions: Awaited<ReturnType<typeof getCommissions>>,
@@ -94,7 +70,7 @@ export function formatCommissionsForExport(
         row[col] = formatMoneyCentsForExport(
           cents,
           commission.currency,
-          commission.id,
+          `commission ${commission.id}`,
         );
       }
     }

--- a/apps/web/lib/api/commissions/format-commissions-for-export.ts
+++ b/apps/web/lib/api/commissions/format-commissions-for-export.ts
@@ -37,6 +37,30 @@ const COLUMN_TYPE_SCHEMAS = {
     .transform((value) => value || ""),
 };
 
+/** Intl.NumberFormat throws RangeError for invalid ISO currency codes; DB allows free-form strings. */
+function formatMoneyCentsForExport(
+  cents: number,
+  currency: string | null | undefined,
+  commissionId: string,
+): string {
+  const code = (currency ?? "").trim() || "USD";
+  try {
+    return currencyFormatter(cents, { currency: code });
+  } catch (error) {
+    const isRangeError = error instanceof RangeError;
+    console.warn(
+      `[formatCommissionsForExport] currency format failed for commission ${commissionId} (currency=${JSON.stringify(currency)}, isRangeError=${isRangeError}); falling back.`,
+      error,
+    );
+    try {
+      return currencyFormatter(cents, { currency: "USD" });
+    } catch {
+      const safe = Number.isFinite(cents) ? cents : 0;
+      return (safe / 100).toFixed(2);
+    }
+  }
+}
+
 // Formats commissions for CSV export with proper column ordering and type coercion
 export function formatCommissionsForExport(
   commissions: Awaited<ReturnType<typeof getCommissions>>,
@@ -67,9 +91,11 @@ export function formatCommissionsForExport(
 
       const cents = commission[col as "amount" | "earnings"];
       if (typeof cents === "number") {
-        row[col] = currencyFormatter(cents, {
-          currency: commission.currency,
-        });
+        row[col] = formatMoneyCentsForExport(
+          cents,
+          commission.currency,
+          commission.id,
+        );
       }
     }
 

--- a/apps/web/lib/api/commissions/format-commissions-for-export.ts
+++ b/apps/web/lib/api/commissions/format-commissions-for-export.ts
@@ -1,4 +1,5 @@
 import { COMMISSION_EXPORT_COLUMNS } from "@/lib/zod/schemas/commissions";
+import { currencyFormatter } from "@dub/utils";
 import * as z from "zod/v4";
 import { getCommissions } from "./get-commissions";
 
@@ -23,6 +24,11 @@ const COLUMN_TYPE_SCHEMAS = {
     .nullable()
     .default(0)
     .transform((value) => value || 0),
+  money: z
+    .string()
+    .nullable()
+    .default("")
+    .transform((value) => value || ""),
   date: z.date().transform((date) => date?.toISOString() || ""),
   string: z
     .string()
@@ -36,24 +42,40 @@ export function formatCommissionsForExport(
   commissions: Awaited<ReturnType<typeof getCommissions>>,
   columns: string[],
 ): Record<string, any>[] {
-  const formattedCommissions = commissions.map((commission) => ({
-    ...commission,
-    customerName: commission.customer?.name || "",
-    customerEmail: commission.customer?.email || "",
-    customerExternalId: commission.customer?.externalId || "",
-    partnerName: commission.partner?.name || "",
-    partnerEmail: commission.partner?.email || "",
-    partnerTenantId: commission.programEnrollment?.tenantId || "",
-  }));
-
-  // Sort columns by their order
-  const sortedColumns = columns.sort(
+  const sortedColumns = [...columns].sort(
     (a, b) =>
       (COLUMN_LOOKUP.get(a)?.order || 999) -
       (COLUMN_LOOKUP.get(b)?.order || 999),
   );
 
-  // Build column schemas
+  const formattedCommissions = commissions.map((commission) => {
+    const row: Record<string, unknown> = {
+      ...commission,
+      customerName: commission.customer?.name || "",
+      customerEmail: commission.customer?.email || "",
+      customerExternalId: commission.customer?.externalId || "",
+      partnerName: commission.partner?.name || "",
+      partnerEmail: commission.partner?.email || "",
+      partnerTenantId: commission.programEnrollment?.tenantId || "",
+    };
+
+    for (const col of sortedColumns) {
+      const columnInfo = COLUMN_LOOKUP.get(col);
+      if (columnInfo?.type !== "money") {
+        continue;
+      }
+
+      const cents = commission[col as "amount" | "earnings"];
+      if (typeof cents === "number") {
+        row[col] = currencyFormatter(cents, {
+          currency: commission.currency,
+        });
+      }
+    }
+
+    return row;
+  });
+
   const columnSchemas: Record<string, z.ZodTypeAny> = {};
 
   for (const column of sortedColumns) {
@@ -63,7 +85,8 @@ export function formatCommissionsForExport(
       continue;
     }
 
-    columnSchemas[column] = COLUMN_TYPE_SCHEMAS[columnInfo.type];
+    columnSchemas[column] =
+      COLUMN_TYPE_SCHEMAS[columnInfo.type as keyof typeof COLUMN_TYPE_SCHEMAS];
   }
 
   return z.array(z.object(columnSchemas)).parse(formattedCommissions);

--- a/apps/web/lib/api/links/format-links-for-export.ts
+++ b/apps/web/lib/api/links/format-links-for-export.ts
@@ -1,3 +1,4 @@
+import { formatMoneyCentsForExport } from "@/lib/api/utils/format-money-cents-for-export";
 import { exportLinksColumns } from "@/lib/zod/schemas/links";
 import { linkConstructor } from "@dub/utils";
 import { transformLink } from "./utils";
@@ -19,7 +20,7 @@ export function formatLinksForExport(
     exportLinksColumns.some((c) => c.id === column),
   );
 
-  const sortedColumns = columns.sort(
+  const sortedColumns = [...columns].sort(
     (a, b) => (columnMap[a]?.order || 999) - (columnMap[b]?.order || 999),
   );
 
@@ -41,7 +42,13 @@ export function formatLinksForExport(
 
       const { label, transform } = columnMap[column];
 
-      if (transform) {
+      if (column === "saleAmount") {
+        result[label] = formatMoneyCentsForExport(
+          Number(value ?? 0),
+          "USD",
+          `link ${link.id}`,
+        );
+      } else if (transform) {
         result[label] = transform(value);
       } else {
         result[label] = value;

--- a/apps/web/lib/api/partners/format-partners-for-export.ts
+++ b/apps/web/lib/api/partners/format-partners-for-export.ts
@@ -1,5 +1,7 @@
+import { formatMoneyCentsForExport } from "@/lib/api/utils/format-money-cents-for-export";
 import { polyfillSocialMediaFields } from "@/lib/social-utils";
 import { exportPartnerColumns } from "@/lib/zod/schemas/partners";
+import { toCentsNumber } from "@dub/utils";
 import * as z from "zod/v4";
 
 const columnIdToLabel = exportPartnerColumns.reduce(
@@ -13,6 +15,13 @@ const columnIdToLabel = exportPartnerColumns.reduce(
 const numericColumns = exportPartnerColumns
   .filter((column) => column.numeric)
   .map((column) => column.id);
+
+/** Stored in cents; exported as formatted currency strings. */
+const numericCentsMoneyColumns = new Set([
+  "totalSaleAmount",
+  "totalCommissions",
+  "netRevenue",
+]);
 
 const dateColumns = ["createdAt", "payoutsEnabledAt"];
 
@@ -30,20 +39,20 @@ export function formatPartnersForExport(
     {} as Record<string, number>,
   );
 
-  const sortedColumns = columns.sort(
+  const sortedColumns = [...columns].sort(
     (a, b) => (columnOrderMap[a] || 999) - (columnOrderMap[b] || 999),
   );
 
   // Create schema for validation
   const schemaFields: Record<string, any> = {};
   sortedColumns.forEach((column) => {
-    if (numericColumns.includes(column)) {
-      schemaFields[columnIdToLabel[column]] = z.coerce
-        .number()
-        .optional()
-        .default(0);
+    const label = columnIdToLabel[column];
+    if (numericCentsMoneyColumns.has(column)) {
+      schemaFields[label] = z.string().optional().default("");
+    } else if (numericColumns.includes(column)) {
+      schemaFields[label] = z.coerce.number().optional().default(0);
     } else {
-      schemaFields[columnIdToLabel[column]] = z.string().optional().default("");
+      schemaFields[label] = z.string().optional().default("");
     }
   });
 
@@ -59,10 +68,18 @@ export function formatPartnersForExport(
     };
 
     sortedColumns.forEach((column) => {
-      let value = partner[column] || "";
+      let value = partner[column] ?? "";
 
-      // Handle date fields - convert to ISO string format
-      if (dateColumns.includes(column) && value instanceof Date) {
+      if (numericCentsMoneyColumns.has(column)) {
+        value =
+          value === "" || value == null
+            ? ""
+            : formatMoneyCentsForExport(
+                Number(toCentsNumber(value as number | bigint)),
+                "USD",
+                `partner ${partner.id}`,
+              );
+      } else if (dateColumns.includes(column) && value instanceof Date) {
         value = value.toISOString();
       }
 

--- a/apps/web/lib/api/utils/format-money-cents-for-export.ts
+++ b/apps/web/lib/api/utils/format-money-cents-for-export.ts
@@ -1,0 +1,28 @@
+import { currencyFormatter } from "@dub/utils";
+
+/**
+ * Formats cents for CSV export using the same rules as the dashboard (`currencyFormatter`).
+ * Intl.NumberFormat throws RangeError for invalid ISO currency codes; callers may pass free-form DB strings.
+ */
+export function formatMoneyCentsForExport(
+  cents: number,
+  currency: string | null | undefined,
+  contextId: string,
+): string {
+  const code = (currency ?? "").trim() || "USD";
+  try {
+    return currencyFormatter(cents, { currency: code });
+  } catch (error) {
+    const isRangeError = error instanceof RangeError;
+    console.warn(
+      `[formatMoneyCentsForExport] currency format failed for ${contextId} (currency=${JSON.stringify(currency)}, isRangeError=${isRangeError}); falling back.`,
+      error,
+    );
+    try {
+      return currencyFormatter(cents, { currency: "USD" });
+    } catch {
+      const safe = Number.isFinite(cents) ? cents : 0;
+      return (safe / 100).toFixed(2);
+    }
+  }
+}

--- a/apps/web/lib/customers/api/format-customers-export.ts
+++ b/apps/web/lib/customers/api/format-customers-export.ts
@@ -1,3 +1,4 @@
+import { formatMoneyCentsForExport } from "@/lib/api/utils/format-money-cents-for-export";
 import {
   CUSTOMER_EXPORT_COLUMNS,
   CUSTOMER_EXPORT_DEFAULT_COLUMNS,
@@ -46,7 +47,11 @@ export function formatCustomersForExport(
       stripeCustomerId: c.stripeCustomerId ?? "",
       country: c.country ?? "",
       sales: c.sales ?? 0,
-      saleAmount: toCentsNumber(c.saleAmount ?? 0),
+      saleAmount: formatMoneyCentsForExport(
+        toCentsNumber(c.saleAmount ?? 0),
+        "USD",
+        `customer ${c.id}`,
+      ),
       createdAt: dateToIso(c.createdAt),
       firstSaleAt: dateToIso(c.firstSaleAt),
       subscriptionCanceledAt: dateToIso(c.subscriptionCanceledAt),

--- a/apps/web/lib/zod/schemas/commissions.ts
+++ b/apps/web/lib/zod/schemas/commissions.ts
@@ -324,8 +324,8 @@ export const createClawbackSchema = z.object({
 export const COMMISSION_EXPORT_COLUMNS = [
   { id: "id", label: "ID", type: "string", default: true },
   { id: "type", label: "Type", type: "string", default: true },
-  { id: "amount", label: "Amount", type: "number", default: true },
-  { id: "earnings", label: "Earnings", type: "number", default: true },
+  { id: "amount", label: "Amount", type: "money", default: true },
+  { id: "earnings", label: "Earnings", type: "money", default: true },
   { id: "currency", label: "Currency", type: "string", default: true },
   { id: "status", label: "Status", type: "string", default: true },
   { id: "invoiceId", label: "Invoice ID", type: "string", default: true },

--- a/apps/web/lib/zod/schemas/sales.ts
+++ b/apps/web/lib/zod/schemas/sales.ts
@@ -162,6 +162,10 @@ export const saleEventSchemaTBEndpoint = z.object({
   qr: z.number().nullable(),
   ip: z.string().nullable(),
   metadata: z.string().nullish(),
+  currency: z
+    .string()
+    .default("usd")
+    .transform((val) => val.toLowerCase()),
 });
 
 // response from dub api
@@ -176,6 +180,7 @@ export const saleEventResponseSchema = z
       amount: true,
       invoiceId: true,
       paymentProcessor: true,
+      currency: true,
     }),
     metadata: z.any().nullish(),
     // nested objects


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exports now format monetary fields consistently with currency-aware display and resilient fallbacks; commissions, partners, customers, sales, and link amounts show formatted currency strings.
  * Sale events now include currency so exported sale values reflect correct currencies.

* **Bug Fixes**
  * Export column ordering no longer mutates configuration, preventing unexpected reordering.

* **Stability**
  * Nullable/falsy money values normalize to consistent export outputs; formatting errors are logged and safely fall back to USD-style output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->