### PR TITLE
fix: return 200 on business-logic errors in Stripe webhook handler

### DIFF
--- a/apps/web/app/(ee)/api/stripe/webhook/route.ts
+++ b/apps/web/app/(ee)/api/stripe/webhook/route.ts
@@ -83,8 +83,10 @@ export const POST = async (req: Request) => {
       message: `Stripe webhook failed (${event.type}). Error: ${error.message}`,
       type: "errors",
     });
+    // Return 200 so Stripe does not retry on business-logic failures.
+    // Signature/construction errors (above) still return 400, which is correct.
     return new Response(`Webhook error: ${error.message}`, {
-      status: 400,
+      status: 200,
     });
   }
 


### PR DESCRIPTION
## What

Changes the business-logic catch block in `apps/web/app/(ee)/api/stripe/webhook/route.ts` to return `status: 200` instead of `status: 400`.

## Why

Per [Stripe's webhook docs](https://stripe.com/docs/webhooks#acknowledge-events-immediately), any non-2xx response signals that the event was not received and triggers automatic retries. When a handler throws due to a transient error (e.g. an email delivery failure), the current 400 response causes Stripe to re-deliver the event repeatedly — potentially resulting in duplicate subscription upgrades, charges, or other idempotent-sensitive operations.

Signature verification errors correctly keep `400` (those are genuine bad requests). Internal handler errors should acknowledge receipt and rely on our own alerting/logging for investigation.

Closes #3752

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated webhook handling to return correct HTTP status codes for processing failures, preventing redundant retries and improving webhook reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dubinc/dub/pull/3883)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->