### PR TITLE
Improve mobile navigation contrast in dark mode

### DIFF
--- a/apps/web/docker-compose.yml
+++ b/apps/web/docker-compose.yml
@@ -15,7 +15,7 @@ services:
         "--default-authentication-plugin=mysql_native_password",
       ]
     ports:
-      - 3306:3306
+      - 3307:3306
     volumes:
       - ps-mysql:/var/lib/mysql
 

--- a/packages/ui/src/nav/content/solutions-content.tsx
+++ b/packages/ui/src/nav/content/solutions-content.tsx
@@ -71,7 +71,7 @@ export function SolutionsContent({ domain }: { domain: string }) {
                   <span className="text-sm font-medium text-neutral-900 dark:text-white">
                     {title}
                   </span>
-                  <p className="mt-2 text-xs text-neutral-500 dark:text-white/60">
+                  <p className="mt-2 text-xs text-neutral-500 dark:text-white/80">
                     {description}
                   </p>
                 </div>

--- a/packages/ui/src/nav/nav.tsx
+++ b/packages/ui/src/nav/nav.tsx
@@ -208,7 +208,7 @@ export function Nav({
                     href={APP_DOMAIN}
                     className={cn(
                       buttonVariants({ variant: "primary" }),
-                      "flex h-8 items-center rounded-lg border px-4 text-sm",
+                      "flex h-8 items-center whitespace-nowrap rounded-lg border px-4 text-sm",
                       "dark:border-white dark:bg-white dark:text-black dark:hover:bg-neutral-50 dark:hover:ring-white/10",
                     )}
                   >
@@ -220,7 +220,7 @@ export function Nav({
                       href="https://app.dub.co/login"
                       className={cn(
                         buttonVariants({ variant: "secondary" }),
-                        "flex h-8 items-center rounded-lg border px-4 text-sm",
+                        "flex h-8 items-center whitespace-nowrap rounded-lg border px-4 text-sm",
                         "dark:border-white/10 dark:bg-black dark:text-white dark:hover:bg-neutral-900",
                       )}
                     >
@@ -230,7 +230,7 @@ export function Nav({
                       href="https://app.dub.co/register"
                       className={cn(
                         buttonVariants({ variant: "primary" }),
-                        "flex h-8 items-center rounded-lg border px-4 text-sm",
+                        "flex h-8 items-center whitespace-nowrap rounded-lg border px-4 text-sm",
                         "dark:border-white dark:bg-white dark:text-black dark:hover:bg-neutral-50 dark:hover:ring-white/10",
                       )}
                     >


### PR DESCRIPTION
## Summary

Improves readability of mobile navigation menu items in dark mode on the `/brand` page.

## Changes

* Increased contrast of solution description text in dark mode
* Updated `dark:text-white/60` to `dark:text-white/80`

## Issue

Menu items appeared too dim on dark backgrounds, reducing readability on mobile devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved dark mode contrast for card descriptions
  * Prevented navigation button text from wrapping on smaller screens

* **Chores**
  * Updated database port configuration in local development environment

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dubinc/dub/pull/3879)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->