### PR TITLE
Pass timezone to partner earnings OG image

### DIFF
--- a/apps/web/app/(ee)/partners.dub.co/(dashboard)/programs/[programSlug]/(enrolled)/share-earnings-modal.tsx
+++ b/apps/web/app/(ee)/partners.dub.co/(dashboard)/programs/[programSlug]/(enrolled)/share-earnings-modal.tsx
@@ -69,17 +69,17 @@ function ShareEarningsModalInner({
   const [isLoading, setIsLoading] = useState(false);
   const [blob, setBlob] = useState<Blob | null>(null);
 
-  const imageUrl = useMemo(
-    () =>
-      `/api/og/partner-earnings?${new URLSearchParams({
-        programId,
-        background,
-        interval,
-        ...(start && { start: start.toISOString() }),
-        ...(end && { end: end.toISOString() }),
-      }).toString()}`,
-    [programId, background, interval, start, end],
-  );
+  const imageUrl = useMemo(() => {
+    const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    return `/api/og/partner-earnings?${new URLSearchParams({
+      programId,
+      background,
+      interval,
+      timezone,
+      ...(start && { start: start.toISOString() }),
+      ...(end && { end: end.toISOString() }),
+    }).toString()}`;
+  }, [programId, background, interval, start, end]);
 
   useEffect(() => {
     if (!programId) return;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * The partner earnings sharing feature now automatically detects and applies your local timezone to shared earnings charts, ensuring accurate data representation across different regions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->