### PR TITLE
Use integration ID for `captureWebhookLog` userId

### DIFF
--- a/apps/web/app/(ee)/api/appsflyer/webhook/route.ts
+++ b/apps/web/app/(ee)/api/appsflyer/webhook/route.ts
@@ -142,7 +142,7 @@ export const GET = withAxiom(async (req) => {
       captureWebhookLog({
         workspaceId: workspace.id,
         method: req.method,
-        path: "/api/appsflyer/webhook",
+        path: "/appsflyer/webhook",
         statusCode: 200,
         duration: Date.now() - startTime,
         requestBody: queryParams,
@@ -160,7 +160,7 @@ export const GET = withAxiom(async (req) => {
         captureWebhookLog({
           workspaceId: workspace.id,
           method: req.method,
-          path: "/api/appsflyer/webhook",
+          path: "/appsflyer/webhook",
           statusCode: errorResponse.status,
           duration: Date.now() - startTime,
           requestBody: queryParams,

--- a/apps/web/app/(ee)/api/stripe/integration/webhook/route.ts
+++ b/apps/web/app/(ee)/api/stripe/integration/webhook/route.ts
@@ -156,7 +156,7 @@ export const POST = withAxiom(async (req: Request) => {
         await captureWebhookLog({
           workspaceId: result.workspaceId,
           method: req.method,
-          path: "/api/stripe/integration/webhook",
+          path: "/stripe/integration/webhook",
           statusCode: 200,
           duration: Date.now() - startTime,
           requestBody: event,

--- a/apps/web/lib/api-logs/capture-webhook-log.ts
+++ b/apps/web/lib/api-logs/capture-webhook-log.ts
@@ -1,3 +1,4 @@
+import { WEBHOOK_REQUEST_ACTORS_BY_PATH } from "./constants";
 import { recordApiLog } from "./record-api-log";
 
 async function parseResponseBody(responseBody: unknown): Promise<unknown> {
@@ -31,6 +32,7 @@ export async function captureWebhookLog({
   responseBody: unknown;
   userAgent: string | null;
 }) {
+  const actor = WEBHOOK_REQUEST_ACTORS_BY_PATH[path];
   return await recordApiLog({
     workspaceId,
     method,
@@ -42,7 +44,7 @@ export async function captureWebhookLog({
     requestBody,
     responseBody: await parseResponseBody(responseBody),
     tokenId: null,
-    userId: null,
+    userId: actor.id ?? null,
     requestType: "webhook",
   });
 }

--- a/apps/web/lib/api-logs/capture-webhook-log.ts
+++ b/apps/web/lib/api-logs/capture-webhook-log.ts
@@ -25,7 +25,7 @@ export async function captureWebhookLog({
 }: {
   workspaceId: string;
   method: string;
-  path: string;
+  path: keyof typeof WEBHOOK_REQUEST_ACTORS_BY_PATH;
   statusCode: number;
   duration: number;
   requestBody: unknown;
@@ -44,7 +44,7 @@ export async function captureWebhookLog({
     requestBody,
     responseBody: await parseResponseBody(responseBody),
     tokenId: null,
-    userId: actor.id ?? null,
+    userId: actor.id,
     requestType: "webhook",
   });
 }

--- a/apps/web/lib/api-logs/constants.ts
+++ b/apps/web/lib/api-logs/constants.ts
@@ -96,26 +96,23 @@ export const METHOD_BADGE_VARIANTS: Record<string, string> = {
   GET: "success",
 } as const;
 
-export const WEBHOOK_REQUEST_ACTORS_BY_PATH: Record<
-  string,
-  { id: string; name: string; image: string }
-> = {
-  "/api/appsflyer/webhook": {
+export const WEBHOOK_REQUEST_ACTORS_BY_PATH = {
+  "/appsflyer/webhook": {
     id: APPSFLYER_INTEGRATION_ID,
     name: "AppsFlyer",
     image:
       "https://dubassets.com/integrations/int_1KN8JP7ET3VQQRF7ZQEVNFPJ5_2Geprc8",
   },
-  "/api/stripe/integration/webhook": {
+  "/stripe/integration/webhook": {
     id: STRIPE_INTEGRATION_ID,
     name: "Stripe",
     image:
       "https://dubassets.com/integrations/clzra1ya60001wnj4a89zcg9h_jtyaGa7",
   },
-  "/api/shopify/integration/webhook": {
+  "/shopify/integration/webhook": {
     id: SHOPIFY_INTEGRATION_ID,
     name: "Shopify",
     image:
       "https://dubassets.com/integrations/int_iWOtrZgmcyU6XDwKr4AYYqLN_jUmF77W",
   },
-};
+} as const;

--- a/apps/web/lib/api-logs/constants.ts
+++ b/apps/web/lib/api-logs/constants.ts
@@ -1,4 +1,9 @@
 import type { PlanProps } from "@/lib/types";
+import {
+  APPSFLYER_INTEGRATION_ID,
+  SHOPIFY_INTEGRATION_ID,
+  STRIPE_INTEGRATION_ID,
+} from "@dub/utils";
 
 // Route patterns for parameterized path matching.
 // Used both for logging eligibility and route pattern extraction.
@@ -90,3 +95,27 @@ export const METHOD_BADGE_VARIANTS: Record<string, string> = {
   DELETE: "error",
   GET: "success",
 } as const;
+
+export const WEBHOOK_REQUEST_ACTORS_BY_PATH: Record<
+  string,
+  { id: string; name: string; image: string }
+> = {
+  "/api/appsflyer/webhook": {
+    id: APPSFLYER_INTEGRATION_ID,
+    name: "AppsFlyer",
+    image:
+      "https://dubassets.com/integrations/int_1KN8JP7ET3VQQRF7ZQEVNFPJ5_2Geprc8",
+  },
+  "/api/stripe/integration/webhook": {
+    id: STRIPE_INTEGRATION_ID,
+    name: "Stripe",
+    image:
+      "https://dubassets.com/integrations/clzra1ya60001wnj4a89zcg9h_jtyaGa7",
+  },
+  "/api/shopify/integration/webhook": {
+    id: SHOPIFY_INTEGRATION_ID,
+    name: "Shopify",
+    image:
+      "https://dubassets.com/integrations/int_iWOtrZgmcyU6XDwKr4AYYqLN_jUmF77W",
+  },
+};

--- a/apps/web/lib/api-logs/enrich-api-logs.ts
+++ b/apps/web/lib/api-logs/enrich-api-logs.ts
@@ -51,7 +51,7 @@ export async function enrichApiLogs(
   const userMap = new Map(users.map((u) => [u.id, u] as const));
   const webhookRequestActorsMap = new Map(
     Object.values(WEBHOOK_REQUEST_ACTORS_BY_PATH).map((actor) => [
-      actor.id,
+      actor.id as string, // coerce back to string from const type
       { ...actor, email: null },
     ]),
   );

--- a/apps/web/lib/api-logs/enrich-api-logs.ts
+++ b/apps/web/lib/api-logs/enrich-api-logs.ts
@@ -1,29 +1,6 @@
 import { prisma } from "@dub/prisma";
 import { ApiLogTB, EnrichedApiLog } from "../types";
-
-const WEBHOOK_REQUEST_ACTORS: Record<
-  string,
-  { id: string; name: string; image: string }
-> = {
-  "/appsflyer/webhook": {
-    id: "appsflyer",
-    name: "AppsFlyer",
-    image:
-      "https://dubassets.com/integrations/int_1KN8JP7ET3VQQRF7ZQEVNFPJ5_2Geprc8",
-  },
-  "/stripe/integration/webhook": {
-    id: "stripe",
-    name: "Stripe",
-    image:
-      "https://dubassets.com/integrations/clzra1ya60001wnj4a89zcg9h_jtyaGa7",
-  },
-  "/shopify/integration/webhook": {
-    id: "shopify",
-    name: "Shopify",
-    image:
-      "https://dubassets.com/integrations/int_iWOtrZgmcyU6XDwKr4AYYqLN_jUmF77W",
-  },
-};
+import { WEBHOOK_REQUEST_ACTORS_BY_PATH } from "./constants";
 
 export async function enrichApiLogs(
   logs: ApiLogTB | ApiLogTB[],
@@ -72,18 +49,21 @@ export async function enrichApiLogs(
 
   const tokenMap = new Map(tokens.map((t) => [t.id, t] as const));
   const userMap = new Map(users.map((u) => [u.id, u] as const));
+  const webhookRequestActorsMap = new Map(
+    Object.values(WEBHOOK_REQUEST_ACTORS_BY_PATH).map((actor) => [
+      actor.id,
+      { ...actor, email: null },
+    ]),
+  );
 
   const enriched = logsArray.map((log) => ({
     ...log,
     token: log.token_id ? tokenMap.get(log.token_id) ?? null : null,
-    user: WEBHOOK_REQUEST_ACTORS[log.path]
-      ? {
-          ...WEBHOOK_REQUEST_ACTORS[log.path],
-          email: null,
-        }
-      : log.user_id
-        ? userMap.get(log.user_id) ?? null
-        : null,
+    user: log.user_id
+      ? webhookRequestActorsMap.get(log.user_id) ??
+        userMap.get(log.user_id) ??
+        null
+      : null,
   }));
 
   return isSingle ? enriched[0] : enriched;

--- a/apps/web/ui/logs/logs-table.tsx
+++ b/apps/web/ui/logs/logs-table.tsx
@@ -171,7 +171,7 @@ export function LogsTable() {
         cell: ({ row }: { row: Row<EnrichedApiLog> }) => (
           <TimestampTooltip
             timestamp={row.original.timestamp}
-            rows={["local"]}
+            rows={["local", "utc", "unix"]}
             side="left"
             delayDuration={150}
           >


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Logs table now shows timestamps in local, UTC, and Unix formats.

* **Improvements**
  * Webhook requests are now attributed to specific integrations for clearer API logs and accurate actor identification.
  * Logging paths for supported integrations were standardized to ensure consistent webhook tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->