### PR TITLE
Add supportEmail for partner-banned email

### DIFF
--- a/apps/web/app/(ee)/api/cron/partners/ban/route.ts
+++ b/apps/web/app/(ee)/api/cron/partners/ban/route.ts
@@ -162,6 +162,7 @@ export const POST = withCron(async ({ rawBody }) => {
           program: {
             name: program.name,
             slug: program.slug,
+            supportEmail: program.supportEmail,
           },
           // A reason is always present because we validate the schema
           bannedReason: programEnrollment.bannedReason

--- a/packages/email/src/templates/partner-banned.tsx
+++ b/packages/email/src/templates/partner-banned.tsx
@@ -22,6 +22,7 @@ export default function PartnerBanned({
   program = {
     name: "Acme",
     slug: "acme",
+    supportEmail: "support@acme.com",
   },
   bannedReason = "Terms of Service Violation",
 }: {
@@ -32,6 +33,7 @@ export default function PartnerBanned({
   program: {
     name: string;
     slug: string;
+    supportEmail?: string | null;
   };
   bannedReason: string;
 }) {
@@ -67,7 +69,7 @@ export default function PartnerBanned({
             <Text className="text-sm leading-6 text-neutral-600">
               If you have any questions, please{" "}
               <Link
-                href={`https://partners.dub.co/messages/${program.slug}`}
+                href={`mailto:${program.supportEmail}`}
                 className="font-semibold text-neutral-700 underline underline-offset-2"
               >
                 reach out to the {program.name} team ↗


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Partner program banned notification emails now include and utilize the program's support email address. The contact information link has been updated to direct users to the designated support email instead of the previous constructed method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->