### PR TITLE
Onboarding fixes

### DIFF
--- a/apps/web/app/(ee)/partners.dub.co/(onboarding)/onboarding/onboarding-form.tsx
+++ b/apps/web/app/(ee)/partners.dub.co/(onboarding)/onboarding/onboarding-form.tsx
@@ -53,6 +53,7 @@ export function OnboardingForm({
   const { isMobile } = useMediaQuery();
   const [accountCreated, setAccountCreated] = useState(false);
   const [isCountryComboboxOpen, setIsCountryComboboxOpen] = useState(false);
+  const isTabbingRef = useRef(false);
   const { data: session, update: refreshSession } = useSession();
   const countryChangeWarning = useCountryChangeWarningModal();
 
@@ -117,6 +118,12 @@ export function OnboardingForm({
     <form
       ref={formRef}
       onSubmit={handleSubmit(async (data) => await executeAsync(data))}
+      onKeyDownCapture={(e) => {
+        isTabbingRef.current = e.key === "Tab";
+      }}
+      onPointerDownCapture={() => {
+        isTabbingRef.current = false;
+      }}
       className="flex w-full flex-col gap-6 text-left"
     >
       {countryChangeWarning.modal}
@@ -148,7 +155,7 @@ export function OnboardingForm({
             render={({ field }) => (
               <FileUpload
                 accept="images"
-                className="mt-1.5 size-20 rounded-full border border-neutral-300"
+                className="mt-1.5 size-20 rounded-full border border-neutral-300 transition-none focus-within:border-neutral-500 focus-within:ring-1 focus-within:ring-neutral-500"
                 iconClassName="size-5"
                 previewClassName="size-20 rounded-full"
                 variant="plain"
@@ -158,6 +165,7 @@ export function OnboardingForm({
                 content={null}
                 maxFileSizeMB={2}
                 targetResolution={{ width: 160, height: 160 }}
+                accessibilityLabel="Upload profile image"
               />
             )}
           />
@@ -200,6 +208,28 @@ export function OnboardingForm({
                 }
 
                 setIsCountryComboboxOpen(true);
+              }}
+              buttonProps={{
+                onFocus: () => {
+                  const shouldShowCountryChangeWarning =
+                    !partner?.payoutsEnabledAt &&
+                    !countryChangeWarning.isAcknowledged &&
+                    !countryChangeWarning.isOpen;
+
+                  if (
+                    !shouldShowCountryChangeWarning ||
+                    !isTabbingRef.current
+                  ) {
+                    return;
+                  }
+
+                  countryChangeWarning.acknowledgeAndContinue(
+                    () => {
+                      setIsCountryComboboxOpen(true);
+                    },
+                    { focusAcknowledgeButton: true },
+                  );
+                },
               }}
               disabledTooltip={
                 partner?.payoutsEnabledAt ? (
@@ -271,7 +301,7 @@ export function OnboardingForm({
                 partner?.payoutsEnabledAt && "cursor-not-allowed opacity-70",
               )}
               optionClassName={cn(
-                "h-9 flex items-center justify-center rounded-lg flex-1",
+                "h-9 flex items-center justify-center rounded-lg flex-1 outline-none transition-none focus-visible:z-20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-neutral-500",
                 partner?.payoutsEnabledAt && "pointer-events-none",
               )}
               indicatorClassName="bg-white"

--- a/apps/web/app/app.dub.co/(onboarding)/signed-in-hint.tsx
+++ b/apps/web/app/app.dub.co/(onboarding)/signed-in-hint.tsx
@@ -9,27 +9,29 @@ export function SignedInHint() {
   const [isLoading, setIsLoading] = useState(false);
 
   return (
-    <div className="fixed bottom-0 left-0 z-40 m-5 flex flex-col gap-2">
-      <div className="flex items-center gap-1 text-xs text-neutral-600">
-        You're signed in as{" "}
-        {session ? (
-          <b className="text-neutral-800">{session.user?.email}</b>
-        ) : (
-          <span className="h-3 w-32 animate-pulse rounded-md border border-neutral-300 bg-neutral-200" />
-        )}
+    <div className="pointer-events-none fixed inset-x-0 bottom-0 z-30 min-[769px]:inset-x-auto min-[769px]:left-0 min-[769px]:z-40 min-[769px]:m-5 min-[769px]:w-auto">
+      <div className="pointer-events-auto flex w-full flex-col gap-2 bg-gradient-to-t from-white from-30% via-white/95 to-white/0 px-4 pb-4 pr-24 pt-10 min-[769px]:w-auto min-[769px]:bg-none min-[769px]:p-0">
+        <div className="flex min-w-0 items-center gap-1 text-xs text-neutral-600">
+          <span className="shrink-0">You're signed in as</span>
+          {session ? (
+            <b className="truncate text-neutral-800">{session.user?.email}</b>
+          ) : (
+            <span className="h-3 w-32 animate-pulse rounded-md border border-neutral-300 bg-neutral-200" />
+          )}
+        </div>
+        <Button
+          variant="secondary"
+          text="Sign in as a different user"
+          onClick={() => {
+            setIsLoading(true);
+            signOut({
+              callbackUrl: "/login",
+            });
+          }}
+          loading={isLoading}
+          className="h-8 w-fit rounded-lg px-3 text-xs shadow-sm"
+        />
       </div>
-      <Button
-        variant="secondary"
-        text="Sign in as a different user"
-        onClick={() => {
-          setIsLoading(true);
-          signOut({
-            callbackUrl: "/login",
-          });
-        }}
-        loading={isLoading}
-        className="h-8 w-fit rounded-lg px-3 text-xs shadow-sm"
-      />
     </div>
   );
 }

--- a/apps/web/playwright/partners/onboarding.spec.ts
+++ b/apps/web/playwright/partners/onboarding.spec.ts
@@ -26,6 +26,31 @@ test.describe("Partner onboarding", () => {
     await expect(page.getByRole("button", { name: "Continue" })).toBeVisible();
   });
 
+  test("tabbing to country opens the acknowledgement modal and focuses the confirm button", async ({
+    page,
+  }) => {
+    await page.goto("/onboarding");
+
+    const nameInput = page.locator('input[name="name"]').first();
+    const acknowledgeButton = page.getByRole("button", {
+      name: "I acknowledge",
+    });
+    const searchCountriesInput = page.getByPlaceholder("Search countries...");
+
+    await expect(nameInput).toBeFocused();
+
+    await page.keyboard.press("Tab");
+    await page.keyboard.press("Tab");
+
+    await expect(acknowledgeButton).toBeVisible();
+    await expect(acknowledgeButton).toBeFocused();
+
+    await page.keyboard.press("Enter");
+
+    await expect(searchCountriesInput).toBeVisible();
+    await expect(searchCountriesInput).toBeFocused();
+  });
+
   test("profile submit redirects to platforms", async ({ page }) => {
     await page.goto("/onboarding");
 

--- a/apps/web/ui/layout/sidebar/help-button.tsx
+++ b/apps/web/ui/layout/sidebar/help-button.tsx
@@ -5,7 +5,7 @@ export async function HelpButton() {
     <a
       href="https://dub.co/contact/support"
       target="_blank"
-      className="text-content-default hover:bg-bg-inverted/5 flex size-11 shrink-0 items-center justify-center rounded-lg"
+      className="text-content-default hover:bg-bg-inverted/5 max-[768px]:bg-bg-inverted/5 flex size-11 shrink-0 items-center justify-center rounded-lg"
     >
       <CircleQuestion className="size-5" strokeWidth={2} />
     </a>

--- a/apps/web/ui/partners/country-combobox.tsx
+++ b/apps/web/ui/partners/country-combobox.tsx
@@ -1,4 +1,4 @@
-import { Combobox } from "@dub/ui";
+import { type ButtonProps, Combobox } from "@dub/ui";
 import { cn, COUNTRIES } from "@dub/utils";
 import { ReactNode, useMemo } from "react";
 
@@ -10,6 +10,7 @@ export function CountryCombobox({
   className,
   open,
   onOpenChange,
+  buttonProps,
 }: {
   value: string;
   onChange: (value: string) => void;
@@ -18,6 +19,7 @@ export function CountryCombobox({
   className?: string;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
+  buttonProps?: Partial<ButtonProps>;
 }) {
   const options = useMemo(
     () =>
@@ -60,6 +62,7 @@ export function CountryCombobox({
       searchPlaceholder="Search countries..."
       matchTriggerWidth
       buttonProps={{
+        ...buttonProps,
         className: cn(
           "mt-1.5 w-full justify-start border-neutral-300 px-3",
           "data-[state=open]:ring-1 data-[state=open]:ring-neutral-500 data-[state=open]:border-neutral-500",
@@ -67,6 +70,7 @@ export function CountryCombobox({
           !value && "text-neutral-400",
           disabledTooltip && "cursor-not-allowed",
           error && "border-red-500 ring-red-500 ring-1",
+          buttonProps?.className,
           className,
         ),
         disabledTooltip,

--- a/apps/web/ui/partners/use-country-change-warning-modal.tsx
+++ b/apps/web/ui/partners/use-country-change-warning-modal.tsx
@@ -1,20 +1,36 @@
 "use client";
 
 import { Button, Modal } from "@dub/ui";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 export function useCountryChangeWarningModal() {
   const [showModalState, setShowModalState] = useState(false);
   const [isAcknowledged, setIsAcknowledged] = useState(false);
+  const [focusAcknowledgeButton, setFocusAcknowledgeButton] = useState(false);
   const onAcknowledgeRef = useRef<(() => void) | null>(null);
+  const acknowledgeButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!showModalState || !focusAcknowledgeButton) {
+      return;
+    }
+
+    const frame = requestAnimationFrame(() => {
+      acknowledgeButtonRef.current?.focus();
+    });
+
+    return () => cancelAnimationFrame(frame);
+  }, [focusAcknowledgeButton, showModalState]);
 
   const handleCancel = useCallback(() => {
     onAcknowledgeRef.current = null;
+    setFocusAcknowledgeButton(false);
     setShowModalState(false);
   }, []);
 
   const handleAcknowledge = useCallback(() => {
     setIsAcknowledged(true);
+    setFocusAcknowledgeButton(false);
     setShowModalState(false);
     onAcknowledgeRef.current?.();
     onAcknowledgeRef.current = null;
@@ -47,13 +63,14 @@ export function useCountryChangeWarningModal() {
       <div className="border-border-subtle flex items-center justify-end gap-2 border-t bg-neutral-50 px-5 py-4">
         <Button
           variant="secondary"
-          className="h-8 w-fit px-3"
+          className="h-8 w-fit px-3 focus-visible:border-neutral-500 focus-visible:ring-1 focus-visible:ring-neutral-500"
           text="Cancel"
           onClick={handleCancel}
         />
         <Button
+          ref={acknowledgeButtonRef}
           variant="primary"
-          className="h-8 w-fit px-3"
+          className="h-8 w-fit px-3 focus-visible:border-neutral-500 focus-visible:ring-1 focus-visible:ring-neutral-500"
           text="I acknowledge"
           onClick={handleAcknowledge}
         />
@@ -66,14 +83,19 @@ export function useCountryChangeWarningModal() {
     setShowModalState(true);
   }, []);
 
-  const acknowledgeAndContinue = useCallback((callback?: () => void) => {
-    onAcknowledgeRef.current = callback ?? null;
-    setShowModalState(true);
-  }, []);
+  const acknowledgeAndContinue = useCallback(
+    (callback?: () => void, options?: { focusAcknowledgeButton?: boolean }) => {
+      onAcknowledgeRef.current = callback ?? null;
+      setFocusAcknowledgeButton(Boolean(options?.focusAcknowledgeButton));
+      setShowModalState(true);
+    },
+    [],
+  );
 
   return {
     modal,
     showModal,
+    isOpen: showModalState,
     isAcknowledged,
     acknowledgeAndContinue,
   };


### PR DESCRIPTION
Assorted updates
- On the main onboarding page, I added more focus indicators when tabbing through the fields
- Added the focus state to the profile image
- Updated the account type focus state to match the rest of the inputs
- Triggers the country modal if tabbing to the input, then shows the country selector after hitting enter to acknowledge.
- Added a gradient at the bottom of the page over the "you're signed in as.." section. On smaller screens it's showing overtop and you can't read the inputs. At least this way the user knows to scroll. But we'll need a better position in the future.

<img width="502" height="716" alt="CleanShot 2026-04-14 at 22 44 59@2x" src="https://github.com/user-attachments/assets/fb93d66f-ae88-4d90-8ced-7578ad1c204d" />
