### PR TITLE
Add stripe customer id commission export

### DIFF
--- a/apps/web/lib/api/commissions/format-commissions-for-export.ts
+++ b/apps/web/lib/api/commissions/format-commissions-for-export.ts
@@ -54,6 +54,7 @@ export function formatCommissionsForExport(
       customerName: commission.customer?.name || "",
       customerEmail: commission.customer?.email || "",
       customerExternalId: commission.customer?.externalId || "",
+      stripeCustomerId: commission.customer?.stripeCustomerId || "",
       partnerName: commission.partner?.name || "",
       partnerEmail: commission.partner?.email || "",
       partnerTenantId: commission.programEnrollment?.tenantId || "",

--- a/apps/web/lib/zod/schemas/commissions.ts
+++ b/apps/web/lib/zod/schemas/commissions.ts
@@ -393,7 +393,7 @@ export const COMMISSION_EXPORT_COLUMNS = [
     id: "stripeCustomerId",
     label: "Stripe customer ID",
     type: "string",
-    default: true,
+    default: false,
   },
 ] as const;
 

--- a/apps/web/lib/zod/schemas/commissions.ts
+++ b/apps/web/lib/zod/schemas/commissions.ts
@@ -389,6 +389,12 @@ export const COMMISSION_EXPORT_COLUMNS = [
     type: "string",
     default: false,
   },
+  {
+    id: "stripeCustomerId",
+    label: "Stripe customer ID",
+    type: "string",
+    default: true,
+  },
 ] as const;
 
 type CommissionExportColumnId =


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Commission exports now include an optional Stripe customer ID column. Users can select this field when generating commission reports to include customer Stripe identifiers alongside other commission details for enhanced tracking and reconciliation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dubinc/dub/pull/3922?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->