### PR TITLE
Sitemap fix: support index + safe redirects

### DIFF
--- a/apps/web/lib/sitemaps/import-tracked-sitemaps.ts
+++ b/apps/web/lib/sitemaps/import-tracked-sitemaps.ts
@@ -1,8 +1,8 @@
 import { bulkCreateLinks } from "@/lib/api/links/bulk-create-links";
+import { fetchSitemapResponse } from "@/lib/sitemaps/safe-fetch-sitemap";
 import type { TrackedSitemap } from "@/lib/sitemaps/site-visit-tracking";
 import { ProcessedLinkProps } from "@/lib/types";
 import { prisma } from "@dub/prisma";
-import { fetchWithTimeout } from "@dub/utils/src";
 import { XMLParser } from "fast-xml-parser";
 
 type SitemapXmlUrlEntry = {
@@ -33,8 +33,25 @@ function extractKeyFromUrl(url: string) {
   return key === "" ? "_root" : key;
 }
 
-/** Max page URLs collected from a single registered sitemap file (no nested fetches). */
-export const MAX_URLS_PER_SITEMAP = 2000;
+/** Max unique page URLs per import (single urlset or combined nested sitemaps). Exceeding fails the import. */
+export const MAX_URLS_PER_SITEMAP = 10_000;
+
+/** Max nesting level for sitemap indexes (root is depth 0; reject when depth exceeds this). */
+const MAX_SITEMAP_INDEX_DEPTH = 5;
+
+/** Max HTTP fetches per import to cap cost on pathological indexes. */
+const MAX_SITEMAP_FETCHES_PER_IMPORT = 100;
+
+/** Max links per `bulkCreateLinks` call during import. */
+const SITEMAP_IMPORT_BULK_CREATE_BATCH_SIZE = 250;
+
+function normalizeSitemapUrl(url: string): string {
+  try {
+    return new URL(url.trim()).href;
+  } catch {
+    return url.trim();
+  }
+}
 
 async function decompressIfGzip(buffer: ArrayBuffer): Promise<string> {
   const bytes = new Uint8Array(buffer);
@@ -72,7 +89,7 @@ async function decompressIfGzip(buffer: ArrayBuffer): Promise<string> {
 async function fetchAndParseSitemap(
   sitemapUrl: string,
 ): Promise<SitemapXmlResult> {
-  const response = await fetchWithTimeout(sitemapUrl, { redirect: "error" }); // don't follow redirects
+  const response = await fetchSitemapResponse(sitemapUrl);
   const MAX_SITEMAP_BYTES = 10 * 1024 * 1024; // 10 MB
   const contentLength = response.headers.get("content-length");
   if (contentLength && parseInt(contentLength, 10) > MAX_SITEMAP_BYTES) {
@@ -87,29 +104,76 @@ async function fetchAndParseSitemap(
 }
 
 export async function crawlSitemapUrls(sitemapUrl: string) {
+  const collected = new Set<string>();
   let hadErrors = false;
+  const visited = new Set<string>();
+  let fetchCount = 0;
 
-  let parsed: SitemapXmlResult;
-  try {
-    parsed = await fetchAndParseSitemap(sitemapUrl);
-  } catch (error) {
-    console.error(`Failed to fetch sitemap ${sitemapUrl}:`, error);
-    return { urls: [] as string[], hadErrors: true };
+  async function crawlRecursive(url: string, depth: number): Promise<void> {
+    if (depth > MAX_SITEMAP_INDEX_DEPTH) {
+      hadErrors = true;
+      return;
+    }
+
+    const normalized = normalizeSitemapUrl(url);
+    if (visited.has(normalized)) {
+      return;
+    }
+
+    if (fetchCount >= MAX_SITEMAP_FETCHES_PER_IMPORT) {
+      hadErrors = true;
+      return;
+    }
+
+    visited.add(normalized);
+    fetchCount += 1;
+
+    let parsed: SitemapXmlResult;
+    try {
+      parsed = await fetchAndParseSitemap(url);
+    } catch (error) {
+      console.error(`Failed to fetch sitemap ${url}:`, error);
+      hadErrors = true;
+      return;
+    }
+
+    const urlsetLocs = toArray(parsed.urlset?.url)
+      .map((entry) => entry?.loc?.trim())
+      .filter((loc): loc is string => Boolean(loc));
+
+    const pageUrlsThisFile = urlsetLocs.filter((loc) => !loc.endsWith(".xml"));
+    const uniqueInThisFile = new Set(pageUrlsThisFile);
+    if (uniqueInThisFile.size > MAX_URLS_PER_SITEMAP) {
+      throw new Error(
+        `Sitemap contains too many unique URLs: ${uniqueInThisFile.size} (max ${MAX_URLS_PER_SITEMAP})`,
+      );
+    }
+
+    for (const pageUrl of pageUrlsThisFile) {
+      if (!collected.has(pageUrl) && collected.size >= MAX_URLS_PER_SITEMAP) {
+        throw new Error(
+          `Sitemap contains too many unique URLs (max ${MAX_URLS_PER_SITEMAP})`,
+        );
+      }
+      collected.add(pageUrl);
+    }
+
+    const indexChildren = toArray(parsed.sitemapindex?.sitemap)
+      .map((entry) => entry?.loc?.trim())
+      .filter((loc): loc is string => Boolean(loc));
+
+    for (const childUrl of indexChildren) {
+      if (fetchCount >= MAX_SITEMAP_FETCHES_PER_IMPORT) {
+        hadErrors = true;
+        break;
+      }
+      await crawlRecursive(childUrl, depth + 1);
+    }
   }
 
-  const urlsetLocs = toArray(parsed.urlset?.url)
-    .map((entry) => entry?.loc?.trim())
-    .filter((url): url is string => Boolean(url));
+  await crawlRecursive(sitemapUrl, 0);
 
-  const urls = Array.from(
-    new Set(urlsetLocs.filter((url) => !url.endsWith(".xml"))),
-  );
-
-  if (urls.length > MAX_URLS_PER_SITEMAP) {
-    throw new Error(
-      `Sitemap contains too many unique URLs: ${urls.length} (max ${MAX_URLS_PER_SITEMAP})`,
-    );
-  }
+  const urls = Array.from(collected);
 
   return { urls, hadErrors };
 }
@@ -212,13 +276,25 @@ export async function importTrackedSitemaps({
   );
 
   console.log(
-    `[importTrackedSitemaps] Found ${linksToCreate.length} links to create, running bulkCreateLinks...`,
+    `[importTrackedSitemaps] Found ${linksToCreate.length} links to create, running bulkCreateLinks in batches of ${SITEMAP_IMPORT_BULK_CREATE_BATCH_SIZE}...`,
   );
 
-  const createdLinks = await bulkCreateLinks({
-    links: linksToCreate,
-    skipRedisCache: true,
-  });
+  const createdLinks: Awaited<ReturnType<typeof bulkCreateLinks>> = [];
+  for (
+    let i = 0;
+    i < linksToCreate.length;
+    i += SITEMAP_IMPORT_BULK_CREATE_BATCH_SIZE
+  ) {
+    const batch = linksToCreate.slice(
+      i,
+      i + SITEMAP_IMPORT_BULK_CREATE_BATCH_SIZE,
+    );
+    const batchCreated = await bulkCreateLinks({
+      links: batch,
+      skipRedisCache: true,
+    });
+    createdLinks.push(...batchCreated);
+  }
 
   console.log({
     linksToCreate,

--- a/apps/web/lib/sitemaps/safe-fetch-sitemap.ts
+++ b/apps/web/lib/sitemaps/safe-fetch-sitemap.ts
@@ -3,7 +3,7 @@ import dns from "dns/promises";
 import net from "net";
 
 /** Max HTTP redirects when fetching a sitemap (e.g. CDN → object storage). */
-export const MAX_SITEMAP_REDIRECTS = 2;
+export const MAX_SITEMAP_REDIRECTS = 3;
 
 const FETCH_TIMEOUT_MS = 15_000;
 
@@ -134,7 +134,7 @@ export async function fetchSitemapResponse(
   let currentUrl = new URL(startUrl).href;
   let redirectCount = 0;
 
-  while (redirectCount <= MAX_SITEMAP_REDIRECTS) {
+  while (redirectCount < MAX_SITEMAP_REDIRECTS) {
     await assertSitemapFetchUrlSafe(currentUrl);
 
     const response = await fetchWithTimeout(

--- a/apps/web/lib/sitemaps/safe-fetch-sitemap.ts
+++ b/apps/web/lib/sitemaps/safe-fetch-sitemap.ts
@@ -1,0 +1,164 @@
+import { fetchWithTimeout } from "@dub/utils/src";
+import dns from "dns/promises";
+import net from "net";
+
+/** Max HTTP redirects when fetching a sitemap (e.g. CDN → object storage). */
+export const MAX_SITEMAP_REDIRECTS = 2;
+
+const FETCH_TIMEOUT_MS = 15_000;
+
+function isBlockedIpv4(ip: string): boolean {
+  const parts = ip.split(".").map((p) => parseInt(p, 10));
+  if (
+    parts.length !== 4 ||
+    parts.some((n) => Number.isNaN(n) || n < 0 || n > 255)
+  ) {
+    return true;
+  }
+  const [a, b] = parts;
+  if (a === 0 || a === 127) return true;
+  if (a === 10) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 169 && b === 254) return true;
+  if (a === 100 && b >= 64 && b <= 127) return true;
+  if (a === 255 && parts[1] === 255 && parts[2] === 255 && parts[3] === 255) {
+    return true;
+  }
+  return false;
+}
+
+function isBlockedIpv6(ip: string): boolean {
+  const lower = ip.toLowerCase();
+  if (lower === "::1") return true;
+  if (lower.startsWith("fe80:")) return true;
+  const first = lower.split(":")[0];
+  if (first.length >= 2 && (first.startsWith("fc") || first.startsWith("fd"))) {
+    return true;
+  }
+  if (lower.startsWith("::ffff:")) {
+    const embedded = lower.slice(7).split("%")[0];
+    if (net.isIPv4(embedded)) {
+      return isBlockedIpv4(embedded);
+    }
+  }
+  return false;
+}
+
+function isBlockedIp(ip: string): boolean {
+  if (net.isIPv4(ip)) {
+    return isBlockedIpv4(ip);
+  }
+  if (net.isIPv6(ip)) {
+    return isBlockedIpv6(ip);
+  }
+  return true;
+}
+
+/**
+ * Resolve hostname and ensure no resolved address is private / loopback / metadata (SSRF guard).
+ */
+export async function assertResolvedHostSafe(hostname: string): Promise<void> {
+  if (hostname === "localhost") {
+    throw new Error("Blocked hostname");
+  }
+  if (hostname.endsWith(".local") || hostname.endsWith(".localhost")) {
+    throw new Error("Blocked hostname");
+  }
+
+  if (net.isIPv4(hostname) || net.isIPv6(hostname)) {
+    if (isBlockedIp(hostname)) {
+      throw new Error("Blocked IP address");
+    }
+    return;
+  }
+
+  const ips: string[] = [];
+  try {
+    ips.push(...(await dns.resolve4(hostname)));
+  } catch {
+    // ignore
+  }
+  try {
+    ips.push(...(await dns.resolve6(hostname)));
+  } catch {
+    // ignore
+  }
+
+  if (ips.length === 0) {
+    throw new Error("Hostname did not resolve");
+  }
+
+  for (const ip of ips) {
+    if (isBlockedIp(ip)) {
+      throw new Error("Hostname resolves to a blocked address");
+    }
+  }
+}
+
+/**
+ * Validates URL shape and that the host resolves to a public address (SSRF mitigation).
+ * Call before each redirect hop and the initial request.
+ */
+export async function assertSitemapFetchUrlSafe(
+  urlString: string,
+): Promise<void> {
+  let parsed: URL;
+  try {
+    parsed = new URL(urlString);
+  } catch {
+    throw new Error("Invalid sitemap URL");
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("Only HTTP(S) sitemap URLs are allowed");
+  }
+
+  if (parsed.username || parsed.password) {
+    throw new Error("Sitemap URL must not contain credentials");
+  }
+
+  if (!parsed.hostname) {
+    throw new Error("Invalid sitemap host");
+  }
+
+  await assertResolvedHostSafe(parsed.hostname);
+}
+
+/**
+ * Fetches a sitemap response, following redirects with a cap and validating each hop (SSRF-safe).
+ */
+export async function fetchSitemapResponse(
+  startUrl: string,
+): Promise<Response> {
+  let currentUrl = new URL(startUrl).href;
+  let redirectCount = 0;
+
+  while (redirectCount <= MAX_SITEMAP_REDIRECTS) {
+    await assertSitemapFetchUrlSafe(currentUrl);
+
+    const response = await fetchWithTimeout(
+      currentUrl,
+      { redirect: "manual" },
+      FETCH_TIMEOUT_MS,
+    );
+
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get("location");
+      if (!location) {
+        throw new Error("Redirect response missing Location header");
+      }
+      currentUrl = new URL(location, currentUrl).href;
+      redirectCount += 1;
+      continue;
+    }
+
+    if (!response.ok) {
+      throw new Error(`Sitemap fetch failed: ${response.status}`);
+    }
+
+    return response;
+  }
+
+  throw new Error(`Too many sitemap redirects (max ${MAX_SITEMAP_REDIRECTS})`);
+}

--- a/apps/web/tests/misc/import-tracked-sitemaps.test.ts
+++ b/apps/web/tests/misc/import-tracked-sitemaps.test.ts
@@ -6,6 +6,13 @@ import { parseTrackedSitemaps } from "@/lib/sitemaps/site-visit-tracking";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { gzipSync } from "zlib";
 
+vi.mock("dns/promises", () => ({
+  default: {
+    resolve4: vi.fn(async () => ["93.184.216.34"]),
+    resolve6: vi.fn(async () => []),
+  },
+}));
+
 function toArrayBuffer(buf: Buffer): ArrayBuffer {
   const ab = new ArrayBuffer(buf.length);
   new Uint8Array(ab).set(buf);
@@ -146,6 +153,26 @@ describe("crawlSitemapUrls", () => {
   });
 
   describe("flat urlset", () => {
+    it("follows HTTP redirects before reading the sitemap", async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          redirectResponse("https://cdn.example.com/sitemap.xml"),
+        )
+        .mockResolvedValueOnce(
+          makeFetchResponse(
+            Buffer.from(urlsetXml(["https://example.com/page-1"])),
+          ),
+        );
+
+      const { urls, hadErrors } = await crawlSitemapUrls(
+        "https://example.com/sitemap.xml.gz",
+      );
+
+      expect(urls).toEqual(["https://example.com/page-1"]);
+      expect(hadErrors).toBe(false);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
     it("returns all page URLs from a simple urlset", async () => {
       const pageUrls = [
         "https://example.com/page-1",
@@ -185,28 +212,57 @@ describe("crawlSitemapUrls", () => {
   });
 
   describe("sitemapindex", () => {
-    it("does not fetch nested sitemaps from a sitemap index", async () => {
-      mockFetch.mockResolvedValueOnce(
-        makeFetchResponse(
-          Buffer.from(
-            sitemapindexXml([
-              "https://example.com/sitemap-posts.xml",
-              "https://example.com/sitemap-pages.xml",
-            ]),
+    it("fetches child sitemaps from a sitemap index and merges page URLs", async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          makeFetchResponse(
+            Buffer.from(
+              sitemapindexXml([
+                "https://example.com/sitemap-posts.xml",
+                "https://example.com/sitemap-pages.xml",
+              ]),
+            ),
           ),
-        ),
-      );
+        )
+        .mockResolvedValueOnce(
+          makeFetchResponse(
+            Buffer.from(
+              urlsetXml([
+                "https://example.com/blog/post-a",
+                "https://example.com/blog/post-b",
+              ]),
+            ),
+          ),
+        )
+        .mockResolvedValueOnce(
+          makeFetchResponse(
+            Buffer.from(
+              urlsetXml([
+                "https://example.com/about",
+                "https://example.com/pricing",
+              ]),
+            ),
+          ),
+        );
 
       const { urls, hadErrors } = await crawlSitemapUrls(
         "https://example.com/sitemap.xml",
       );
 
-      expect(urls).toEqual([]);
+      expect(urls).toEqual(
+        expect.arrayContaining([
+          "https://example.com/blog/post-a",
+          "https://example.com/blog/post-b",
+          "https://example.com/about",
+          "https://example.com/pricing",
+        ]),
+      );
+      expect(urls).toHaveLength(4);
       expect(hadErrors).toBe(false);
-      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledTimes(3);
     });
 
-    it("returns no page URLs when the index only references itself", async () => {
+    it("returns no page URLs when the index only references itself (cycle)", async () => {
       mockFetch.mockResolvedValue(
         makeFetchResponse(
           Buffer.from(sitemapindexXml(["https://example.com/sitemap.xml"])),
@@ -219,6 +275,37 @@ describe("crawlSitemapUrls", () => {
 
       expect(urls).toEqual([]);
       expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("follows a nested sitemap index before reaching a urlset", async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          makeFetchResponse(
+            Buffer.from(
+              sitemapindexXml(["https://example.com/blog/sitemap.xml"]),
+            ),
+          ),
+        )
+        .mockResolvedValueOnce(
+          makeFetchResponse(
+            Buffer.from(
+              sitemapindexXml(["https://example.com/blog/sitemap-posts.xml"]),
+            ),
+          ),
+        )
+        .mockResolvedValueOnce(
+          makeFetchResponse(
+            Buffer.from(urlsetXml(["https://example.com/blog/hello"])),
+          ),
+        );
+
+      const { urls, hadErrors } = await crawlSitemapUrls(
+        "https://example.com/sitemap.xml",
+      );
+
+      expect(urls).toEqual(["https://example.com/blog/hello"]);
+      expect(hadErrors).toBe(false);
+      expect(mockFetch).toHaveBeenCalledTimes(3);
     });
   });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recursive import of nested/indexed sitemaps and following HTTP redirects during retrieval.

* **Improvements**
  * Increased per-sitemap URL capacity (2,000 → 10,000).
  * Batched link creation for large imports.
  * Added caps on recursion depth, sitemap fetches, and duplicate suppression across nested imports.
  * Enhanced SSRF protections with hostname/IP validation and redirect safety checks.

* **Tests**
  * Updated tests for nested indexes, cycles, and redirect handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->