### PR TITLE
Use `z.httpUrl()` for stricter URL validation

### DIFF
--- a/apps/web/app/(ee)/api/embed/referrals/bounties/[bountyId]/social-content-stats/route.ts
+++ b/apps/web/app/(ee)/api/embed/referrals/bounties/[bountyId]/social-content-stats/route.ts
@@ -8,7 +8,7 @@ import { NextResponse } from "next/server";
 import * as z from "zod/v4";
 
 const searchParamsSchema = z.object({
-  url: z.url("Social media URL is required."),
+  url: z.httpUrl("Social media URL is required."),
 });
 
 // GET /api/embed/referrals/bounties/[bountyId]/social-content-stats

--- a/apps/web/app/(ee)/api/partner-profile/programs/[programId]/bounties/[bountyId]/social-content-stats/route.ts
+++ b/apps/web/app/(ee)/api/partner-profile/programs/[programId]/bounties/[bountyId]/social-content-stats/route.ts
@@ -9,7 +9,7 @@ import { NextResponse } from "next/server";
 import * as z from "zod/v4";
 
 const searchParamsSchema = z.object({
-  url: z.url("Social media URL is required."),
+  url: z.httpUrl("Social media URL is required."),
 });
 
 // GET /api/partner-profile/programs/[programId]/bounties/[bountyId]/social-content-stats

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/resources/program-brand-assets/add-link-modal.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/resources/program-brand-assets/add-link-modal.tsx
@@ -27,7 +27,7 @@ type LinkModalProps = {
 
 const linkFormSchema = z.object({
   name: z.string().min(1, "Display name is required"),
-  url: z.url("Please enter a valid URL"),
+  url: z.httpUrl("Please enter a valid URL"),
 });
 
 type LinkFormData = z.infer<typeof linkFormSchema>;

--- a/apps/web/lib/actions/partners/generate-lander.ts
+++ b/apps/web/lib/actions/partners/generate-lander.ts
@@ -23,7 +23,7 @@ import { throwIfNoPermission } from "../throw-if-no-permission";
 
 const schema = z.object({
   workspaceId: z.string(),
-  websiteUrl: z.url(),
+  websiteUrl: z.httpUrl(),
   landerData: programLanderSchema.optional(),
   prompt: z.string().optional(),
 });

--- a/apps/web/lib/actions/partners/program-resources/add-program-resource.ts
+++ b/apps/web/lib/actions/partners/program-resources/add-program-resource.ts
@@ -43,7 +43,7 @@ const colorResourceSchema = baseResourceSchema.extend({
 // Schema for link resources
 const linkResourceSchema = baseResourceSchema.extend({
   resourceType: z.literal("link"),
-  url: z.url(),
+  url: z.httpUrl(),
 });
 
 // Combined schema that can handle any resource type

--- a/apps/web/lib/actions/partners/program-resources/update-program-resource.ts
+++ b/apps/web/lib/actions/partners/program-resources/update-program-resource.ts
@@ -48,7 +48,7 @@ const updateColorSchema = baseUpdateSchema.extend({
 const updateLinkSchema = baseUpdateSchema.extend({
   resourceType: z.literal("link"),
   name: z.string().min(1).optional(),
-  url: z.url().optional(),
+  url: z.httpUrl().optional(),
 });
 
 // Combined schema that can handle any resource type

--- a/apps/web/lib/actions/partners/verify-social-account-by-code.ts
+++ b/apps/web/lib/actions/partners/verify-social-account-by-code.ts
@@ -12,7 +12,7 @@ import { authPartnerActionClient } from "../safe-action";
 const schema = z.object({
   platform: z.enum(PlatformType),
   handle: z.string().min(1),
-  postUrl: z.url().optional(),
+  postUrl: z.httpUrl().optional(),
 });
 
 // Verify social accounts using the verification code

--- a/apps/web/lib/zod/schemas/images.ts
+++ b/apps/web/lib/zod/schemas/images.ts
@@ -80,11 +80,8 @@ export const uploadedImageSchema = z
   .transform((v) => v || null);
 
 export const publicHostedImageSchema = z
-  .url()
-  .trim()
-  .refine((url) => url.startsWith("http://") || url.startsWith("https://"), {
-    message: "Image URL must start with http:// or https://",
-  });
+  .httpUrl({ error: "Image URL must start with http:// or https://" })
+  .trim();
 
 /** Coerce unusable preview strings (e.g. data:favicons) to null before create/update link validation. */
 export function preprocessLinkPreviewImage(

--- a/apps/web/lib/zod/schemas/program-lander.ts
+++ b/apps/web/lib/zod/schemas/program-lander.ts
@@ -10,7 +10,7 @@ export const programLanderImageBlockSchema =
   programLanderBlockCommonSchema.extend({
     type: z.literal("image"),
     data: z.object({
-      url: z.url(),
+      url: z.httpUrl(),
       alt: z.string().optional(),
       width: z.number().optional(),
       height: z.number().optional(),
@@ -30,11 +30,7 @@ export const programLanderFileSchema = z.object({
   id: z.string(),
   name: z.string(),
   description: z.string().optional(),
-  url: z
-    .url()
-    .refine((url) => url.startsWith("http://") || url.startsWith("https://"), {
-      message: "Only HTTP and HTTPS URLs are allowed for files.",
-    }),
+  url: z.httpUrl({ error: "Only HTTP and HTTPS URLs are allowed for files." }),
   external: z.boolean().optional(), // TODO: not using this atm, might wanna change this to `downloadable` boolean instead
 });
 

--- a/apps/web/lib/zod/schemas/program-resources.ts
+++ b/apps/web/lib/zod/schemas/program-resources.ts
@@ -13,7 +13,7 @@ export const programResourceFileSchema = z.object({
   id: z.string(),
   name: z.string(),
   size: z.number(),
-  url: z.url(),
+  url: z.httpUrl(),
 });
 
 export const programResourceColorSchema = z.object({
@@ -25,7 +25,7 @@ export const programResourceColorSchema = z.object({
 export const programResourceLinkSchema = z.object({
   id: z.string(),
   name: z.string(),
-  url: z.url(),
+  url: z.httpUrl(),
 });
 
 export const programResourcesSchema = z.object({

--- a/apps/web/lib/zod/schemas/programs.ts
+++ b/apps/web/lib/zod/schemas/programs.ts
@@ -104,8 +104,8 @@ export const updateProgramSchema = z.object({
       message: `Minimum payout amount must be one of ${ALLOWED_MIN_PAYOUT_AMOUNTS.join(", ")}`,
     }),
   supportEmail: z.email().max(255).nullish(),
-  helpUrl: z.url().max(500).nullish(),
-  termsUrl: z.url().max(500).nullish(),
+  helpUrl: z.httpUrl().max(500).nullish(),
+  termsUrl: z.httpUrl().max(500).nullish(),
   messagingEnabledAt: z.coerce.date().nullish(),
   referralFormData: referralFormSchema.nullish(),
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened URL validation across the application by restricting accepted URL formats to HTTP and HTTPS protocols only. This affects URL input fields for social content, program resources, partner verification, and configuration settings. Previously, other URL protocol formats may have been accepted but are now rejected during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->