### PR TITLE
feat: Add custom reward display configuration for embed

### DIFF
--- a/apps/web/app/(ee)/app.dub.co/embed/referrals/activity.tsx
+++ b/apps/web/app/(ee)/app.dub.co/embed/referrals/activity.tsx
@@ -1,6 +1,6 @@
 import { CursorRays } from "@/ui/layout/sidebar/icons/cursor-rays";
 import { InfoTooltip, MiniAreaChart } from "@dub/ui";
-import { cn, currencyFormatter, fetcher, nFormatter } from "@dub/utils";
+import { cn, fetcher, nFormatter, rewardFormatter } from "@dub/utils";
 import { AnalyticsTimeseries } from "dub/models/components";
 import { SVGProps, useId } from "react";
 import useSWR from "swr";
@@ -11,6 +11,7 @@ export function ReferralsEmbedActivity() {
   const {
     group: { brandColor: color },
     stats: { clicks, leads, sales, saleAmount },
+    programEmbedData,
   } = useReferralsEmbedData();
 
   const token = useEmbedToken();
@@ -37,6 +38,8 @@ export function ReferralsEmbedActivity() {
       dedupingInterval: 60000,
     },
   );
+
+  const rewardDisplayOptions = programEmbedData?.rewardDisplay ?? undefined;
 
   return (
     <div className="border-border-subtle bg-bg-default rounded-lg border sm:col-span-2">
@@ -77,7 +80,7 @@ export function ReferralsEmbedActivity() {
                   {nFormatter(value, { full: true })}{" "}
                   {subValue || subValue === 0 ? (
                     <span className="text-content-subtle text-xs">
-                      ({currencyFormatter(subValue)})
+                      ({rewardFormatter(subValue, rewardDisplayOptions)})
                     </span>
                   ) : null}
                 </span>

--- a/apps/web/app/(ee)/app.dub.co/embed/referrals/bounties/performance-section.tsx
+++ b/apps/web/app/(ee)/app.dub.co/embed/referrals/bounties/performance-section.tsx
@@ -22,17 +22,18 @@ import {
 import { Areas, TimeSeriesChart, XAxis } from "@dub/ui/charts";
 import {
   cn,
-  currencyFormatter,
   fetcher,
   formatDateTimeSmart,
   getApexDomain,
   getPrettyUrl,
   nFormatter,
+  rewardFormatter,
 } from "@dub/utils";
 import { ColumnDef } from "@tanstack/react-table";
 import { useMemo, useState } from "react";
 import useSWR from "swr";
 import { useEmbedToken } from "../../use-embed-token";
+import { useReferralsEmbedData } from "../page-client";
 
 type PerformanceAttribute = keyof typeof PERFORMANCE_BOUNTY_SCOPE_ATTRIBUTES;
 
@@ -125,11 +126,14 @@ function EmbedBountyPerformanceChart({
   programEnrollment: Pick<ProgramEnrollmentProps, "createdAt">;
 }) {
   const token = useEmbedToken();
+  const { programEmbedData } = useReferralsEmbedData();
   const attribute = bounty.performanceCondition?.attribute as
     | PerformanceAttribute
     | undefined;
   const isCurrency = attribute ? isCurrencyAttribute(attribute) : false;
   const isCommissions = attribute === "totalCommissions";
+
+  const rewardDisplayOptions = programEmbedData?.rewardDisplay ?? undefined;
 
   const startDate = useMemo(
     () =>
@@ -246,7 +250,7 @@ function EmbedBountyPerformanceChart({
               </span>
               <p className="text-content-subtle text-right">
                 {isCurrency
-                  ? currencyFormatter(d.values.main)
+                  ? rewardFormatter(d.values.main, rewardDisplayOptions)
                   : nFormatter(d.values.main)}
               </p>
             </div>
@@ -472,7 +476,7 @@ function EmbedBountyEventsTable({
         id: "amount",
         header: "Amount",
         accessorKey: "amount",
-        cell: ({ row }) => currencyFormatter(row.original.amount ?? 0),
+        cell: ({ row }) => rewardFormatter(row.original.amount ?? 0, rewardDisplayOptions),
       });
     }
 
@@ -522,7 +526,10 @@ function EmbedBountyCommissionsTable({
   programEnrollment: Pick<ProgramEnrollmentProps, "createdAt">;
 }) {
   const token = useEmbedToken();
+  const { programEmbedData } = useReferralsEmbedData();
   const [page, setPage] = useState(1);
+
+  const rewardDisplayOptions = programEmbedData?.rewardDisplay ?? undefined;
 
   const { pagination, setPagination } = useTablePagination({
     pageSize: PAGE_SIZE,
@@ -646,7 +653,7 @@ function EmbedBountyCommissionsTable({
         id: "earnings",
         header: "Earnings",
         accessorKey: "amount",
-        cell: ({ row }) => currencyFormatter(row.original.amount ?? 0),
+        cell: ({ row }) => rewardFormatter(row.original.amount ?? 0, rewardDisplayOptions),
       },
     ],
     [],

--- a/apps/web/app/(ee)/app.dub.co/embed/referrals/earnings-summary.tsx
+++ b/apps/web/app/(ee)/app.dub.co/embed/referrals/earnings-summary.tsx
@@ -1,9 +1,12 @@
 import { Button, InfoTooltip } from "@dub/ui";
-import { currencyFormatter } from "@dub/utils";
+import { rewardFormatter } from "@dub/utils";
 import { useReferralsEmbedData } from "./page-client";
 
 export function ReferralsEmbedEarningsSummary() {
-  const { program, partner, earnings } = useReferralsEmbedData();
+  const { program, partner, earnings, programEmbedData } =
+    useReferralsEmbedData();
+
+  const rewardDisplayOptions = programEmbedData?.rewardDisplay ?? undefined;
 
   return (
     <div className="border-border-subtle bg-bg-default flex flex-col justify-between gap-4 rounded-lg border p-4">
@@ -39,7 +42,7 @@ export function ReferralsEmbedEarningsSummary() {
           <div key={label} className="flex justify-between text-sm">
             <span className="text-content-subtle font-medium">{label}</span>
             <span className="text-content-default font-semibold">
-              {currencyFormatter(value)}
+              {rewardFormatter(value, rewardDisplayOptions)}
             </span>
           </div>
         ))}

--- a/apps/web/app/(ee)/app.dub.co/embed/referrals/earnings.tsx
+++ b/apps/web/app/(ee)/app.dub.co/embed/referrals/earnings.tsx
@@ -10,10 +10,10 @@ import {
   useTable,
 } from "@dub/ui";
 import {
-  currencyFormatter,
   fetcher,
   formatDate,
   formatDateTime,
+  rewardFormatter,
 } from "@dub/utils";
 import { motion } from "motion/react";
 import useSWR from "swr";
@@ -24,7 +24,10 @@ export function ReferralsEmbedEarnings() {
   const token = useEmbedToken();
   const {
     earnings: { totalCount: earningsCount },
+    programEmbedData,
   } = useReferralsEmbedData();
+
+  const rewardDisplayOptions = programEmbedData?.rewardDisplay ?? undefined;
 
   const { pagination, setPagination } = usePagination(
     REFERRALS_EMBED_EARNINGS_LIMIT,
@@ -66,7 +69,7 @@ export function ReferralsEmbedEarnings() {
         id: "amount",
         header: "Amount",
         cell: ({ row }) => {
-          return currencyFormatter(row.original.amount);
+          return rewardFormatter(row.original.amount, rewardDisplayOptions);
         },
       },
       {
@@ -74,7 +77,7 @@ export function ReferralsEmbedEarnings() {
         header: "Earnings",
         accessorKey: "earnings",
         cell: ({ row }) => {
-          return currencyFormatter(row.original.earnings);
+          return rewardFormatter(row.original.earnings, rewardDisplayOptions);
         },
       },
       {

--- a/apps/web/app/(ee)/app.dub.co/embed/referrals/leaderboard.tsx
+++ b/apps/web/app/(ee)/app.dub.co/embed/referrals/leaderboard.tsx
@@ -10,15 +10,19 @@ import {
   Users,
   useTable,
 } from "@dub/ui";
-import { currencyFormatter, fetcher } from "@dub/utils";
+import { fetcher, rewardFormatter } from "@dub/utils";
 import { cn } from "@dub/utils/src/functions";
 import { motion } from "motion/react";
 import useSWR from "swr";
 import * as z from "zod/v4";
 import { useEmbedToken } from "../../embed/use-embed-token";
+import { useReferralsEmbedData } from "./page-client";
 
 export function ReferralsEmbedLeaderboard() {
   const token = useEmbedToken();
+  const { programEmbedData } = useReferralsEmbedData();
+
+  const rewardDisplayOptions = programEmbedData?.rewardDisplay ?? undefined;
 
   const { data: partners, isLoading } = useSWR<
     z.infer<typeof LeaderboardPartnerSchema>[]
@@ -81,7 +85,7 @@ export function ReferralsEmbedLeaderboard() {
         id: "totalCommissions",
         header: "Earnings",
         cell: ({ row }) => {
-          return currencyFormatter(row.original.totalCommissions);
+          return rewardFormatter(row.original.totalCommissions, rewardDisplayOptions);
         },
       },
     ],

--- a/apps/web/app/(ee)/app.dub.co/embed/referrals/links-list.tsx
+++ b/apps/web/app/(ee)/app.dub.co/embed/referrals/links-list.tsx
@@ -10,11 +10,11 @@ import {
 } from "@dub/ui";
 import { ArrowTurnRight2, Pen2, Plus2 } from "@dub/ui/icons";
 import {
-  currencyFormatter,
   fetcher,
   getApexDomain,
   getPrettyUrl,
   nFormatter,
+  rewardFormatter,
 } from "@dub/utils";
 import { motion } from "motion/react";
 import { useEffect, useState } from "react";
@@ -30,8 +30,10 @@ interface Props {
 
 export function ReferralsEmbedLinksList({ onCreateLink, onEditLink }: Props) {
   const token = useEmbedToken();
-  const { links, program, group } = useReferralsEmbedData();
+  const { links, program, group, programEmbedData } = useReferralsEmbedData();
   const [partnerLinks, setPartnerLinks] = useState<ReferralsEmbedLink[]>(links);
+
+  const rewardDisplayOptions = programEmbedData?.rewardDisplay ?? undefined;
 
   const { data: refreshedLinks, isLoading } = useSWR<ReferralsEmbedLink[]>(
     "/api/embed/referrals/links",
@@ -123,7 +125,7 @@ export function ReferralsEmbedLinksList({ onCreateLink, onEditLink }: Props) {
         header: "Sales",
         minSize: 80,
         maxSize: 100,
-        cell: ({ row }) => currencyFormatter(row.original.saleAmount),
+        cell: ({ row }) => rewardFormatter(row.original.saleAmount, rewardDisplayOptions),
       },
       {
         id: "actions",

--- a/apps/web/app/(ee)/app.dub.co/embed/referrals/page-client.tsx
+++ b/apps/web/app/(ee)/app.dub.co/embed/referrals/page-client.tsx
@@ -99,6 +99,7 @@ type ReferralsEmbedData = {
     saleAmount: number;
   };
   bounties: PartnerBountyProps[];
+  programEmbedData: z.infer<typeof programEmbedSchema>;
 };
 
 type ReferralsEmbedPageClientProps = ReferralsEmbedData & {
@@ -210,6 +211,7 @@ export function ReferralsEmbedPageClient({
       programEnrollment,
       group,
       bounties,
+      programEmbedData,
     }),
     [
       program,
@@ -223,6 +225,7 @@ export function ReferralsEmbedPageClient({
       programEnrollment,
       group,
       bounties,
+      programEmbedData,
     ],
   );
 

--- a/apps/web/lib/zod/schemas/program-embed.ts
+++ b/apps/web/lib/zod/schemas/program-embed.ts
@@ -10,5 +10,14 @@ export const programEmbedSchema = z
       })
       .nullish(),
     hidePoweredByBadge: z.boolean().default(false),
+    rewardDisplay: z
+      .object({
+        mode: z.enum(["currency", "custom"]).default("currency"),
+        prefix: z.string().default(""),
+        suffix: z.string().default(""),
+        divisor: z.number().positive().default(100),
+        compact: z.boolean().default(false),
+      })
+      .nullish(),
   })
   .nullish();

--- a/packages/utils/src/functions/index.ts
+++ b/packages/utils/src/functions/index.ts
@@ -34,6 +34,7 @@ export * from "./punycode";
 export * from "./random-value";
 export * from "./regex-escape";
 export * from "./resize-image";
+export * from "./reward-formatter";
 export * from "./smart-truncate";
 export * from "./stable-sort";
 export * from "./text-fetcher";

--- a/packages/utils/src/functions/reward-formatter.ts
+++ b/packages/utils/src/functions/reward-formatter.ts
@@ -1,0 +1,48 @@
+import { currencyFormatter } from "./currency-formatter";
+import { nFormatter } from "./nformatter";
+
+export interface RewardDisplayOptions {
+  mode?: "currency" | "custom";
+  prefix?: string;
+  suffix?: string;
+  divisor?: number;
+  compact?: boolean;
+}
+
+/**
+ * Formats a reward amount in cents based on the display options.
+ * 
+ * @param valueInCents - The reward amount in cents
+ * @param options - Display options for formatting
+ * @returns Formatted reward string
+ */
+export const rewardFormatter = (
+  valueInCents: number | bigint,
+  options?: RewardDisplayOptions,
+): string => {
+  // Default to currency mode if no options provided
+  if (!options || options.mode === "currency") {
+    return currencyFormatter(valueInCents);
+  }
+
+  // Custom mode
+  const cents = typeof valueInCents === "bigint" ? Number(valueInCents) : valueInCents;
+  const divisor = options.divisor ?? 100;
+  const value = cents / divisor;
+  
+  // Format the number
+  let formattedValue: string;
+  
+  if (options.compact) {
+    // Use compact notation (e.g., 22k instead of 22000)
+    formattedValue = nFormatter(value, { digits: 1 });
+  } else {
+    // Use standard number formatting
+    formattedValue = new Intl.NumberFormat("en-US", {
+      maximumFractionDigits: 2,
+      minimumFractionDigits: value % 1 === 0 ? 0 : 2,
+    }).format(value);
+  }
+  
+  return `${options.prefix ?? ""}${formattedValue}${options.suffix ?? ""}`;
+};


### PR DESCRIPTION
## Summary

This PR adds a `rewardDisplay` option to the program embed configuration, allowing programs to customize how reward amounts are rendered in the embed UI.

## Changes

- Added `rewardDisplay` configuration to `programEmbedSchema` with options:
  - `mode`: "currency" (default) | "custom"
  - `prefix`: string (e.g., "")
  - `suffix`: string (e.g., " credits")
  - `divisor`: number (default: 100, for cents to units conversion)
  - `compact`: boolean (e.g., "22k" vs "22000")

- Created `rewardFormatter` utility function that respects the display configuration
- Updated all embed components to use `rewardFormatter` instead of `currencyFormatter`:
  - activity.tsx
  - earnings-summary.tsx
  - earnings.tsx
  - leaderboard.tsx
  - links-list.tsx
  - bounties/performance-section.tsx

## Usage Example

```json
{
  "rewardDisplay": {
    "mode": "custom",
    "prefix": "",
    "suffix": " credits",
    "divisor": 100,
    "compact": true
  }
}
```

This would display `$220.00` as "2.2k credits" instead.

Closes #3775

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable reward display formatting for referral embeds, supporting multiple display modes (currency and custom).
  * Rewards can now be displayed with custom prefixes, suffixes, divisors, and compact formatting across all referral pages.

* **Documentation**
  * Extended program embed schema with new `rewardDisplay` configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->