### PR TITLE
Use crypto.randomInt for OTP generation

### DIFF
--- a/apps/web/lib/auth/utils.ts
+++ b/apps/web/lib/auth/utils.ts
@@ -1,5 +1,6 @@
 import { getServerSession } from "next-auth/next";
 import { NextRequest } from "next/server";
+import { randomInt } from "node:crypto";
 import { DubApiError } from "../api/errors";
 import { authOptions } from "./options";
 
@@ -37,8 +38,7 @@ export const getAuthTokenOrThrow = (
 };
 
 export function generateOTP() {
-  // Generate a random number between 0 and 999999
-  const randomNumber = Math.floor(Math.random() * 1000000);
+  const randomNumber = randomInt(0, 1000000);
 
   // Pad the number with leading zeros if necessary to ensure it is always 6 digits
   return randomNumber.toString().padStart(6, "0");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security of OTP generation by switching to a stronger randomness source. OTPs remain 6-digit and left-padded as before, so there are no user-facing format or workflow changes. This is a transparent backend hardening with no action required from users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->