### PR TITLE
Add manual referring partner attribution with commission backfill

### DIFF
--- a/apps/web/app/(ee)/admin.dub.co/(dashboard)/components/renew-domain.tsx
+++ b/apps/web/app/(ee)/admin.dub.co/(dashboard)/components/renew-domain.tsx
@@ -36,7 +36,9 @@ export function RenewDomain() {
             const text = await res.text();
             let payload: Record<string, unknown> = {};
             try {
-              payload = text ? (JSON.parse(text) as Record<string, unknown>) : {};
+              payload = text
+                ? (JSON.parse(text) as Record<string, unknown>)
+                : {};
             } catch {
               payload = {};
             }

--- a/apps/web/app/(ee)/admin.dub.co/(dashboard)/partners/network/page.tsx
+++ b/apps/web/app/(ee)/admin.dub.co/(dashboard)/partners/network/page.tsx
@@ -129,7 +129,8 @@ export default function NetworkApplicationsPage() {
   const onSearchChange = (value: string) => {
     const search = value.trim();
     const hasActiveFilters =
-      Boolean(searchParamsObj.networkStatus) || Boolean(searchParamsObj.country);
+      Boolean(searchParamsObj.networkStatus) ||
+      Boolean(searchParamsObj.country);
 
     if (!search || !hasActiveFilters) {
       return;

--- a/apps/web/app/(ee)/api/cron/commissions/referrals/backfill/route.ts
+++ b/apps/web/app/(ee)/api/cron/commissions/referrals/backfill/route.ts
@@ -77,6 +77,7 @@ export const POST = withCron(async ({ rawBody }) => {
       {
         queueName: "create-referral-commissions",
         url: `${APP_DOMAIN_WITH_NGROK}/api/cron/commissions/referrals/create`,
+        deduplicationId: `create-referral-commissions-${programId}-${partnerId}`,
         body: {
           programId,
           partnerId,

--- a/apps/web/app/(ee)/api/cron/commissions/referrals/backfill/route.ts
+++ b/apps/web/app/(ee)/api/cron/commissions/referrals/backfill/route.ts
@@ -1,0 +1,134 @@
+import { enqueueBatchJobs } from "@/lib/cron/enqueue-batch-jobs";
+import { withCron } from "@/lib/cron/with-cron";
+import { referralRewardConfigSchema } from "@/lib/zod/schemas/rewards";
+import { prisma } from "@dub/prisma";
+import { CommissionType } from "@dub/prisma/client";
+import { APP_DOMAIN_WITH_NGROK, chunk } from "@dub/utils";
+import * as z from "zod/v4";
+import { logAndRespond } from "../../../utils";
+
+export const dynamic = "force-dynamic";
+
+const inputSchema = z.object({
+  programId: z.string(),
+  partnerId: z.string(),
+});
+
+// POST /api/cron/commissions/referrals/backfill
+export const POST = withCron(async ({ rawBody }) => {
+  const { programId, partnerId } = inputSchema.parse(JSON.parse(rawBody));
+
+  const applicationEvent = await prisma.programApplicationEvent.findUnique({
+    where: {
+      programId_partnerId: {
+        programId,
+        partnerId,
+      },
+    },
+    select: {
+      referredByPartnerId: true,
+    },
+  });
+
+  if (!applicationEvent) {
+    return logAndRespond(
+      `Application event not found for partner ${partnerId} in program ${programId}. Skipping...`,
+    );
+  }
+
+  const { referredByPartnerId } = applicationEvent;
+
+  if (!referredByPartnerId) {
+    return logAndRespond(
+      `Application event for partner ${partnerId} in program ${programId} has no referred by partner. Skipping...`,
+    );
+  }
+
+  const referrerEnrollment = await prisma.programEnrollment.findUnique({
+    where: {
+      partnerId_programId: {
+        partnerId: referredByPartnerId,
+        programId,
+      },
+    },
+    select: {
+      referralReward: true,
+    },
+  });
+
+  if (!referrerEnrollment) {
+    return logAndRespond(
+      `Referrer program enrollment not found for partner ${referredByPartnerId} in program ${programId}. Skipping...`,
+    );
+  }
+
+  const { referralReward } = referrerEnrollment;
+
+  if (!referralReward) {
+    return logAndRespond(
+      `Referrer has no referral reward. Skipping past commission backfill.`,
+    );
+  }
+
+  const { trigger } = referralRewardConfigSchema.parse(referralReward.config);
+
+  if (["commissionThreshold", "partnerApproved"].includes(trigger)) {
+    await enqueueBatchJobs([
+      {
+        queueName: "create-referral-commissions",
+        url: `${APP_DOMAIN_WITH_NGROK}/api/cron/commissions/referrals/create`,
+        body: {
+          programId,
+          partnerId,
+        },
+      },
+    ]);
+
+    return logAndRespond(
+      `Enqueued 1 referral commission job for partner ${partnerId}.`,
+    );
+  }
+
+  if (["saleRecorded", "commissionEarned"].includes(trigger)) {
+    const commissions = await prisma.commission.findMany({
+      where: {
+        programId,
+        partnerId,
+        type: CommissionType.sale,
+        status: {
+          in: ["pending", "processed", "paid"],
+        },
+      },
+      select: {
+        id: true,
+      },
+    });
+
+    if (commissions.length === 0) {
+      return logAndRespond(
+        `No eligible sale commissions found for partner ${partnerId}.`,
+      );
+    }
+
+    for (const commissionChunk of chunk(commissions, 50)) {
+      await enqueueBatchJobs(
+        commissionChunk.map((commission) => ({
+          queueName: "create-referral-commissions",
+          url: `${APP_DOMAIN_WITH_NGROK}/api/cron/commissions/referrals/create`,
+          deduplicationId: `create-referral-commissions-${commission.id}`,
+          body: {
+            sourceCommissionId: commission.id,
+          },
+        })),
+      );
+    }
+
+    return logAndRespond(
+      `Enqueued ${commissions.length} referral commission jobs for partner ${partnerId}.`,
+    );
+  }
+
+  return logAndRespond(
+    `Referral reward trigger "${trigger}" does not support past event backfill. Skipping...`,
+  );
+});

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/analytics/applications/application-referral-source-icon.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/analytics/applications/application-referral-source-icon.tsx
@@ -1,5 +1,5 @@
 import { ReferrerIcon } from "@/ui/analytics/referrer-icon";
-import { Globe, Shop } from "@dub/ui/icons";
+import { Globe, Shop, UserArrowRight } from "@dub/ui/icons";
 
 export function ApplicationReferralSourceIcon({
   referralSource,
@@ -11,6 +11,8 @@ export function ApplicationReferralSourceIcon({
       return <Shop />;
     case "direct":
       return <Globe />;
+    case "manual":
+      return <UserArrowRight />;
     default:
       return <ReferrerIcon display={referralSource} />;
   }

--- a/apps/web/lib/application-events/utils.ts
+++ b/apps/web/lib/application-events/utils.ts
@@ -18,5 +18,6 @@ export const STAGE_VALUE_KEY: Record<
 export const getReferralSourceDisplayValue = (referralSource: string) => {
   if (referralSource === "marketplace") return "Dub Program Marketplace";
   if (referralSource === "direct") return "Direct application";
+  if (referralSource === "manual") return "Manual attribution";
   return referralSource;
 };

--- a/apps/web/lib/partner-referrals/attribute-referring-partner.ts
+++ b/apps/web/lib/partner-referrals/attribute-referring-partner.ts
@@ -1,0 +1,149 @@
+"use server";
+
+import { DubApiError } from "@/lib/api/errors";
+import { getDefaultProgramIdOrThrow } from "@/lib/api/programs/get-default-program-id-or-throw";
+import { getProgramEnrollmentOrThrow } from "@/lib/api/programs/get-program-enrollment-or-throw";
+import { prisma } from "@dub/prisma";
+import { APP_DOMAIN_WITH_NGROK } from "@dub/utils";
+import { subHours, subMinutes } from "date-fns";
+import { authActionClient } from "../actions/safe-action";
+import { throwIfNoPermission } from "../actions/throw-if-no-permission";
+import { createId } from "../api/create-id";
+import { qstash } from "../cron";
+import { attributeReferringPartnerSchema } from "./schemas";
+
+export const attributeReferringPartnerAction = authActionClient
+  .inputSchema(attributeReferringPartnerSchema)
+  .action(async ({ parsedInput, ctx }) => {
+    const { workspace } = ctx;
+    const { partnerId, referredByPartnerId, createCommissionsForPastEvents } =
+      parsedInput;
+
+    throwIfNoPermission({
+      role: workspace.role,
+      requiredRoles: ["owner", "member"],
+    });
+
+    if (referredByPartnerId === partnerId) {
+      throw new DubApiError({
+        code: "bad_request",
+        message: "A partner cannot refer themselves.",
+      });
+    }
+
+    const programId = getDefaultProgramIdOrThrow(workspace);
+
+    const [programEnrollment, referringProgramEnrollment] = await Promise.all([
+      getProgramEnrollmentOrThrow({
+        partnerId,
+        programId,
+        include: {
+          applicationEvent: {
+            select: {
+              referredByPartnerId: true,
+            },
+          },
+          application: {
+            select: {
+              createdAt: true,
+            },
+          },
+        },
+      }),
+
+      // Check the referring partner is enrolled in the program
+      getProgramEnrollmentOrThrow({
+        partnerId: referredByPartnerId,
+        programId,
+        include: {
+          applicationEvent: {
+            select: {
+              referredByPartnerId: true,
+            },
+          },
+          partner: {
+            select: {
+              country: true,
+            },
+          },
+          referralReward: true,
+        },
+      }),
+    ]);
+
+    if (programEnrollment.status !== "approved") {
+      throw new DubApiError({
+        code: "bad_request",
+        message:
+          "Only approved partners can be attributed a referring partner.",
+      });
+    }
+
+    if (referringProgramEnrollment.status !== "approved") {
+      throw new DubApiError({
+        code: "bad_request",
+        message: "The referring partner is not approved.",
+      });
+    }
+
+    if (programEnrollment.applicationEvent?.referredByPartnerId) {
+      throw new DubApiError({
+        code: "bad_request",
+        message: "This partner already has a referring partner.",
+      });
+    }
+
+    if (
+      referringProgramEnrollment.applicationEvent?.referredByPartnerId ===
+      partnerId
+    ) {
+      throw new DubApiError({
+        code: "bad_request",
+        message:
+          "This referral relationship is not allowed because it would create a referral loop.",
+      });
+    }
+
+    // Attribute the referring partner to the application
+    const baseDate =
+      programEnrollment.application?.createdAt ?? programEnrollment.createdAt;
+
+    await prisma.programApplicationEvent.upsert({
+      where: {
+        programId_partnerId: {
+          programId,
+          partnerId,
+        },
+        referredByPartnerId: null,
+      },
+      update: {
+        referredByPartnerId,
+      },
+      create: {
+        id: createId({ prefix: "pga_evt_" }),
+        programId,
+        partnerId,
+        referredByPartnerId,
+        referralSource: "manual",
+        country: referringProgramEnrollment.partner.country,
+        visitedAt: subHours(baseDate, 1),
+        startedAt: baseDate,
+        submittedAt: subMinutes(baseDate, 1),
+        approvedAt: programEnrollment.createdAt,
+      },
+    });
+
+    if (
+      createCommissionsForPastEvents &&
+      referringProgramEnrollment.referralReward
+    ) {
+      await qstash.publishJSON({
+        url: `${APP_DOMAIN_WITH_NGROK}/api/cron/commissions/referrals/backfill`,
+        body: {
+          programId,
+          partnerId,
+          referredByPartnerId,
+        },
+      });
+    }
+  });

--- a/apps/web/lib/partner-referrals/attribute-referring-partner.ts
+++ b/apps/web/lib/partner-referrals/attribute-referring-partner.ts
@@ -72,14 +72,6 @@ export const attributeReferringPartnerAction = authActionClient
       }),
     ]);
 
-    if (programEnrollment.status !== "approved") {
-      throw new DubApiError({
-        code: "bad_request",
-        message:
-          "Only approved partners can be attributed a referring partner.",
-      });
-    }
-
     if (referringProgramEnrollment.status !== "approved") {
       throw new DubApiError({
         code: "bad_request",
@@ -105,30 +97,41 @@ export const attributeReferringPartnerAction = authActionClient
     const baseDate =
       programEnrollment.application?.createdAt ?? programEnrollment.createdAt;
 
-    await prisma.programApplicationEvent.upsert({
-      where: {
-        programId_partnerId: {
+    try {
+      await prisma.programApplicationEvent.upsert({
+        where: {
+          programId_partnerId: {
+            programId,
+            partnerId,
+          },
+          referredByPartnerId: null,
+        },
+        update: {
+          referredByPartnerId,
+        },
+        create: {
+          id: createId({ prefix: "pga_evt_" }),
           programId,
           partnerId,
+          referredByPartnerId,
+          referralSource: "manual",
+          country: referringProgramEnrollment.partner.country,
+          visitedAt: subMinutes(baseDate, 30),
+          startedAt: subMinutes(baseDate, 5),
+          submittedAt: subMinutes(baseDate, 1),
+          approvedAt: programEnrollment.createdAt,
         },
-        referredByPartnerId: null,
-      },
-      update: {
-        referredByPartnerId,
-      },
-      create: {
-        id: createId({ prefix: "pga_evt_" }),
-        programId,
-        partnerId,
-        referredByPartnerId,
-        referralSource: "manual",
-        country: referringProgramEnrollment.partner.country,
-        visitedAt: subMinutes(baseDate, 30),
-        startedAt: subMinutes(baseDate, 5),
-        submittedAt: subMinutes(baseDate, 1),
-        approvedAt: programEnrollment.createdAt,
-      },
-    });
+      });
+    } catch (error) {
+      if (error.code === "P2002") {
+        throw new DubApiError({
+          code: "conflict",
+          message: "This partner already has a referring partner.",
+        });
+      }
+
+      throw error;
+    }
 
     if (
       createCommissionsForPastEvents &&
@@ -153,7 +156,6 @@ export const attributeReferringPartnerAction = authActionClient
           correlation: {
             programId,
             partnerId,
-            referredByPartnerId,
           },
         });
 

--- a/apps/web/lib/partner-referrals/attribute-referring-partner.ts
+++ b/apps/web/lib/partner-referrals/attribute-referring-partner.ts
@@ -5,10 +5,11 @@ import { getDefaultProgramIdOrThrow } from "@/lib/api/programs/get-default-progr
 import { getProgramEnrollmentOrThrow } from "@/lib/api/programs/get-program-enrollment-or-throw";
 import { prisma } from "@dub/prisma";
 import { APP_DOMAIN_WITH_NGROK } from "@dub/utils";
-import { subHours, subMinutes } from "date-fns";
+import { subMinutes } from "date-fns";
 import { authActionClient } from "../actions/safe-action";
 import { throwIfNoPermission } from "../actions/throw-if-no-permission";
 import { createId } from "../api/create-id";
+import { logger } from "../axiom/server";
 import { qstash } from "../cron";
 import { attributeReferringPartnerSchema } from "./schemas";
 
@@ -126,8 +127,8 @@ export const attributeReferringPartnerAction = authActionClient
         referredByPartnerId,
         referralSource: "manual",
         country: referringProgramEnrollment.partner.country,
-        visitedAt: subHours(baseDate, 1),
-        startedAt: baseDate,
+        visitedAt: subMinutes(baseDate, 30),
+        startedAt: subMinutes(baseDate, 5),
         submittedAt: subMinutes(baseDate, 1),
         approvedAt: programEnrollment.createdAt,
       },
@@ -137,13 +138,30 @@ export const attributeReferringPartnerAction = authActionClient
       createCommissionsForPastEvents &&
       referringProgramEnrollment.referralReward
     ) {
-      await qstash.publishJSON({
-        url: `${APP_DOMAIN_WITH_NGROK}/api/cron/commissions/referrals/backfill`,
-        body: {
-          programId,
-          partnerId,
-          referredByPartnerId,
-        },
-      });
+      try {
+        await qstash.publishJSON({
+          url: `${APP_DOMAIN_WITH_NGROK}/api/cron/commissions/referrals/backfill`,
+          body: {
+            programId,
+            partnerId,
+            referredByPartnerId,
+          },
+        });
+      } catch (error) {
+        logger.error("publishJSON.failed", {
+          service: "qstash",
+          event: "publishJSON.failed",
+          url: `/api/cron/commissions/referrals/backfill`,
+          errorName: error instanceof Error ? error.name : undefined,
+          errorStack: error instanceof Error ? error.stack : undefined,
+          correlation: {
+            programId,
+            partnerId,
+            referredByPartnerId,
+          },
+        });
+
+        await logger.flush();
+      }
     }
   });

--- a/apps/web/lib/partner-referrals/attribute-referring-partner.ts
+++ b/apps/web/lib/partner-referrals/attribute-referring-partner.ts
@@ -30,7 +30,8 @@ export const attributeReferringPartnerAction = authActionClient
     if (referredByPartnerId === partnerId) {
       throw new DubApiError({
         code: "bad_request",
-        message: "A partner cannot refer themselves.",
+        message:
+          "A partner cannot be attributed to themselves as a referring partner.",
       });
     }
 
@@ -75,14 +76,15 @@ export const attributeReferringPartnerAction = authActionClient
     if (referringProgramEnrollment.status !== "approved") {
       throw new DubApiError({
         code: "bad_request",
-        message: "The referring partner is not approved.",
+        message: "The referring partner is not enrolled in the program.",
       });
     }
 
     if (programEnrollment.applicationEvent?.referredByPartnerId) {
       throw new DubApiError({
         code: "bad_request",
-        message: "This partner already has a referring partner.",
+        message:
+          "This partner has already been attributed to another referring partner.",
       });
     }
 

--- a/apps/web/lib/partner-referrals/attribute-referring-partner.ts
+++ b/apps/web/lib/partner-referrals/attribute-referring-partner.ts
@@ -94,16 +94,12 @@ export const attributeReferringPartnerAction = authActionClient
       });
     }
 
-    if (
-      referringProgramEnrollment.applicationEvent?.referredByPartnerId ===
-      partnerId
-    ) {
-      throw new DubApiError({
-        code: "bad_request",
-        message:
-          "This referral relationship is not allowed because it would create a referral loop.",
-      });
-    }
+    await throwIfReferralLoop({
+      programId,
+      partnerId,
+      initialReferrerId:
+        referringProgramEnrollment.applicationEvent?.referredByPartnerId,
+    });
 
     // Attribute the referring partner to the application
     const baseDate =
@@ -165,3 +161,49 @@ export const attributeReferringPartnerAction = authActionClient
       }
     }
   });
