### PR TITLE
fix: correct account setting  sidebar notification route to use absolute path

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/account/settings/notifications/page-client.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/account/settings/notifications/page-client.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { AnimatedEmptyState } from "@/ui/shared/animated-empty-state";
+import { Bell, DubLinksIcon, DubPartnersIcon, UserPlus } from "@dub/ui/icons";
+
+export function NotificationsPageClient() {
+  return (
+    <div className="p-10">
+      <AnimatedEmptyState
+        title="Notification preferences"
+        description="Email notification controls for product updates, partner activity, and account alerts are coming soon."
+        className="border-none"
+        cardContent={
+          <>
+            <Bell className="size-4 text-neutral-700" />
+            <div className="h-2.5 w-24 min-w-0 rounded-sm bg-neutral-200" />
+            <div className="xs:flex hidden grow items-center justify-end gap-1.5 text-neutral-500">
+              <DubLinksIcon className="size-3.5" />
+              <DubPartnersIcon className="size-3.5" />
+              <UserPlus className="size-3.5" />
+            </div>
+          </>
+        }
+        pillContent="Coming soon"
+      />
+    </div>
+  );
+}

--- a/apps/web/app/app.dub.co/(dashboard)/account/settings/notifications/page.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/account/settings/notifications/page.tsx
@@ -1,0 +1,5 @@
+import { NotificationsPageClient } from "./page-client";
+
+export default function NotificationsPage() {
+  return <NotificationsPageClient />;
+}

--- a/apps/web/ui/layout/sidebar/app-sidebar-nav.tsx
+++ b/apps/web/ui/layout/sidebar/app-sidebar-nav.tsx
@@ -478,7 +478,7 @@ const NAV_AREAS: SidebarNavAreas<SidebarNavData> = {
           {
             name: "Notifications",
             icon: Bell,
-            href: `/${slug}/settings/notifications`,
+            href: "/account/settings/notifications",
             arrow: true,
           },
         ],


### PR DESCRIPTION
## Description

Fixes the account settings sidebar Notifications link and adds the placeholder Notifications settings UI.
<img width="959" height="512" alt="image" src="https://github.com/user-attachments/assets/def69c22-e432-4d67-9574-abff86e954d8" />

## Changes

- Updated the account settings sidebar Notifications route to use `/account/settings/notifications`
- Prevents the browser from navigating to the malformed `http://settings/notifications`
- Added a Coming Soon notifications page UI matching the existing referrals empty-state style
- No notification functionality or API behavior was added

## Testing

- Verified the sidebar link now points to `/account/settings/notifications`
- Ran Prettier check for the notifications page files

## Demo

Recorded video attached showing:

- Previous behavior

https://github.com/user-attachments/assets/d1be11a3-dec1-4c74-a522-be187e8b34b6

- Updated behavior after the fix

https://github.com/user-attachments/assets/ebfcb3c2-8bbb-490d-af1c-2356a1a7b1ce




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Notifications settings page accessible from your account settings. The notifications preferences interface is coming soon and will allow you to manage your notification settings once available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->