### PR TITLE
Fix workspace delete cron stopping after the first batch

### DIFF
--- a/apps/web/app/(ee)/api/cron/workspaces/delete/delete-workspace-customers.ts
+++ b/apps/web/app/(ee)/api/cron/workspaces/delete/delete-workspace-customers.ts
@@ -11,7 +11,7 @@ const MAX_CUSTOMERS_PER_BATCH = 100;
 export async function deleteWorkspaceCustomers(
   payload: DeleteWorkspacePayload,
 ) {
-  const { workspaceId, startingAfter } = payload;
+  const { workspaceId } = payload;
 
   const customers = await prisma.customer.findMany({
     where: {
@@ -20,12 +20,6 @@ export async function deleteWorkspaceCustomers(
     orderBy: {
       id: "asc",
     },
-    ...(startingAfter && {
-      skip: 1,
-      cursor: {
-        id: startingAfter,
-      },
-    }),
     take: MAX_CUSTOMERS_PER_BATCH,
   });
 

--- a/apps/web/app/(ee)/api/cron/workspaces/delete/delete-workspace-domains.ts
+++ b/apps/web/app/(ee)/api/cron/workspaces/delete/delete-workspace-domains.ts
@@ -8,7 +8,7 @@ import {
 const MAX_DOMAINS_PER_BATCH = 10;
 
 export async function deleteWorkspaceDomains(payload: DeleteWorkspacePayload) {
-  const { workspaceId, startingAfter } = payload;
+  const { workspaceId } = payload;
 
   const domains = await prisma.domain.findMany({
     where: {
@@ -17,12 +17,6 @@ export async function deleteWorkspaceDomains(payload: DeleteWorkspacePayload) {
     orderBy: {
       id: "asc",
     },
-    ...(startingAfter && {
-      skip: 1,
-      cursor: {
-        id: startingAfter,
-      },
-    }),
     take: MAX_DOMAINS_PER_BATCH,
   });
 

--- a/apps/web/app/(ee)/api/cron/workspaces/delete/delete-workspace-folders.ts
+++ b/apps/web/app/(ee)/api/cron/workspaces/delete/delete-workspace-folders.ts
@@ -7,7 +7,7 @@ import {
 const MAX_FOLDERS_PER_BATCH = 100;
 
 export async function deleteWorkspaceFolders(payload: DeleteWorkspacePayload) {
-  const { workspaceId, startingAfter } = payload;
+  const { workspaceId } = payload;
 
   const folders = await prisma.folder.findMany({
     where: {
@@ -16,12 +16,6 @@ export async function deleteWorkspaceFolders(payload: DeleteWorkspacePayload) {
     orderBy: {
       id: "asc",
     },
-    ...(startingAfter && {
-      skip: 1,
-      cursor: {
-        id: startingAfter,
-      },
-    }),
     take: MAX_FOLDERS_PER_BATCH,
   });
 

--- a/apps/web/app/(ee)/api/cron/workspaces/delete/delete-workspace-links.ts
+++ b/apps/web/app/(ee)/api/cron/workspaces/delete/delete-workspace-links.ts
@@ -8,7 +8,7 @@ import {
 const MAX_LINKS_PER_BATCH = 100;
 
 export async function deleteWorkspaceLinks(payload: DeleteWorkspacePayload) {
-  const { workspaceId, startingAfter } = payload;
+  const { workspaceId } = payload;
 
   const links = await prisma.link.findMany({
     where: {
@@ -17,12 +17,6 @@ export async function deleteWorkspaceLinks(payload: DeleteWorkspacePayload) {
     orderBy: {
       id: "asc",
     },
-    ...(startingAfter && {
-      skip: 1,
-      cursor: {
-        id: startingAfter,
-      },
-    }),
     take: MAX_LINKS_PER_BATCH,
   });
 

--- a/apps/web/app/(ee)/api/cron/workspaces/delete/utils.ts
+++ b/apps/web/app/(ee)/api/cron/workspaces/delete/utils.ts
@@ -15,7 +15,6 @@ export const deleteWorkspaceSchema = z.object({
     ])
     .optional()
     .default("delete-links"),
-  startingAfter: z.string().optional(),
 });
 
 export type DeleteWorkspacePayload = z.infer<typeof deleteWorkspaceSchema>;
@@ -33,13 +32,16 @@ export async function enqueueNextWorkspaceDeleteStep({
   items: { id: string }[];
   maxBatchSize: number;
 }) {
+  // Each step deletes the rows it fetched in-place, so the next invocation just
+  // re-fetches the first N remaining rows. We re-enqueue the same step until a
+  // batch comes back smaller than maxBatchSize, signaling that there's nothing
+  // left to delete for this step.
   const hasMore = items.length === maxBatchSize;
 
   const { messageId } = await qstash.publishJSON({
     url: `${APP_DOMAIN_WITH_NGROK}/api/cron/workspaces/delete`,
     body: {
       ...payload,
-      startingAfter: hasMore ? items[items.length - 1].id : undefined,
       step: hasMore ? currentStep : nextStep,
     },
   });


### PR DESCRIPTION
The bug is the cursor pagination. Look at the sequence:

Batch 1: fetches links 1..100 (sorted by id asc), deletes them all, sets startingAfter = id_of_link_100.

Batch 2 runs with cursor: { id: id_of_link_100 }, skip: 1 — but id_of_link_100 no longer exists because we just deleted it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified workspace deletion processes by removing cursor-based pagination logic from customer, domain, folder, and link deletion operations. The system now processes workspace cleanup in consistent batches without pagination markers while maintaining all deletion functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->