### PR TITLE
Save button disabled when editing domain settings

### DIFF
--- a/apps/web/ui/domains/add-edit-domain-form.tsx
+++ b/apps/web/ui/domains/add-edit-domain-form.tsx
@@ -261,10 +261,12 @@ export function AddEditDomainForm({
 
   useEffect(() => {
     if (domain && isValidDomain(domain)) {
-      // Skip validation when editing an existing domain that hasn't changed —
-      // the validate API returns "conflict" for already-registered domains,
-      // which would disable the Save button even when other fields are edited.
-      if (props && domain === props.slug) return;
+      if (props && domain === props.slug) {
+        debouncedValidateDomain.cancel();
+        setDomainStatus("available");
+        setDomainValidateMessage(null);
+        return;
+      }
       debouncedValidateDomain(domain);
     }
   }, [domain, debouncedValidateDomain]);

--- a/apps/web/ui/domains/add-edit-domain-form.tsx
+++ b/apps/web/ui/domains/add-edit-domain-form.tsx
@@ -261,6 +261,10 @@ export function AddEditDomainForm({
 
   useEffect(() => {
     if (domain && isValidDomain(domain)) {
+      // Skip validation when editing an existing domain that hasn't changed —
+      // the validate API returns "conflict" for already-registered domains,
+      // which would disable the Save button even when other fields are edited.
+      if (props && domain === props.slug) return;
       debouncedValidateDomain(domain);
     }
   }, [domain, debouncedValidateDomain]);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation no longer blocks saving when editing a domain but the slug is unchanged; pending validations are canceled and the UI resets so users can save other field changes without unnecessary validation interruptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->