### PR TITLE
Add date range filter to request logs, hide DELETE body

### DIFF
--- a/apps/web/app/api/logs/[logId]/route.ts
+++ b/apps/web/app/api/logs/[logId]/route.ts
@@ -20,9 +20,11 @@ export const GET = withWorkspace(
       });
     }
 
-    const { start } = getApiLogsDateRange(workspace.plan);
+    const { startDate } = getApiLogsDateRange({
+      plan: workspace.plan,
+    });
 
-    if (new Date(log.timestamp) < new Date(start)) {
+    if (new Date(log.timestamp) < new Date(startDate)) {
       throw new DubApiError({
         code: "not_found",
         message:

--- a/apps/web/app/api/logs/count/route.ts
+++ b/apps/web/app/api/logs/count/route.ts
@@ -7,11 +7,20 @@ import { NextResponse } from "next/server";
 // GET /api/logs/count
 export const GET = withWorkspace(
   async ({ workspace, searchParams }) => {
-    const filters = getApiLogsCountQuerySchema.parse(searchParams);
+    const { start, end, interval, ...filters } =
+      getApiLogsCountQuerySchema.parse(searchParams);
+
+    const { startDate, endDate } = getApiLogsDateRange({
+      plan: workspace.plan,
+      start,
+      end,
+      interval,
+    });
 
     const rows = await getApiLogsCount({
       ...filters,
-      ...getApiLogsDateRange(workspace.plan),
+      start: startDate,
+      end: endDate,
       workspaceId: workspace.id,
     });
 

--- a/apps/web/app/api/logs/route.ts
+++ b/apps/web/app/api/logs/route.ts
@@ -8,11 +8,20 @@ import { NextResponse } from "next/server";
 // GET /api/logs
 export const GET = withWorkspace(
   async ({ workspace, searchParams }) => {
-    const filters = getApiLogsQuerySchema.parse(searchParams);
+    const { start, end, interval, ...filters } =
+      getApiLogsQuerySchema.parse(searchParams);
+
+    const { startDate, endDate } = getApiLogsDateRange({
+      plan: workspace.plan,
+      start,
+      end,
+      interval,
+    });
 
     const logs = await getApiLogs({
       ...filters,
-      ...getApiLogsDateRange(workspace.plan),
+      start: startDate,
+      end: endDate,
       workspaceId: workspace.id,
     });
 

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/logs/[logId]/page-client.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/logs/[logId]/page-client.tsx
@@ -193,21 +193,23 @@ function LogDetailContent({ log }: { log: EnrichedApiLog }) {
               </div>
             )}
           </div>
-          <div className="flex flex-col gap-2">
-            <h3 className="text-content-emphasis text-lg font-semibold">
-              Request body
-            </h3>
-            {highlightedRequest ? (
-              <div
-                className="shiki-wrapper max-h-[800px] overflow-auto rounded-xl border border-neutral-200 bg-white p-4 text-sm"
-                dangerouslySetInnerHTML={{ __html: highlightedRequest }}
-              />
-            ) : (
-              <div className="rounded-xl border border-neutral-200 bg-white p-4 font-mono text-xs text-neutral-500">
-                No request body
-              </div>
-            )}
-          </div>
+          {log.method !== "DELETE" && (
+            <div className="flex flex-col gap-2">
+              <h3 className="text-content-emphasis text-lg font-semibold">
+                Request body
+              </h3>
+              {highlightedRequest ? (
+                <div
+                  className="shiki-wrapper max-h-[800px] overflow-auto rounded-xl border border-neutral-200 bg-white p-4 text-sm"
+                  dangerouslySetInnerHTML={{ __html: highlightedRequest }}
+                />
+              ) : (
+                <div className="rounded-xl border border-neutral-200 bg-white p-4 font-mono text-xs text-neutral-500">
+                  No request body
+                </div>
+              )}
+            </div>
+          )}
         </div>
       </div>
 

--- a/apps/web/lib/api-logs/api-log-retention.ts
+++ b/apps/web/lib/api-logs/api-log-retention.ts
@@ -29,10 +29,17 @@ export function getApiLogsDateRange({
     // Clamp start to retention boundary
     const clampedStart =
       startDate < retentionBoundary ? retentionBoundary : startDate;
+    const clampedEnd =
+      endDate < retentionBoundary ? retentionBoundary : endDate;
+
+    const normalizedStart =
+      clampedStart <= clampedEnd ? clampedStart : clampedEnd;
+    const normalizedEnd =
+      clampedStart <= clampedEnd ? clampedEnd : clampedStart;
 
     return {
-      startDate: formatUTCDateTimeClickhouse(clampedStart),
-      endDate: formatUTCDateTimeClickhouse(endDate),
+      startDate: formatUTCDateTimeClickhouse(normalizedStart),
+      endDate: formatUTCDateTimeClickhouse(normalizedEnd),
     };
   }
 

--- a/apps/web/lib/api-logs/api-log-retention.ts
+++ b/apps/web/lib/api-logs/api-log-retention.ts
@@ -11,8 +11,8 @@ export function getApiLogsDateRange({
   interval,
 }: {
   plan: PlanProps;
-  start?: string;
-  end?: string;
+  start?: string | Date | null;
+  end?: string | Date | null;
   interval?: string;
 }) {
   const retentionDays = API_LOG_RETENTION_DAYS[plan] ?? DEFAULT_RETENTION_DAYS;

--- a/apps/web/lib/api-logs/api-log-retention.ts
+++ b/apps/web/lib/api-logs/api-log-retention.ts
@@ -1,16 +1,44 @@
 import { formatUTCDateTimeClickhouse } from "@/lib/analytics/utils/format-utc-datetime-clickhouse";
 import { PlanProps } from "@/lib/types";
 import { subDays } from "date-fns";
+import { getStartEndDates } from "../analytics/utils/get-start-end-dates";
 import { API_LOG_RETENTION_DAYS, DEFAULT_RETENTION_DAYS } from "./constants";
 
-export function getApiLogsDateRange(plan: PlanProps) {
-  const days = API_LOG_RETENTION_DAYS[plan] ?? DEFAULT_RETENTION_DAYS;
+export function getApiLogsDateRange({
+  plan,
+  start,
+  end,
+  interval,
+}: {
+  plan: PlanProps;
+  start?: string;
+  end?: string;
+  interval?: string;
+}) {
+  const retentionDays = API_LOG_RETENTION_DAYS[plan] ?? DEFAULT_RETENTION_DAYS;
+  const retentionBoundary = subDays(new Date(), retentionDays);
 
-  const end = new Date();
-  const start = subDays(end, days);
+  // If interval or custom start/end provided, resolve them
+  if (interval || (start && end)) {
+    const { startDate, endDate } = getStartEndDates({
+      interval,
+      start,
+      end,
+    });
 
+    // Clamp start to retention boundary
+    const clampedStart =
+      startDate < retentionBoundary ? retentionBoundary : startDate;
+
+    return {
+      startDate: formatUTCDateTimeClickhouse(clampedStart),
+      endDate: formatUTCDateTimeClickhouse(endDate),
+    };
+  }
+
+  // Default: full retention window
   return {
-    start: formatUTCDateTimeClickhouse(start),
-    end: formatUTCDateTimeClickhouse(end),
+    startDate: formatUTCDateTimeClickhouse(retentionBoundary),
+    endDate: formatUTCDateTimeClickhouse(new Date()),
   };
 }

--- a/apps/web/lib/api-logs/constants.ts
+++ b/apps/web/lib/api-logs/constants.ts
@@ -84,8 +84,8 @@ export const API_LOG_RETENTION_DAYS: Record<PlanProps, number> = {
 
 export const API_LOGS_PRESETS_BY_RETENTION: Record<number, string[]> = {
   30: ["24h", "7d", "30d"],
-  60: ["24h", "7d", "30d"],
-  90: ["24h", "7d", "30d", "90d"],
+  60: ["24h", "7d", "30d", "60d"],
+  90: ["24h", "7d", "30d", "60d", "90d"],
 };
 
 // Default when plan is missing from workspace data (should not happen for known plans).

--- a/apps/web/lib/api-logs/constants.ts
+++ b/apps/web/lib/api-logs/constants.ts
@@ -63,14 +63,11 @@ export const HTTP_STATUS_CODES = [
   { value: 500, label: "500 Server Error" },
 ] as const;
 
-export const HTTP_MUTATION_METHODS = [
-  "POST",
-  "PATCH",
-  "PUT",
-  "DELETE",
-] as const;
-
 export const HTTP_METHODS = ["POST", "PATCH", "PUT", "DELETE", "GET"] as const;
+
+export const HTTP_MUTATION_METHODS = HTTP_METHODS.filter(
+  (method) => method !== "GET",
+);
 
 export const API_LOGS_MAX_PAGE_SIZE = 50;
 
@@ -83,6 +80,12 @@ export const API_LOG_RETENTION_DAYS: Record<PlanProps, number> = {
   "business max": 60,
   advanced: 60,
   enterprise: 90,
+};
+
+export const API_LOGS_PRESETS_BY_RETENTION: Record<number, string[]> = {
+  30: ["24h", "7d", "30d"],
+  60: ["24h", "7d", "30d"],
+  90: ["24h", "7d", "30d", "90d"],
 };
 
 // Default when plan is missing from workspace data (should not happen for known plans).

--- a/apps/web/lib/api-logs/get-api-logs-count.ts
+++ b/apps/web/lib/api-logs/get-api-logs-count.ts
@@ -7,7 +7,10 @@ import {
   getApiLogsCountQuerySchema,
 } from "./schemas";
 
-type GetApiLogsCountParams = z.infer<typeof getApiLogsCountQuerySchema> & {
+type GetApiLogsCountParams = Omit<
+  z.infer<typeof getApiLogsCountQuerySchema>,
+  "start" | "end"
+> & {
   workspaceId: string;
   start: string;
   end: string;

--- a/apps/web/lib/api-logs/get-api-logs.ts
+++ b/apps/web/lib/api-logs/get-api-logs.ts
@@ -6,7 +6,10 @@ import {
   getApiLogsQuerySchema,
 } from "./schemas";
 
-type GetApiLogsParams = z.infer<typeof getApiLogsQuerySchema> & {
+type GetApiLogsParams = Omit<
+  z.infer<typeof getApiLogsQuerySchema>,
+  "start" | "end"
+> & {
   workspaceId: string;
   start: string;
   end: string;

--- a/apps/web/lib/api-logs/schemas.ts
+++ b/apps/web/lib/api-logs/schemas.ts
@@ -3,10 +3,7 @@ import { tokenSchema } from "@/lib/zod/schemas/token";
 import { UserSchema } from "@/lib/zod/schemas/users";
 import * as z from "zod/v4";
 import { parseDateSchema } from "../zod/schemas/utils";
-import {
-  API_LOGS_MAX_PAGE_SIZE,
-  API_LOGS_PRESETS_BY_RETENTION,
-} from "./constants";
+import { API_LOGS_MAX_PAGE_SIZE } from "./constants";
 
 export const requestTypeSchema = z.enum(["api", "webhook"]);
 
@@ -91,7 +88,7 @@ export const getApiLogsQuerySchema = z
     requestType: requestTypeSchema.optional(),
     start: parseDateSchema.optional(),
     end: parseDateSchema.optional(),
-    interval: z.enum(API_LOGS_PRESETS_BY_RETENTION[90]).optional(),
+    interval: z.enum(["24h", "7d", "30d", "60d", "90d"]).optional(),
   })
   .extend(
     getPaginationQuerySchema({

--- a/apps/web/lib/api-logs/schemas.ts
+++ b/apps/web/lib/api-logs/schemas.ts
@@ -85,6 +85,9 @@ export const getApiLogsQuerySchema = z
     tokenId: z.string().optional(),
     requestId: z.string().optional(),
     requestType: requestTypeSchema.optional(),
+    start: z.string().optional(),
+    end: z.string().optional(),
+    interval: z.string().optional(),
   })
   .extend(
     getPaginationQuerySchema({

--- a/apps/web/lib/api-logs/schemas.ts
+++ b/apps/web/lib/api-logs/schemas.ts
@@ -2,6 +2,7 @@ import { getPaginationQuerySchema } from "@/lib/zod/schemas/misc";
 import { tokenSchema } from "@/lib/zod/schemas/token";
 import { UserSchema } from "@/lib/zod/schemas/users";
 import * as z from "zod/v4";
+import { parseDateSchema } from "../zod/schemas/utils";
 import { API_LOGS_MAX_PAGE_SIZE } from "./constants";
 
 export const requestTypeSchema = z.enum(["api", "webhook"]);
@@ -85,9 +86,9 @@ export const getApiLogsQuerySchema = z
     tokenId: z.string().optional(),
     requestId: z.string().optional(),
     requestType: requestTypeSchema.optional(),
-    start: z.string().optional(),
-    end: z.string().optional(),
-    interval: z.string().optional(),
+    start: parseDateSchema.optional(),
+    end: parseDateSchema.optional(),
+    interval: z.enum(["24h", "7d", "30d", "90d"]).optional(),
   })
   .extend(
     getPaginationQuerySchema({

--- a/apps/web/lib/api-logs/schemas.ts
+++ b/apps/web/lib/api-logs/schemas.ts
@@ -3,7 +3,10 @@ import { tokenSchema } from "@/lib/zod/schemas/token";
 import { UserSchema } from "@/lib/zod/schemas/users";
 import * as z from "zod/v4";
 import { parseDateSchema } from "../zod/schemas/utils";
-import { API_LOGS_MAX_PAGE_SIZE } from "./constants";
+import {
+  API_LOGS_MAX_PAGE_SIZE,
+  API_LOGS_PRESETS_BY_RETENTION,
+} from "./constants";
 
 export const requestTypeSchema = z.enum(["api", "webhook"]);
 
@@ -88,7 +91,7 @@ export const getApiLogsQuerySchema = z
     requestType: requestTypeSchema.optional(),
     start: parseDateSchema.optional(),
     end: parseDateSchema.optional(),
-    interval: z.enum(["24h", "7d", "30d", "90d"]).optional(),
+    interval: z.enum(API_LOGS_PRESETS_BY_RETENTION[90]).optional(),
   })
   .extend(
     getPaginationQuerySchema({

--- a/apps/web/lib/api/payouts/get-eligible-payouts.ts
+++ b/apps/web/lib/api/payouts/get-eligible-payouts.ts
@@ -10,9 +10,8 @@ import { getEffectivePayoutMode } from "./get-effective-payout-mode";
 import { getPayoutEligibilityFilter } from "./payout-eligibility-filter";
 import { payoutIdSelectionWhere } from "./payout-id-selection-where";
 
-interface GetEligiblePayoutsProps extends z.output<
-  typeof eligiblePayoutsQuerySchema
-> {
+interface GetEligiblePayoutsProps
+  extends z.output<typeof eligiblePayoutsQuerySchema> {
   program: Pick<Program, "id" | "name" | "minPayoutAmount" | "payoutMode">;
   workspace: Pick<Project, "plan">;
 }

--- a/apps/web/lib/swr/use-api-logs-count.ts
+++ b/apps/web/lib/swr/use-api-logs-count.ts
@@ -27,6 +27,9 @@ export function useApiLogsCount({
         "tokenId",
         "requestId",
         "requestType",
+        "start",
+        "end",
+        "interval",
       ],
     },
   );

--- a/apps/web/ui/logs/logs-table.tsx
+++ b/apps/web/ui/logs/logs-table.tsx
@@ -4,6 +4,7 @@ import {
   API_LOGS_MAX_PAGE_SIZE,
   API_LOGS_PRESETS_BY_RETENTION,
   API_LOG_RETENTION_DAYS,
+  DEFAULT_RETENTION_DAYS,
   METHOD_BADGE_VARIANTS,
 } from "@/lib/api-logs/constants";
 import { useApiLogsCount } from "@/lib/swr/use-api-logs-count";
@@ -352,7 +353,7 @@ function LogsFilters({
 
   const presets =
     API_LOGS_PRESETS_BY_RETENTION[retentionDays] ??
-    API_LOGS_PRESETS_BY_RETENTION[30];
+    API_LOGS_PRESETS_BY_RETENTION[DEFAULT_RETENTION_DAYS];
 
   return (
     <div>

--- a/apps/web/ui/logs/logs-table.tsx
+++ b/apps/web/ui/logs/logs-table.tsx
@@ -307,7 +307,7 @@ export function LogsTable() {
         onRemove={onRemove}
         onRemoveAll={onRemoveAll}
         setSelectedFilter={setSelectedFilter}
-        plan={plan}
+        plan={plan || "free"}
       />
       {logs?.length !== 0 ? (
         <Table {...tableProps} table={table} />
@@ -346,9 +346,9 @@ function LogsFilters({
   onRemove: (key: string) => void;
   onRemoveAll: () => void;
   setSelectedFilter: (f: string | null) => void;
-  plan?: PlanProps;
+  plan: PlanProps;
 }) {
-  const retentionDays = plan ? API_LOG_RETENTION_DAYS[plan] ?? 30 : 30;
+  const retentionDays = API_LOG_RETENTION_DAYS[plan];
 
   const presets =
     API_LOGS_PRESETS_BY_RETENTION[retentionDays] ??

--- a/apps/web/ui/logs/logs-table.tsx
+++ b/apps/web/ui/logs/logs-table.tsx
@@ -2,14 +2,18 @@
 
 import {
   API_LOGS_MAX_PAGE_SIZE,
+  API_LOGS_PRESETS_BY_RETENTION,
+  API_LOG_RETENTION_DAYS,
   METHOD_BADGE_VARIANTS,
 } from "@/lib/api-logs/constants";
 import { useApiLogsCount } from "@/lib/swr/use-api-logs-count";
 import useWorkspace from "@/lib/swr/use-workspace";
+import type { PlanProps } from "@/lib/types";
 import { EnrichedApiLog } from "@/lib/types";
 import { AnimatedEmptyState } from "@/ui/shared/animated-empty-state";
 import { FilterButtonTableRow } from "@/ui/shared/filter-button-table-row";
 import { SearchBoxPersisted } from "@/ui/shared/search-box";
+import SimpleDateRangePicker from "@/ui/shared/simple-date-range-picker";
 import { UserAvatar } from "@/ui/users/user-avatar";
 import {
   AnimatedSizeContainer,
@@ -26,6 +30,7 @@ import {
 import { StackY3 } from "@dub/ui/icons";
 import { fetcher } from "@dub/utils";
 import { Cell, Row } from "@tanstack/react-table";
+import { subDays } from "date-fns";
 import { useRouter } from "next/navigation";
 import { useMemo } from "react";
 import useSWR from "swr";
@@ -54,7 +59,7 @@ const LOGS_TABLE_COLUMNS = {
 
 export function LogsTable() {
   const router = useRouter();
-  const { id: workspaceId, slug } = useWorkspace();
+  const { id: workspaceId, slug, plan } = useWorkspace();
   const { searchParamsObj } = useRouterStuff();
 
   const {
@@ -302,6 +307,7 @@ export function LogsTable() {
         onRemove={onRemove}
         onRemoveAll={onRemoveAll}
         setSelectedFilter={setSelectedFilter}
+        plan={plan}
       />
       {logs?.length !== 0 ? (
         <Table {...tableProps} table={table} />
@@ -332,6 +338,7 @@ function LogsFilters({
   onRemove,
   onRemoveAll,
   setSelectedFilter,
+  plan,
 }: {
   filters: any[];
   activeFilters: any[];
@@ -339,18 +346,34 @@ function LogsFilters({
   onRemove: (key: string) => void;
   onRemoveAll: () => void;
   setSelectedFilter: (f: string | null) => void;
+  plan?: PlanProps;
 }) {
+  const retentionDays = plan ? API_LOG_RETENTION_DAYS[plan] ?? 30 : 30;
+
+  const presets =
+    API_LOGS_PRESETS_BY_RETENTION[retentionDays] ??
+    API_LOGS_PRESETS_BY_RETENTION[30];
+
   return (
     <div>
       <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-        <Filter.Select
-          className="w-full md:w-fit"
-          filters={filters}
-          activeFilters={activeFilters}
-          onSelect={onSelect}
-          onRemove={onRemove}
-          onSelectedFilterChange={setSelectedFilter}
-        />
+        <div className="flex items-center gap-2">
+          <Filter.Select
+            className="w-full md:w-fit"
+            filters={filters}
+            activeFilters={activeFilters}
+            onSelect={onSelect}
+            onRemove={onRemove}
+            onSelectedFilterChange={setSelectedFilter}
+          />
+          <SimpleDateRangePicker
+            className="w-full md:w-fit"
+            align="start"
+            defaultInterval="30d"
+            presets={presets as any}
+            fromDate={subDays(new Date(), retentionDays)}
+          />
+        </div>
         <SearchBoxPersisted
           urlParam="requestId"
           placeholder="Search by request ID"

--- a/apps/web/ui/logs/logs-table.tsx
+++ b/apps/web/ui/logs/logs-table.tsx
@@ -357,7 +357,7 @@ function LogsFilters({
   return (
     <div>
       <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-        <div className="flex items-center gap-2">
+        <div className="flex flex-col items-start gap-2 md:flex-row md:items-center">
           <Filter.Select
             className="w-full md:w-fit"
             filters={filters}

--- a/apps/web/ui/logs/use-log-filters.ts
+++ b/apps/web/ui/logs/use-log-filters.ts
@@ -135,7 +135,16 @@ export function useLogFilters() {
   const onRemoveAll = useCallback(
     () =>
       queryParams({
-        del: ["method", "statusCode", "routePattern", "tokenId", "requestType"],
+        del: [
+          "method",
+          "statusCode",
+          "routePattern",
+          "tokenId",
+          "requestType",
+          "start",
+          "end",
+          "interval",
+        ],
       }),
     [queryParams],
   );

--- a/apps/web/ui/logs/use-log-filters.ts
+++ b/apps/web/ui/logs/use-log-filters.ts
@@ -152,8 +152,27 @@ export function useLogFilters() {
       params.requestId = searchParamsObj.requestId;
     }
 
+    if (searchParamsObj.start) {
+      params.start = searchParamsObj.start;
+    }
+
+    if (searchParamsObj.end) {
+      params.end = searchParamsObj.end;
+    }
+
+    if (searchParamsObj.interval) {
+      params.interval = searchParamsObj.interval;
+    }
+
     return new URLSearchParams(params).toString();
-  }, [activeFilters, workspaceId, searchParamsObj.requestId]);
+  }, [
+    activeFilters,
+    workspaceId,
+    searchParamsObj.requestId,
+    searchParamsObj.start,
+    searchParamsObj.end,
+    searchParamsObj.interval,
+  ]);
 
   return {
     filters,

--- a/apps/web/ui/partners/confirm-payouts-sheet.tsx
+++ b/apps/web/ui/partners/confirm-payouts-sheet.tsx
@@ -185,8 +185,8 @@ function ConfirmPayoutsSheetContent() {
   );
 
   const eligiblePayoutsTableRowCount = isExplicitSelectionMode
-    ? (eligiblePayoutsSummaryCount?.count ?? 0)
-    : (eligiblePayoutsTableTotalCount?.count ?? 0);
+    ? eligiblePayoutsSummaryCount?.count ?? 0
+    : eligiblePayoutsTableTotalCount?.count ?? 0;
 
   const { data: payoutsCount } = useSWR<
     {
@@ -233,10 +233,12 @@ function ConfirmPayoutsSheetContent() {
     isLoading: eligiblePayoutsLoading,
   } = useSWR<PayoutResponse[]>(
     defaultProgramId
-      ? `/api/programs/${defaultProgramId}/payouts/eligible?${new URLSearchParams({
-          ...tableQuery,
-          page: pagination.pageIndex.toString(),
-        }).toString()}`
+      ? `/api/programs/${defaultProgramId}/payouts/eligible?${new URLSearchParams(
+          {
+            ...tableQuery,
+            page: pagination.pageIndex.toString(),
+          },
+        ).toString()}`
       : null,
     fetcher,
     {
@@ -594,7 +596,7 @@ function ConfirmPayoutsSheetContent() {
           ),
       },
       ...(payoutsIncludedInInvoice.length > 0 &&
-        payoutsIncludedInInvoice.some(isExternalPayout)
+      payoutsIncludedInInvoice.some(isExternalPayout)
         ? [
             {
               key: "External Amount",

--- a/apps/web/ui/shared/inline-badge-popover.tsx
+++ b/apps/web/ui/shared/inline-badge-popover.tsx
@@ -62,7 +62,7 @@ export function InlineBadgePopover({
       align="start"
       content={
         <InlineBadgePopoverContext.Provider value={{ isOpen, setIsOpen }}>
-          <ScrollContainer className="w-full min-w-32 max-h-[50dvh] min-h-0 overscroll-contain p-1 text-sm sm:w-auto">
+          <ScrollContainer className="max-h-[50dvh] min-h-0 w-full min-w-32 overscroll-contain p-1 text-sm sm:w-auto">
             {children}
           </ScrollContainer>
         </InlineBadgePopoverContext.Provider>

--- a/apps/web/ui/shared/simple-date-range-picker.tsx
+++ b/apps/web/ui/shared/simple-date-range-picker.tsx
@@ -18,6 +18,7 @@ export default function SimpleDateRangePicker({
   values,
   disabled,
   presets,
+  fromDate,
 }: {
   className?: string;
   align?: "start" | "center" | "end";
@@ -25,6 +26,7 @@ export default function SimpleDateRangePicker({
   values?: Values;
   disabled?: boolean;
   presets?: (typeof DATE_RANGE_INTERVAL_PRESETS)[number][];
+  fromDate?: Date;
 }) {
   const { queryParams, searchParamsObj } = useRouterStuff();
   const { start, end, interval } = values ?? (searchParamsObj as Values);
@@ -88,6 +90,7 @@ export default function SimpleDateRangePicker({
         };
       })}
       disabled={disabled}
+      fromDate={fromDate}
     />
   );
 }


### PR DESCRIPTION
## Changes

- **Date Range Filtering**: Added date range picker to the logs table, allowing users to filter logs by custom start/end dates or preset intervals (24h, 7d, 30d, 90d based on plan)
- **Request Body Visibility**: Hide request body section for DELETE requests in log details
- **API Enhancements**: Updated `/api/logs` and `/api/logs/count` endpoints to accept and process `start`, `end`, and `interval` query parameters
- **Retention Boundaries**: Date range inputs are now clamped to the plan's data retention boundary to prevent out-of-range queries
- **UI/UX**: Added `SimpleDateRangePicker` component to logs filters with dynamic preset options based on workspace plan retention days
- **Schema Updates**: Extended query schemas to include date range parameters and updated SWR hook to track these new filters

<img width="2764" height="1320" alt="CleanShot 2026-04-13 at 11  04 02@2x" src="https://github.com/user-attachments/assets/ab51242a-de63-4872-bd2d-5c879eaa296a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Date range filtering for API logs with plan-aware retention presets and custom intervals
  * Date range picker added to the filter header with a from-date option

* **Bug Fixes / Improvements**
  * Log queries and counts now honor explicit start/end/interval selections
  * Request body hidden for DELETE entries in log details
<!-- end of auto-generated comment: release notes by coderabbit.ai -->