### PR TITLE
Support subscriptions for Shopify discounts

### DIFF
--- a/apps/web/lib/discounts/discount-provider-shopify.ts
+++ b/apps/web/lib/discounts/discount-provider-shopify.ts
@@ -96,11 +96,22 @@ function createShopifyDiscountProvider() {
     shouldRetry = true,
   }: {
     workspace: Pick<Project, "id" | "shopifyStoreId">;
-    discount: Pick<Discount, "id" | "amount" | "type">;
+    discount: Pick<Discount, "id" | "amount" | "type" | "maxDuration">;
     code: string;
     shouldRetry?: boolean;
   }) => {
     const { credentials } = await requireInstalledIntegration(workspace);
+
+    // Map Dub's maxDuration (months) to Shopify's recurringCycleLimit (subscription billing cycles):
+    // - null  -> 0 (Shopify: applies indefinitely / forever)
+    // - 0     -> 1 (one-time only -> only first subscription cycle)
+    // - N     -> N (applies for N billing cycles)
+    const recurringCycleLimit =
+      discount.maxDuration === null
+        ? 0
+        : discount.maxDuration === 0
+          ? 1
+          : discount.maxDuration;
 
     let attempt = 0;
     let currentCode = code;
@@ -144,8 +155,11 @@ function createShopifyDiscountProvider() {
               startsAt: new Date().toISOString(),
               customerSelection: { all: true },
               appliesOncePerCustomer: true,
+              recurringCycleLimit,
               customerGets: {
                 items: { all: true },
+                appliesOnOneTimePurchase: true,
+                appliesOnSubscription: true,
                 value:
                   discount.type === "percentage"
                     ? { percentage: discount.amount / 100 }

--- a/apps/web/ui/partners/discounts/add-edit-discount-sheet.tsx
+++ b/apps/web/ui/partners/discounts/add-edit-discount-sheet.tsx
@@ -103,11 +103,9 @@ function DiscountSheetContent({
           : defaultValuesSource.amount,
       type: defaultValuesSource.type,
       maxDuration:
-        discountProvider === DiscountProvider.shopify
-          ? 0
-          : defaultValuesSource.maxDuration === null
-            ? Infinity
-            : defaultValuesSource.maxDuration,
+        defaultValuesSource.maxDuration === null
+          ? Infinity
+          : defaultValuesSource.maxDuration,
       couponId: defaultValuesSource.couponId || "",
       couponTestId: defaultValuesSource.couponTestId,
       autoProvision: Boolean(defaultValuesSource.autoProvisionEnabledAt),
@@ -283,21 +281,11 @@ function DiscountSheetContent({
                             ...rest,
                             onChange: (e: ChangeEvent<HTMLSelectElement>) => {
                               onProviderChange(e);
+                              setUseExistingCoupon(false);
+                              setUseStripeTestCouponId(false);
                               if (e.target.value === DiscountProvider.shopify) {
-                                setUseExistingCoupon(false);
-                                setUseStripeTestCouponId(false);
                                 setValue("couponId", "");
                                 setValue("couponTestId", "");
-                                setValue("maxDuration", 0);
-                              } else {
-                                setUseExistingCoupon(false);
-                                setUseStripeTestCouponId(false);
-                                setValue(
-                                  "maxDuration",
-                                  defaultValuesSource.maxDuration === null
-                                    ? Infinity
-                                    : defaultValuesSource.maxDuration,
-                                );
                               }
                             },
                           };
@@ -499,20 +487,16 @@ function DiscountSheetContent({
                           text: "one time",
                           value: "0",
                         },
-                        ...(provider === DiscountProvider.shopify
-                          ? []
-                          : [
-                              ...RECURRING_MAX_DURATIONS.filter(
-                                (v) => v !== 0,
-                              ).map((v) => ({
-                                text: `for ${v} ${pluralize("month", Number(v))}`,
-                                value: v.toString(),
-                              })),
-                              {
-                                text: "for the customer's lifetime",
-                                value: "Infinity",
-                              },
-                            ]),
+                        ...RECURRING_MAX_DURATIONS.filter((v) => v !== 0).map(
+                          (v) => ({
+                            text: `for ${v} ${pluralize("month", Number(v))}`,
+                            value: v.toString(),
+                          }),
+                        ),
+                        {
+                          text: "for the customer's lifetime",
+                          value: "Infinity",
+                        },
                       ]}
                     />
                   </InlineBadgePopover>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shopify discount codes can now include maximum duration limits (one-time, fixed number of cycles, or lifetime) for precise promo control.
  * Discount creation payloads now apply recurring limits to both one-time and subscription offers.
  * Editing UI: duration options are consistent across providers; provider changes reset coupon-related selections and map null duration to lifetime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->