### PR TITLE
Adding icons to the upgrade plans

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/billing/upgrade/page.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/billing/upgrade/page.tsx
@@ -11,11 +11,13 @@ import {
   Check,
   CircleQuestion,
   ConnectedDots4,
+  DubProductIcon,
   Globe,
   Hyperlink,
   Icon,
   Plug2,
   ToggleGroup,
+  Tooltip,
   Users2,
 } from "@dub/ui";
 import {
@@ -233,6 +235,7 @@ export default function WorkspaceBillingUpgradePage() {
                           </>
                         )}
                       </div>
+                      <PlanIncludedProducts plan={plan} />
                     </div>
                     <div className="flex gap-3">
                       <button
@@ -322,6 +325,42 @@ export default function WorkspaceBillingUpgradePage() {
         </div>
       </PageWidthWrapper>
     </PageContent>
+  );
+}
+
+function PlanIncludedProducts({ plan }: { plan: PlanDetails }) {
+  return (
+    <div className="mt-5 flex items-center gap-2 text-sm text-neutral-500">
+      <span>Includes</span>
+      <div className="flex items-center gap-1.5">
+        <Tooltip
+          content="[Dub Links](https://dub.co/links)"
+          contentClassName="px-3 py-2"
+        >
+          <span>
+            <DubProductIcon
+              product="links"
+              className="size-5"
+              iconClassName="size-3"
+            />
+          </span>
+        </Tooltip>
+        {plan.limits.payouts > 0 && (
+          <Tooltip
+            content="[Dub Partners](https://dub.co/partners)"
+            contentClassName="px-3 py-2"
+          >
+            <span>
+              <DubProductIcon
+                product="partners"
+                className="size-5"
+                iconClassName="size-3"
+              />
+            </span>
+          </Tooltip>
+        )}
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
<img width="1320" height="362" alt="CleanShot 2026-04-30 at 12 32 51@2x" src="https://github.com/user-attachments/assets/5ab47279-3394-4e38-b784-af9af36f81f7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Plan cards now display included products with visual icons for improved clarity
  * Links product is shown on all billing plans
  * Partners product displays when available, helping you quickly identify which features are included in each plan tier

<!-- end of auto-generated comment: release notes by coderabbit.ai -->