### PR TITLE
Mask sensitive fields in API logs response body

### DIFF
--- a/apps/web/lib/api-logs/capture-request-log.ts
+++ b/apps/web/lib/api-logs/capture-request-log.ts
@@ -2,6 +2,10 @@ import { WorkspaceWithUsers } from "@/lib/types";
 import { TokenCacheItem } from "../auth/token-cache";
 import { Session } from "../auth/utils";
 import { HTTP_MUTATION_METHODS, ROUTE_PATTERNS } from "./constants";
+import {
+  maskSensitiveFields,
+  SENSITIVE_RESPONSE_FIELDS_BY_ROUTE,
+} from "./mask-sensitive-fields";
 import { recordApiLog } from "./record-api-log";
 
 // Precompile route patterns into regexes at module load
@@ -78,6 +82,19 @@ export async function captureRequestLog({
   try {
     responseBody = await responseClone.json();
   } catch {}
+
+  // Mask sensitive fields in the response body
+  if (responseBody) {
+    const sensitiveResponseFields =
+      SENSITIVE_RESPONSE_FIELDS_BY_ROUTE[routePattern];
+
+    if (sensitiveResponseFields) {
+      responseBody = maskSensitiveFields({
+        body: responseBody,
+        keys: sensitiveResponseFields,
+      });
+    }
+  }
 
   return await recordApiLog({
     workspaceId: workspace.id,

--- a/apps/web/lib/api-logs/mask-sensitive-fields.ts
+++ b/apps/web/lib/api-logs/mask-sensitive-fields.ts
@@ -1,0 +1,61 @@
+const FULL_MASK = "***";
+const MIDDLE_MASK = "*****";
+const MIN_HIDDEN_CHARS = 4;
+
+// Map of route pattern -> response body fields that should be masked before logging.
+export const SENSITIVE_RESPONSE_FIELDS_BY_ROUTE = {
+  "/tokens/embed/referrals": ["publicToken"],
+} as const;
+
+// Partially masks a sensitive value: shows ~50% of the string at the start and
+// ~25% at the end, replacing the middle with a fixed `*****`.
+// Short strings and non-strings are fully masked to avoid revealing most of the value.
+export function maskSensitiveValue(value: unknown): string {
+  if (typeof value !== "string") {
+    return FULL_MASK;
+  }
+
+  const visibleStart = Math.floor(value.length / 2);
+  const visibleEnd = Math.floor(value.length / 4);
+  const hidden = value.length - visibleStart - visibleEnd;
+
+  if (hidden < MIN_HIDDEN_CHARS) {
+    return FULL_MASK;
+  }
+
+  return `${value.slice(0, visibleStart)}${MIDDLE_MASK}${value.slice(-visibleEnd)}`;
+}
+
+// Recursively mask the given keys in an object/array. Returns a new value and
+// does not mutate the input. Non-object values are returned as-is.
+export function maskSensitiveFields<T>({
+  body,
+  keys,
+}: {
+  body: T;
+  keys: string[];
+}): T {
+  if (!body || keys.length === 0) {
+    return body;
+  }
+
+  const keySet = new Set(keys);
+
+  const mask = (value: unknown): unknown => {
+    if (Array.isArray(value)) {
+      return value.map(mask);
+    }
+
+    if (value && typeof value === "object") {
+      const result: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(value)) {
+        result[k] = keySet.has(k) ? maskSensitiveValue(v) : mask(v);
+      }
+      return result;
+    }
+
+    return value;
+  };
+
+  return mask(body) as T;
+}

--- a/apps/web/lib/api-logs/mask-sensitive-fields.ts
+++ b/apps/web/lib/api-logs/mask-sensitive-fields.ts
@@ -1,29 +1,39 @@
 const FULL_MASK = "***";
 const MIDDLE_MASK = "*****";
 const MIN_HIDDEN_CHARS = 4;
+const LAST_VISIBLE_CHARS = 6;
 
 // Map of route pattern -> response body fields that should be masked before logging.
 export const SENSITIVE_RESPONSE_FIELDS_BY_ROUTE = {
   "/tokens/embed/referrals": ["publicToken"],
 } as const;
 
-// Partially masks a sensitive value: shows ~50% of the string at the start and
-// ~25% at the end, replacing the middle with a fixed `*****`.
-// Short strings and non-strings are fully masked to avoid revealing most of the value.
+// Stripe-style partial mask: visible prefix through the last `_` (e.g. `sk_live_`),
+// a fixed middle mask, and the last 6 characters (e.g. `sk_live_*****xyz123`).
+// Values without enough characters between prefix and suffix fully mask.
 export function maskSensitiveValue(value: unknown): string {
-  if (typeof value !== "string") {
+  if (typeof value !== "string" || value.length === 0) {
     return FULL_MASK;
   }
 
-  const visibleStart = Math.floor(value.length / 2);
-  const visibleEnd = Math.floor(value.length / 4);
-  const hidden = value.length - visibleStart - visibleEnd;
+  const suffixLen = Math.min(LAST_VISIBLE_CHARS, value.length);
+  const suffixStart = value.length - suffixLen;
 
-  if (hidden < MIN_HIDDEN_CHARS) {
+  const lastUnderscore = value.lastIndexOf("_");
+  const prefixEnd = lastUnderscore >= 0 ? lastUnderscore + 1 : 0;
+
+  if (prefixEnd > suffixStart) {
     return FULL_MASK;
   }
 
-  return `${value.slice(0, visibleStart)}${MIDDLE_MASK}${value.slice(-visibleEnd)}`;
+  if (suffixStart - prefixEnd < MIN_HIDDEN_CHARS) {
+    return FULL_MASK;
+  }
+
+  const prefix = value.slice(0, prefixEnd);
+  const suffix = value.slice(suffixStart);
+
+  return `${prefix}${MIDDLE_MASK}${suffix}`;
 }
 
 // Recursively mask the given keys in an object/array. Returns a new value and


### PR DESCRIPTION

<img width="897" height="193" alt="CleanShot 2026-04-21 at 9  35 15" src="https://github.com/user-attachments/assets/4d17966b-ca8a-4fe4-9250-b89e94d1b081" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * API logs now automatically mask sensitive response fields (e.g., tokens) before storage, reducing risk of exposing private data while preserving other log details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->