### PR TITLE
Send `/api/stripe/connect/` webhooks to Axiom

### DIFF
--- a/apps/web/app/(ee)/api/stripe/connect/v2/webhook/route.ts
+++ b/apps/web/app/(ee)/api/stripe/connect/v2/webhook/route.ts
@@ -25,7 +25,7 @@ export const POST = withAxiomBodyLog(async (req: Request) => {
   const clonedReq = req.clone();
   const buf = await clonedReq.text();
 
-  const signature = req.headers.get("Stripe-Signature");
+  const signature = clonedReq.headers.get("Stripe-Signature");
 
   if (!signature) {
     return logAndRespond("Missing Stripe-Signature header.", {

--- a/apps/web/app/(ee)/api/stripe/connect/v2/webhook/route.ts
+++ b/apps/web/app/(ee)/api/stripe/connect/v2/webhook/route.ts
@@ -1,3 +1,4 @@
+import { withAxiomBodyLog } from "@/lib/axiom/server";
 import { stripe } from "@/lib/stripe";
 import { log } from "@dub/utils";
 import { logAndRespond } from "app/(ee)/api/cron/utils";
@@ -20,12 +21,16 @@ const relevantEvents = new Set([
 const webhookSecret = process.env.STRIPE_CONNECT_V2_WEBHOOK_SECRET;
 
 // POST /api/stripe/connect/v2/webhook – Stripe Connect Account v2 webhooks
-export const POST = async (req: Request) => {
-  const body = await req.text();
+export const POST = withAxiomBodyLog(async (req: Request) => {
+  const clonedReq = req.clone();
+  const buf = await clonedReq.text();
+
   const signature = req.headers.get("Stripe-Signature");
 
   if (!signature) {
-    return logAndRespond("Missing Stripe-Signature header.");
+    return logAndRespond("Missing Stripe-Signature header.", {
+      status: 400,
+    });
   }
 
   if (!webhookSecret) {
@@ -40,7 +45,7 @@ export const POST = async (req: Request) => {
   let event: Stripe.ThinEvent;
 
   try {
-    event = stripe.parseThinEvent(body, signature, webhookSecret);
+    event = stripe.parseThinEvent(buf, signature, webhookSecret);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
 
@@ -88,4 +93,4 @@ export const POST = async (req: Request) => {
   }
 
   return logAndRespond(`[${event.type}]: ${response}`);
-};
+});

--- a/apps/web/app/(ee)/api/stripe/connect/webhook/route.ts
+++ b/apps/web/app/(ee)/api/stripe/connect/webhook/route.ts
@@ -1,3 +1,4 @@
+import { withAxiomBodyLog } from "@/lib/axiom/server";
 import { stripe } from "@/lib/stripe";
 import { log } from "@dub/utils";
 import { logAndRespond } from "app/(ee)/api/cron/utils";
@@ -17,28 +18,42 @@ const relevantEvents = new Set([
   "payout.failed",
 ]);
 
-// POST /api/stripe/connect/webhook – listen to Stripe Connect webhooks (for connected accounts)
-export const POST = async (req: Request) => {
-  const buf = await req.text();
-  const sig = req.headers.get("Stripe-Signature");
-  const webhookSecret = process.env.STRIPE_CONNECT_WEBHOOK_SECRET;
-  let event: Stripe.Event;
+const webhookSecret = process.env.STRIPE_CONNECT_WEBHOOK_SECRET;
 
+// POST /api/stripe/connect/webhook – listen to Stripe Connect webhooks (for connected accounts)
+export const POST = withAxiomBodyLog(async (req: Request) => {
+  const clonedReq = req.clone();
+  const buf = await clonedReq.text();
+
+  const signature = clonedReq.headers.get("Stripe-Signature");
+
+  if (!signature) {
+    return logAndRespond("Missing Stripe-Signature header.", {
+      status: 400,
+    });
+  }
+
+  if (!webhookSecret) {
+    return logAndRespond(
+      "STRIPE_CONNECT_WEBHOOK_SECRET environment variable is not set.",
+      {
+        status: 500,
+      },
+    );
+  }
+
+  let event: Stripe.Event;
   try {
-    if (!sig || !webhookSecret) return;
-    event = stripe.webhooks.constructEvent(buf, sig, webhookSecret);
+    event = stripe.webhooks.constructEvent(buf, signature, webhookSecret);
   } catch (err: any) {
-    console.log(`❌ Error message: ${err.message}`);
-    return new Response(`Webhook Error: ${err.message}`, {
+    return logAndRespond(`Webhook Error: ${err.message}`, {
       status: 400,
     });
   }
 
   // Ignore unsupported events
   if (!relevantEvents.has(event.type)) {
-    return new Response("Unsupported event, skipping...", {
-      status: 200,
-    });
+    return logAndRespond(`Unsupported event ${event.type}, skipping...`);
   }
 
   let response = "OK";
@@ -67,10 +82,10 @@ export const POST = async (req: Request) => {
       type: "errors",
     });
 
-    return new Response(`Webhook error: ${error.message}`, {
+    return logAndRespond(`Webhook error: ${error.message}`, {
       status: 400,
     });
   }
 
   return logAndRespond(`[${event.type}]: ${response}`);
-};
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved webhook logging by routing handlers through a request body-logging wrapper.
  * Made request body handling more robust by reading from a cloned request before verification.
  * Standardized error responses for missing webhook signatures (400) and misconfigured webhook secrets (500).
  * Unified unsupported-event handling and replaced ad-hoc console output with logged responses.
  * Ensured signature extraction and event verification use the cloned request body for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->