### PR TITLE
Add `hideEarnings` prop in referral embed

### DIFF
--- a/apps/web/app/(ee)/app.dub.co/embed/referrals/page-client.tsx
+++ b/apps/web/app/(ee)/app.dub.co/embed/referrals/page-client.tsx
@@ -157,6 +157,9 @@ export function ReferralsEmbedPageClient({
 
   const programEmbedData = programEmbedSchema.parse(program.embedData);
 
+  const termsHref =
+    (programEmbedData?.customTermsUrl || program.termsUrl) ?? undefined;
+
   const hasResources =
     resources &&
     ["logos", "colors", "files"].some(
@@ -174,7 +177,7 @@ export function ReferralsEmbedPageClient({
     () => [
       ...(showQuickstart ? ["Quickstart"] : []),
       ...(activeBountiesCount > 0 ? ["Bounties"] : []),
-      "Earnings",
+      ...(!programEmbedData?.hideEarnings ? ["Earnings"] : []),
       ...(group.additionalLinks.length > 0 ? ["Links"] : []),
       ...(programEmbedData?.leaderboard?.mode === "disabled"
         ? []
@@ -248,9 +251,9 @@ export function ReferralsEmbedPageClient({
                 <span className="text-content-emphasis text-base font-semibold leading-none">
                   Rewards
                 </span>
-                {program.termsUrl && (
+                {termsHref && (
                   <a
-                    href={program.termsUrl}
+                    href={termsHref}
                     target="_blank"
                     className="text-content-subtle text-xs font-medium leading-none underline-offset-2 hover:underline"
                   >
@@ -261,8 +264,14 @@ export function ReferralsEmbedPageClient({
               <div className="text-content-emphasis relative mt-4 text-lg">
                 <ProgramRewardList rewards={rewards} discount={discount} />
                 <ProgramRewardTerms
-                  minPayoutAmount={program.minPayoutAmount}
-                  holdingPeriodDays={group.holdingPeriodDays ?? 0}
+                  minPayoutAmount={
+                    programEmbedData?.hideEarnings ? 0 : program.minPayoutAmount
+                  }
+                  holdingPeriodDays={
+                    programEmbedData?.hideEarnings
+                      ? 0
+                      : group.holdingPeriodDays ?? 0
+                  }
                 />
               </div>
             </div>
@@ -281,9 +290,18 @@ export function ReferralsEmbedPageClient({
               </div>
             )}
           </div>
-          <div className="mt-4 grid gap-2 sm:h-32 sm:grid-cols-3">
+          <div
+            className={cn(
+              "mt-4 grid gap-2 sm:h-32 sm:grid-cols-3",
+              programEmbedData?.hideEarnings
+                ? "sm:grid-cols-1"
+                : "sm:grid-cols-3",
+            )}
+          >
             <ReferralsEmbedActivity />
-            <ReferralsEmbedEarningsSummary />
+            {!programEmbedData?.hideEarnings && (
+              <ReferralsEmbedEarningsSummary />
+            )}
           </div>
           <div className="mt-4">
             <div className="border-border-subtle flex items-center border-b">

--- a/apps/web/app/(ee)/app.dub.co/embed/referrals/quickstart.tsx
+++ b/apps/web/app/(ee)/app.dub.co/embed/referrals/quickstart.tsx
@@ -1,4 +1,5 @@
 import { constructPartnerLink } from "@/lib/partners/construct-partner-link";
+import { programEmbedSchema } from "@/lib/zod/schemas/program-embed";
 import {
   Button,
   Carousel,
@@ -23,9 +24,10 @@ export function ReferralsEmbedQuickstart({
   setSelectedTab,
 }: {
   hasResources: boolean;
-  setSelectedTab: (tab: "Links" | "Resources") => void;
+  setSelectedTab: (tab: "Links" | "Resources" | "FAQ") => void;
 }) {
   const { program, group, links, earnings } = useReferralsEmbedData();
+  const programEmbedData = programEmbedSchema.parse(program.embedData);
 
   const [copied, copyToClipboard] = useCopyToClipboard();
   const { isMobile } = useMediaQuery();
@@ -99,26 +101,46 @@ export function ReferralsEmbedQuickstart({
         />
       ),
     },
-    {
-      title: "Receive earnings",
-      description:
-        "Connect payouts to get rewarded for the activity you drive, with earnings tracked automatically.",
-      illustration: <ConnectPayouts logo={group.logo ?? DUB_LOGO} />,
-      cta: (
-        <Button
-          className={payoutsDisabled ? "h-9 rounded-lg" : BUTTON_CLASSNAME}
-          disabledTooltip={
-            payoutsDisabled
-              ? "You will be able to withdraw your earnings once you have made at least one sale."
-              : undefined
-          }
-          onClick={() =>
-            window.open("https://partners.dub.co/payouts", "_blank")
-          }
-          text="Connect payouts"
-        />
-      ),
-    },
+    ...(programEmbedData?.hideEarnings
+      ? [
+          {
+            title: "Browse the FAQ",
+            description:
+              "Find answers about this program, how referrals are tracked, and what happens after you share your link.",
+            illustration: <FaqAccordionList />,
+            cta: (
+              <Button
+                className="h-9 rounded-lg"
+                text="View FAQs"
+                onClick={() => setSelectedTab("FAQ")}
+              />
+            ),
+          },
+        ]
+      : [
+          {
+            title: "Receive earnings",
+            description:
+              "Connect payouts to get rewarded for the activity you drive, with earnings tracked automatically.",
+            illustration: <ConnectPayouts logo={group.logo ?? DUB_LOGO} />,
+            cta: (
+              <Button
+                className={
+                  payoutsDisabled ? "h-9 rounded-lg" : BUTTON_CLASSNAME
+                }
+                disabledTooltip={
+                  payoutsDisabled
+                    ? "You will be able to withdraw your earnings once you have made at least one sale."
+                    : undefined
+                }
+                onClick={() =>
+                  window.open("https://partners.dub.co/payouts", "_blank")
+                }
+                text="Connect payouts"
+              />
+            ),
+          },
+        ]),
   ];
 
   return (
@@ -174,6 +196,146 @@ const BG_MUTED = "rgb(var(--bg-muted))";
 const BG_DEFAULT = "rgb(var(--bg-default))";
 const BORDER_SUBTLE = "rgb(var(--border-subtle))";
 const CONTENT_SUBTLE = "rgb(var(--content-subtle))";
+
+/** Accordion-style FAQ list illustration (matches 194×121 quickstart art). */
+const FaqAccordionList = () => (
+  <svg
+    width="194"
+    height="121"
+    viewBox="0 0 194 121"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    className="h-auto w-full"
+    aria-hidden
+  >
+    <rect width="194" height="121" fill={BG_MUTED} />
+    <rect
+      x="20.5"
+      y="11.5"
+      width="153"
+      height="98"
+      rx="10.5"
+      fill={BG_DEFAULT}
+      stroke={BORDER_SUBTLE}
+    />
+    {/* Expanded item — header */}
+    <rect x="28" y="19" width="138" height="18" rx="5" fill={BG_MUTED} />
+    <rect
+      x="36"
+      y="25.5"
+      width="72"
+      height="3"
+      rx="1.5"
+      fill={CONTENT_SUBTLE}
+      opacity={0.45}
+    />
+    <rect
+      x="36"
+      y="31"
+      width="48"
+      height="3"
+      rx="1.5"
+      fill={CONTENT_SUBTLE}
+      opacity={0.32}
+    />
+    {/* × — expanded (rotated +) */}
+    <path
+      d="M155.25 25.25l5.5 5.5M160.75 25.25l-5.5 5.5"
+      stroke={CONTENT_SUBTLE}
+      strokeWidth="1.25"
+      strokeLinecap="round"
+    />
+    {/* Expanded item — answer body */}
+    <rect
+      x="28"
+      y="39"
+      width="138"
+      height="22"
+      rx="5"
+      fill={BG_DEFAULT}
+      stroke={BORDER_SUBTLE}
+    />
+    <rect
+      x="36"
+      y="46"
+      width="98"
+      height="2.5"
+      rx="1.25"
+      fill={CONTENT_SUBTLE}
+      opacity={0.38}
+    />
+    <rect
+      x="36"
+      y="52"
+      width="76"
+      height="2.5"
+      rx="1.25"
+      fill={CONTENT_SUBTLE}
+      opacity={0.28}
+    />
+    <rect
+      x="36"
+      y="58"
+      width="56"
+      height="2.5"
+      rx="1.25"
+      fill={CONTENT_SUBTLE}
+      opacity={0.22}
+    />
+    {/* Collapsed row 2 */}
+    <rect
+      x="28"
+      y="65"
+      width="138"
+      height="17"
+      rx="5"
+      fill={BG_DEFAULT}
+      stroke={BORDER_SUBTLE}
+    />
+    <rect
+      x="36"
+      y="72"
+      width="68"
+      height="3"
+      rx="1.5"
+      fill={CONTENT_SUBTLE}
+      opacity={0.42}
+    />
+    {/* + — collapsed */}
+    <path
+      d="M155.25 73.5h5.5M158 71.25v5.5"
+      stroke={CONTENT_SUBTLE}
+      strokeWidth="1.25"
+      strokeLinecap="round"
+    />
+    {/* Collapsed row 3 */}
+    <rect
+      x="28"
+      y="86"
+      width="138"
+      height="17"
+      rx="5"
+      fill={BG_DEFAULT}
+      stroke={BORDER_SUBTLE}
+    />
+    <rect
+      x="36"
+      y="93"
+      width="58"
+      height="3"
+      rx="1.5"
+      fill={CONTENT_SUBTLE}
+      opacity={0.38}
+    />
+    {/* + — collapsed */}
+    <path
+      d="M155.25 94.5h5.5M158 92.25v5.5"
+      stroke={CONTENT_SUBTLE}
+      strokeWidth="1.25"
+      strokeLinecap="round"
+    />
+  </svg>
+);
 
 const ShareLink = () => {
   return (

--- a/apps/web/lib/zod/schemas/program-embed.ts
+++ b/apps/web/lib/zod/schemas/program-embed.ts
@@ -10,5 +10,7 @@ export const programEmbedSchema = z
       })
       .nullish(),
     hidePoweredByBadge: z.boolean().default(false),
+    hideEarnings: z.boolean().default(false),
+    customTermsUrl: z.httpUrl().nullish(),
   })
   .nullish();


### PR DESCRIPTION
Closes #3774 & #3776

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Embedded referral programs can now hide earnings information, including the earnings tab and summary section, via configuration
  * Custom terms URL support added, allowing override of default program terms for embedded referral programs
  * Referral embed quickstart now features a new FAQ accordion section for improved user guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->