### PR TITLE
Skip invalid subscription status in `customer.subscription.updated`

### DIFF
--- a/apps/web/app/(ee)/api/stripe/webhook/customer-subscription-updated.ts
+++ b/apps/web/app/(ee)/api/stripe/webhook/customer-subscription-updated.ts
@@ -16,6 +16,10 @@ export async function customerSubscriptionUpdated(
     return `Invalid price ID in customer.subscription.updated event: ${priceId}`;
   }
 
+  if (!["active", "trialing"].includes(updatedSubscription.status)) {
+    return `Invalid updated subscription status "${updatedSubscription.status}" for subscription ${updatedSubscription.id}, skipping...`;
+  }
+
   const stripeId = updatedSubscription.customer.toString();
 
   const workspace = await prisma.project.findUnique({
@@ -57,12 +61,7 @@ export async function customerSubscriptionUpdated(
     subscription: updatedSubscription,
   });
 
-  const subscriptionCanceled =
-    (updatedSubscription.status === "active" ||
-      updatedSubscription.status === "trialing") &&
-    updatedSubscription.cancel_at_period_end;
-
-  if (subscriptionCanceled) {
+  if (updatedSubscription.cancel_at_period_end) {
     const owners = workspace.users.map(({ user }) => user);
     const cancelReason = updatedSubscription.cancellation_details?.feedback;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription update handling: updates for non-active or non-trialing subscriptions are now skipped to avoid incorrect changes.
  * Cancellation notices are now more reliably sent when a subscription is set to cancel at period end, ensuring workspace owners receive accurate cancellation feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->