+
+async function throwIfReferralLoop({
+  programId,
+  partnerId,
+  initialReferrerId,
+}: {
+  programId: string;
+  partnerId: string;
+  initialReferrerId: string | null | undefined;
+}) {
+  const visited = new Set<string>();
+  let currentReferrerId = initialReferrerId;
+
+  while (currentReferrerId) {
+    if (currentReferrerId === partnerId) {
+      throw new DubApiError({
+        code: "bad_request",
+        message:
+          "This referral relationship is not allowed because it would create a referral loop.",
+      });
+    }
+
+    // Malformed data: ancestor chain already cycles (e.g. A→B→A) without
+    // including partnerId — stop walking instead of looping forever.
+    // Should never happen in practice
+    if (visited.has(currentReferrerId)) {
+      break;
+    }
+
+    visited.add(currentReferrerId);
+
+    const applicationEvent = await prisma.programApplicationEvent.findUnique({
+      where: {
+        programId_partnerId: {
+          programId,
+          partnerId: currentReferrerId,
+        },
+      },
+      select: {
+        referredByPartnerId: true,
+      },
+    });
+
+    currentReferrerId = applicationEvent?.referredByPartnerId ?? null;
+  }
+}

--- a/apps/web/lib/partner-referrals/attribute-referring-partner.ts
+++ b/apps/web/lib/partner-referrals/attribute-referring-partner.ts
@@ -24,14 +24,14 @@ export const attributeReferringPartnerAction = authActionClient
       requiredRoles: ["owner", "member"],
     });
 
