### PR TITLE
Exclude tax from commission amount when importing Stripe invoices

### DIFF
--- a/apps/web/lib/api/customers/get-customer-stripe-invoices.ts
+++ b/apps/web/lib/api/customers/get-customer-stripe-invoices.ts
@@ -137,7 +137,11 @@ export async function getCustomerStripeInvoices({
   const stripeCustomerInvoices = invoices.map((invoice) =>
     StripeCustomerInvoiceSchema.parse({
       id: invoice.id,
-      amount: invoice.amount_paid,
+      amount:
+        invoice.amount_paid === invoice.total &&
+        invoice.total_excluding_tax != null
+          ? invoice.total_excluding_tax
+          : invoice.amount_paid,
       createdAt: new Date(invoice.created * 1000),
       refunded: processInvoice(invoice).refunded,
       dubCommissionId: invoiceIdCommissionIdMap[invoice.id],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of invoice amount calculations for fully paid invoices, ensuring correct amounts are displayed in customer invoice records.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dubinc/dub/pull/3895)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->