### PR TITLE
Replace inline character counters with MaxCharactersCounter

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/bounties/add-edit-bounty/add-edit-bounty-sheet.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/bounties/add-edit-bounty/add-edit-bounty-sheet.tsx
@@ -187,9 +187,11 @@ function BountySheetContent({ setIsOpen, bounty }: BountySheetProps) {
                               })}
                             />
                             <div className="mt-1 text-left">
-                              <span className="text-xs text-neutral-400">
-                                {name?.length || 0}/100
-                              </span>
+                              <MaxCharactersCounter
+                                name="name"
+                                maxLength={100}
+                                control={control}
+                              />
                             </div>
                           </div>
                         </div>

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/commissions/create-commission-sheet.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/commissions/create-commission-sheet.tsx
@@ -15,6 +15,7 @@ import {
   ProgramSheetAccordionTrigger,
 } from "@/ui/partners/program-sheet-accordion";
 import { X } from "@/ui/shared/icons";
+import { MaxCharactersCounter } from "@/ui/shared/max-characters-counter";
 import { CommissionType } from "@dub/prisma/client";
 import {
   AnimatedSizeContainer,
@@ -493,9 +494,11 @@ function CreateCommissionSheetContent({
                             (optional)
                           </span>
                         </label>
-                        <span className="text-xs text-neutral-400">
-                          {description?.length || 0}/190
-                        </span>
+                        <MaxCharactersCounter
+                          name="description"
+                          maxLength={190}
+                          control={control}
+                        />
                       </div>
                       <div className="mt-2">
                         <textarea

--- a/apps/web/ui/modals/link-builder/og-modal.tsx
+++ b/apps/web/ui/modals/link-builder/og-modal.tsx
@@ -4,6 +4,7 @@ import {
   useLinkBuilderContext,
 } from "@/ui/links/link-builder/link-builder-provider";
 import { Link } from "@/ui/shared/icons";
+import { MaxCharactersCounter } from "@/ui/shared/max-characters-counter";
 import { ProBadgeTooltip } from "@/ui/shared/pro-badge-tooltip";
 import { UpgradeRequiredToast } from "@/ui/shared/upgrade-required-toast";
 import { useCompletion } from "@ai-sdk/react";
@@ -65,6 +66,7 @@ function OGModalInner({
     setValue,
     reset,
     handleSubmit,
+    control,
     formState: { isDirty },
   } = useForm<Pick<LinkFormData, "image" | "title" | "description" | "proxy">>({
     defaultValues: {
@@ -326,9 +328,11 @@ function OGModalInner({
                   Title
                 </p>
                 <div className="flex items-center gap-2">
-                  <p className="text-sm text-neutral-500">
-                    {title?.length || 0}/120
-                  </p>
+                  <MaxCharactersCounter
+                    name="title"
+                    maxLength={120}
+                    control={control}
+                  />
                   <ButtonTooltip
                     tooltipProps={{
                       content: exceededAI
@@ -380,9 +384,11 @@ function OGModalInner({
                   Description
                 </p>
                 <div className="flex items-center gap-2">
-                  <p className="text-sm text-neutral-500">
-                    {description?.length || 0}/240
-                  </p>
+                  <MaxCharactersCounter
+                    name="description"
+                    maxLength={240}
+                    control={control}
+                  />
                   <ButtonTooltip
                     tooltipProps={{
                       content: exceededAI

--- a/apps/web/ui/partners/bounties/reject-bounty-submission-modal.tsx
+++ b/apps/web/ui/partners/bounties/reject-bounty-submission-modal.tsx
@@ -8,6 +8,7 @@ import useBounty from "@/lib/swr/use-bounty";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { BountySubmissionProps } from "@/lib/types";
 import { rejectBountySubmissionBodySchema } from "@/lib/zod/schemas/bounties";
+import { MaxCharactersCounter } from "@/ui/shared/max-characters-counter";
 import { Button, Modal, useKeyboardShortcut } from "@dub/ui";
 import { cn } from "@dub/utils";
 import { useAction } from "next-safe-action/hooks";
@@ -36,6 +37,7 @@ const RejectBountySubmissionModal = ({
     register,
     watch,
     getValues,
+    control,
     formState: { errors },
   } = useForm<z.infer<typeof rejectBountySubmissionBodySchema>>({
     defaultValues: {
@@ -133,10 +135,11 @@ const RejectBountySubmissionModal = ({
                   (optional)
                 </span>
               </label>
-              <span className="text-xs text-neutral-400">
-                {watch("rejectionNote")?.length || 0}/
-                {BOUNTY_MAX_SUBMISSION_REJECTION_NOTE_LENGTH}
-              </span>
+              <MaxCharactersCounter
+                name="rejectionNote"
+                maxLength={BOUNTY_MAX_SUBMISSION_REJECTION_NOTE_LENGTH}
+                control={control}
+              />
             </div>
             <div className="mt-2">
               <textarea


### PR DESCRIPTION
## Changes

Refactored character counter displays across multiple components to use the reusable `MaxCharactersCounter` component instead of inline implementations.

### Updated Components

- **add-edit-bounty-sheet.tsx**: Replaced inline counter for bounty name field (100 char limit)
- **create-commission-sheet.tsx**: Replaced inline counter for commission description (190 char limit)
- **og-modal.tsx**: Replaced inline counters for title (120 chars) and description (240 chars)
- **reject-bounty-submission-modal.tsx**: Replaced inline counter for rejection note field

### Benefits

- Improved code reusability and consistency
- Centralized character counter styling and logic
- Reduced code duplication across forms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized character counter displays across bounty management, commission creation, link preview, and bounty rejection forms by consolidating to a unified component for improved consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->