### PR TITLE
Discount icon change

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/[partnerId]/links/page.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/[partnerId]/links/page.tsx
@@ -18,9 +18,9 @@ import { DiscountProvider } from "@dub/prisma/client";
 import {
   Button,
   CopyButton,
+  DiscountCode,
   LoadingSpinner,
   Table,
-  Tag,
   TooltipContent,
   useTable,
 } from "@dub/ui";
@@ -328,7 +328,7 @@ const PartnerDiscountCodes = ({
         </div>
       ) : !error && (!discountCodes || discountCodes.length === 0) ? (
         <div className="flex flex-col items-center justify-center gap-2 rounded-lg border border-neutral-200 bg-neutral-50 py-6">
-          <Tag className="mb-2 size-6 text-neutral-900" />
+          <DiscountCode className="mb-2 size-6 text-neutral-900" />
           <h3 className="text-content-emphasis text-sm font-semibold leading-5">
             No codes created
           </h3>

--- a/apps/web/ui/modals/add-discount-code-modal.tsx
+++ b/apps/web/ui/modals/add-discount-code-modal.tsx
@@ -7,11 +7,11 @@ import {
   Button,
   Combobox,
   ComboboxOption,
+  DiscountCode,
   Modal,
   useCopyToClipboard,
 } from "@dub/ui";
 import { cn, getPrettyUrl } from "@dub/utils";
-import { Tag } from "lucide-react";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
@@ -193,7 +193,7 @@ const AddDiscountCodeModal = ({
 
               <div className="relative">
                 <div className="absolute inset-y-0 left-0 flex items-center pl-3">
-                  <Tag className="text-content-default h-4 w-4" />
+                  <DiscountCode className="text-content-default h-4 w-4" />
                 </div>
                 <input
                   {...register("code")}

--- a/apps/web/ui/modals/delete-discount-code-modal.tsx
+++ b/apps/web/ui/modals/delete-discount-code-modal.tsx
@@ -1,8 +1,7 @@
 import { mutatePrefix } from "@/lib/swr/mutate";
 import { useApiMutation } from "@/lib/swr/use-api-mutation";
 import { DiscountCodeProps } from "@/lib/types";
-import { Button, Modal, useMediaQuery } from "@dub/ui";
-import { Tag } from "@dub/ui/icons";
+import { Button, DiscountCode, Modal, useMediaQuery } from "@dub/ui";
 import { FormEvent } from "react";
 import { toast } from "sonner";
 
@@ -47,7 +46,7 @@ export const DeleteDiscountCodeModal = ({
             </div>
 
             <div className="relative flex h-7 w-fit items-center gap-1.5 rounded-lg bg-green-100 px-2 py-0">
-              <Tag className="size-3 text-green-700" strokeWidth={1.5} />
+              <DiscountCode className="size-3 text-green-700" />
               <div className="text-xs font-medium text-green-700">
                 {discountCode.code}
               </div>

--- a/apps/web/ui/modals/delete-discount-code-modal.tsx
+++ b/apps/web/ui/modals/delete-discount-code-modal.tsx
@@ -46,7 +46,10 @@ export const DeleteDiscountCodeModal = ({
             </div>
 
             <div className="relative flex h-7 w-fit items-center gap-1.5 rounded-lg bg-green-100 px-2 py-0">
-              <DiscountCode className="size-3 text-green-700" />
+              <DiscountCode
+                className="size-3 text-green-700"
+                strokeWidth={1.5}
+              />
               <div className="text-xs font-medium text-green-700">
                 {discountCode.code}
               </div>

--- a/apps/web/ui/partners/discounts/discount-code-badge.tsx
+++ b/apps/web/ui/partners/discounts/discount-code-badge.tsx
@@ -20,7 +20,7 @@ export function DiscountCodeBadge({ code }: { code: string }) {
         })
       }
     >
-      <DiscountCode className="size-3 text-green-700" />
+      <DiscountCode className="size-3 text-green-700" strokeWidth={1.5} />
       <div className="text-xs font-medium text-green-700 decoration-dotted underline-offset-2 transition-colors group-hover/discountcode:underline">
         {code}
       </div>

--- a/apps/web/ui/partners/discounts/discount-code-badge.tsx
+++ b/apps/web/ui/partners/discounts/discount-code-badge.tsx
@@ -1,4 +1,4 @@
-import { Tag, useCopyToClipboard } from "@dub/ui";
+import { DiscountCode, useCopyToClipboard } from "@dub/ui";
 import { cn } from "@dub/utils";
 import { toast } from "sonner";
 
@@ -20,7 +20,7 @@ export function DiscountCodeBadge({ code }: { code: string }) {
         })
       }
     >
-      <Tag className="size-3 text-green-700" strokeWidth={1.5} />
+      <DiscountCode className="size-3 text-green-700" />
       <div className="text-xs font-medium text-green-700 decoration-dotted underline-offset-2 transition-colors group-hover/discountcode:underline">
         {code}
       </div>

--- a/packages/ui/src/icons/nucleo/discount-code.tsx
+++ b/packages/ui/src/icons/nucleo/discount-code.tsx
@@ -1,0 +1,37 @@
+import { SVGProps } from "react";
+
+export function DiscountCode(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      height="18"
+      width="18"
+      viewBox="0 0 18 18"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <g fill="currentColor">
+        <circle cx="7" cy="7" fill="currentColor" r="1" stroke="none" />
+        <circle cx="11" cy="11" fill="currentColor" r="1" stroke="none" />
+        <line
+          fill="none"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="1.5"
+          x1="6.75"
+          x2="11.25"
+          y1="11.25"
+          y2="6.75"
+        />
+        <path
+          d="M14.5,9c0-.967,.784-1.75,1.75-1.75v-1.5c0-1.104-.895-2-2-2H3.75c-1.105,0-2,.896-2,2v1.5c.966,0,1.75,.783,1.75,1.75s-.784,1.75-1.75,1.75v1.5c0,1.104,.895,2,2,2H14.25c1.105,0,2-.896,2-2v-1.5c-.966,0-1.75-.783-1.75-1.75Z"
+          fill="none"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="1.5"
+        />
+      </g>
+    </svg>
+  );
+}

--- a/packages/ui/src/icons/nucleo/index.ts
+++ b/packages/ui/src/icons/nucleo/index.ts
@@ -85,6 +85,7 @@ export * from "./diamond-turn-right";
 export * from "./diamond-turn-right-fill";
 export * from "./directions";
 export * from "./discount";
+export * from "./discount-code";
 export * from "./dots";
 export * from "./download";
 export * from "./duplicate";


### PR DESCRIPTION
Updated on the partner details discount code section

<img width="904" height="298" alt="CleanShot 2026-05-13 at 16 39 24@2x" src="https://github.com/user-attachments/assets/e707ea85-7380-4da2-a0df-9dde81b6f264" />

<img width="919" height="288" alt="CleanShot 2026-05-13 at 16 39 18@2x" src="https://github.com/user-attachments/assets/dc641a26-a65d-4099-a322-f82ccf549211" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new DiscountCode icon component to the UI library.

* **Style**
  * Replaced prior tag icon usage across partner discount screens and modals with the new DiscountCode icon (empty states, input adornments, badges, and verification/confirmation pill).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dubinc/dub/pull/3903)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->