+    const programId = getDefaultProgramIdOrThrow(workspace);
+
     if (referredByPartnerId === partnerId) {
       throw new DubApiError({
         code: "bad_request",
         message: "A partner cannot refer themselves.",
       });
     }
-
-    const programId = getDefaultProgramIdOrThrow(workspace);
 
     const [programEnrollment, referringProgramEnrollment] = await Promise.all([
       getProgramEnrollmentOrThrow({

--- a/apps/web/lib/partner-referrals/components/attribute-referring-partner-modal.tsx
+++ b/apps/web/lib/partner-referrals/components/attribute-referring-partner-modal.tsx
@@ -74,6 +74,14 @@ function AttributeReferringPartnerModal({
     createCommissionsForPastEvents,
   ]);
 
+  const disabledTooltip = !referredByPartner?.id
+    ? "Please select a referring partner first."
+    : partner.id === referredByPartner?.id
+      ? "You cannot attribute a partner to themselves."
+      : partner.totalCommissions === 0
+        ? "This partner has no eligible commissions."
+        : undefined;
+
   return (
     <Modal showModal={showModal} setShowModal={setShowModal}>
       <div className="border-b border-neutral-200 p-4 sm:p-6">
@@ -121,11 +129,7 @@ function AttributeReferringPartnerModal({
             <Switch
               checked={createCommissionsForPastEvents}
               fn={setCreateCommissionsForPastEvents}
-              disabled={
-                !referredByPartner?.id ||
-                partner.id === referredByPartner?.id ||
-                partner.totalCommissions === 0
-              }
+              disabledTooltip={disabledTooltip}
             />
 
             <div className="-mt-0.5 space-y-1">
@@ -168,13 +172,8 @@ function AttributeReferringPartnerModal({
           onClick={onSubmit}
           variant="primary"
           text="Attribute partner"
-          disabled={
-            !workspaceId ||
-            !referredByPartner?.id ||
-            isPending ||
-            partner.id === referredByPartner?.id
-          }
           loading={isPending}
+          disabledTooltip={disabledTooltip}
           className="h-8 w-fit px-3"
         />
       </div>

--- a/apps/web/lib/partner-referrals/components/attribute-referring-partner-modal.tsx
+++ b/apps/web/lib/partner-referrals/components/attribute-referring-partner-modal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { parseActionError } from "@/lib/actions/parse-action-errors";
 import { mutatePrefix } from "@/lib/swr/mutate";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { EnrolledPartnerProps } from "@/lib/types";
@@ -46,7 +47,7 @@ function AttributeReferringPartnerModal({
         setShowModal(false);
       },
       onError({ error }) {
-        toast.error(error.serverError);
+        toast.error(parseActionError(error));
       },
     },
   );
@@ -135,7 +136,7 @@ function AttributeReferringPartnerModal({
           onClick={onSubmit}
           variant="primary"
           text="Attribute partner"
-          disabled={!referredByPartnerId}
+          disabled={!workspaceId || !referredByPartnerId || isPending}
           loading={isPending}
           className="h-8 w-fit px-3"
         />

--- a/apps/web/lib/partner-referrals/components/attribute-referring-partner-modal.tsx
+++ b/apps/web/lib/partner-referrals/components/attribute-referring-partner-modal.tsx
@@ -1,10 +1,8 @@
 "use client";
 
 import { mutatePrefix } from "@/lib/swr/mutate";
-import useGroup from "@/lib/swr/use-group";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { EnrolledPartnerProps } from "@/lib/types";
-import { DEFAULT_PARTNER_GROUP } from "@/lib/zod/schemas/groups";
 import { PartnerAvatar } from "@/ui/partners/partner-avatar";
 import { PartnerSelector } from "@/ui/partners/partner-selector";
 import { Markdown } from "@/ui/shared/markdown";
@@ -38,12 +36,6 @@ function AttributeReferringPartnerModal({
   );
   const [createCommissionsForPastEvents, setCreateCommissionsForPastEvents] =
     useState(false);
-
-  const { group } = useGroup({
-    groupIdOrSlug: partner.groupId || DEFAULT_PARTNER_GROUP.slug,
-  });
-
-  const showCommissionToggle = group?.referralReward?.type === "percentage";
 
   const { executeAsync, isPending } = useAction(
     attributeReferringPartnerAction,
@@ -117,7 +109,7 @@ function AttributeReferringPartnerModal({
           </div>
         </div>
 
-        {showCommissionToggle && (
+        <div>
           <div className="flex items-center gap-3">
             <Switch
               checked={createCommissionsForPastEvents}
@@ -128,7 +120,7 @@ function AttributeReferringPartnerModal({
               Create commissions for eligible past events
             </span>
           </div>
-        )}
+        </div>
       </div>
 
       <div className="border-border-subtle flex items-center justify-end gap-2 border-t px-4 py-4">

--- a/apps/web/lib/partner-referrals/components/attribute-referring-partner-modal.tsx
+++ b/apps/web/lib/partner-referrals/components/attribute-referring-partner-modal.tsx
@@ -78,9 +78,7 @@ function AttributeReferringPartnerModal({
     ? "Please select a referring partner first."
     : partner.id === referredByPartner?.id
       ? "You cannot attribute a partner to themselves."
-      : partner.totalCommissions === 0
-        ? "This partner has no eligible commissions."
-        : undefined;
+      : undefined;
 
   return (
     <Modal showModal={showModal} setShowModal={setShowModal}>

--- a/apps/web/lib/partner-referrals/components/attribute-referring-partner-modal.tsx
+++ b/apps/web/lib/partner-referrals/components/attribute-referring-partner-modal.tsx
@@ -5,9 +5,13 @@ import { mutatePrefix } from "@/lib/swr/mutate";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { EnrolledPartnerProps } from "@/lib/types";
 import { PartnerAvatar } from "@/ui/partners/partner-avatar";
-import { PartnerSelector } from "@/ui/partners/partner-selector";
+import {
+  PartnerSelector,
+  SelectedPartner,
+} from "@/ui/partners/partner-selector";
 import { Markdown } from "@/ui/shared/markdown";
 import { Button, Modal, Switch } from "@dub/ui";
+import { currencyFormatter } from "@dub/utils";
 import { useAction } from "next-safe-action/hooks";
 import {
   Dispatch,
@@ -28,13 +32,14 @@ function AttributeReferringPartnerModal({
   setShowModal: Dispatch<SetStateAction<boolean>>;
   partner: Pick<
     EnrolledPartnerProps,
-    "id" | "name" | "email" | "image" | "groupId"
+    "id" | "name" | "email" | "image" | "groupId" | "totalCommissions"
   >;
 }) {
   const { id: workspaceId } = useWorkspace();
-  const [referredByPartnerId, setReferredByPartnerId] = useState<string | null>(
-    null,
-  );
+
+  const [referredByPartner, setReferredByPartner] =
+    useState<SelectedPartner | null>(null);
+
   const [createCommissionsForPastEvents, setCreateCommissionsForPastEvents] =
     useState(false);
 
@@ -53,19 +58,19 @@ function AttributeReferringPartnerModal({
   );
 
   const onSubmit = useCallback(async () => {
-    if (!workspaceId || !referredByPartnerId) return;
+    if (!workspaceId || !referredByPartner?.id) return;
 
     await executeAsync({
       workspaceId,
       partnerId: partner.id,
-      referredByPartnerId,
+      referredByPartnerId: referredByPartner?.id,
       createCommissionsForPastEvents,
     });
   }, [
     executeAsync,
     workspaceId,
     partner.id,
-    referredByPartnerId,
+    referredByPartner?.id,
     createCommissionsForPastEvents,
   ]);
 
@@ -104,22 +109,49 @@ function AttributeReferringPartnerModal({
           </label>
           <div className="mt-1.5">
             <PartnerSelector
-              selectedPartnerId={referredByPartnerId}
-              setSelectedPartnerId={setReferredByPartnerId}
+              selectedPartnerId={referredByPartner?.id || null}
+              setSelectedPartnerId={() => {}}
+              onSelectedPartner={setReferredByPartner}
             />
           </div>
         </div>
 
         <div>
-          <div className="flex items-center gap-3">
+          <div className="flex items-start gap-3">
             <Switch
               checked={createCommissionsForPastEvents}
               fn={setCreateCommissionsForPastEvents}
+              disabled={
+                !referredByPartner?.id ||
+                partner.id === referredByPartner?.id ||
+                partner.totalCommissions === 0
+              }
             />
 
-            <span className="text-sm font-medium text-neutral-800">
-              Create commissions for eligible past events
-            </span>
+            <div className="-mt-0.5 space-y-1">
+              <p className="text-sm font-medium text-neutral-800">
+                Create commissions for eligible past events
+              </p>
+
+              {createCommissionsForPastEvents && (
+                <p className="text-content-subtle text-sm">
+                  This will generate partner referral commissions for{" "}
+                  <span className="font-semibold text-neutral-900">
+                    {referredByPartner?.name}
+                  </span>{" "}
+                  based on all of{" "}
+                  <span className="font-semibold text-neutral-900">
+                    {partner.name}
+                  </span>
+                  's historical commissions (
+                  <span className="font-semibold text-neutral-900">
+                    Total:
+                    {currencyFormatter(partner.totalCommissions)}
+                  </span>
+                  )
+                </p>
+              )}
+            </div>
           </div>
         </div>
       </div>
@@ -136,7 +168,12 @@ function AttributeReferringPartnerModal({
           onClick={onSubmit}
           variant="primary"
           text="Attribute partner"
-          disabled={!workspaceId || !referredByPartnerId || isPending}
+          disabled={
+            !workspaceId ||
+            !referredByPartner?.id ||
+            isPending ||
+            partner.id === referredByPartner?.id
+          }
           loading={isPending}
           className="h-8 w-fit px-3"
         />
@@ -150,7 +187,7 @@ export function useAttributeReferringPartnerModal({
 }: {
   partner: Pick<
     EnrolledPartnerProps,
-    "id" | "name" | "email" | "image" | "groupId"
+    "id" | "name" | "email" | "image" | "groupId" | "totalCommissions"
   >;
 }) {
   const [showModal, setShowModal] = useState(false);

--- a/apps/web/lib/partner-referrals/components/attribute-referring-partner-modal.tsx
+++ b/apps/web/lib/partner-referrals/components/attribute-referring-partner-modal.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { mutatePrefix } from "@/lib/swr/mutate";
+import useGroup from "@/lib/swr/use-group";
+import useWorkspace from "@/lib/swr/use-workspace";
+import { EnrolledPartnerProps } from "@/lib/types";
+import { DEFAULT_PARTNER_GROUP } from "@/lib/zod/schemas/groups";
+import { PartnerAvatar } from "@/ui/partners/partner-avatar";
+import { PartnerSelector } from "@/ui/partners/partner-selector";
+import { Markdown } from "@/ui/shared/markdown";
+import { Button, Modal, Switch } from "@dub/ui";
+import { useAction } from "next-safe-action/hooks";
+import {
+  Dispatch,
+  SetStateAction,
+  useCallback,
+  useMemo,
+  useState,
+} from "react";
+import { toast } from "sonner";
+import { attributeReferringPartnerAction } from "../attribute-referring-partner";
+
+function AttributeReferringPartnerModal({
+  showModal,
+  setShowModal,
+  partner,
+}: {
+  showModal: boolean;
+  setShowModal: Dispatch<SetStateAction<boolean>>;
+  partner: Pick<
+    EnrolledPartnerProps,
+    "id" | "name" | "email" | "image" | "groupId"
+  >;
+}) {
+  const { id: workspaceId } = useWorkspace();
+  const [referredByPartnerId, setReferredByPartnerId] = useState<string | null>(
+    null,
+  );
+  const [createCommissionsForPastEvents, setCreateCommissionsForPastEvents] =
+    useState(false);
+
+  const { group } = useGroup({
+    groupIdOrSlug: partner.groupId || DEFAULT_PARTNER_GROUP.slug,
+  });
+
+  const showCommissionToggle = group?.referralReward?.type === "percentage";
+
+  const { executeAsync, isPending } = useAction(
+    attributeReferringPartnerAction,
+    {
+      onSuccess: async () => {
+        await mutatePrefix("/api/partners");
+        toast.success("Referring partner attributed successfully!");
+        setShowModal(false);
+      },
+      onError({ error }) {
+        toast.error(error.serverError);
+      },
+    },
+  );
+
+  const onSubmit = useCallback(async () => {
+    if (!workspaceId || !referredByPartnerId) return;
+
+    await executeAsync({
+      workspaceId,
+      partnerId: partner.id,
+      referredByPartnerId,
+      createCommissionsForPastEvents,
+    });
+  }, [
+    executeAsync,
+    workspaceId,
+    partner.id,
+    referredByPartnerId,
+    createCommissionsForPastEvents,
+  ]);
+
+  return (
+    <Modal showModal={showModal} setShowModal={setShowModal}>
+      <div className="border-b border-neutral-200 p-4 sm:p-6">
+        <h3 className="text-lg font-medium leading-none">
+          Attribute referring partner
+        </h3>
+      </div>
+
+      <div className="flex flex-col gap-6 bg-neutral-50 p-4 sm:p-6">
+        <Markdown className="text-sm font-normal leading-5 text-neutral-600">
+          Attribute this partner to the partner who referred them and generate
+          eligible referral rewards. [Learn
+          more](https://dub.co/help/article/referring-partners)
+        </Markdown>
+
+        <div className="rounded-lg border border-neutral-200 bg-neutral-100 p-3">
+          <div className="flex items-center gap-4">
+            <PartnerAvatar partner={partner} className="size-10 bg-white" />
+            <div className="flex min-w-0 flex-col">
+              <h4 className="truncate text-sm font-medium text-neutral-900">
+                {partner.name}
+              </h4>
+              <p className="truncate text-xs text-neutral-500">
+                {partner.email}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-neutral-900">
+            Referring partner
+          </label>
+          <div className="mt-1.5">
+            <PartnerSelector
+              selectedPartnerId={referredByPartnerId}
+              setSelectedPartnerId={setReferredByPartnerId}
+            />
+          </div>
+        </div>
+
+        {showCommissionToggle && (
+          <div className="flex items-center gap-3">
+            <Switch
+              checked={createCommissionsForPastEvents}
+              fn={setCreateCommissionsForPastEvents}
+            />
+
+            <span className="text-sm font-medium text-neutral-800">
+              Create commissions for eligible past events
+            </span>
+          </div>
+        )}
+      </div>
+
+      <div className="border-border-subtle flex items-center justify-end gap-2 border-t px-4 py-4">
+        <Button
+          onClick={() => setShowModal(false)}
+          variant="secondary"
+          text="Cancel"
+          className="h-8 w-fit px-3"
+          disabled={isPending}
+        />
+        <Button
+          onClick={onSubmit}
+          variant="primary"
+          text="Attribute partner"
+          disabled={!referredByPartnerId}
+          loading={isPending}
+          className="h-8 w-fit px-3"
+        />
+      </div>
+    </Modal>
+  );
+}
+
+export function useAttributeReferringPartnerModal({
+  partner,
+}: {
+  partner: Pick<
+    EnrolledPartnerProps,
+    "id" | "name" | "email" | "image" | "groupId"
+  >;
+}) {
+  const [showModal, setShowModal] = useState(false);
+
+  const AttributeReferringPartnerModalCallback = useCallback(() => {
+    return (
+      <AttributeReferringPartnerModal
+        showModal={showModal}
+        setShowModal={setShowModal}
+        partner={partner}
+      />
+    );
+  }, [showModal, setShowModal, partner]);
+
+  return useMemo(
+    () => ({
+      setShowAttributeReferringPartnerModal: setShowModal,
+      AttributeReferringPartnerModal: AttributeReferringPartnerModalCallback,
+    }),
+    [setShowModal, AttributeReferringPartnerModalCallback],
+  );
+}

--- a/apps/web/lib/partner-referrals/components/attribute-referring-partner-modal.tsx
+++ b/apps/web/lib/partner-referrals/components/attribute-referring-partner-modal.tsx
@@ -88,7 +88,7 @@ function AttributeReferringPartnerModal({
         <Markdown className="text-sm font-normal leading-5 text-neutral-600">
           Attribute this partner to the partner who referred them and generate
           eligible referral rewards. [Learn
-          more](https://dub.co/help/article/referring-partners)
+          more](https://dub.co/help/article/partner-referrals)
         </Markdown>
 
         <div className="rounded-lg border border-neutral-200 bg-neutral-100 p-3">

--- a/apps/web/lib/partner-referrals/create-referral-commission.ts
+++ b/apps/web/lib/partner-referrals/create-referral-commission.ts
@@ -28,6 +28,9 @@ export const createReferralCommission = async (
     context;
 
   if (programId === NETWORK_PROGRAM_ID) {
+    console.log(
+      `Skipping referral commission creation for network program ${programId}...`,
+    );
     return null;
   }
 

--- a/apps/web/lib/partner-referrals/create-referral-commission.ts
+++ b/apps/web/lib/partner-referrals/create-referral-commission.ts
@@ -376,9 +376,9 @@ async function resolveReferralContext(props: CreateReferralCommissionProps) {
       return null;
     }
 
-    if (!["processed", "paid"].includes(sourceCommission.status)) {
+    if (!["pending", "processed", "paid"].includes(sourceCommission.status)) {
       console.log(
-        `Source commission ${sourceCommissionId} is not a processed or paid.`,
+        `Source commission ${sourceCommissionId} is not pending, processed or paid.`,
       );
       return null;
     }

--- a/apps/web/lib/partner-referrals/hooks/use-partner-referral.ts
+++ b/apps/web/lib/partner-referrals/hooks/use-partner-referral.ts
@@ -15,6 +15,9 @@ export function usePartnerReferral({
       ? `/api/partners/${partnerId}/referral?workspaceId=${workspaceId}`
       : null,
     fetcher,
+    {
+      keepPreviousData: true,
+    },
   );
 
   return {

--- a/apps/web/lib/partner-referrals/schemas.ts
+++ b/apps/web/lib/partner-referrals/schemas.ts
@@ -73,3 +73,10 @@ export const networkReferralsTimeseriesSchema = z.object({
   partners: z.number().int().nonnegative(),
   earnings: z.number().int(),
 });
+
+export const attributeReferringPartnerSchema = z.object({
+  workspaceId: z.string(),
+  partnerId: z.string(),
+  referredByPartnerId: z.string(),
+  createCommissionsForPastEvents: z.boolean().default(false),
+});

--- a/apps/web/ui/activity-logs/commission-activity.tsx
+++ b/apps/web/ui/activity-logs/commission-activity.tsx
@@ -122,15 +122,20 @@ export function CommissionActivity({
           icon: CommissionStatusBadges["pending"].icon,
           timestamp: commission.createdAt,
           note: (() => {
-            const text = commission.reward
-              ? `Earn ${
-                  commission.reward.type === "percentage"
-                    ? `${commission.reward.amountInPercentage ?? 0}%`
-                    : currencyFormatter(commission.reward.amountInCents ?? 0, {
-                        trailingZeroDisplay: "stripIfInteger",
-                      })
-                } per ${commission.reward.event}`
-              : commission.description ?? null;
+            const text =
+              commission.description ||
+              (commission.reward
+                ? `Earn ${
+                    commission.reward.type === "percentage"
+                      ? `${commission.reward.amountInPercentage ?? 0}%`
+                      : currencyFormatter(
+                          commission.reward.amountInCents ?? 0,
+                          {
+                            trailingZeroDisplay: "stripIfInteger",
+                          },
+                        )
+                  } per ${commission.reward.event}`
+                : null);
 
             if (!text) return undefined;
 

--- a/apps/web/ui/partners/partner-info-cards.tsx
+++ b/apps/web/ui/partners/partner-info-cards.tsx
@@ -503,7 +503,7 @@ function ReferredByPartner({
 }) {
   const { slug } = useWorkspace();
 
-  const { referral, loading } = usePartnerReferral({
+  const { referral, loading, error } = usePartnerReferral({
     partnerId: partner?.id,
   });
 
@@ -511,6 +511,10 @@ function ReferredByPartner({
     AttributeReferringPartnerModal,
     setShowAttributeReferringPartnerModal,
   } = useAttributeReferringPartnerModal({ partner });
+
+  if (error) {
+    return null;
+  }
 
   if (loading) {
     return (

--- a/apps/web/ui/partners/partner-info-cards.tsx
+++ b/apps/web/ui/partners/partner-info-cards.tsx
@@ -524,7 +524,7 @@ function ReferredByPartner({
   if (loading) {
     return (
       <span className="flex min-w-0 items-center gap-1">
-        <div className="h-4 w-24 animate-pulse rounded bg-neutral-200" />
+        <div className="h-5 w-24 animate-pulse rounded bg-neutral-200" />
       </span>
     );
   }

--- a/apps/web/ui/partners/partner-info-cards.tsx
+++ b/apps/web/ui/partners/partner-info-cards.tsx
@@ -537,11 +537,7 @@ function ReferredByPartner({
   }
 
   // No referring partner
-  if (
-    !referral?.referredBy &&
-    "status" in partner &&
-    partner.status === "approved"
-  ) {
+  if (!referral?.referredBy) {
     return (
       <>
         <AttributeReferringPartnerModal />

--- a/apps/web/ui/partners/partner-info-cards.tsx
+++ b/apps/web/ui/partners/partner-info-cards.tsx
@@ -195,11 +195,15 @@ export function PartnerInfoCards({
         : []),
 
       // Referred by
-      {
-        id: "referredBy",
-        icon: <UserArrowRight className="size-3.5 shrink-0" />,
-        text: <ReferredByPartner partner={partner} />,
-      },
+      ...(type === "enrolled"
+        ? [
+            {
+              id: "referredBy",
+              icon: <UserArrowRight className="size-3.5 shrink-0" />,
+              text: <ReferredByPartner partner={partner} />,
+            },
+          ]
+        : []),
     ]);
   }
 
@@ -498,7 +502,7 @@ function ReferredByPartner({
 }: {
   partner: Pick<
     EnrolledPartnerExtendedProps,
-    "id" | "name" | "image" | "email" | "groupId"
+    "id" | "name" | "image" | "email" | "groupId" | "totalCommissions"
   >;
 }) {
   const { slug } = useWorkspace();

--- a/apps/web/ui/partners/partner-info-cards.tsx
+++ b/apps/web/ui/partners/partner-info-cards.tsx
@@ -195,7 +195,7 @@ export function PartnerInfoCards({
         : []),
 
       // Referred by
-      ...(type === "enrolled"
+      ...(isEnrolled
         ? [
             {
               id: "referredBy",
@@ -544,22 +544,17 @@ function ReferredByPartner({
     );
   }
 
-  // No referring partner
-  if (!referral?.referredBy) {
-    return (
-      <>
-        <AttributeReferringPartnerModal />
-        <button
-          type="button"
-          onClick={() => setShowAttributeReferringPartnerModal(true)}
-          aria-label="Attribute referring partner"
-          className="bg-bg-inverted/5 text-content-default hover:bg-bg-inverted/10 inline-flex h-6 min-h-6 min-w-0 select-none items-center whitespace-nowrap rounded-md px-1.5 py-0.5 text-xs font-medium"
-        >
-          Attribute referring partner
-        </button>
-      </>
-    );
-  }
-
-  return null;
+  return (
+    <>
+      <AttributeReferringPartnerModal />
+      <button
+        type="button"
+        onClick={() => setShowAttributeReferringPartnerModal(true)}
+        aria-label="Attribute referring partner"
+        className="bg-bg-inverted/5 text-content-default hover:bg-bg-inverted/10 inline-flex h-6 min-h-6 min-w-0 select-none items-center whitespace-nowrap rounded-md px-1.5 py-0.5 text-xs font-medium"
+      >
+        Attribute referring partner
+      </button>
+    </>
+  );
 }

--- a/apps/web/ui/partners/partner-info-cards.tsx
+++ b/apps/web/ui/partners/partner-info-cards.tsx
@@ -1,3 +1,4 @@
+import { useAttributeReferringPartnerModal } from "@/lib/partner-referrals/components/attribute-referring-partner-modal";
 import { usePartnerReferral } from "@/lib/partner-referrals/hooks/use-partner-referral";
 import useGroup from "@/lib/swr/use-group";
 import useWorkspace from "@/lib/swr/use-workspace";
@@ -126,10 +127,6 @@ export function PartnerInfoCards({
     fetcher,
   );
 
-  const { referral } = usePartnerReferral({
-    partnerId: partner?.id,
-  });
-
   let basicFields: BasicField[] = [
     {
       id: "country",
@@ -198,29 +195,11 @@ export function PartnerInfoCards({
         : []),
 
       // Referred by
-      ...(referral && referral.referredBy
-        ? [
-            {
-              id: "referredBy",
-              icon: <UserArrowRight className="size-3.5 shrink-0" />,
-              text: (
-                <span className="flex min-w-0 items-center gap-1">
-                  Referred by
-                  <Link
-                    href={`/${workspaceSlug}/program/partners/${referral.referredBy.id}`}
-                    className="inline-flex min-w-0 max-w-full cursor-alias items-center gap-1 rounded decoration-dotted underline-offset-2 hover:underline"
-                  >
-                    <PartnerAvatar
-                      partner={referral.referredBy}
-                      className="size-3.5"
-                    />
-                    <span className="truncate">{referral.referredBy.name}</span>
-                  </Link>
-                </span>
-              ),
-            },
-          ]
-        : []),
+      {
+        id: "referredBy",
+        icon: <UserArrowRight className="size-3.5 shrink-0" />,
+        text: <ReferredByPartner partner={partner} />,
+      },
     ]);
   }
 
@@ -512,4 +491,69 @@ function TagsList({ partner }: { partner: EnrolledPartnerExtendedProps }) {
       />
     </div>
   );
+}
+
+function ReferredByPartner({
+  partner,
+}: {
+  partner: Pick<
+    EnrolledPartnerExtendedProps,
+    "id" | "name" | "image" | "email" | "groupId"
+  >;
+}) {
+  const { slug } = useWorkspace();
+
+  const { referral, loading } = usePartnerReferral({
+    partnerId: partner?.id,
+  });
+
+  const {
+    AttributeReferringPartnerModal,
+    setShowAttributeReferringPartnerModal,
+  } = useAttributeReferringPartnerModal({ partner });
+
+  if (loading) {
+    return (
+      <span className="flex min-w-0 items-center gap-1">
+        <div className="h-4 w-24 animate-pulse rounded bg-neutral-200" />
+      </span>
+    );
+  }
+
+  // Has a referring partner
+  if (referral && referral.referredBy) {
+    return (
+      <span className="flex min-w-0 items-center gap-1">
+        Referred by
+        <Link
+          href={`/${slug}/program/partners/${referral.referredBy.id}`}
+          className="inline-flex min-w-0 max-w-full cursor-alias items-center gap-1 rounded decoration-dotted underline-offset-2 hover:underline"
+        >
+          <PartnerAvatar partner={referral.referredBy} className="size-3.5" />
+          <span className="truncate">{referral.referredBy.name}</span>
+        </Link>
+      </span>
+    );
+  }
+
+  // No referring partner
+  if (
+    !referral?.referredBy &&
+    "status" in partner &&
+    partner.status === "approved"
+  ) {
+    return (
+      <>
+        <AttributeReferringPartnerModal />
+        <button
+          type="button"
+          onClick={() => setShowAttributeReferringPartnerModal(true)}
+          aria-label="Attribute referring partner"
+          className="bg-bg-inverted/5 text-content-default hover:bg-bg-inverted/10 inline-flex h-6 min-h-6 min-w-0 select-none items-center whitespace-nowrap rounded-md px-1.5 py-0.5 text-xs font-medium"
+        >
+          Attribute referring partner
+        </button>
+      </>
+    );
+  }
 }

--- a/apps/web/ui/partners/partner-info-cards.tsx
+++ b/apps/web/ui/partners/partner-info-cards.tsx
@@ -556,4 +556,6 @@ function ReferredByPartner({
       </>
     );
   }
+
+  return null;
 }

--- a/apps/web/ui/partners/partner-selector.tsx
+++ b/apps/web/ui/partners/partner-selector.tsx
@@ -7,11 +7,18 @@ import { useEffect, useMemo, useState } from "react";
 import { useDebounce } from "use-debounce";
 import { PartnerAvatar } from "./partner-avatar";
 
-export type Partner = Pick<PartnerProps, "id" | "name">;
+export type SelectedPartner = Pick<
+  PartnerProps,
+  "id" | "name" | "email" | "image"
+>;
+
+// TODO:
+// Make this return the full partner object instead of just the id by default
 
 type PartnerSelectorProps = {
   selectedPartnerId: string | null;
   setSelectedPartnerId: (partnerId: string) => void;
+  onSelectedPartner?: (selectedPartner: SelectedPartner) => void;
   disabled?: boolean;
   variant?: "default" | "header";
 } & Partial<ComboboxProps<false, any>>;
@@ -19,6 +26,7 @@ type PartnerSelectorProps = {
 export function PartnerSelector({
   selectedPartnerId,
   setSelectedPartnerId,
+  onSelectedPartner,
   disabled,
   variant = "default",
   ...rest
@@ -75,6 +83,13 @@ export function PartnerSelector({
       setSelected={(option) => {
         if (!option) return;
         setSelectedPartnerId(option.value);
+        const partner = [...(partners || []), ...(selectedPartners || [])].find(
+          (p) => p.id === option.value,
+        );
+
+        if (partner) {
+          onSelectedPartner?.(partner);
+        }
       }}
       selected={selectedOption}
       icon={


### PR DESCRIPTION
<img width="981" height="736" alt="CleanShot 2026-05-19 at 12  21 39" src="https://github.com/user-attachments/assets/d052cf8c-041e-4d84-8ff0-542a12e1e8f4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manually attribute a referring partner to enrolled partners, with checks to prevent self-referrals and loops.
  * Option to enqueue commission backfill for eligible past events when attributing a referrer.
  * New modal UI to pick a referrer; success refreshes partner data and shows toasts.

* **Refactor**
  * Referral fetching now keeps previous data while reloading.

* **Bug Fix / Behavior**
  * Referral commission eligibility now includes pending commissions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dubinc/dub/pull/3925?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->