### PR TITLE
Use nullish for optional nullable fields in stripe v2 outbound payment

### DIFF
--- a/apps/web/lib/stripe/stripe-v2-schemas.ts
+++ b/apps/web/lib/stripe/stripe-v2-schemas.ts
@@ -117,21 +117,19 @@ export const outboundPaymentSchema = z.object({
         .object({
           reason: z.string().default("unknown_failure"),
         })
-        .optional(),
+        .nullish(),
       returned: z
         .object({
           reason: z.string().default("unknown_failure"),
         })
-        .optional(),
+        .nullish(),
     })
-    .nullable()
-    .optional(),
+    .nullish(),
   trace_id: z
     .object({
       value: z.string(),
     })
-    .nullable()
-    .optional(),
+    .nullish(),
 });
 
 export const listPayoutMethodsQuerySchema = z.object({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved payment status field validation schema for enhanced data consistency in outbound payment processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->