### PR TITLE
Consolidate `partnerDuplicatePayoutMethod` into `partnerDuplicateAccount`

### DIFF
--- a/apps/web/app/(ee)/api/cron/partners/merge-accounts/route.ts
+++ b/apps/web/app/(ee)/api/cron/partners/merge-accounts/route.ts
@@ -346,7 +346,7 @@ export async function POST(req: Request) {
       where: {
         partnerId: sourcePartnerId,
         fraudEventGroup: {
-          type: FraudRuleType.partnerDuplicatePayoutMethod,
+          type: FraudRuleType.partnerDuplicateAccount,
         },
       },
       include: {
@@ -395,7 +395,7 @@ export async function POST(req: Request) {
               ]
             : []),
         ],
-        type: FraudRuleType.partnerDuplicatePayoutMethod,
+        type: FraudRuleType.partnerDuplicateAccount,
       },
       resolutionReason:
         "Automatically resolved because partners with duplicate payout methods were merged. No other partners share this payout method.",

--- a/apps/web/lib/api/fraud/constants.ts
+++ b/apps/web/lib/api/fraud/constants.ts
@@ -48,23 +48,13 @@ export const FRAUD_RULES: FraudRuleInfo[] = [
     configurable: true,
   },
   {
-    type: "partnerDuplicatePayoutMethod",
+    type: "partnerDuplicateAccount",
     name: "Duplicate account detected",
     description:
       "This partner was flagged by our system for having 2 or more Dub accounts. Please review to prevent abuse of program restrictions, caps, or bonuses.",
     scope: "partner",
     severity: "high",
     configurable: true,
-  },
-  // Not visible in the UI
-  {
-    type: "partnerDuplicateAccount",
-    name: "Duplicate account detected",
-    description:
-      "This partner was flagged by our system for having 2 or more Dub accounts. Please review to prevent abuse of program restrictions, caps, or bonuses.",
-    scope: "partner",
-    severity: "low",
-    configurable: false,
   },
   {
     type: "partnerEmailDomainMismatch",

--- a/apps/web/lib/api/fraud/detect-duplicate-identity-fraud.ts
+++ b/apps/web/lib/api/fraud/detect-duplicate-identity-fraud.ts
@@ -72,7 +72,7 @@ export async function detectDuplicateIdentityFraud({
   programEnrollments = programEnrollments.filter((enrollment) =>
     isFraudRuleEnabled({
       fraudRules: enrollment.program.fraudRules,
-      ruleType: FraudRuleType.partnerDuplicatePayoutMethod, // TODO: Change to partnerDuplicateAccount
+      ruleType: FraudRuleType.partnerDuplicateAccount,
     }),
   );
 

--- a/apps/web/lib/api/fraud/detect-duplicate-payout-method-fraud.ts
+++ b/apps/web/lib/api/fraud/detect-duplicate-payout-method-fraud.ts
@@ -44,11 +44,11 @@ export async function detectDuplicatePayoutMethodFraud({
     return;
   }
 
-  // Filter out program enrollments where the partnerDuplicatePayoutMethod rule is disabled
+  // Filter out program enrollments where the partnerDuplicateAccount rule is disabled
   programEnrollments = programEnrollments.filter((enrollment) =>
     isFraudRuleEnabled({
       fraudRules: enrollment.program.fraudRules,
-      ruleType: FraudRuleType.partnerDuplicatePayoutMethod,
+      ruleType: FraudRuleType.partnerDuplicateAccount,
     }),
   );
 
@@ -89,7 +89,7 @@ export async function detectDuplicatePayoutMethodFraud({
         fraudEvents.push({
           programId,
           partnerId: sourcePartner.partnerId,
-          type: FraudRuleType.partnerDuplicatePayoutMethod,
+          type: FraudRuleType.partnerDuplicateAccount,
           metadata: {
             ...(payoutMethodHash ? { payoutMethodHash } : {}),
             ...(cryptoWalletAddress ? { cryptoWalletAddress } : {}),

--- a/apps/web/lib/api/fraud/detect-record-fraud-application.ts
+++ b/apps/web/lib/api/fraud/detect-record-fraud-application.ts
@@ -33,7 +33,7 @@ export async function detectAndRecordFraudApplication({
   if (
     isFraudRuleEnabled({
       fraudRules,
-      ruleType: FraudRuleType.partnerDuplicatePayoutMethod,
+      ruleType: FraudRuleType.partnerDuplicateAccount,
     })
   ) {
     const { payoutMethodHash, cryptoWalletAddress } = partner;
@@ -81,7 +81,7 @@ export async function detectAndRecordFraudApplication({
             fraudEvents.push({
               programId: program.id,
               partnerId: sourcePartner.id,
-              type: FraudRuleType.partnerDuplicatePayoutMethod,
+              type: FraudRuleType.partnerDuplicateAccount,
               metadata: {
                 ...(payoutMethodHash ? { payoutMethodHash } : {}),
                 ...(cryptoWalletAddress ? { cryptoWalletAddress } : {}),

--- a/apps/web/lib/api/fraud/get-partner-application-risks.ts
+++ b/apps/web/lib/api/fraud/get-partner-application-risks.ts
@@ -21,7 +21,7 @@ export async function getPartnerApplicationRisks({
       partnerId: partner.id,
       status: "pending",
       type: {
-        in: ["partnerCrossProgramBan", "partnerDuplicatePayoutMethod"],
+        in: ["partnerCrossProgramBan", "partnerDuplicateAccount"],
       },
     },
   });
@@ -30,13 +30,13 @@ export async function getPartnerApplicationRisks({
     (group) => group.type === "partnerCrossProgramBan",
   );
 
-  const hasDuplicatePayoutMethod = fraudGroups.some(
-    (group) => group.type === "partnerDuplicatePayoutMethod",
+  const hasDuplicateAccounts = fraudGroups.some(
+    (group) => group.type === "partnerDuplicateAccount",
   );
 
   const risksDetected: Partial<Record<ExtendedFraudRuleType, boolean>> = {
     partnerCrossProgramBan: hasCrossProgramBan,
-    partnerDuplicatePayoutMethod: hasDuplicatePayoutMethod,
+    partnerDuplicateAccount: hasDuplicateAccounts,
     partnerEmailDomainMismatch: checkPartnerEmailDomainMismatch(partner),
     partnerEmailMasked: checkPartnerEmailMasked(partner),
     partnerNoSocialLinks: checkPartnerNoSocialLinks(partner),

--- a/apps/web/lib/api/fraud/utils.ts
+++ b/apps/web/lib/api/fraud/utils.ts
@@ -94,6 +94,7 @@ function getIdentityFieldsForFraudEvent({
         duplicatePartnerId: eventMetadata?.duplicatePartnerId,
       };
 
+    // Note: This will be removed in the next PR
     case "partnerDuplicatePayoutMethod":
       throw new Error("Fraud rule is no longer supported.");
 

--- a/apps/web/lib/api/fraud/utils.ts
+++ b/apps/web/lib/api/fraud/utils.ts
@@ -89,11 +89,13 @@ function getIdentityFieldsForFraudEvent({
         customerId,
       };
 
-    case "partnerDuplicatePayoutMethod":
     case "partnerDuplicateAccount":
       return {
         duplicatePartnerId: eventMetadata?.duplicatePartnerId,
       };
+
+    case "partnerDuplicatePayoutMethod":
+      throw new Error("Fraud rule is no longer supported.");
 
     case "partnerCrossProgramBan":
       if (!sourceProgramId) {
@@ -136,10 +138,7 @@ export function getPartnerIdForFraudEvent(
 ) {
   const metadata = event.metadata as Record<string, string> | undefined;
 
-  if (
-    event.type === "partnerDuplicatePayoutMethod" ||
-    event.type === "partnerDuplicateAccount"
-  ) {
+  if (event.type === "partnerDuplicateAccount") {
     return metadata?.duplicatePartnerId ?? event.partnerId;
   }
 

--- a/apps/web/lib/zod/schemas/fraud.ts
+++ b/apps/web/lib/zod/schemas/fraud.ts
@@ -251,7 +251,6 @@ export const updateFraudRuleSettingsSchema = z.object({
   customerEmailMatch: toggleOnlyFraudRuleSchema,
   customerEmailSuspiciousDomain: toggleOnlyFraudRuleSchema,
   partnerCrossProgramBan: toggleOnlyFraudRuleSchema,
-  partnerDuplicatePayoutMethod: toggleOnlyFraudRuleSchema,
   partnerDuplicateAccount: toggleOnlyFraudRuleSchema,
 });
 
@@ -325,8 +324,6 @@ export const fraudEventSchemas = {
       bannedReason: z.string(),
     }),
   }),
-
-  partnerDuplicatePayoutMethod: baseFraudEventSchema,
 
   partnerDuplicateAccount: baseFraudEventSchema,
 };

--- a/apps/web/scripts/migrations/consolidate-duplicate-account-fraud.ts
+++ b/apps/web/scripts/migrations/consolidate-duplicate-account-fraud.ts
@@ -1,0 +1,41 @@
+import { prisma } from "@dub/prisma";
+import "dotenv-flow/config";
+
+async function main() {
+  // Migrate FraudRule
+  const { count } = await prisma.fraudRule.updateMany({
+    where: {
+      type: "partnerDuplicatePayoutMethod",
+    },
+    data: {
+      type: "partnerDuplicateAccount",
+    },
+  });
+
+  console.log(
+    `Updated ${count} fraud rules from partnerDuplicatePayoutMethod to partnerDuplicateAccount`,
+  );
+
+  // Migrate FraudEventGroup
+  while (true) {
+    const { count } = await prisma.fraudEventGroup.updateMany({
+      where: {
+        type: "partnerDuplicatePayoutMethod",
+      },
+      data: {
+        type: "partnerDuplicateAccount",
+      },
+      limit: 100,
+    });
+
+    console.log(
+      `Updated ${count} fraud event groups from partnerDuplicatePayoutMethod to partnerDuplicateAccount`,
+    );
+
+    if (count === 0) {
+      break;
+    }
+  }
+}
+
+main();

--- a/apps/web/ui/partners/fraud-risks/fraud-events-tables/fraud-partner-info-table.tsx
+++ b/apps/web/ui/partners/fraud-risks/fraud-events-tables/fraud-partner-info-table.tsx
@@ -10,7 +10,7 @@ import Link from "next/link";
 import * as z from "zod/v4";
 
 type EventDataProps = z.infer<
-  (typeof fraudEventSchemas)["partnerDuplicatePayoutMethod"]
+  (typeof fraudEventSchemas)["partnerDuplicateAccount"]
 >;
 
 export function FraudPartnerInfoTable() {

--- a/apps/web/ui/partners/fraud-risks/fraud-events-tables/index.tsx
+++ b/apps/web/ui/partners/fraud-risks/fraud-events-tables/index.tsx
@@ -14,7 +14,6 @@ const FRAUD_EVENTS_TABLES: Partial<Record<FraudRuleType, React.ComponentType>> =
     referralSourceBanned: FraudReferralSourceBannedTable,
     paidTrafficDetected: FraudPaidTrafficDetectedTable,
     partnerCrossProgramBan: FraudCrossProgramBanTable,
-    partnerDuplicatePayoutMethod: FraudPartnerInfoTable,
     partnerDuplicateAccount: FraudPartnerInfoTable,
   };
 


### PR DESCRIPTION
… fraud rule

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consolidated duplicate-account and duplicate-payout-method fraud detection so reports, risk flags, and UI now consistently surface duplicate-account issues.
  * Validation and event handling updated so legacy duplicate-payout-method events are no longer treated as a separate rule.

* **Chores**
  * Ran a migration to convert historical fraud records and remove the deprecated duplicate-payout-method rule variant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->