### PR TITLE
feat(embed): add hidePayouts option to hide payout-related UI

### DIFF
--- a/apps/web/app/(ee)/app.dub.co/embed/referrals/earnings-summary.tsx
+++ b/apps/web/app/(ee)/app.dub.co/embed/referrals/earnings-summary.tsx
@@ -2,7 +2,11 @@ import { Button, InfoTooltip } from "@dub/ui";
 import { currencyFormatter } from "@dub/utils";
 import { useReferralsEmbedData } from "./page-client";
 
-export function ReferralsEmbedEarningsSummary() {
+export function ReferralsEmbedEarningsSummary({
+  hidePayouts,
+}: {
+  hidePayouts: boolean;
+}) {
   const { program, partner, earnings } = useReferralsEmbedData();
 
   return (
@@ -12,18 +16,20 @@ export function ReferralsEmbedEarningsSummary() {
           <p className="text-content-subtle text-sm">Earnings</p>
           <InfoTooltip content="Summary of your commission earnings from your referrals." />
         </div>
-        <a
-          href={`https://partners.dub.co/${program.slug}/register${
-            partner.email ? `?email=${partner.email}` : ""
-          }`}
-          target="_blank"
-        >
-          <Button
-            text="Settings"
-            variant="secondary"
-            className="h-7 p-2 text-sm"
-          />
-        </a>
+        {!hidePayouts && (
+          <a
+            href={`https://partners.dub.co/${program.slug}/register${
+              partner.email ? `?email=${partner.email}` : ""
+            }`}
+            target="_blank"
+          >
+            <Button
+              text="Settings"
+              variant="secondary"
+              className="h-7 p-2 text-sm"
+            />
+          </a>
+        )}
       </div>
       <div className="grid gap-1">
         {[

--- a/apps/web/app/(ee)/app.dub.co/embed/referrals/page-client.tsx
+++ b/apps/web/app/(ee)/app.dub.co/embed/referrals/page-client.tsx
@@ -283,7 +283,9 @@ export function ReferralsEmbedPageClient({
           </div>
           <div className="mt-4 grid gap-2 sm:h-32 sm:grid-cols-3">
             <ReferralsEmbedActivity />
-            <ReferralsEmbedEarningsSummary />
+            <ReferralsEmbedEarningsSummary
+              hidePayouts={programEmbedData?.hidePayouts ?? false}
+            />
           </div>
           <div className="mt-4">
             <div className="border-border-subtle flex items-center border-b">
@@ -330,6 +332,7 @@ export function ReferralsEmbedPageClient({
                   <ReferralsEmbedQuickstart
                     hasResources={hasResources}
                     setSelectedTab={setSelectedTab}
+                    hidePayouts={programEmbedData?.hidePayouts ?? false}
                   />
                 ) : selectedTab === "Bounties" ? (
                   <ReferralsEmbedBounties />

--- a/apps/web/app/(ee)/app.dub.co/embed/referrals/quickstart.tsx
+++ b/apps/web/app/(ee)/app.dub.co/embed/referrals/quickstart.tsx
@@ -21,9 +21,11 @@ const BUTTON_CLASSNAME =
 export function ReferralsEmbedQuickstart({
   hasResources,
   setSelectedTab,
+  hidePayouts,
 }: {
   hasResources: boolean;
   setSelectedTab: (tab: "Links" | "Resources") => void;
+  hidePayouts: boolean;
 }) {
   const { program, group, links, earnings } = useReferralsEmbedData();
 
@@ -99,26 +101,32 @@ export function ReferralsEmbedQuickstart({
         />
       ),
     },
-    {
-      title: "Receive earnings",
-      description:
-        "Connect payouts to get rewarded for the activity you drive, with earnings tracked automatically.",
-      illustration: <ConnectPayouts logo={group.logo ?? DUB_LOGO} />,
-      cta: (
-        <Button
-          className={payoutsDisabled ? "h-9 rounded-lg" : BUTTON_CLASSNAME}
-          disabledTooltip={
-            payoutsDisabled
-              ? "You will be able to withdraw your earnings once you have made at least one sale."
-              : undefined
-          }
-          onClick={() =>
-            window.open("https://partners.dub.co/payouts", "_blank")
-          }
-          text="Connect payouts"
-        />
-      ),
-    },
+    ...(!hidePayouts
+      ? [
+          {
+            title: "Receive earnings",
+            description:
+              "Connect payouts to get rewarded for the activity you drive, with earnings tracked automatically.",
+            illustration: <ConnectPayouts logo={group.logo ?? DUB_LOGO} />,
+            cta: (
+              <Button
+                className={
+                  payoutsDisabled ? "h-9 rounded-lg" : BUTTON_CLASSNAME
+                }
+                disabledTooltip={
+                  payoutsDisabled
+                    ? "You will be able to withdraw your earnings once you have made at least one sale."
+                    : undefined
+                }
+                onClick={() =>
+                  window.open("https://partners.dub.co/payouts", "_blank")
+                }
+                text="Connect payouts"
+              />
+            ),
+          },
+        ]
+      : []),
   ];
 
   return (

--- a/apps/web/lib/zod/schemas/program-embed.ts
+++ b/apps/web/lib/zod/schemas/program-embed.ts
@@ -10,5 +10,6 @@ export const programEmbedSchema = z
       })
       .nullish(),
     hidePoweredByBadge: z.boolean().default(false),
+    hidePayouts: z.boolean().default(false),
   })
   .nullish();


### PR DESCRIPTION
Closes #3774

Adds a `hidePayouts` boolean to `programEmbedData` schema (default: `false`).

When enabled:
- Removes 'Receive earnings' card from Quickstart
- Hides 'Settings' button in earnings summary

Useful for programs using `payoutMode: 'internal'` where rewards are credits/points, not cash payouts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option to control the visibility of payout-related elements within referral embeds. When enabled, this option hides the settings link in the earnings summary view and removes the earnings card from the quickstart section, providing more flexible embed customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->