### PR TITLE
Add `afsrc=1` query param for partner links

### DIFF
--- a/apps/web/lib/middleware/utils/get-final-url.ts
+++ b/apps/web/lib/middleware/utils/get-final-url.ts
@@ -35,6 +35,7 @@ export const getFinalUrl = (
 
   if (via) {
     urlObj.searchParams.set("via", via);
+    urlObj.searchParams.set("afsrc", "1");
   }
 
   if (clickId) {

--- a/apps/web/tests/redirects/index.test.ts
+++ b/apps/web/tests/redirects/index.test.ts
@@ -29,6 +29,7 @@ async function assertRedirectWithDubIdCookie(
 
   if (options?.via != null) {
     expect(redirectUrl.searchParams.get("via")).toBe(options.via);
+    expect(redirectUrl.searchParams.get("afsrc")).toBe("1");
   }
 
   expect(response.headers.get("x-powered-by")).toBe(poweredBy);


### PR DESCRIPTION
x-ref: https://blog.pie.org/afsrc-1-a-simple-option-for-consistent-stand-down-in-affiliate-marketing/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded test coverage for URL parameter validation in redirect operations

---

**Summary:** URL redirect parameter handling has been enhanced. When certain redirect conditions are met, additional query parameters are now included in destination URLs. Test validation has been updated to verify this parameter behavior and ensure proper URL construction consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->