### PR TITLE
Top view type fix

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/analytics/commissions-analytics-cards.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/analytics/commissions-analytics-cards.tsx
@@ -180,7 +180,10 @@ function CommissionAnalyticsCardShell<T extends string>({
               onSelect={onSelectTab}
             />
           ) : (
-            <p className="py-3 text-sm font-medium text-neutral-900">{title}</p>
+            <TabSelect
+              options={[{ id: "single", label: title }]}
+              selected="single"
+            />
           )}
           <div className="flex items-center gap-1 pr-2 text-neutral-500">
             <StatusIcon className="hidden h-4 w-4 sm:block" />


### PR DESCRIPTION
The `type` card was defaulting to no tabs, so rendering as plain text. Now uses `TabSelect` to match the other views.

## After
<img width="1305" height="238" alt="CleanShot 2026-05-15 at 14 08 56@2x" src="https://github.com/user-attachments/assets/3fedb7ca-9169-4f23-a67b-7ca348d67956" />

## Before
<img width="1292" height="117" alt="CleanShot 2026-05-15 at 14 10 52@2x" src="https://github.com/user-attachments/assets/cefdd096-8e6b-4a44-aab4-2c01c16b7b23" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Commission analytics cards header now displays tab selection controls for improved navigation and user experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dubinc/dub/pull/3912?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->