### PR TITLE
Company icon alignment

### DIFF
--- a/apps/web/ui/partners/partner-info-cards.tsx
+++ b/apps/web/ui/partners/partner-info-cards.tsx
@@ -284,10 +284,12 @@ export function PartnerInfoCards({
               .filter(({ text }) => text !== null)
               .map(({ id, icon, text, timestamp, wrapper: RowWrapper }) => {
                 const rowInner = (
-                  <div className="text-content-subtle flex items-center gap-1">
+                  <div className="text-content-subtle flex items-start gap-1">
                     {text !== undefined ? (
                       <>
-                        {icon}
+                        <span className="flex h-4 shrink-0 items-center">
+                          {icon}
+                        </span>
                         <span className="text-xs font-medium">{text}</span>
                       </>
                     ) : (


### PR DESCRIPTION
Aligning the company icon to the start instead of center, so if the company name wraps, the icon is aligned with the first line.

## After
<img width="1346" height="806" alt="CleanShot 2026-05-14 at 15 37 53@2x" src="https://github.com/user-attachments/assets/5999f73e-2178-4609-beec-3561baba6533" />


## Before
<img width="1486" height="926" alt="CleanShot 2026-05-14 at 15 37 17@2x" src="https://github.com/user-attachments/assets/51b7b842-36b8-4131-bdee-262179462835" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined partner information card layout with improved element alignment and spacing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dubinc/dub/pull/3908)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->