### PR TITLE
Case-insensitive HubSpot lifecycle stage comparisons

### DIFF
--- a/apps/web/lib/integrations/hubspot/track-lead.ts
+++ b/apps/web/lib/integrations/hubspot/track-lead.ts
@@ -148,7 +148,8 @@ export const trackHubSpotLeadEvent = async ({
     }
 
     if (
-      contactInfo.properties.lifecyclestage !== settings.leadLifecycleStageId
+      contactInfo.properties.lifecyclestage?.toLowerCase() !==
+      settings.leadLifecycleStageId?.toLowerCase()
     ) {
       return `Unknown contact lifecyclestage ${contactInfo.properties.lifecyclestage}. Expected ${settings.leadLifecycleStageId}.`;
     }

--- a/apps/web/lib/integrations/hubspot/track-sale.ts
+++ b/apps/web/lib/integrations/hubspot/track-sale.ts
@@ -28,7 +28,9 @@ export const trackHubSpotSaleEvent = async ({
     return `Unknown propertyName ${propertyName}. Expected dealstage.`;
   }
 
-  if (propertyValue !== settings.closedWonDealStageId) {
+  if (
+    propertyValue.toLowerCase() !== settings.closedWonDealStageId?.toLowerCase()
+  ) {
     return `Unknown propertyValue ${propertyValue}. Expected ${settings.closedWonDealStageId}.`;
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Improved HubSpot integration by making lead lifecycle stage and deal stage comparisons case-insensitive, ensuring accurate identification regardless of case variations in stored values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->