### PR TITLE
Fix partner referral reward logic

### DIFF
--- a/apps/web/lib/partner-referrals/create-referral-commission.ts
+++ b/apps/web/lib/partner-referrals/create-referral-commission.ts
@@ -93,11 +93,10 @@ export const createReferralCommission = async (
     const amountInPercentage = Number(referralReward.amountInPercentage ?? 0);
 
     if (typeof referralReward.maxDuration === "number") {
-      const firstReferralCommission = await prisma.commission.findFirst({
+      const referredPartnerFirstCommission = await prisma.commission.findFirst({
         where: {
           partnerId: referredByPartnerId,
-          customerId: sourceCommission.customerId,
-          type: "referral",
+          programId,
         },
         orderBy: {
           createdAt: "asc",
@@ -107,22 +106,14 @@ export const createReferralCommission = async (
         },
       });
 
-      if (firstReferralCommission) {
-        const subscriptionDurationMonths = differenceInMonths(
+      if (referredPartnerFirstCommission) {
+        const monthsSinceFirstCommission = differenceInMonths(
           sourceCommission.createdAt,
-          firstReferralCommission.createdAt,
+          referredPartnerFirstCommission.createdAt,
         );
 
-        // One-time
-        if (referralReward.maxDuration === 0) {
-          console.log(
-            `Referrer ${referredByPartnerId} reached max duration (first-sale only) for referred partner ${partnerId} for the customer ${sourceCommission.customerId}.`,
-          );
-          return null;
-        }
-
         // Recurring
-        if (subscriptionDurationMonths >= referralReward.maxDuration) {
+        if (monthsSinceFirstCommission >= referralReward.maxDuration) {
           console.log(
             `Referrer ${referredByPartnerId} reached max duration (${referralReward.maxDuration} months) for referred partner ${partnerId} for the customer ${sourceCommission.customerId}.`,
           );

--- a/apps/web/lib/partner-referrals/create-referral-commission.ts
+++ b/apps/web/lib/partner-referrals/create-referral-commission.ts
@@ -95,7 +95,7 @@ export const createReferralCommission = async (
     if (typeof referralReward.maxDuration === "number") {
       const referredPartnerFirstCommission = await prisma.commission.findFirst({
         where: {
-          partnerId: referredByPartnerId,
+          partnerId,
           programId,
         },
         orderBy: {

--- a/apps/web/ui/partners/format-reward-description.ts
+++ b/apps/web/ui/partners/format-reward-description.ts
@@ -121,7 +121,7 @@ function formatReferralRewardDescription(
 
 function formatReferralDuration(maxDuration: number | null | undefined) {
   if (maxDuration === null) {
-    return "for the customer's lifetime";
+    return "for the referred partner's lifetime";
   }
 
   if (maxDuration === 0) {

--- a/apps/web/ui/partners/program-reward-description.tsx
+++ b/apps/web/ui/partners/program-reward-description.tsx
@@ -159,7 +159,7 @@ function ReferralRewardDescription({
           {" "}
           for the{" "}
           <strong className={cn("font-semibold", periodClassName)}>
-            customer's lifetime
+            referred partner's lifetime
           </strong>
         </>
       );

--- a/apps/web/ui/partners/rewards/partner-referral-reward-builder.tsx
+++ b/apps/web/ui/partners/rewards/partner-referral-reward-builder.tsx
@@ -13,12 +13,12 @@ import { RECURRING_MAX_DURATIONS } from "@/lib/zod/schemas/misc";
 import { RewardStructure } from "@dub/prisma/client";
 import { capitalize, cn, currencyFormatter, pluralize } from "@dub/utils";
 import { useContext, useEffect, useMemo } from "react";
+import { DurationPopoverContent } from "../../shared/duration-popover-content";
 import {
   InlineBadgePopover,
   InlineBadgePopoverContext,
   InlineBadgePopoverMenu,
 } from "../../shared/inline-badge-popover";
-import { DurationPopoverContent } from "../../shared/duration-popover-content";
 import { useAddEditRewardForm } from "./add-edit-reward-sheet";
 
 type Trigger = (typeof PARTNER_REFERRAL_TRIGGER)[number];
@@ -137,9 +137,9 @@ export function PartnerReferralRewardBuilder() {
 
   const maxDurationText = useMemo(() => {
     if (maxDuration === 0) return "one time";
-    if (maxDuration === Infinity) return "for the customer's lifetime";
+    if (maxDuration === Infinity) return "for the referred partner's lifetime";
     if (maxDuration == null || Number.isNaN(Number(maxDuration))) {
-      return "for the customer's lifetime";
+      return "for the referred partner's lifetime";
     }
     return `for ${maxDuration} ${pluralize("month", Number(maxDuration))}`;
   }, [maxDuration]);
@@ -159,7 +159,7 @@ export function PartnerReferralRewardBuilder() {
           ]}
         />
       </InlineBadgePopover>{" "}
-      of{" "}
+      {type === "percentage" && "of "}
       <InlineBadgePopover
         text={amountText}
         invalid={amount == null || Number.isNaN(Number(amount))}
@@ -193,6 +193,7 @@ export function PartnerReferralRewardBuilder() {
               presetDurations={RECURRING_MAX_DURATIONS.filter(
                 (v) => v !== 0 && v !== 1, // filter out one-time and 1-month intervals (we only use 1-month for discounts)
               )}
+              partnerReferralReward
             />
           </InlineBadgePopover>
         </>

--- a/apps/web/ui/shared/duration-popover-content.tsx
+++ b/apps/web/ui/shared/duration-popover-content.tsx
@@ -8,10 +8,18 @@ import {
   InlineBadgePopoverMenu,
 } from "./inline-badge-popover";
 
+type DurationPopoverContentProps = {
+  value: number | undefined;
+  onChange: (value: number) => void;
+  presetDurations: number[];
+  partnerReferralReward?: boolean;
+};
+
 export function DurationPopoverContent({
   value,
   onChange,
   presetDurations,
+  partnerReferralReward,
 }: DurationPopoverContentProps) {
   const { isOpen, setIsOpen } = useContext(InlineBadgePopoverContext);
   const [customDurationInput, setCustomDurationInput] = useState<string>(() => {
@@ -132,22 +140,19 @@ export function DurationPopoverContent({
         setCustomDurationInput("");
       }}
       items={[
-        { text: "one time", value: "0" },
+        ...(!partnerReferralReward ? [{ text: "one time", value: "0" }] : []),
         ...presetDurations
           .filter((duration) => duration !== 0)
           .map((duration) => ({
             text: `for ${duration} ${pluralize("month", Number(duration))}`,
             value: duration.toString(),
           })),
-        { text: "for the customer's lifetime", value: "Infinity" },
+        {
+          text: `for the ${partnerReferralReward ? "referred partner's" : "customer's"} lifetime`,
+          value: "Infinity",
+        },
         { text: "custom", value: "custom", preventClose: true },
       ]}
     />
   );
 }
-
-type DurationPopoverContentProps = {
-  value: number | undefined;
-  onChange: (value: number) => void;
-  presetDurations: number[];
-};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Referral commission eligibility now uses the referred partner’s first commission to enforce max-duration, preventing commissions beyond the allowed window.

* **UI Updates**
  * Updated duration text to say "referred partner's lifetime" where applicable.
  * Duration picker presets now omit the one-time option for partner-referral rewards and show lifetime as the referred partner’s lifetime.
  * Reward phrasing refined to include "of" only for percentage amounts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dubinc/dub/pull/3916?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->