### PR TITLE
feat(embed): configurable reward display (custom currency/units)

### DIFF
--- a/apps/web/app/(ee)/app.dub.co/embed/referrals/activity.tsx
+++ b/apps/web/app/(ee)/app.dub.co/embed/referrals/activity.tsx
@@ -1,16 +1,18 @@
 import { CursorRays } from "@/ui/layout/sidebar/icons/cursor-rays";
 import { InfoTooltip, MiniAreaChart } from "@dub/ui";
-import { cn, currencyFormatter, fetcher, nFormatter } from "@dub/utils";
+import { cn, fetcher, nFormatter } from "@dub/utils";
 import { AnalyticsTimeseries } from "dub/models/components";
 import { SVGProps, useId } from "react";
 import useSWR from "swr";
 import { useEmbedToken } from "../../embed/use-embed-token";
+import { formatReward } from "./format-reward";
 import { useReferralsEmbedData } from "./page-client";
 
 export function ReferralsEmbedActivity() {
   const {
     group: { brandColor: color },
     stats: { clicks, leads, sales, saleAmount },
+    rewardDisplay,
   } = useReferralsEmbedData();
 
   const token = useEmbedToken();
@@ -77,7 +79,7 @@ export function ReferralsEmbedActivity() {
                   {nFormatter(value, { full: true })}{" "}
                   {subValue || subValue === 0 ? (
                     <span className="text-content-subtle text-xs">
-                      ({currencyFormatter(subValue)})
+                      ({formatReward(subValue, rewardDisplay)})
                     </span>
                   ) : null}
                 </span>

--- a/apps/web/app/(ee)/app.dub.co/embed/referrals/earnings-summary.tsx
+++ b/apps/web/app/(ee)/app.dub.co/embed/referrals/earnings-summary.tsx
@@ -2,7 +2,11 @@ import { Button, InfoTooltip } from "@dub/ui";
 import { currencyFormatter } from "@dub/utils";
 import { useReferralsEmbedData } from "./page-client";
 
-export function ReferralsEmbedEarningsSummary() {
+export function ReferralsEmbedEarningsSummary({
+  hidePayouts,
+}: {
+  hidePayouts: boolean;
+}) {
   const { program, partner, earnings } = useReferralsEmbedData();
 
   return (
@@ -12,18 +16,20 @@ export function ReferralsEmbedEarningsSummary() {
           <p className="text-content-subtle text-sm">Earnings</p>
           <InfoTooltip content="Summary of your commission earnings from your referrals." />
         </div>
-        <a
-          href={`https://partners.dub.co/${program.slug}/register${
-            partner.email ? `?email=${partner.email}` : ""
-          }`}
-          target="_blank"
-        >
-          <Button
-            text="Settings"
-            variant="secondary"
-            className="h-7 p-2 text-sm"
-          />
-        </a>
+        {!hidePayouts && (
+          <a
+            href={`https://partners.dub.co/${program.slug}/register${
+              partner.email ? `?email=${partner.email}` : ""
+            }`}
+            target="_blank"
+          >
+            <Button
+              text="Settings"
+              variant="secondary"
+              className="h-7 p-2 text-sm"
+            />
+          </a>
+        )}
       </div>
       <div className="grid gap-1">
         {[

--- a/apps/web/app/(ee)/app.dub.co/embed/referrals/earnings-summary.tsx
+++ b/apps/web/app/(ee)/app.dub.co/embed/referrals/earnings-summary.tsx
@@ -1,5 +1,5 @@
 import { Button, InfoTooltip } from "@dub/ui";
-import { currencyFormatter } from "@dub/utils";
+import { formatReward } from "./format-reward";
 import { useReferralsEmbedData } from "./page-client";
 
 export function ReferralsEmbedEarningsSummary({
@@ -7,7 +7,8 @@ export function ReferralsEmbedEarningsSummary({
 }: {
   hidePayouts: boolean;
 }) {
-  const { program, partner, earnings } = useReferralsEmbedData();
+  const { program, partner, earnings, rewardDisplay } =
+    useReferralsEmbedData();
 
   return (
     <div className="border-border-subtle bg-bg-default flex flex-col justify-between gap-4 rounded-lg border p-4">
@@ -45,7 +46,7 @@ export function ReferralsEmbedEarningsSummary({
           <div key={label} className="flex justify-between text-sm">
             <span className="text-content-subtle font-medium">{label}</span>
             <span className="text-content-default font-semibold">
-              {currencyFormatter(value)}
+              {formatReward(value, rewardDisplay)}
             </span>
           </div>
         ))}

--- a/apps/web/app/(ee)/app.dub.co/embed/referrals/earnings.tsx
+++ b/apps/web/app/(ee)/app.dub.co/embed/referrals/earnings.tsx
@@ -10,7 +10,6 @@ import {
   useTable,
 } from "@dub/ui";
 import {
-  currencyFormatter,
   fetcher,
   formatDate,
   formatDateTime,
@@ -18,12 +17,14 @@ import {
 import { motion } from "motion/react";
 import useSWR from "swr";
 import { useEmbedToken } from "../../embed/use-embed-token";
+import { formatReward } from "./format-reward";
 import { useReferralsEmbedData } from "./page-client";
 
 export function ReferralsEmbedEarnings() {
   const token = useEmbedToken();
   const {
     earnings: { totalCount: earningsCount },
+    rewardDisplay,
   } = useReferralsEmbedData();
 
   const { pagination, setPagination } = usePagination(
@@ -66,7 +67,7 @@ export function ReferralsEmbedEarnings() {
         id: "amount",
         header: "Amount",
         cell: ({ row }) => {
-          return currencyFormatter(row.original.amount);
+          return formatReward(row.original.amount, rewardDisplay);
         },
       },
       {
@@ -74,7 +75,7 @@ export function ReferralsEmbedEarnings() {
         header: "Earnings",
         accessorKey: "earnings",
         cell: ({ row }) => {
-          return currencyFormatter(row.original.earnings);
+          return formatReward(row.original.earnings, rewardDisplay);
         },
       },
       {

--- a/apps/web/app/(ee)/app.dub.co/embed/referrals/format-reward.ts
+++ b/apps/web/app/(ee)/app.dub.co/embed/referrals/format-reward.ts
@@ -1,0 +1,23 @@
+import { currencyFormatter, nFormatter } from "@dub/utils";
+
+export type RewardDisplayConfig = {
+  mode: "currency" | "custom";
+  suffix: string;
+  compact: boolean;
+} | null;
+
+export function formatReward(
+  amountInCents: number,
+  config: RewardDisplayConfig,
+): string {
+  if (!config || config.mode === "currency") {
+    return currencyFormatter(amountInCents);
+  }
+
+  const value = amountInCents / 100;
+  const formatted = config.compact
+    ? nFormatter(value, { full: value < 1000 })
+    : value.toLocaleString();
+
+  return `${formatted}${config.suffix}`;
+}

--- a/apps/web/app/(ee)/app.dub.co/embed/referrals/leaderboard.tsx
+++ b/apps/web/app/(ee)/app.dub.co/embed/referrals/leaderboard.tsx
@@ -10,15 +10,18 @@ import {
   Users,
   useTable,
 } from "@dub/ui";
-import { currencyFormatter, fetcher } from "@dub/utils";
+import { fetcher } from "@dub/utils";
 import { cn } from "@dub/utils/src/functions";
 import { motion } from "motion/react";
 import useSWR from "swr";
 import * as z from "zod/v4";
 import { useEmbedToken } from "../../embed/use-embed-token";
+import { formatReward } from "./format-reward";
+import { useReferralsEmbedData } from "./page-client";
 
 export function ReferralsEmbedLeaderboard() {
   const token = useEmbedToken();
+  const { rewardDisplay } = useReferralsEmbedData();
 
   const { data: partners, isLoading } = useSWR<
     z.infer<typeof LeaderboardPartnerSchema>[]
@@ -81,7 +84,7 @@ export function ReferralsEmbedLeaderboard() {
         id: "totalCommissions",
         header: "Earnings",
         cell: ({ row }) => {
-          return currencyFormatter(row.original.totalCommissions);
+          return formatReward(row.original.totalCommissions, rewardDisplay);
         },
       },
     ],

--- a/apps/web/app/(ee)/app.dub.co/embed/referrals/links-list.tsx
+++ b/apps/web/app/(ee)/app.dub.co/embed/referrals/links-list.tsx
@@ -10,7 +10,6 @@ import {
 } from "@dub/ui";
 import { ArrowTurnRight2, Pen2, Plus2 } from "@dub/ui/icons";
 import {
-  currencyFormatter,
   fetcher,
   getApexDomain,
   getPrettyUrl,
@@ -20,6 +19,7 @@ import { motion } from "motion/react";
 import { useEffect, useState } from "react";
 import useSWR from "swr";
 import { useEmbedToken } from "../use-embed-token";
+import { formatReward } from "./format-reward";
 import { useReferralsEmbedData } from "./page-client";
 import { ReferralsEmbedLink } from "./types";
 
@@ -30,7 +30,7 @@ interface Props {
 
 export function ReferralsEmbedLinksList({ onCreateLink, onEditLink }: Props) {
   const token = useEmbedToken();
-  const { links, program, group } = useReferralsEmbedData();
+  const { links, program, group, rewardDisplay } = useReferralsEmbedData();
   const [partnerLinks, setPartnerLinks] = useState<ReferralsEmbedLink[]>(links);
 
   const { data: refreshedLinks, isLoading } = useSWR<ReferralsEmbedLink[]>(
@@ -123,7 +123,7 @@ export function ReferralsEmbedLinksList({ onCreateLink, onEditLink }: Props) {
         header: "Sales",
         minSize: 80,
         maxSize: 100,
-        cell: ({ row }) => currencyFormatter(row.original.saleAmount),
+        cell: ({ row }) => formatReward(row.original.saleAmount, rewardDisplay),
       },
       {
         id: "actions",

--- a/apps/web/app/(ee)/app.dub.co/embed/referrals/page-client.tsx
+++ b/apps/web/app/(ee)/app.dub.co/embed/referrals/page-client.tsx
@@ -52,6 +52,7 @@ import { ReferralsEmbedQuickstart } from "./quickstart";
 import { ReferralsEmbedResources } from "./resources";
 import { ThemeOptions } from "./theme-options";
 import { ReferralsReferralsEmbedToken } from "./token";
+import { RewardDisplayConfig } from "./format-reward";
 import { ReferralsEmbedLink } from "./types";
 
 type ReferralsEmbedData = {
@@ -99,6 +100,7 @@ type ReferralsEmbedData = {
     saleAmount: number;
   };
   bounties: PartnerBountyProps[];
+  rewardDisplay: RewardDisplayConfig;
 };
 
 type ReferralsEmbedPageClientProps = ReferralsEmbedData & {
@@ -197,6 +199,9 @@ export function ReferralsEmbedPageClient({
     if (!tabs.includes(selectedTab)) setSelectedTab(tabs[0]);
   }, [tabs, selectedTab]);
 
+  const rewardDisplay: RewardDisplayConfig =
+    programEmbedData?.rewardDisplay ?? null;
+
   const embedData = useMemo(
     () => ({
       program,
@@ -210,6 +215,7 @@ export function ReferralsEmbedPageClient({
       programEnrollment,
       group,
       bounties,
+      rewardDisplay,
     }),
     [
       program,
@@ -223,6 +229,7 @@ export function ReferralsEmbedPageClient({
       programEnrollment,
       group,
       bounties,
+      rewardDisplay,
     ],
   );
 

--- a/apps/web/app/(ee)/app.dub.co/embed/referrals/page-client.tsx
+++ b/apps/web/app/(ee)/app.dub.co/embed/referrals/page-client.tsx
@@ -283,7 +283,9 @@ export function ReferralsEmbedPageClient({
           </div>
           <div className="mt-4 grid gap-2 sm:h-32 sm:grid-cols-3">
             <ReferralsEmbedActivity />
-            <ReferralsEmbedEarningsSummary />
+            <ReferralsEmbedEarningsSummary
+              hidePayouts={programEmbedData?.hidePayouts ?? false}
+            />
           </div>
           <div className="mt-4">
             <div className="border-border-subtle flex items-center border-b">
@@ -330,6 +332,7 @@ export function ReferralsEmbedPageClient({
                   <ReferralsEmbedQuickstart
                     hasResources={hasResources}
                     setSelectedTab={setSelectedTab}
+                    hidePayouts={programEmbedData?.hidePayouts ?? false}
                   />
                 ) : selectedTab === "Bounties" ? (
                   <ReferralsEmbedBounties />

--- a/apps/web/app/(ee)/app.dub.co/embed/referrals/quickstart.tsx
+++ b/apps/web/app/(ee)/app.dub.co/embed/referrals/quickstart.tsx
@@ -21,9 +21,11 @@ const BUTTON_CLASSNAME =
 export function ReferralsEmbedQuickstart({
   hasResources,
   setSelectedTab,
+  hidePayouts,
 }: {
   hasResources: boolean;
   setSelectedTab: (tab: "Links" | "Resources") => void;
+  hidePayouts: boolean;
 }) {
   const { program, group, links, earnings } = useReferralsEmbedData();
 
@@ -99,26 +101,32 @@ export function ReferralsEmbedQuickstart({
         />
       ),
     },
-    {
-      title: "Receive earnings",
-      description:
-        "Connect payouts to get rewarded for the activity you drive, with earnings tracked automatically.",
-      illustration: <ConnectPayouts logo={group.logo ?? DUB_LOGO} />,
-      cta: (
-        <Button
-          className={payoutsDisabled ? "h-9 rounded-lg" : BUTTON_CLASSNAME}
-          disabledTooltip={
-            payoutsDisabled
-              ? "You will be able to withdraw your earnings once you have made at least one sale."
-              : undefined
-          }
-          onClick={() =>
-            window.open("https://partners.dub.co/payouts", "_blank")
-          }
-          text="Connect payouts"
-        />
-      ),
-    },
+    ...(!hidePayouts
+      ? [
+          {
+            title: "Receive earnings",
+            description:
+              "Connect payouts to get rewarded for the activity you drive, with earnings tracked automatically.",
+            illustration: <ConnectPayouts logo={group.logo ?? DUB_LOGO} />,
+            cta: (
+              <Button
+                className={
+                  payoutsDisabled ? "h-9 rounded-lg" : BUTTON_CLASSNAME
+                }
+                disabledTooltip={
+                  payoutsDisabled
+                    ? "You will be able to withdraw your earnings once you have made at least one sale."
+                    : undefined
+                }
+                onClick={() =>
+                  window.open("https://partners.dub.co/payouts", "_blank")
+                }
+                text="Connect payouts"
+              />
+            ),
+          },
+        ]
+      : []),
   ];
 
   return (

--- a/apps/web/lib/zod/schemas/program-embed.ts
+++ b/apps/web/lib/zod/schemas/program-embed.ts
@@ -11,5 +11,12 @@ export const programEmbedSchema = z
       .nullish(),
     hidePoweredByBadge: z.boolean().default(false),
     hidePayouts: z.boolean().default(false),
+    rewardDisplay: z
+      .object({
+        mode: z.enum(["currency", "custom"]).default("currency"),
+        suffix: z.string().default(""),
+        compact: z.boolean().default(false),
+      })
+      .nullish(),
   })
   .nullish();

--- a/apps/web/lib/zod/schemas/program-embed.ts
+++ b/apps/web/lib/zod/schemas/program-embed.ts
@@ -10,5 +10,6 @@ export const programEmbedSchema = z
       })
       .nullish(),
     hidePoweredByBadge: z.boolean().default(false),
+    hidePayouts: z.boolean().default(false),
   })
   .nullish();


### PR DESCRIPTION
Closes #3775

Adds a `rewardDisplay` option to `programEmbedData`:

```json
{
  "rewardDisplay": {
    "mode": "custom",
    "suffix": " credits",
    "compact": true
  }
}
```

When `mode: "custom"`, replaces `currencyFormatter()` with a configurable formatter throughout the embed.
Example: `22k credits` instead of `$220.00`.

Default behavior unchanged (`mode: "currency"` or omitted) — no existing embeds are affected.

**Files changed (8):**
- Schema: added `rewardDisplay` to `programEmbedSchema`
- New helper: `format-reward.ts` — delegates to `currencyFormatter` by default, custom format when configured
- Updated 5 embed files to use `formatReward()` instead of `currencyFormatter()` directly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new reward display configuration option for flexible earnings formatting, supporting standard currency mode and custom mode with suffix and compact display options
  * Added hidePayouts configuration to conditionally display payout-related settings in the referral interface
  * Applied new reward formatting consistently across earnings summary, activity, leaderboard, and links components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->