### PR TITLE
Invite email and builder updates

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/invite-partner-sheet.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/invite-partner-sheet.tsx
@@ -15,8 +15,8 @@ import { GroupSelector } from "@/ui/partners/groups/group-selector";
 import { X } from "@/ui/shared/icons";
 import {
   AnimatedSizeContainer,
-  BlurImage,
   Button,
+  Gift,
   InfoTooltip,
   MultiValueInput,
   type MultiValueInputRef,
@@ -24,12 +24,15 @@ import {
   RichTextProvider,
   RichTextToolbar,
   Sheet,
+  Trophy,
   useMediaQuery,
 } from "@dub/ui";
+import { Lock } from "@dub/ui/icons";
 import { cn, pluralize } from "@dub/utils";
 import { useAction } from "next-safe-action/hooks";
 import {
   Dispatch,
+  ReactNode,
   SetStateAction,
   useEffect,
   useMemo,
@@ -458,7 +461,6 @@ function EmailPreview({
   onCancel: () => void;
   isSavingEmailData: boolean;
 }) {
-  const { program } = useProgram();
   const { verifiedEmailDomain } = useEmailDomains();
 
   const { isMobile } = useMediaQuery();
@@ -631,14 +633,7 @@ function EmailPreview({
                 {displayContent.subject}
               </p>
             </div>
-            <div className="grid grid-cols-1 gap-3 p-4 pb-8">
-              <BlurImage
-                src={program?.logo || "https://assets.dub.co/wordmark.png"}
-                alt={program?.name || "Dub"}
-                className="my-1 size-8 rounded-full object-contain"
-                width={48}
-                height={48}
-              />
+            <div className="grid grid-cols-1 gap-3 p-4 pb-6">
               <h3 className="font-medium text-neutral-900">
                 {displayContent.title}
               </h3>
@@ -655,15 +650,48 @@ function EmailPreview({
                   <RichTextArea />
                 </RichTextProvider>
               </div>
-              <Button
-                type="button"
-                text="Accept invite"
-                className="mt-4 w-fit"
-              />
+              <InvitePreviewProgramDetails />
             </div>
           </>
         )}
       </div>
+    </div>
+  );
+}
+
+function InvitePreviewProgramDetails() {
+  return (
+    <div className="mt-4 rounded-[10px] border border-blue-200 bg-blue-50 p-4 pt-3">
+      <div className="flex items-center justify-center gap-2 text-sm font-semibold text-blue-900">
+        <Lock className="size-4 text-blue-500" />
+        <span>Program details</span>
+      </div>
+
+      <div className="mt-3 grid grid-cols-2 gap-3">
+        <PreviewInfoCard icon={<Gift className="size-5" />} label="Eligible Rewards" />
+        <PreviewInfoCard icon={<Trophy className="size-5" />} label="Eligible Bounties" />
+      </div>
+
+      <Button
+        type="button"
+        text="View invite"
+        className="mt-3 h-9 w-full rounded-lg bg-neutral-900 font-semibold text-white hover:bg-neutral-900"
+      />
+    </div>
+  );
+}
+
+function PreviewInfoCard({
+  icon,
+  label,
+}: {
+  icon: ReactNode;
+  label: string;
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center rounded-lg border border-blue-100 bg-blue-100 px-4 pb-3 pt-4 text-center text-blue-900">
+      <div className="mb-1.5">{icon}</div>
+      <div className="text-sm font-medium">{label}</div>
     </div>
   );
 }

--- a/apps/web/lib/actions/partners/bulk-invite-partners.ts
+++ b/apps/web/lib/actions/partners/bulk-invite-partners.ts
@@ -168,11 +168,10 @@ export const bulkInvitePartnersAction = authActionClient
           );
         }
 
-        const { group, rewards, bounties } = await getGroupRewardsAndBounties({
+        const { rewards, bounties } = await getGroupRewardsAndBounties({
           programId,
           groupId: groupId || program.defaultGroupId,
         });
-        const programWebsite = group.partnerGroupDefaultLinks[0]?.url;
 
         const inviteEmailData = program.inviteEmailData;
         const emailDomains = program.emailDomains;
@@ -196,7 +195,7 @@ export const bulkInvitePartnersAction = authActionClient
                 name: program.name,
                 slug: program.slug,
                 logo: program.logo,
-                website: programWebsite,
+                website: program.url,
               },
               ...(inviteEmailData?.subject && {
                 subject: inviteEmailData.subject,

--- a/apps/web/lib/actions/partners/bulk-invite-partners.ts
+++ b/apps/web/lib/actions/partners/bulk-invite-partners.ts
@@ -168,10 +168,11 @@ export const bulkInvitePartnersAction = authActionClient
           );
         }
 
-        const rewardsAndBounties = await getGroupRewardsAndBounties({
+        const { group, rewards, bounties } = await getGroupRewardsAndBounties({
           programId,
           groupId: groupId || program.defaultGroupId,
         });
+        const programWebsite = group.partnerGroupDefaultLinks[0]?.url;
 
         const inviteEmailData = program.inviteEmailData;
         const emailDomains = program.emailDomains;
@@ -195,13 +196,15 @@ export const bulkInvitePartnersAction = authActionClient
                 name: program.name,
                 slug: program.slug,
                 logo: program.logo,
+                website: programWebsite,
               },
               ...(inviteEmailData?.subject && {
                 subject: inviteEmailData.subject,
               }),
               ...(inviteEmailData?.title && { title: inviteEmailData.title }),
               ...(inviteEmailData?.body && { body: inviteEmailData.body }),
-              ...rewardsAndBounties,
+              rewards,
+              bounties,
             }),
           })),
         );

