### PR TITLE
`defaultFolderId` after workspace folder bulk delete

### DIFF
--- a/apps/web/app/(ee)/api/cron/folders/delete/route.ts
+++ b/apps/web/app/(ee)/api/cron/folders/delete/route.ts
@@ -39,6 +39,15 @@ export async function POST(req: Request) {
     });
 
     if (linksToUpdate.length === 0) {
+      await prisma.projectUsers.updateMany({
+        where: {
+          defaultFolderId: folderId,
+        },
+        data: {
+          defaultFolderId: null,
+        },
+      });
+
       await prisma.folder.delete({
         where: {
           id: folderId,

--- a/apps/web/lib/api/folders/delete-workspace-folders.ts
+++ b/apps/web/lib/api/folders/delete-workspace-folders.ts
@@ -39,6 +39,16 @@ export async function deleteWorkspaceFolders({
     return;
   }
 
+  await prisma.projectUsers.updateMany({
+    where: {
+      projectId: workspaceId,
+      defaultFolderId: { in: folders.map(({ id }) => id) },
+    },
+    data: {
+      defaultFolderId: null,
+    },
+  });
+
   return await Promise.all([
     ...folders.map(({ id }) =>
       queueFolderDeletion({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed folder deletion to properly clean up default folder references. When folders are removed, the system now clears any associated default folder assignments for workspace users, preventing orphaned data and ensuring consistent state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->