### PR TITLE
Account dropdown link

### DIFF
--- a/apps/web/ui/layout/sidebar/user-dropdown.tsx
+++ b/apps/web/ui/layout/sidebar/user-dropdown.tsx
@@ -10,10 +10,12 @@ import {
   useCurrentSubdomain,
   User,
 } from "@dub/ui";
+import { Gear } from "@dub/ui/icons";
 import { APP_DOMAIN, cn, PARTNERS_DOMAIN } from "@dub/utils";
 import { LogOut } from "lucide-react";
 import { signOut, useSession } from "next-auth/react";
 import Link from "next/link";
+import { useParams } from "next/navigation";
 import {
   ComponentPropsWithoutRef,
   ElementType,
@@ -26,6 +28,11 @@ export function UserDropdown() {
   const { partner } = usePartnerProfile();
   const [openPopover, setOpenPopover] = useState(false);
   const { subdomain } = useCurrentSubdomain();
+  const { slug: paramsSlug } = useParams() as { slug?: string | string[] };
+
+  const workspaceSlug =
+    (Array.isArray(paramsSlug) ? paramsSlug[0] : paramsSlug) ||
+    session?.user?.["defaultWorkspace"];
 
   const menuOptions = useMemo(() => {
     const options: Array<{
@@ -53,6 +60,15 @@ export function UserDropdown() {
     }
 
     if (subdomain === "app") {
+      if (workspaceSlug) {
+        options.push({
+          label: "Workspace settings",
+          icon: Gear,
+          href: `/${workspaceSlug}/settings`,
+          onClick: () => setOpenPopover(false),
+        });
+      }
+
       options.push({
         label: "Refer and earn",
         icon: Gift,
@@ -82,7 +98,7 @@ export function UserDropdown() {
     });
 
     return options;
-  }, [subdomain, partner, setOpenPopover]);
+  }, [subdomain, partner, workspaceSlug, setOpenPopover]);
 
   return (
     <Popover


### PR DESCRIPTION
- Adding "workspace settings" link to the account menu
- Opens the workspace settings for the currently logged in workspace
- Doesn't show on partner account menu

<img width="254" height="293" alt="CleanShot 2026-04-20 at 15 31 53@2x" src="https://github.com/user-attachments/assets/fc661ed9-ae3f-4100-9ca2-f9992065c27c" />

<img width="372" height="288" alt="CleanShot 2026-04-20 at 15 32 08@2x" src="https://github.com/user-attachments/assets/30e677a9-caed-4186-8aa5-66f37cf5e5bd" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Workspace settings" option to the user dropdown menu for quick access to workspace configuration and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->