### PR TITLE
fix: return 200 on Stripe webhook processing errors

### DIFF
--- a/apps/web/app/(ee)/api/stripe/webhook/route.ts
+++ b/apps/web/app/(ee)/api/stripe/webhook/route.ts
@@ -83,8 +83,8 @@ export const POST = async (req: Request) => {
       message: `Stripe webhook failed (${event.type}). Error: ${error.message}`,
       type: "errors",
     });
-    return new Response(`Webhook error: ${error.message}`, {
-      status: 400,
+    return new Response("Webhook received (processing failed internally)", {
+      status: 200,
     });
   }
 


### PR DESCRIPTION
## Summary

Fixes #3752

The Stripe webhook handler at `apps/web/app/(ee)/api/stripe/webhook/route.ts` was returning HTTP 400 when downstream business logic (e.g., email send failures, transient DB issues) threw an error. Stripe interprets 4xx responses as a signal to retry the webhook delivery, which can cause unguarded retries of events like `checkout.session.completed` — potentially leading to double plan upgrades or duplicate processing.

## Changes

- Changed the error response status from `400` to `200` in the catch block so Stripe does not retry on internal processing failures
- Updated the response message to indicate the error was received but processing failed internally
- The existing `log()` call already handles error tracking, so no logging changes were needed

## Test Plan

- Verified that the only change is in the catch block response (2 lines)
- Error logging via `log()` remains unchanged — failures are still tracked internally
- Webhook signature verification errors (line 38-40) still correctly return 400 since those are genuine bad requests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Stripe webhook error handling to ensure consistent message delivery and processing reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->