### PR TITLE
Integration updates

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/integrations/enabled-integrations.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/integrations/enabled-integrations.tsx
@@ -6,9 +6,8 @@ import { IntegrationLogo } from "@/ui/integrations/integration-logo";
 import { Integration } from "@dub/prisma/client";
 import { cn } from "@dub/utils";
 import { ChevronRight } from "lucide-react";
-import { AnimatePresence, motion } from "motion/react";
+import { motion } from "motion/react";
 import Link from "next/link";
-import { useSearchParams } from "next/navigation";
 import { IntegrationsWithInstallations } from "./integrations-list";
 
 export function EnabledIntegrations({
@@ -16,9 +15,6 @@ export function EnabledIntegrations({
 }: {
   integrations: IntegrationsWithInstallations;
 }) {
-  const searchParams = useSearchParams();
-  const search = searchParams.get("search");
-
   const { slug } = useWorkspace();
   const { integrations: activeIntegrations } = useIntegrations();
 
@@ -27,36 +23,32 @@ export function EnabledIntegrations({
   );
 
   return enabledIntegrations?.length ? (
-    <AnimatePresence initial={false}>
-      {!search && (
-        <motion.div
-          key="enabled-integrations"
-          initial={{ opacity: 0, translateY: 10 }}
-          animate={{ opacity: 1, translateY: 0 }}
-          exit={{ opacity: 0, translateY: 10 }}
-          transition={{ duration: 0.1 }}
+    <motion.div
+      key="enabled-integrations"
+      initial={{ opacity: 0, translateY: 10 }}
+      animate={{ opacity: 1, translateY: 0 }}
+      exit={{ opacity: 0, translateY: 10 }}
+      transition={{ duration: 0.1 }}
+    >
+      <div className="flex items-center justify-between text-sm">
+        <h2 className="font-medium leading-4 text-neutral-800">
+          Enabled integrations
+        </h2>
+        <Link
+          href={`/${slug}/settings/integrations/enabled`}
+          className="font-medium leading-4 text-neutral-500 transition-colors duration-100 hover:text-neutral-700"
         >
-          <div className="flex items-center justify-between text-sm">
-            <h2 className="font-medium leading-4 text-neutral-800">
-              Enabled integrations
-            </h2>
-            <Link
-              href={`/${slug}/settings/integrations/enabled`}
-              className="font-medium leading-4 text-neutral-500 transition-colors duration-100 hover:text-neutral-700"
-            >
-              View all ({enabledIntegrations.length})
-            </Link>
-          </div>
-          <ul className="mt-4 divide-y divide-neutral-200 overflow-hidden rounded-lg border border-neutral-200">
-            {enabledIntegrations.slice(0, 3).map((integration) => (
-              <li key={integration.id}>
-                <IntegrationRow integration={integration} />
-              </li>
-            ))}
-          </ul>
-        </motion.div>
-      )}
-    </AnimatePresence>
+          View all ({enabledIntegrations.length})
+        </Link>
+      </div>
+      <ul className="mt-4 divide-y divide-neutral-200 overflow-hidden rounded-lg border border-neutral-200">
+        {enabledIntegrations.slice(0, 3).map((integration) => (
+          <li key={integration.id}>
+            <IntegrationRow integration={integration} />
+          </li>
+        ))}
+      </ul>
+    </motion.div>
   ) : null;
 }
 

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/integrations/featured-integrations.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/integrations/featured-integrations.tsx
@@ -11,22 +11,19 @@ import {
   useCarousel,
 } from "@dub/ui";
 import { cn } from "@dub/utils";
-import { AnimatePresence, motion } from "motion/react";
+import { motion } from "motion/react";
 import Link from "next/link";
-import { useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { IntegrationsWithInstallations } from "./integrations-list";
 
 const FEATURED_SLUGS = ["make", "zapier", "stripe", "shopify"];
+const FEATURED_AUTOPLAY_DELAY = 8000;
 
 export function FeaturedIntegrations({
   integrations,
 }: {
   integrations: IntegrationsWithInstallations;
 }) {
-  const searchParams = useSearchParams();
-  const search = searchParams.get("search");
-
   const { slug } = useWorkspace();
 
   const featuredIntegrations = integrations.filter(
@@ -37,72 +34,68 @@ export function FeaturedIntegrations({
   );
 
   return (
-    <AnimatePresence initial={false}>
-      {!search && (
-        <motion.div
-          key="featured-integrations"
-          initial={{ opacity: 0, translateY: 10 }}
-          animate={{ opacity: 1, translateY: 0 }}
-          exit={{ opacity: 0, translateY: 10 }}
-          transition={{ duration: 0.1 }}
-        >
-          <Carousel
-            autoplay={{ delay: 5000 }}
-            opts={{ loop: true }}
-            className="bg-white"
-          >
-            <div className="[mask-image:linear-gradient(90deg,transparent,black_8%,black_92%,transparent)]">
-              <CarouselContent>
-                {featuredIntegrations.map((integration, idx) => (
-                  <CarouselItem key={idx} className="basis-2/3">
-                    <Link
-                      href={`/${slug}/settings/integrations/${integration.slug}`}
-                      className="group relative block"
-                    >
-                      {/* Image */}
-                      <div className="overflow-hidden rounded-xl border border-neutral-200 bg-white">
-                        <BlurImage
-                          src={integration.screenshots![0]}
-                          alt={`Screenshot of ${integration.name}`}
-                          width={900}
-                          height={580}
-                          className="aspect-[900/580] w-full overflow-hidden rounded-xl object-cover object-top [mask-image:linear-gradient(black_90%,transparent)]"
-                        />
-                      </div>
+    <motion.div
+      key="featured-integrations"
+      initial={{ opacity: 0, translateY: 10 }}
+      animate={{ opacity: 1, translateY: 0 }}
+      exit={{ opacity: 0, translateY: 10 }}
+      transition={{ duration: 0.1 }}
+    >
+      <Carousel
+        autoplay={{ delay: FEATURED_AUTOPLAY_DELAY }}
+        opts={{ loop: true }}
+        className="bg-white"
+      >
+        <div className="[mask-image:linear-gradient(90deg,transparent,black_8%,black_92%,transparent)]">
+          <CarouselContent>
+            {featuredIntegrations.map((integration, idx) => (
+              <CarouselItem key={idx} className="basis-1/2">
+                <Link
+                  href={`/${slug}/settings/integrations/${integration.slug}`}
+                  className="group relative block"
+                >
+                  {/* Image */}
+                  <div className="overflow-hidden rounded-xl border border-neutral-200 bg-white">
+                    <BlurImage
+                      src={integration.screenshots![0]}
+                      alt={`Screenshot of ${integration.name}`}
+                      width={900}
+                      height={580}
+                      className="aspect-[900/580] w-full overflow-hidden rounded-xl object-cover object-top [mask-image:linear-gradient(black_90%,transparent)]"
+                    />
+                  </div>
 
-                      {/* Category badge */}
-                      <div className="absolute left-4 top-4 rounded bg-white px-2 py-1 text-[0.625rem] font-semibold uppercase text-neutral-800 shadow-[0_2px_2px_0_#00000014]">
-                        {integration.category}
-                      </div>
+                  {/* Category badge */}
+                  <div className="absolute left-4 top-4 rounded bg-white px-2 py-1 text-[0.625rem] font-semibold uppercase text-neutral-800 shadow-[0_2px_2px_0_#00000014]">
+                    {integration.category}
+                  </div>
 
-                      {/* Bottom card */}
-                      <div className="absolute inset-x-4 bottom-4 hidden items-center gap-3 rounded-lg bg-white p-3 transition-all duration-100 group-hover:drop-shadow-sm sm:flex">
-                        <div className="shrink-0">
-                          <IntegrationLogo
-                            src={integration.logo}
-                            alt={`Logo for ${integration.name}`}
-                            className="size-12"
-                          />
-                        </div>
-                        <div className="flex flex-col">
-                          <span className="text-base font-medium text-neutral-900">
-                            {integration.name}
-                          </span>
-                          <p className="line-clamp-2 text-sm font-medium text-neutral-700">
-                            {integration.description}
-                          </p>
-                        </div>
-                      </div>
-                    </Link>
-                  </CarouselItem>
-                ))}
-              </CarouselContent>
-            </div>
-            <CarouselNavBar featuredIntegrations={featuredIntegrations} />
-          </Carousel>
-        </motion.div>
-      )}
-    </AnimatePresence>
+                  {/* Bottom card */}
+                  <div className="absolute inset-x-4 bottom-4 hidden items-center gap-3 rounded-lg bg-white p-3 transition-all duration-100 group-hover:drop-shadow-sm sm:flex">
+                    <div className="shrink-0">
+                      <IntegrationLogo
+                        src={integration.logo}
+                        alt={`Logo for ${integration.name}`}
+                        className="size-12"
+                      />
+                    </div>
+                    <div className="flex flex-col">
+                      <span className="text-base font-medium text-neutral-900">
+                        {integration.name}
+                      </span>
+                      <p className="line-clamp-2 text-sm font-medium text-neutral-700">
+                        {integration.description}
+                      </p>
+                    </div>
+                  </div>
+                </Link>
+              </CarouselItem>
+            ))}
+          </CarouselContent>
+        </div>
+        <CarouselNavBar featuredIntegrations={featuredIntegrations} />
+      </Carousel>
+    </motion.div>
   );
 }
 
@@ -173,9 +166,9 @@ export function FeaturedIntegrationsLoader() {
       <div className="overflow-hidden">
         <div className="-ml-4 flex -translate-x-1/2">
           {[...Array(3)].map((_, idx) => (
-            <div key={idx} className="min-w-0 shrink-0 grow-0 basis-2/3 pl-4">
+            <div key={idx} className="min-w-0 shrink-0 grow-0 basis-1/2 pl-4">
               <div className="border border-transparent">
-                <div className="aspect-[900/580] animate-pulse rounded-lg bg-neutral-200" />
+                <div className="aspect-[900/580] animate-pulse rounded-xl bg-neutral-200" />
               </div>
             </div>
           ))}

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/integrations/integrations-cards.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/integrations/integrations-cards.tsx
@@ -79,7 +79,7 @@ export function IntegrationsCards({
                 <h2 className="font-medium leading-4 text-neutral-800">
                   {category}
                 </h2>
-                <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+                <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
                   {groupedIntegrations[category]!.map((integration) => (
                     <IntegrationCard
                       key={integration.id}
@@ -128,7 +128,7 @@ export function IntegrationsCardsLoader() {
   return [...Array(3)].map((_, idx) => (
     <div key={idx}>
       <div className="h-4 w-24 animate-pulse rounded-md bg-neutral-200" />
-      <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+      <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
         {[...Array(3)].map((_, idx) => (
           <div
             key={idx}

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/integrations/integrations-list.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/integrations/integrations-list.tsx
@@ -18,8 +18,11 @@ export async function IntegrationsList() {
       <Suspense
         fallback={
           <>
-            <div className="box-content h-9 animate-pulse rounded-md bg-neutral-200 py-px" />
             <FeaturedIntegrationsLoader />
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div className="h-6 w-48 animate-pulse rounded-md bg-neutral-200" />
+              <div className="h-10 w-full animate-pulse rounded-lg bg-neutral-200 sm:max-w-sm" />
+            </div>
             <IntegrationsCardsLoader />
           </>
         }
@@ -50,10 +53,23 @@ async function IntegrationsListRSC() {
 
   return (
     <>
-      <SearchBoxPersisted debounceTimeoutMs={250} />
       <EnabledIntegrations integrations={integrations} />
       <FeaturedIntegrations integrations={integrations} />
-      <IntegrationsCards integrations={integrations} />
+      <div className="flex flex-col gap-6">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <h2 className="text-lg font-semibold leading-7 text-neutral-900">
+            Available integrations
+          </h2>
+          <div className="w-full sm:max-w-sm">
+            <SearchBoxPersisted
+              debounceTimeoutMs={250}
+              inputClassName="h-10"
+              placeholder="Search integrations..."
+            />
+          </div>
+        </div>
+        <IntegrationsCards integrations={integrations} />
+      </div>
     </>
   );
 }

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/integrations/layout.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/integrations/layout.tsx
@@ -16,9 +16,7 @@ export default function IntegrationsLayout({
         href: "https://d.to/integrations",
       }}
     >
-      <PageWidthWrapper className="max-w-[800px] pb-20">
-        {children}
-      </PageWidthWrapper>
+      <PageWidthWrapper className="pb-20">{children}</PageWidthWrapper>
     </PageContent>
   );
 }

--- a/apps/web/ui/integrations/integration-card.tsx
+++ b/apps/web/ui/integrations/integration-card.tsx
@@ -34,8 +34,12 @@ export default function IntegrationCard(
           </div>
         </Badge>
       ) : undefined}
-      <IntegrationLogo src={integration.logo ?? null} alt={integration.name} />
-      <h3 className="mt-4 flex items-center gap-1.5 text-sm font-semibold text-neutral-800">
+      <IntegrationLogo
+        src={integration.logo ?? null}
+        alt={integration.name}
+        className="size-12 rounded-[10px]"
+      />
+      <h3 className="mt-4 flex items-center gap-1.5 text-base font-semibold text-neutral-800">
         {integration.name}
         {dubCrafted && (
           <Tooltip content="This is an official integration built and maintained by Dub">
@@ -61,7 +65,7 @@ function Wrapper({
   const { slug } = useWorkspace();
 
   const className = cn(
-    "group relative rounded-lg border border-neutral-200 bg-white p-4 transition-[filter]",
+    "group relative rounded-xl border border-neutral-200 bg-white p-5 transition-[filter]",
     integration.comingSoon ? "cursor-default" : "hover:drop-shadow-card-hover",
   );
 
@@ -85,7 +89,7 @@ function Badge({ className, ...rest }: HTMLProps<HTMLDivElement>) {
   return (
     <div
       className={cn(
-        "absolute right-4 top-4 flex items-center rounded px-2 py-1 text-[0.625rem] font-semibold uppercase leading-none",
+        "absolute right-5 top-5 flex items-center rounded-md px-2 py-1 text-[0.625rem] font-semibold uppercase leading-none",
         className,
       )}
       {...rest}


### PR DESCRIPTION
## Summary
- Move the integrations search field below the featured carousel and above the card grid
- Keep enabled integrations visible while searching; only the available integrations grid is filtered
- Match the available integrations heading to the lighter `text-lg` style from the design
- Expand the desktop grid to 4 columns and keep the featured carousel wider and slower to autoplay
- Update integrations card styling, including larger logos, title sizing, and radius tweaks

## Testing
- Ran Prettier on the touched integrations settings files
- Verified the search layout and enabled integrations visibility through code inspection