### PR TITLE
Partners Invited badge next to name

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/partners-table.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/partners-table.tsx
@@ -222,7 +222,8 @@ export function PartnersTable() {
           cell: ({ row }) => {
             const showInvitedInline =
               columnVisibility.status === false &&
-              row.original.status === ProgramEnrollmentStatus.invited;
+              row.original.status === ProgramEnrollmentStatus.invited &&
+              searchParams.get("status") !== ProgramEnrollmentStatus.invited;
 
             return (
               <PartnerRowItem
@@ -471,7 +472,7 @@ export function PartnersTable() {
           ),
         },
       ].filter((c) => c.id === "menu" || partnersColumns.all.includes(c.id)),
-    [workspaceId, groups, columnVisibility],
+    [workspaceId, groups, columnVisibility, searchParams],
   );
 
   const { table, ...tableProps } = useTable({

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/partners-table.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/partners-table.tsx
@@ -220,8 +220,26 @@ export function PartnersTable() {
           minSize: 150,
           maxSize: 250,
           cell: ({ row }) => {
+            const showInvitedInline =
+              columnVisibility.status === false &&
+              row.original.status === ProgramEnrollmentStatus.invited;
+
             return (
-              <PartnerRowItem partner={row.original} showPermalink={false} />
+              <PartnerRowItem
+                partner={row.original}
+                showPermalink={false}
+                suffix={
+                  showInvitedInline ? (
+                    <StatusBadge
+                      size="sm"
+                      icon={null}
+                      variant={PartnerStatusBadges.invited.variant}
+                    >
+                      {PartnerStatusBadges.invited.label}
+                    </StatusBadge>
+                  ) : null
+                }
+              />
             );
           },
         },
@@ -453,7 +471,7 @@ export function PartnersTable() {
           ),
         },
       ].filter((c) => c.id === "menu" || partnersColumns.all.includes(c.id)),
-    [workspaceId, groups],
+    [workspaceId, groups, columnVisibility],
   );
 
   const { table, ...tableProps } = useTable({

--- a/apps/web/ui/partners/partner-row-item.tsx
+++ b/apps/web/ui/partners/partner-row-item.tsx
@@ -5,6 +5,7 @@ import { cn, formatDateTimeSmart } from "@dub/utils";
 import { CircleMinus } from "lucide-react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
+import type { ReactNode } from "react";
 import { PartnerFraudIndicator } from "./fraud-risks/partner-fraud-indicator";
 import { PartnerAvatar } from "./partner-avatar";
 import {
@@ -15,6 +16,7 @@ import {
 interface PartnerRowItemProps {
   showPermalink?: boolean;
   showFraudIndicator?: boolean;
+  suffix?: ReactNode;
   partner: {
     id: string;
     name: string;
@@ -168,6 +170,7 @@ export function PartnerRowItem({
   partner,
   showPermalink = true,
   showFraudIndicator = true,
+  suffix,
 }: PartnerRowItemProps) {
   const { slug } = useParams();
   const { statusKey, showPayoutsEnabled } = usePartnerPayoutStatus(partner);
@@ -218,6 +221,8 @@ export function PartnerRowItem({
       >
         {partner.name}
       </As>
+
+      {suffix}
 
       {showFraudIndicator && <PartnerFraudIndicator partnerId={partner.id} />}
     </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Invited partners now display an inline status indicator when the status column is hidden, keeping enrollment visible regardless of column settings.
  * Partner row items can include an optional suffix area to render additional inline content (e.g., icons or badges).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->