### PR TITLE
`resolveFraudGroups` for both source and target partner

### DIFF
--- a/apps/web/app/(ee)/api/cron/partners/merge-accounts/route.ts
+++ b/apps/web/app/(ee)/api/cron/partners/merge-accounts/route.ts
@@ -63,8 +63,6 @@ export async function POST(req: Request) {
         id: true,
         email: true,
         image: true,
-        payoutMethodHash: true,
-        cryptoWalletAddress: true,
         programs: {
           select: {
             programId: true,

--- a/apps/web/app/(ee)/api/cron/partners/merge-accounts/route.ts
+++ b/apps/web/app/(ee)/api/cron/partners/merge-accounts/route.ts
@@ -367,10 +367,6 @@ export async function POST(req: Request) {
         fraudEventGroup: {
           type: FraudRuleType.partnerDuplicatePayoutMethod,
         },
-        metadata: {
-          path: "$.duplicatePartnerId",
-          equals: sourcePartnerId,
-        },
       },
       include: {
         fraudEventGroup: {
@@ -395,7 +391,9 @@ export async function POST(req: Request) {
     }
 
     const fraudEventGroupsToResolve = fraudEventsToDelete.filter(
-      (e) => e.fraudEventGroup._count.fraudEvents === 1,
+      // this is the count pre-deletion the fraud event, so if there are 2 fraud events
+      // that means post-deletion will leave 1 fraud event in the group (no additional duplicates), hence can be resolved
+      (e) => e.fraudEventGroup._count.fraudEvents === 2,
     );
 
     await resolveFraudGroups({

--- a/apps/web/app/(ee)/api/cron/partners/merge-accounts/route.ts
+++ b/apps/web/app/(ee)/api/cron/partners/merge-accounts/route.ts
@@ -64,6 +64,7 @@ export async function POST(req: Request) {
         email: true,
         image: true,
         payoutMethodHash: true,
+        cryptoWalletAddress: true,
         programs: {
           select: {
             programId: true,
@@ -362,29 +363,60 @@ export async function POST(req: Request) {
       );
     }
 
-    // After merging, check if the fraud condition has been resolved.
-    // If no other partners share the same payout method hash, we can
-    // automatically resolve any pending fraud groups for this partner.
-    if (targetAccount.payoutMethodHash) {
-      const duplicatePartners = await prisma.partner.count({
+    const fraudEventsToDelete = await prisma.fraudEvent.findMany({
+      where: {
+        partnerId: sourcePartnerId,
+        fraudEventGroup: {
+          type: FraudRuleType.partnerDuplicatePayoutMethod,
+        },
+        metadata: {
+          path: "$.duplicatePartnerId",
+          equals: sourcePartnerId,
+        },
+      },
+      include: {
+        fraudEventGroup: {
+          select: {
+            id: true,
+            _count: {
+              select: {
+                fraudEvents: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (fraudEventsToDelete.length > 0) {
+      await prisma.fraudEvent.deleteMany({
         where: {
-          payoutMethodHash: targetAccount.payoutMethodHash,
+          id: { in: fraudEventsToDelete.map((e) => e.id) },
         },
       });
-
-      if (duplicatePartners <= 1) {
-        await resolveFraudGroups({
-          where: {
-            partnerId: {
-              in: [sourcePartnerId, targetPartnerId],
-            },
-            type: FraudRuleType.partnerDuplicatePayoutMethod,
-          },
-          resolutionReason:
-            "Automatically resolved because partners with duplicate payout methods were merged. No other partners share this payout method.",
-        });
-      }
     }
+
+    const fraudEventGroupsToResolve = fraudEventsToDelete.filter(
+      (e) => e.fraudEventGroup._count.fraudEvents === 1,
+    );
+
+    await resolveFraudGroups({
+      where: {
+        OR: [
+          {
+            partnerId: sourcePartnerId,
+          },
+          {
+            id: {
+              in: fraudEventGroupsToResolve.map((e) => e.fraudEventGroup.id),
+            },
+          },
+        ],
+        type: FraudRuleType.partnerDuplicatePayoutMethod,
+      },
+      resolutionReason:
+        "Automatically resolved because partners with duplicate payout methods were merged. No other partners share this payout method.",
+    });
 
     // Make sure the cache is cleared
     await redis.del(`${CACHE_KEY_PREFIX}:${userId}`);

--- a/apps/web/app/(ee)/api/cron/partners/merge-accounts/route.ts
+++ b/apps/web/app/(ee)/api/cron/partners/merge-accounts/route.ts
@@ -343,24 +343,6 @@ export async function POST(req: Request) {
       }
     }
 
-    try {
-      // Finally, delete the partner account
-      await conn.execute(`DELETE FROM Partner WHERE id = ?`, [sourcePartnerId]);
-      console.log(
-        `Deleted partner ${sourceAccount.email} (${sourceAccount.id})`,
-      );
-
-      if (sourceAccount.image) {
-        await storage.delete({
-          key: sourceAccount.image.replace(`${R2_URL}/`, ""),
-        });
-      }
-    } catch (error) {
-      console.error(
-        `Error deleting partner ${sourcePartnerId}: ${error.message}`,
-      );
-    }
-
     const fraudEventsToDelete = await prisma.fraudEvent.findMany({
       where: {
         partnerId: sourcePartnerId,
@@ -402,17 +384,41 @@ export async function POST(req: Request) {
           {
             partnerId: sourcePartnerId,
           },
-          {
-            id: {
-              in: fraudEventGroupsToResolve.map((e) => e.fraudEventGroup.id),
-            },
-          },
+          ...(fraudEventGroupsToResolve.length > 0
+            ? [
+                {
+                  id: {
+                    in: fraudEventGroupsToResolve.map(
+                      (e) => e.fraudEventGroup.id,
+                    ),
+                  },
+                },
+              ]
+            : []),
         ],
         type: FraudRuleType.partnerDuplicatePayoutMethod,
       },
       resolutionReason:
         "Automatically resolved because partners with duplicate payout methods were merged. No other partners share this payout method.",
     });
+
+    try {
+      // Finally, delete the partner account
+      await conn.execute(`DELETE FROM Partner WHERE id = ?`, [sourcePartnerId]);
+      console.log(
+        `Deleted partner ${sourceAccount.email} (${sourceAccount.id})`,
+      );
+
+      if (sourceAccount.image) {
+        await storage.delete({
+          key: sourceAccount.image.replace(`${R2_URL}/`, ""),
+        });
+      }
+    } catch (error) {
+      console.error(
+        `Error deleting partner ${sourcePartnerId}: ${error.message}`,
+      );
+    }
 
     // Make sure the cache is cleared
     await redis.del(`${CACHE_KEY_PREFIX}:${userId}`);

--- a/apps/web/app/(ee)/api/cron/partners/merge-accounts/route.ts
+++ b/apps/web/app/(ee)/api/cron/partners/merge-accounts/route.ts
@@ -12,6 +12,7 @@ import { redis } from "@/lib/upstash";
 import { sendBatchEmail } from "@dub/email";
 import PartnerAccountMerged from "@dub/email/templates/partner-account-merged";
 import { prisma } from "@dub/prisma";
+import { FraudRuleType } from "@dub/prisma/client";
 import { log, prettyPrint, R2_URL } from "@dub/utils";
 import * as z from "zod/v4";
 
@@ -374,8 +375,10 @@ export async function POST(req: Request) {
       if (duplicatePartners <= 1) {
         await resolveFraudGroups({
           where: {
-            partnerId: targetPartnerId,
-            type: "partnerDuplicatePayoutMethod",
+            partnerId: {
+              in: [sourcePartnerId, targetPartnerId],
+            },
+            type: FraudRuleType.partnerDuplicatePayoutMethod,
           },
           resolutionReason:
             "Automatically resolved because partners with duplicate payout methods were merged. No other partners share this payout method.",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Post-merge fraud handling: stale duplicate-fraud events tied to merged accounts are now removed and affected fraud groups are resolved more accurately to reduce false positives after merges.
  * Reduced reliance on payout-method matching, yielding more consistent merge outcomes.

* **Refactor**
  * Fraud-resolution now uses standardized fraud-event group criteria tied to the source account for more reliable processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->