### PR TITLE
Only `remap-default-links`/`discount-codes` for non-`pending` partners

### DIFF
--- a/apps/web/lib/api/groups/move-partners-to-group.ts
+++ b/apps/web/lib/api/groups/move-partners-to-group.ts
@@ -56,6 +56,7 @@ export async function movePartnersToGroup({
     select: {
       id: true,
       partnerId: true,
+      status: true,
       partnerGroup: {
         select: {
           id: true,
@@ -170,7 +171,9 @@ export async function movePartnersToGroup({
           body: {
             programId,
             groupId: group.id,
-            partnerIds,
+            partnerIds: programEnrollments
+              .filter(({ status }) => status !== "pending")
+              .map(({ partnerId }) => partnerId),
             userId: workspaceUserId,
             isGroupDeleted,
           },

--- a/apps/web/lib/api/groups/move-partners-to-group.ts
+++ b/apps/web/lib/api/groups/move-partners-to-group.ts
@@ -171,6 +171,7 @@ export async function movePartnersToGroup({
           body: {
             programId,
             groupId: group.id,
+            // skip remap-default-links / remap-discount-codes for pending applications (no links yet)
             partnerIds: programEnrollments
               .filter(({ status }) => status !== "pending")
               .map(({ partnerId }) => partnerId),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Partner group transfer now excludes pending enrollments when queuing background remapping, ensuring only confirmed enrollments are moved and avoiding incomplete synchronization; other partner-update processes (notifications, draft creation, link/activity logging) continue to use the broader partner list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->