### PR TITLE
Block saving additional links when enabled without a link format

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/groups/[groupSlug]/links/group-additional-links.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/groups/[groupSlug]/links/group-additional-links.tsx
@@ -88,6 +88,10 @@ export function GroupAdditionalLinksForm({ group }: { group: GroupProps }) {
   const onSubmit = async (data: FormData) => {
     if (!group) return;
 
+    if (enableAdditionalLinks && (data.additionalLinks?.length ?? 0) === 0) {
+      return;
+    }
+
     await updateGroup(`/api/groups/${group.id}`, {
       method: "PATCH",
       body: data,
@@ -102,6 +106,8 @@ export function GroupAdditionalLinksForm({ group }: { group: GroupProps }) {
 
   const additionalLinks = watch("additionalLinks") || [];
   const maxPartnerLinks = watch("maxPartnerLinks") || 0;
+  const hasLinkFormat = additionalLinks.length > 0;
+  const cannotSaveWithoutLinkFormat = enableAdditionalLinks && !hasLinkFormat;
 
   const { addDestinationUrlModal, setIsOpen } = useAddDestinationUrlModal({
     additionalLinks,
@@ -120,25 +126,6 @@ export function GroupAdditionalLinksForm({ group }: { group: GroupProps }) {
     >
       {enableAdditionalLinks && (
         <>
-          <SettingsRow
-            heading="Link limit"
-            description="Set how many extra links a partner can create"
-          >
-            <NumberStepper
-              value={maxPartnerLinks}
-              onChange={(v) =>
-                setValue("maxPartnerLinks", v, {
-                  shouldDirty: true,
-                  shouldValidate: true,
-                })
-              }
-              min={0}
-              max={MAX_ADDITIONAL_PARTNER_LINKS}
-              step={1}
-              className="w-full"
-            />
-          </SettingsRow>
-
           <SettingsRow
             heading="Link formats"
             description="Specify the domains or URLs partners can create additional links on"
@@ -185,6 +172,25 @@ export function GroupAdditionalLinksForm({ group }: { group: GroupProps }) {
               />
             </div>
           </SettingsRow>
+
+          <SettingsRow
+            heading="Link limit"
+            description="Set how many extra links a partner can create"
+          >
+            <NumberStepper
+              value={maxPartnerLinks}
+              onChange={(v) =>
+                setValue("maxPartnerLinks", v, {
+                  shouldDirty: true,
+                  shouldValidate: true,
+                })
+              }
+              min={0}
+              max={MAX_ADDITIONAL_PARTNER_LINKS}
+              step={1}
+              className="w-full"
+            />
+          </SettingsRow>
         </>
       )}
 
@@ -218,7 +224,12 @@ export function GroupAdditionalLinksForm({ group }: { group: GroupProps }) {
             text="Save changes"
             className="h-8"
             loading={isSubmitting}
-            disabled={!isValid || !isDirty}
+            disabled={!isValid || !isDirty || cannotSaveWithoutLinkFormat}
+            disabledTooltip={
+              cannotSaveWithoutLinkFormat
+                ? "Add at least one link format before saving."
+                : undefined
+            }
           />
         </div>
       </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented saving group links when additional link formats are enabled but none are configured by skipping the update.
  * Disabled the Save button (with tooltip) when a link format is required but missing.
  * Reordered link settings so the "Link limit" appears after "Link formats" for clearer workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->