--- a/apps/web/lib/actions/partners/create-program.ts
+++ b/apps/web/lib/actions/partners/create-program.ts
@@ -306,6 +306,12 @@ async function invitePartner({
 
   waitUntil(
     (async () => {
+      const { group, rewards, bounties } = await getGroupRewardsAndBounties({
+        programId: program.id,
+        groupId: program.defaultGroupId,
+      });
+      const programWebsite = group.partnerGroupDefaultLinks[0]?.url;
+
       await sendEmail({
         subject: `${program.name} invited you to join Dub Partners`,
         variant: "notifications",
@@ -318,11 +324,10 @@ async function invitePartner({
             name: program.name,
             slug: program.slug,
             logo: program.logo,
+            website: programWebsite,
           },
-          ...(await getGroupRewardsAndBounties({
-            programId: program.id,
-            groupId: program.defaultGroupId,
-          })),
+          rewards,
+          bounties,
         }),
       });
     })(),

--- a/apps/web/lib/actions/partners/create-program.ts
+++ b/apps/web/lib/actions/partners/create-program.ts
@@ -306,11 +306,10 @@ async function invitePartner({
 
   waitUntil(
     (async () => {
-      const { group, rewards, bounties } = await getGroupRewardsAndBounties({
+      const { rewards, bounties } = await getGroupRewardsAndBounties({
         programId: program.id,
         groupId: program.defaultGroupId,
       });
-      const programWebsite = group.partnerGroupDefaultLinks[0]?.url;
 
       await sendEmail({
         subject: `${program.name} invited you to join Dub Partners`,
@@ -324,7 +323,7 @@ async function invitePartner({
             name: program.name,
             slug: program.slug,
             logo: program.logo,
-            website: programWebsite,
+            website: program.url,
           },
           rewards,
           bounties,

--- a/apps/web/lib/actions/partners/invite-partner-from-network.ts
+++ b/apps/web/lib/actions/partners/invite-partner-from-network.ts
@@ -92,11 +92,10 @@ export const invitePartnerFromNetworkAction = authActionClient
       Promise.allSettled([
         (async () => {
           if (!partner.email) return;
-          const { group, rewards, bounties } = await getGroupRewardsAndBounties({
+          const { rewards, bounties } = await getGroupRewardsAndBounties({
             programId,
             groupId: enrolledPartner.groupId || program.defaultGroupId,
           });
-          const programWebsite = group.partnerGroupDefaultLinks[0]?.url;
           await sendEmail({
             subject: `${program.name} invited you to join on Dub Partners`,
             variant: "notifications",
@@ -108,7 +107,7 @@ export const invitePartnerFromNetworkAction = authActionClient
                 name: program.name,
                 slug: program.slug,
                 logo: program.logo,
-                website: programWebsite,
+                website: program.url,
               },
               rewards,
               bounties,

--- a/apps/web/lib/actions/partners/invite-partner-from-network.ts
+++ b/apps/web/lib/actions/partners/invite-partner-from-network.ts
@@ -92,10 +92,11 @@ export const invitePartnerFromNetworkAction = authActionClient
       Promise.allSettled([
         (async () => {
           if (!partner.email) return;
-          const rewardsAndBounties = await getGroupRewardsAndBounties({
+          const { group, rewards, bounties } = await getGroupRewardsAndBounties({
             programId,
             groupId: enrolledPartner.groupId || program.defaultGroupId,
           });
+          const programWebsite = group.partnerGroupDefaultLinks[0]?.url;
           await sendEmail({
             subject: `${program.name} invited you to join on Dub Partners`,
             variant: "notifications",
@@ -107,8 +108,10 @@ export const invitePartnerFromNetworkAction = authActionClient
                 name: program.name,
                 slug: program.slug,
                 logo: program.logo,
+                website: programWebsite,
               },
-              ...rewardsAndBounties,
+              rewards,
+              bounties,
             }),
           });
         })(),

--- a/apps/web/lib/actions/partners/invite-partner.ts
+++ b/apps/web/lib/actions/partners/invite-partner.ts
@@ -83,10 +83,11 @@ export const invitePartnerAction = authActionClient
 
     const sendPartnerInvitePromise = (async () => {
       try {
-        const rewardsAndBounties = await getGroupRewardsAndBounties({
+        const { group, rewards, bounties } = await getGroupRewardsAndBounties({
           programId,
           groupId: enrolledPartner.groupId || program.defaultGroupId,
         });
+        const programWebsite = group.partnerGroupDefaultLinks[0]?.url;
 
         await sendEmail({
           subject:
@@ -107,13 +108,15 @@ export const invitePartnerAction = authActionClient
               name: program.name,
               slug: program.slug,
               logo: program.logo,
+              website: programWebsite,
             },
             ...(inviteEmailData?.subject && {
               subject: inviteEmailData.subject,
             }),
             ...(inviteEmailData?.title && { title: inviteEmailData.title }),
             ...(inviteEmailData?.body && { body: inviteEmailData.body }),
-            ...rewardsAndBounties,
+            rewards,
+            bounties,
           }),
         });
       } catch (error) {

--- a/apps/web/lib/actions/partners/invite-partner.ts
+++ b/apps/web/lib/actions/partners/invite-partner.ts
@@ -83,11 +83,10 @@ export const invitePartnerAction = authActionClient
 
     const sendPartnerInvitePromise = (async () => {
       try {
-        const { group, rewards, bounties } = await getGroupRewardsAndBounties({
+        const { rewards, bounties } = await getGroupRewardsAndBounties({
           programId,
           groupId: enrolledPartner.groupId || program.defaultGroupId,
         });
-        const programWebsite = group.partnerGroupDefaultLinks[0]?.url;
 
         await sendEmail({
           subject:
@@ -108,7 +107,7 @@ export const invitePartnerAction = authActionClient
               name: program.name,
               slug: program.slug,
               logo: program.logo,
-              website: programWebsite,
+              website: program.url,
             },
             ...(inviteEmailData?.subject && {
               subject: inviteEmailData.subject,

--- a/apps/web/lib/actions/partners/resend-program-invite.ts
+++ b/apps/web/lib/actions/partners/resend-program-invite.ts
@@ -58,6 +58,12 @@ export const resendProgramInviteAction = authActionClient
 
     await Promise.allSettled([
       (async () => {
+        const { group, rewards, bounties } = await getGroupRewardsAndBounties({
+          programId,
+          groupId: programEnrollment.groupId || program.defaultGroupId,
+        });
+        const programWebsite = group.partnerGroupDefaultLinks[0]?.url;
+
         await sendEmail({
           subject: `${program.name} invited you to join Dub Partners`,
           variant: "notifications",
@@ -70,11 +76,10 @@ export const resendProgramInviteAction = authActionClient
               name: program.name,
               slug: program.slug,
               logo: program.logo,
+              website: programWebsite,
             },
-            ...(await getGroupRewardsAndBounties({
-              programId,
-              groupId: programEnrollment.groupId || program.defaultGroupId,
-            })),
+            rewards,
+            bounties,
           }),
         });
       })(),

--- a/packages/email/src/templates/program-invite.tsx
+++ b/packages/email/src/templates/program-invite.tsx
@@ -150,7 +150,6 @@ export default function ProgramInvite({
   const emailTitle = title || "You've been invited";
   const emailSubject =
     subject || `${program.name} invited you to join Dub Partners`;
-  const programWebsite = program.website ?? null;
 
   return (
     <Html>
@@ -196,7 +195,8 @@ export default function ProgramInvite({
 
             <>
               <Text className="text-sm leading-6 text-neutral-600">
-                Here’s more details about the program and what you’ll be eligible to earn:
+                Here’s more details about the program and what you’ll be
+                eligible to earn:
               </Text>
               <Section className="overflow-hidden rounded-xl border border-solid border-neutral-200 bg-white">
                 <Section className="px-5 py-4">
@@ -204,7 +204,8 @@ export default function ProgramInvite({
                     <Column className="w-[48px] align-top">
                       <Img
                         src={
-                          program.logo || "https://assets.dub.co/misc/acme-logo.png"
+                          program.logo ||
+                          "https://assets.dub.co/misc/acme-logo.png"
                         }
                         width="40"
                         height="40"
@@ -216,12 +217,12 @@ export default function ProgramInvite({
                       <Text className="my-0 text-base font-semibold leading-5 text-black">
                         {program.name}
                       </Text>
-                      {programWebsite && (
+                      {program.website && (
                         <Link
-                          href={programWebsite}
+                          href={program.website}
                           className="mt-0 block text-xs font-medium leading-4 text-neutral-500 underline"
                         >
-                          {getPrettyUrl(programWebsite)}
+                          {getPrettyUrl(program.website)}
                         </Link>
                       )}
                     </Column>

--- a/packages/email/src/templates/program-invite.tsx
+++ b/packages/email/src/templates/program-invite.tsx
@@ -150,7 +150,7 @@ export default function ProgramInvite({
   const emailTitle = title || "You've been invited";
   const emailSubject =
     subject || `${program.name} invited you to join Dub Partners`;
-  const programWebsite = program.website || "https://acme.dub.sh";
+  const programWebsite = program.website ?? null;
 
   return (
     <Html>
@@ -194,89 +194,89 @@ export default function ProgramInvite({
               </>
             )}
 
-            {Boolean(rewards?.length || bounties?.length) && (
-              <>
-                <Text className="text-sm leading-6 text-neutral-600">
-                  Here’s more details about the program and what you’ll be eligible to earn:
-                </Text>
-                <Section className="overflow-hidden rounded-xl border border-solid border-neutral-200 bg-white">
-                  <Section className="px-5 py-4">
-                    <Row>
-                      <Column className="w-[48px] align-top">
-                        <Img
-                          src={
-                            program.logo || "https://assets.dub.co/misc/acme-logo.png"
-                          }
-                          width="40"
-                          height="40"
-                          alt={program.name}
-                          className="rounded-full"
-                        />
-                      </Column>
-                      <Column className="w-full pl-3">
-                        <Text className="my-0 text-base font-semibold leading-5 text-black">
-                          {program.name}
-                        </Text>
+            <>
+              <Text className="text-sm leading-6 text-neutral-600">
+                Here’s more details about the program and what you’ll be eligible to earn:
+              </Text>
+              <Section className="overflow-hidden rounded-xl border border-solid border-neutral-200 bg-white">
+                <Section className="px-5 py-4">
+                  <Row>
+                    <Column className="w-[48px] align-top">
+                      <Img
+                        src={
+                          program.logo || "https://assets.dub.co/misc/acme-logo.png"
+                        }
+                        width="40"
+                        height="40"
+                        alt={program.name}
+                        className="rounded-full"
+                      />
+                    </Column>
+                    <Column className="w-full pl-3">
+                      <Text className="my-0 text-base font-semibold leading-5 text-black">
+                        {program.name}
+                      </Text>
+                      {programWebsite && (
                         <Link
                           href={programWebsite}
                           className="mt-0 block text-xs font-medium leading-4 text-neutral-500 underline"
                         >
                           {getPrettyUrl(programWebsite)}
                         </Link>
-                      </Column>
-                    </Row>
-                  </Section>
-                  <Section className="rounded-xl border-t border-solid border-neutral-200 bg-neutral-50 px-5 py-4">
-                    {rewards && Boolean(rewards.length) && (
-                      <>
-                        <Text className="my-0 text-base font-semibold text-black">
-                          Rewards
-                        </Text>
-                        {rewards.map((reward) => (
-                          <Row key={reward.label} className="mb-0 mt-2">
-                            <Column className="align-center">
-                              <Img src={reward.icon} height="16" alt="" />
-                            </Column>
-                            <Column className="w-full pl-2">
-                              <Text className="my-0 text-sm font-medium text-neutral-600">
-                                {reward.label}
-                              </Text>
-                            </Column>
-                          </Row>
-                        ))}
-                      </>
-                    )}
-                    {bounties && Boolean(bounties.length) && (
-                      <>
-                        <Text
-                          className={`mb-0 text-base font-semibold text-black ${rewards?.length ? "mt-5" : "mt-0"}`}
-                        >
-                          Bounties
-                        </Text>
-                        {bounties.map((bounty) => (
-                          <Row key={bounty.label} className="mb-0 mt-2">
-                            <Column className="align-center">
-                              <Img src={bounty.icon} height="16" alt="" />
-                            </Column>
-                            <Column className="w-full pl-2">
-                              <Text className="my-0 text-sm font-medium text-neutral-600">
-                                {bounty.label}
-                              </Text>
-                            </Column>
-                          </Row>
-                        ))}
-                      </>
-                    )}
-                    <Link
-                      className="mt-5 block rounded-lg bg-neutral-900 px-4 py-3 text-center text-xs font-semibold text-white no-underline"
-                      href={`https://partners.dub.co/${program.slug}/register?email=${encodeURIComponent(email)}&next=/programs/${program.slug}/invite`}
-                    >
-                      View invite
-                    </Link>
-                  </Section>
+                      )}
+                    </Column>
+                  </Row>
                 </Section>
-              </>
-            )}
+                <Section className="rounded-xl border-t border-solid border-neutral-200 bg-neutral-50 px-5 py-4">
+                  {rewards && Boolean(rewards.length) && (
+                    <>
+                      <Text className="my-0 text-base font-semibold text-black">
+                        Rewards
+                      </Text>
+                      {rewards.map((reward) => (
+                        <Row key={reward.label} className="mb-0 mt-2">
+                          <Column className="align-center">
+                            <Img src={reward.icon} height="16" alt="" />
+                          </Column>
+                          <Column className="w-full pl-2">
+                            <Text className="my-0 text-sm font-medium text-neutral-600">
+                              {reward.label}
+                            </Text>
+                          </Column>
+                        </Row>
+                      ))}
+                    </>
+                  )}
+                  {bounties && Boolean(bounties.length) && (
+                    <>
+                      <Text
+                        className={`mb-0 text-base font-semibold text-black ${rewards?.length ? "mt-5" : "mt-0"}`}
+                      >
+                        Bounties
+                      </Text>
+                      {bounties.map((bounty) => (
+                        <Row key={bounty.label} className="mb-0 mt-2">
+                          <Column className="align-center">
+                            <Img src={bounty.icon} height="16" alt="" />
+                          </Column>
+                          <Column className="w-full pl-2">
+                            <Text className="my-0 text-sm font-medium text-neutral-600">
+                              {bounty.label}
+                            </Text>
+                          </Column>
+                        </Row>
+                      ))}
+                    </>
+                  )}
+                  <Link
+                    className="mt-5 block rounded-lg bg-neutral-900 px-4 py-3 text-center text-xs font-semibold text-white no-underline"
+                    href={`https://partners.dub.co/${program.slug}/register?email=${encodeURIComponent(email)}&next=/programs/${program.slug}/invite`}
+                  >
+                    View invite
+                  </Link>
+                </Section>
+              </Section>
+            </>
 
             <Footer email={email} />
           </Container>

--- a/packages/email/src/templates/program-invite.tsx
+++ b/packages/email/src/templates/program-invite.tsx
@@ -1,4 +1,4 @@
-import { DUB_WORDMARK } from "@dub/utils";
+import { DUB_WORDMARK, getPrettyUrl } from "@dub/utils";
 import {
   Body,
   Column,
@@ -106,7 +106,8 @@ export default function ProgramInvite({
   program = {
     name: "Acme",
     slug: "acme",
-    logo: DUB_WORDMARK,
+    logo: "https://assets.dub.co/misc/acme-logo.png",
+    website: "https://acme.dub.sh",
   },
   rewards = [
     {
@@ -138,6 +139,7 @@ export default function ProgramInvite({
     name: string;
     slug: string;
     logo: string | null;
+    website?: string | null;
   };
   rewards: { icon: string; label: string }[] | null;
   bounties: { icon: string; label: string }[] | null;
@@ -148,6 +150,7 @@ export default function ProgramInvite({
   const emailTitle = title || "You've been invited";
   const emailSubject =
     subject || `${program.name} invited you to join Dub Partners`;
+  const programWebsite = program.website || "https://acme.dub.sh";
 
   return (
     <Html>
@@ -157,11 +160,7 @@ export default function ProgramInvite({
         <Body className="mx-auto my-auto bg-white font-sans">
           <Container className="mx-auto my-8 max-w-[600px] px-8 py-8">
             <Section className="mb-8 mt-6">
-              <Img
-                src={program.logo || "https://assets.dub.co/wordmark.png"}
-                height="32"
-                alt={program.name}
-              />
+              <Img src={DUB_WORDMARK} height="32" alt="Dub" />
             </Section>
 
             <Heading className="bt-5 mx-0 mt-10 p-0 text-lg font-medium text-black">
@@ -195,62 +194,86 @@ export default function ProgramInvite({
               </>
             )}
 
-            <Section className="my-8">
-              <Link
-                className="rounded-lg bg-neutral-900 px-4 py-3 text-xs font-semibold text-white no-underline"
-                href={`https://partners.dub.co/${program.slug}/register?email=${encodeURIComponent(email)}&next=/programs/${program.slug}/invite`}
-              >
-                Accept Invite
-              </Link>
-            </Section>
-
             {Boolean(rewards?.length || bounties?.length) && (
               <>
                 <Text className="text-sm leading-6 text-neutral-600">
-                  If you accept the invite, you're immediately eligible for the
-                  following:
+                  Here’s more details about the program and what you’ll be eligible to earn:
                 </Text>
-                <Section className="rounded-xl border border-solid border-neutral-200 bg-neutral-50 px-5 py-4">
-                  {rewards && Boolean(rewards.length) && (
-                    <>
-                      <Text className="my-0 text-base font-semibold text-black">
-                        Rewards
-                      </Text>
-                      {rewards.map((reward) => (
-                        <Row key={reward.label} className="mb-0 mt-2">
-                          <Column className="align-center">
-                            <Img src={reward.icon} height="16" alt="" />
-                          </Column>
-                          <Column className="w-full pl-2">
-                            <Text className="my-0 text-sm font-medium text-neutral-600">
-                              {reward.label}
-                            </Text>
-                          </Column>
-                        </Row>
-                      ))}
-                    </>
-                  )}
-                  {bounties && Boolean(bounties.length) && (
-                    <>
-                      <Text
-                        className={`mb-0 text-base font-semibold text-black ${rewards?.length ? "mt-5" : "mt-0"}`}
-                      >
-                        Bounties
-                      </Text>
-                      {bounties.map((bounty) => (
-                        <Row key={bounty.label} className="mb-0 mt-2">
-                          <Column className="align-center">
-                            <Img src={bounty.icon} height="16" alt="" />
-                          </Column>
-                          <Column className="w-full pl-2">
-                            <Text className="my-0 text-sm font-medium text-neutral-600">
-                              {bounty.label}
-                            </Text>
-                          </Column>
-                        </Row>
-                      ))}
-                    </>
-                  )}
+                <Section className="overflow-hidden rounded-xl border border-solid border-neutral-200 bg-white">
+                  <Section className="px-5 py-4">
+                    <Row>
+                      <Column className="w-[48px] align-top">
+                        <Img
+                          src={
+                            program.logo || "https://assets.dub.co/misc/acme-logo.png"
+                          }
+                          width="40"
+                          height="40"
+                          alt={program.name}
+                          className="rounded-full"
+                        />
+                      </Column>
+                      <Column className="w-full pl-3">
+                        <Text className="my-0 text-base font-semibold leading-5 text-black">
+                          {program.name}
+                        </Text>
+                        <Link
+                          href={programWebsite}
+                          className="mt-0 block text-xs font-medium leading-4 text-neutral-500 underline"
+                        >
+                          {getPrettyUrl(programWebsite)}
+                        </Link>
+                      </Column>
+                    </Row>
+                  </Section>
+                  <Section className="rounded-xl border-t border-solid border-neutral-200 bg-neutral-50 px-5 py-4">
+                    {rewards && Boolean(rewards.length) && (
+                      <>
+                        <Text className="my-0 text-base font-semibold text-black">
+                          Rewards
+                        </Text>
+                        {rewards.map((reward) => (
+                          <Row key={reward.label} className="mb-0 mt-2">
+                            <Column className="align-center">
+                              <Img src={reward.icon} height="16" alt="" />
+                            </Column>
+                            <Column className="w-full pl-2">
+                              <Text className="my-0 text-sm font-medium text-neutral-600">
+                                {reward.label}
+                              </Text>
+                            </Column>
+                          </Row>
+                        ))}
+                      </>
+                    )}
+                    {bounties && Boolean(bounties.length) && (
+                      <>
+                        <Text
+                          className={`mb-0 text-base font-semibold text-black ${rewards?.length ? "mt-5" : "mt-0"}`}
+                        >
+                          Bounties
+                        </Text>
+                        {bounties.map((bounty) => (
+                          <Row key={bounty.label} className="mb-0 mt-2">
+                            <Column className="align-center">
+                              <Img src={bounty.icon} height="16" alt="" />
+                            </Column>
+                            <Column className="w-full pl-2">
+                              <Text className="my-0 text-sm font-medium text-neutral-600">
+                                {bounty.label}
+                              </Text>
+                            </Column>
+                          </Row>
+                        ))}
+                      </>
+                    )}
+                    <Link
+                      className="mt-5 block rounded-lg bg-neutral-900 px-4 py-3 text-center text-xs font-semibold text-white no-underline"
+                      href={`https://partners.dub.co/${program.slug}/register?email=${encodeURIComponent(email)}&next=/programs/${program.slug}/invite`}
+                    >
+                      View invite
+                    </Link>
+                  </Section>
                 </Section>
               </>
             )}

--- a/packages/email/src/templates/program-network-invite.tsx
+++ b/packages/email/src/templates/program-network-invite.tsx
@@ -57,7 +57,7 @@ export default function ProgramNetworkInvite({
   rewards: { icon: string; label: string }[] | null;
   bounties: { icon: string; label: string }[] | null;
 }) {
-  const programWebsite = program.website || "https://acme.dub.sh";
+  const programWebsite = program.website ?? null;
 
   return (
     <Html>
@@ -80,89 +80,89 @@ export default function ProgramNetworkInvite({
               you to join their partner program.
             </Text>
 
-            {Boolean(rewards?.length || bounties?.length) && (
-              <>
-                <Text className="text-sm leading-6 text-neutral-600">
-                  Here’s more details about the program and what you’ll be eligible to earn:
-                </Text>
-                <Section className="overflow-hidden rounded-xl border border-solid border-neutral-200 bg-white">
-                  <Section className="px-5 py-4 gap-0">
-                    <Row>
-                      <Column className="w-[48px] align-top">
-                        <Img
-                          src={
-                            program.logo || "https://assets.dub.co/misc/acme-logo.png"
-                          }
-                          width="40"
-                          height="40"
-                          alt={program.name}
-                          className="rounded-full"
-                        />
-                      </Column>
-                      <Column className="w-full pl-3">
-                        <Text className="my-0 text-base font-semibold leading-5 text-black">
-                          {program.name}
-                        </Text>
+            <>
+              <Text className="text-sm leading-6 text-neutral-600">
+                Here’s more details about the program and what you’ll be eligible to earn:
+              </Text>
+              <Section className="overflow-hidden rounded-xl border border-solid border-neutral-200 bg-white">
+                <Section className="px-5 py-4">
+                  <Row>
+                    <Column className="w-[48px] align-top">
+                      <Img
+                        src={
+                          program.logo || "https://assets.dub.co/misc/acme-logo.png"
+                        }
+                        width="40"
+                        height="40"
+                        alt={program.name}
+                        className="rounded-full"
+                      />
+                    </Column>
+                    <Column className="w-full pl-3">
+                      <Text className="my-0 text-base font-semibold leading-5 text-black">
+                        {program.name}
+                      </Text>
+                      {programWebsite && (
                         <Link
                           href={programWebsite}
                           className="mt-0 block text-xs font-medium leading-4 text-neutral-500 underline"
                         >
                           {getPrettyUrl(programWebsite)}
                         </Link>
-                      </Column>
-                    </Row>
-                  </Section>
-                  <Section className="rounded-xl border-t border-solid border-neutral-200 bg-neutral-50 px-5 py-4">
-                    {rewards && Boolean(rewards.length) && (
-                      <>
-                        <Text className="my-0 text-base font-semibold text-black">
-                          Rewards
-                        </Text>
-                        {rewards.map((reward) => (
-                          <Row key={reward.label} className="mb-0 mt-2">
-                            <Column className="align-center">
-                              <Img src={reward.icon} height="16" alt="" />
-                            </Column>
-                            <Column className="w-full pl-2">
-                              <Text className="my-0 text-sm font-medium text-neutral-600">
-                                {reward.label}
-                              </Text>
-                            </Column>
-                          </Row>
-                        ))}
-                      </>
-                    )}
-                    {bounties && Boolean(bounties.length) && (
-                      <>
-                        <Text
-                          className={`mb-0 text-base font-semibold text-black ${rewards?.length ? "mt-5" : "mt-0"}`}
-                        >
-                          Bounties
-                        </Text>
-                        {bounties.map((bounty) => (
-                          <Row key={bounty.label} className="mb-0 mt-2">
-                            <Column className="align-center">
-                              <Img src={bounty.icon} height="16" alt="" />
-                            </Column>
-                            <Column className="w-full pl-2">
-                              <Text className="my-0 text-sm font-medium text-neutral-600">
-                                {bounty.label}
-                              </Text>
-                            </Column>
-                          </Row>
-                        ))}
-                      </>
-                    )}
-                    <Link
-                      className="mt-5 block rounded-lg bg-neutral-900 px-4 py-3 text-center text-[12px] font-semibold text-white no-underline"
-                      href={`https://partners.dub.co/${program.slug}/register?email=${encodeURIComponent(email)}&next=/programs/${program.slug}`}
-                    >
-                      View invite
-                    </Link>
-                  </Section>
+                      )}
+                    </Column>
+                  </Row>
                 </Section>
-              </>
-            )}
+                <Section className="rounded-xl border-t border-solid border-neutral-200 bg-neutral-50 px-5 py-4">
+                  {rewards && Boolean(rewards.length) && (
+                    <>
+                      <Text className="my-0 text-base font-semibold text-black">
+                        Rewards
+                      </Text>
+                      {rewards.map((reward) => (
+                        <Row key={reward.label} className="mb-0 mt-2">
+                          <Column className="align-center">
+                            <Img src={reward.icon} height="16" alt="" />
+                          </Column>
+                          <Column className="w-full pl-2">
+                            <Text className="my-0 text-sm font-medium text-neutral-600">
+                              {reward.label}
+                            </Text>
+                          </Column>
+                        </Row>
+                      ))}
+                    </>
+                  )}
+                  {bounties && Boolean(bounties.length) && (
+                    <>
+                      <Text
+                        className={`mb-0 text-base font-semibold text-black ${rewards?.length ? "mt-5" : "mt-0"}`}
+                      >
+                        Bounties
+                      </Text>
+                      {bounties.map((bounty) => (
+                        <Row key={bounty.label} className="mb-0 mt-2">
+                          <Column className="align-center">
+                            <Img src={bounty.icon} height="16" alt="" />
+                          </Column>
+                          <Column className="w-full pl-2">
+                            <Text className="my-0 text-sm font-medium text-neutral-600">
+                              {bounty.label}
+                            </Text>
+                          </Column>
+                        </Row>
+                      ))}
+                    </>
+                  )}
+                  <Link
+                    className="mt-5 block rounded-lg bg-neutral-900 px-4 py-3 text-center text-[12px] font-semibold text-white no-underline"
+                    href={`https://partners.dub.co/${program.slug}/register?email=${encodeURIComponent(email)}&next=/programs/${program.slug}`}
+                  >
+                    View invite
+                  </Link>
+                </Section>
+              </Section>
+            </>
             <Footer email={email} />
           </Container>
         </Body>

--- a/packages/email/src/templates/program-network-invite.tsx
+++ b/packages/email/src/templates/program-network-invite.tsx
@@ -1,4 +1,4 @@
-import { DUB_WORDMARK } from "@dub/utils";
+import { DUB_WORDMARK, getPrettyUrl } from "@dub/utils";
 import {
   Body,
   Column,
@@ -22,7 +22,8 @@ export default function ProgramNetworkInvite({
   program = {
     name: "Acme",
     slug: "acme",
-    logo: DUB_WORDMARK,
+    logo: "https://assets.dub.co/misc/acme-logo.png",
+    website: "https://acme.dub.sh",
   },
   rewards = [
     {
@@ -51,10 +52,13 @@ export default function ProgramNetworkInvite({
     name: string;
     slug: string;
     logo: string | null;
+    website?: string | null;
   };
   rewards: { icon: string; label: string }[] | null;
   bounties: { icon: string; label: string }[] | null;
 }) {
+  const programWebsite = program.website || "https://acme.dub.sh";
+
   return (
     <Html>
       <Head />
@@ -63,11 +67,7 @@ export default function ProgramNetworkInvite({
         <Body className="mx-auto my-auto bg-white font-sans">
           <Container className="mx-auto my-8 max-w-[600px] px-8 py-8">
             <Section className="mb-8 mt-6">
-              <Img
-                src={program.logo || "https://assets.dub.co/wordmark.png"}
-                height="32"
-                alt={program.name}
-              />
+              <Img src={DUB_WORDMARK} height="32" alt="Dub" />
             </Section>
 
             <Heading className="mx-0 mt-10 p-0 text-lg font-medium text-black">
@@ -80,62 +80,86 @@ export default function ProgramNetworkInvite({
               you to join their partner program.
             </Text>
 
-            <Section className="my-8">
-              <Link
-                className="rounded-lg bg-neutral-900 px-4 py-3 text-[12px] font-semibold text-white no-underline"
-                href={`https://partners.dub.co/${program.slug}/register?email=${encodeURIComponent(email)}&next=/programs/${program.slug}`}
-              >
-                Accept Invite
-              </Link>
-            </Section>
-
             {Boolean(rewards?.length || bounties?.length) && (
               <>
                 <Text className="text-sm leading-6 text-neutral-600">
-                  If you accept the invite, you're immediately eligible for the
-                  following:
+                  Here’s more details about the program and what you’ll be eligible to earn:
                 </Text>
-                <Section className="rounded-xl border border-solid border-neutral-200 bg-neutral-50 px-5 py-4">
-                  {rewards && Boolean(rewards.length) && (
-                    <>
-                      <Text className="my-0 text-base font-semibold text-black">
-                        Rewards
-                      </Text>
-                      {rewards.map((reward) => (
-                        <Row key={reward.label} className="mb-0 mt-2">
-                          <Column className="align-center">
-                            <Img src={reward.icon} height="16" alt="" />
-                          </Column>
-                          <Column className="w-full pl-2">
-                            <Text className="my-0 text-sm font-medium text-neutral-600">
-                              {reward.label}
-                            </Text>
-                          </Column>
-                        </Row>
-                      ))}
-                    </>
-                  )}
-                  {bounties && Boolean(bounties.length) && (
-                    <>
-                      <Text
-                        className={`mb-0 text-base font-semibold text-black ${rewards?.length ? "mt-5" : "mt-0"}`}
-                      >
-                        Bounties
-                      </Text>
-                      {bounties.map((bounty) => (
-                        <Row key={bounty.label} className="mb-0 mt-2">
-                          <Column className="align-center">
-                            <Img src={bounty.icon} height="16" alt="" />
-                          </Column>
-                          <Column className="w-full pl-2">
-                            <Text className="my-0 text-sm font-medium text-neutral-600">
-                              {bounty.label}
-                            </Text>
-                          </Column>
-                        </Row>
-                      ))}
-                    </>
-                  )}
+                <Section className="overflow-hidden rounded-xl border border-solid border-neutral-200 bg-white">
+                  <Section className="px-5 py-4 gap-0">
+                    <Row>
+                      <Column className="w-[48px] align-top">
+                        <Img
+                          src={
+                            program.logo || "https://assets.dub.co/misc/acme-logo.png"
+                          }
+                          width="40"
+                          height="40"
+                          alt={program.name}
+                          className="rounded-full"
+                        />
+                      </Column>
+                      <Column className="w-full pl-3">
+                        <Text className="my-0 text-base font-semibold leading-5 text-black">
+                          {program.name}
+                        </Text>
+                        <Link
+                          href={programWebsite}
+                          className="mt-0 block text-xs font-medium leading-4 text-neutral-500 underline"
+                        >
+                          {getPrettyUrl(programWebsite)}
+                        </Link>
+                      </Column>
+                    </Row>
+                  </Section>
+                  <Section className="rounded-xl border-t border-solid border-neutral-200 bg-neutral-50 px-5 py-4">
+                    {rewards && Boolean(rewards.length) && (
+                      <>
+                        <Text className="my-0 text-base font-semibold text-black">
+                          Rewards
+                        </Text>
+                        {rewards.map((reward) => (
+                          <Row key={reward.label} className="mb-0 mt-2">
+                            <Column className="align-center">
+                              <Img src={reward.icon} height="16" alt="" />
+                            </Column>
+                            <Column className="w-full pl-2">
+                              <Text className="my-0 text-sm font-medium text-neutral-600">
+                                {reward.label}
+                              </Text>
+                            </Column>
+                          </Row>
+                        ))}
+                      </>
+                    )}
+                    {bounties && Boolean(bounties.length) && (
+                      <>
+                        <Text
+                          className={`mb-0 text-base font-semibold text-black ${rewards?.length ? "mt-5" : "mt-0"}`}
+                        >
+                          Bounties
+                        </Text>
+                        {bounties.map((bounty) => (
+                          <Row key={bounty.label} className="mb-0 mt-2">
+                            <Column className="align-center">
+                              <Img src={bounty.icon} height="16" alt="" />
+                            </Column>
+                            <Column className="w-full pl-2">
+                              <Text className="my-0 text-sm font-medium text-neutral-600">
+                                {bounty.label}
+                              </Text>
+                            </Column>
+                          </Row>
+                        ))}
+                      </>
+                    )}
+                    <Link
+                      className="mt-5 block rounded-lg bg-neutral-900 px-4 py-3 text-center text-[12px] font-semibold text-white no-underline"
+                      href={`https://partners.dub.co/${program.slug}/register?email=${encodeURIComponent(email)}&next=/programs/${program.slug}`}
+                    >
+                      View invite
+                    </Link>
+                  </Section>
                 </Section>
               </>
             )}

--- a/packages/email/src/templates/program-network-invite.tsx
+++ b/packages/email/src/templates/program-network-invite.tsx
@@ -57,8 +57,6 @@ export default function ProgramNetworkInvite({
   rewards: { icon: string; label: string }[] | null;
   bounties: { icon: string; label: string }[] | null;
 }) {
-  const programWebsite = program.website ?? null;
-
   return (
     <Html>
       <Head />
@@ -82,7 +80,8 @@ export default function ProgramNetworkInvite({
 
             <>
               <Text className="text-sm leading-6 text-neutral-600">
-                Here’s more details about the program and what you’ll be eligible to earn:
+                Here’s more details about the program and what you’ll be
+                eligible to earn:
               </Text>
               <Section className="overflow-hidden rounded-xl border border-solid border-neutral-200 bg-white">
                 <Section className="px-5 py-4">
@@ -90,7 +89,8 @@ export default function ProgramNetworkInvite({
                     <Column className="w-[48px] align-top">
                       <Img
                         src={
-                          program.logo || "https://assets.dub.co/misc/acme-logo.png"
+                          program.logo ||
+                          "https://assets.dub.co/misc/acme-logo.png"
                         }
                         width="40"
                         height="40"
@@ -102,12 +102,12 @@ export default function ProgramNetworkInvite({
                       <Text className="my-0 text-base font-semibold leading-5 text-black">
                         {program.name}
                       </Text>
-                      {programWebsite && (
+                      {program.website && (
                         <Link
-                          href={programWebsite}
+                          href={program.website}
                           className="mt-0 block text-xs font-medium leading-4 text-neutral-500 underline"
                         >
-                          {getPrettyUrl(programWebsite)}
+                          {getPrettyUrl(program.website)}
                         </Link>
                       )}
                     </Column>


### PR DESCRIPTION
## 1. Invite emails (email and network)
- Changed the action button to "View invite" as "Accept invite" doesn't convey to the user that clicking allows them to view, and instead automatically accepts.
- Changed the email header to show the Dub logo always, since it's coming from the system and we're using the program logo in the content below.
- Added the program logo, name, and destination url to the program details section, giving the user more info about the company without having to click through.
- Minor language updates

<img width="724" height="897" alt="CleanShot 2026-04-13 at 13 46 06@2x" src="https://github.com/user-attachments/assets/a9eff6df-4328-4188-928a-d91ab81d18b2" />


## 2. Email invite builder
- Removed the program logo from the preview
- Added a new section similar to the page builder, that shows some of the content being shared, so the program knows they don't need to repeat that info.

<img width="2166" height="2374" alt="CleanShot 2026-04-13 at 13 50 20@2x" src="https://github.com/user-attachments/assets/1fd8e636-165d-4487-8055-f04b95c46cdd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Partner invite emails and previews now emphasize program details (name and optional website) with a consistent top branding and a locked “Program details” header.
  * Invite previews include informational cards for eligible rewards and bounties and a unified “View invite” call-to-action inside the details block.
* **Other**
  * Preview padding and layout refined for a tighter presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->