### PR TITLE
Fix Zod validation for flat Instagram response

### DIFF
--- a/apps/web/lib/api/scrape-creators/get-social-content.ts
+++ b/apps/web/lib/api/scrape-creators/get-social-content.ts
@@ -233,6 +233,7 @@ function normalizeUrl(raw: string) {
     "si",
     "feature",
     "igshid",
+    "igsh",
     "t",
   ].forEach((p) => url.searchParams.delete(p));
 

--- a/apps/web/lib/api/scrape-creators/schema.ts
+++ b/apps/web/lib/api/scrape-creators/schema.ts
@@ -219,8 +219,10 @@ export const socialContentSchema = z.preprocess(
                 edges: [{ node: { text: String(data.caption) } }],
               }
             : undefined,
-          display_url: data.image_url ?? undefined,
-          thumbnail_src: data.image_url ?? undefined,
+          display_url:
+            typeof data.image_url === "string" ? data.image_url : undefined,
+          thumbnail_src:
+            typeof data.image_url === "string" ? data.image_url : undefined,
         };
       }
 

--- a/apps/web/lib/api/scrape-creators/schema.ts
+++ b/apps/web/lib/api/scrape-creators/schema.ts
@@ -168,7 +168,40 @@ export const socialContentSchema = z.preprocess(
         };
       }
 
-      // Instagram detection
+      // Instagram v2 (flat post/reel — current ScrapeCreators API): map into the same
+      // shape as xdt_shortcode_media so Zod + getSocialContent stay unchanged.
+      if (
+        data.success === true &&
+        typeof data.shortcode === "string" &&
+        typeof data.like_count === "number" &&
+        data.user &&
+        typeof data.user === "object" &&
+        typeof data.user.username === "string"
+      ) {
+        const takenAtSec =
+          typeof data.created_at === "number"
+            ? data.created_at
+            : typeof data.created_at_utc === "string"
+              ? Math.floor(new Date(data.created_at_utc).getTime() / 1000)
+              : 0;
+
+        return {
+          platform: "instagram" as const,
+          taken_at_timestamp: takenAtSec,
+          owner: { username: data.user.username },
+          video_play_count: 0,
+          edge_media_preview_like: { count: data.like_count },
+          edge_media_to_caption: data.caption
+            ? {
+                edges: [{ node: { text: String(data.caption) } }],
+              }
+            : undefined,
+          display_url: data.image_url ?? undefined,
+          thumbnail_src: data.image_url ?? undefined,
+        };
+      }
+
+      // Instagram (legacy GraphQL xdt_shortcode_media shape)
       if ("data" in data && "xdt_shortcode_media" in data.data) {
         return {
           ...data.data.xdt_shortcode_media,

--- a/apps/web/lib/api/scrape-creators/schema.ts
+++ b/apps/web/lib/api/scrape-creators/schema.ts
@@ -178,18 +178,41 @@ export const socialContentSchema = z.preprocess(
         typeof data.user === "object" &&
         typeof data.user.username === "string"
       ) {
-        const takenAtSec =
-          typeof data.created_at === "number"
-            ? data.created_at
-            : typeof data.created_at_utc === "string"
-              ? Math.floor(new Date(data.created_at_utc).getTime() / 1000)
-              : 0;
+        const takenAtSec = (() => {
+          if (
+            typeof data.created_at === "number" &&
+            Number.isFinite(data.created_at)
+          ) {
+            return data.created_at;
+          }
+          if (typeof data.created_at_utc === "string") {
+            const ms = new Date(data.created_at_utc).getTime();
+            if (Number.isFinite(ms)) {
+              return Math.floor(ms / 1000);
+            }
+          }
+          return 0;
+        })();
 
         return {
           platform: "instagram" as const,
           taken_at_timestamp: takenAtSec,
           owner: { username: data.user.username },
-          video_play_count: 0,
+          video_play_count: (() => {
+            if (
+              typeof data.video_play_count === "number" &&
+              Number.isFinite(data.video_play_count)
+            ) {
+              return data.video_play_count;
+            }
+            if (
+              typeof data.play_count === "number" &&
+              Number.isFinite(data.play_count)
+            ) {
+              return data.play_count;
+            }
+            return 0;
+          })(),
           edge_media_preview_like: { count: data.like_count },
           edge_media_to_caption: data.caption
             ? {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Instagram URL normalization now strips an extra tracking query parameter for cleaner links.

* **New Features**
  * Improved handling of modern Instagram post/reel payloads so posts, reels, captions, timestamps, and play/like counts are detected and surfaced more reliably, while maintaining legacy payload support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->