### PR TITLE
Skip `/remap-default-links` cron if group is not found

### DIFF
--- a/apps/web/app/(ee)/api/cron/groups/remap-default-links/route.ts
+++ b/apps/web/app/(ee)/api/cron/groups/remap-default-links/route.ts
@@ -60,7 +60,8 @@ export async function POST(req: Request) {
           workspace: true,
         },
       }),
-      prisma.partnerGroup.findUniqueOrThrow({
+
+      prisma.partnerGroup.findUnique({
         where: {
           id: groupId,
         },
@@ -69,6 +70,7 @@ export async function POST(req: Request) {
           partnerGroupDefaultLinks: true,
         },
       }),
+
       prisma.programEnrollment.findMany({
         where: {
           partnerId: {
@@ -99,6 +101,10 @@ export async function POST(req: Request) {
         },
       }),
     ]);
+
+    if (!partnerGroup) {
+      return logAndRespond(`Partner group ${groupId} not found. Skipping...`);
+    }
 
     console.log(
       `Updating ${programEnrollments.length} partners to be moved to group ${partnerGroup.name} (${partnerGroup.id}) for program ${program.name} (${program.id}).`,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved error handling in the link remapping cron job to gracefully handle missing partner groups, preventing errors and ensuring the job continues operating reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->