### PR TITLE
Add `reapplicationTimeframe` prop

### DIFF
--- a/apps/web/app/(ee)/api/cron/cleanup/rejected-applications/route.ts
+++ b/apps/web/app/(ee)/api/cron/cleanup/rejected-applications/route.ts
@@ -28,7 +28,8 @@ export async function POST(req: Request) {
             updatedAt: {
               lt: subDays(new Date(), 30),
             },
-            // only delete if there are no commissions or messages
+            reapplicationTimeframe: "standard",
+            // only delete if there are no commissions
             commissions: {
               none: {},
             },

--- a/apps/web/app/(ee)/api/partners/applications/reject/route.ts
+++ b/apps/web/app/(ee)/api/partners/applications/reject/route.ts
@@ -11,7 +11,7 @@ export const POST = withWorkspace(
       partnerId,
       rejectionReason,
       rejectionNote,
-      allowImmediateReapply,
+      reapplicationTimeframe,
       flagForFraud,
       flagForFraudReason,
     } = rejectPartnerSchema.parse(await parseRequestBody(req));
@@ -21,7 +21,7 @@ export const POST = withWorkspace(
       partnerId,
       rejectionReason,
       rejectionNote,
-      allowImmediateReapply,
+      reapplicationTimeframe,
       flagForFraud,
       flagForFraudReason,
       userId: session.user.id,

--- a/apps/web/lib/actions/partners/bulk-reject-partner-applications.ts
+++ b/apps/web/lib/actions/partners/bulk-reject-partner-applications.ts
@@ -160,7 +160,7 @@ export const bulkRejectPartnerApplicationsAction = authActionClient
                 },
                 rejectionReason: undefined,
                 additionalNotes: undefined,
-                canReapplyImmediately: false,
+                reapplicationTimeframe: "standard",
               }),
             })),
           );

--- a/apps/web/lib/actions/partners/reject-partner-application.ts
+++ b/apps/web/lib/actions/partners/reject-partner-application.ts
@@ -19,7 +19,7 @@ export const rejectPartnerApplicationAction = authActionClient
       partnerId,
       rejectionReason,
       rejectionNote,
-      allowImmediateReapply,
+      reapplicationTimeframe,
       flagForFraud,
       flagForFraudReason,
     } = parsedInput;
@@ -34,7 +34,7 @@ export const rejectPartnerApplicationAction = authActionClient
       partnerId,
       rejectionReason,
       rejectionNote,
-      allowImmediateReapply,
+      reapplicationTimeframe,
       flagForFraud,
       flagForFraudReason,
       userId: user.id,

--- a/apps/web/lib/api/partners/applications/reject-partner.ts
+++ b/apps/web/lib/api/partners/applications/reject-partner.ts
@@ -23,14 +23,18 @@ export async function rejectPartner({
   partnerId,
   rejectionReason,
   rejectionNote,
+  reapplicationTimeframe,
   allowImmediateReapply,
   flagForFraud,
   flagForFraudReason,
   userId,
 }: RejectPartnerInput) {
   const programId = getDefaultProgramIdOrThrow(workspace);
+  const resolvedReapplicationTimeframe = allowImmediateReapply
+    ? "instant"
+    : reapplicationTimeframe;
 
-  if (flagForFraud && allowImmediateReapply) {
+  if (flagForFraud && resolvedReapplicationTimeframe === "instant") {
     throw new DubApiError({
       code: "bad_request",
       message:
@@ -94,8 +98,8 @@ export async function rejectPartner({
       });
     }
 
-    // If the partner can immediately re-apply, delete the application
-    if (allowImmediateReapply) {
+    // If the partner can immediately re-apply, delete the enrollment
+    if (resolvedReapplicationTimeframe === "instant") {
       const { count } = await tx.programEnrollment.deleteMany({
         where: {
           id: programEnrollment.id,
@@ -114,7 +118,7 @@ export async function rejectPartner({
       return;
     }
 
-    // If the partner cannot immediately re-apply, reject the application
+    // Reject the enrollment and persist the reapplication timeframe
     await tx.programEnrollment.update({
       where: {
         id: programEnrollment.id,
@@ -122,6 +126,7 @@ export async function rejectPartner({
       },
       data: {
         status: ProgramEnrollmentStatus.rejected,
+        reapplicationTimeframe: resolvedReapplicationTimeframe,
         clickRewardId: null,
         leadRewardId: null,
         saleRewardId: null,
@@ -195,7 +200,7 @@ export async function rejectPartner({
             additionalNotes: rejectionNote,
             rejectionReason:
               getProgramApplicationRejectionReasonLabel(rejectionReason),
-            canReapplyImmediately: allowImmediateReapply,
+            canReapplyImmediately: resolvedReapplicationTimeframe === "instant",
           }),
         }),
     ]),

--- a/apps/web/lib/api/partners/applications/reject-partner.ts
+++ b/apps/web/lib/api/partners/applications/reject-partner.ts
@@ -24,17 +24,13 @@ export async function rejectPartner({
   rejectionReason,
   rejectionNote,
   reapplicationTimeframe,
-  allowImmediateReapply,
   flagForFraud,
   flagForFraudReason,
   userId,
 }: RejectPartnerInput) {
   const programId = getDefaultProgramIdOrThrow(workspace);
-  const resolvedReapplicationTimeframe = allowImmediateReapply
-    ? "instant"
-    : reapplicationTimeframe;
 
-  if (flagForFraud && resolvedReapplicationTimeframe === "instant") {
+  if (flagForFraud && reapplicationTimeframe === "instant") {
     throw new DubApiError({
       code: "bad_request",
       message:
@@ -99,7 +95,7 @@ export async function rejectPartner({
     }
 
     // If the partner can immediately re-apply, delete the enrollment
-    if (resolvedReapplicationTimeframe === "instant") {
+    if (reapplicationTimeframe === "instant") {
       const { count } = await tx.programEnrollment.deleteMany({
         where: {
           id: programEnrollment.id,
@@ -126,7 +122,7 @@ export async function rejectPartner({
       },
       data: {
         status: ProgramEnrollmentStatus.rejected,
-        reapplicationTimeframe: resolvedReapplicationTimeframe,
+        reapplicationTimeframe,
         clickRewardId: null,
         leadRewardId: null,
         saleRewardId: null,
@@ -200,7 +196,7 @@ export async function rejectPartner({
             additionalNotes: rejectionNote,
             rejectionReason:
               getProgramApplicationRejectionReasonLabel(rejectionReason),
-            canReapplyImmediately: resolvedReapplicationTimeframe === "instant",
+            reapplicationTimeframe,
           }),
         }),
     ]),

--- a/apps/web/lib/zod/schemas/partners.ts
+++ b/apps/web/lib/zod/schemas/partners.ts
@@ -923,18 +923,21 @@ export const rejectPartnerSchema = z
       .describe(
         "Additional details about the rejection. This will be shared with the partner via email.",
       ),
-    allowImmediateReapply: z
-      .boolean()
-      .optional()
-      .default(false)
+    reapplicationTimeframe: z
+      .enum(["instant", "standard", "never"])
+      .default("standard")
       .describe(
-        "When true, pending enrollment is removed so the partner can submit a new application immediately.",
+        "The mode for reapplying for the program. `instant`: The partner can reapply immediately. `standard`: The partner can reapply after 30 days. `never`: The partner can never reapply for the program. Defaults to `standard` if undefined.",
       ),
+    allowImmediateReapply: z.boolean().optional().default(false).meta({
+      deprecated: true,
+      description: "Deprecated: Use `reapplicationTimeframe` instead.",
+    }),
     flagForFraud: z
       .boolean()
       .optional()
       .describe(
-        "Whether to flag the partner for fraud review by the Dub team. Cannot be combined with allowImmediateReapply.",
+        "Whether to flag the partner for fraud review by the Dub team. Cannot be combined with `reapplicationTimeframe: instant`.",
       ),
     flagForFraudReason: z
       .string()
@@ -949,7 +952,11 @@ export const rejectPartnerSchema = z
       ),
   })
   .superRefine((data, ctx) => {
-    if (data.allowImmediateReapply && data.flagForFraud) {
+    const reapplicationTimeframe = data.allowImmediateReapply
+      ? "instant"
+      : data.reapplicationTimeframe;
+
+    if (reapplicationTimeframe === "instant" && data.flagForFraud) {
       ctx.addIssue({
         code: "custom",
         message:

--- a/apps/web/lib/zod/schemas/partners.ts
+++ b/apps/web/lib/zod/schemas/partners.ts
@@ -903,78 +903,49 @@ export const PROGRAM_APPLICATION_REJECTION_NOTE_MAX_LENGTH = 500;
 // Max length for optional `flagForFraudReason` on `FraudAlert`
 export const MAX_FRAUD_REASON_LENGTH = 2000;
 
-export const rejectPartnerSchema = z
-  .object({
-    partnerId: z.string().describe("The ID of the partner to reject."),
-    rejectionReason: z
-      .enum(ProgramApplicationRejectionReason)
-      .optional()
-      .describe(
-        "The reason for rejecting the partner application. This will be shared with the partner via email.",
-      ),
-    rejectionNote: z
-      .string()
-      .max(PROGRAM_APPLICATION_REJECTION_NOTE_MAX_LENGTH)
-      .optional()
-      .transform((s) => {
-        const t = s?.trim();
-        return t === "" ? undefined : t;
-      })
-      .describe(
-        "Additional details about the rejection. This will be shared with the partner via email.",
-      ),
-    reapplicationTimeframe: z
-      .enum(["instant", "standard", "never"])
-      .default("standard")
-      .describe(
-        "The mode for reapplying for the program. `instant`: The partner can reapply immediately. `standard`: The partner can reapply after 30 days. `never`: The partner can never reapply for the program. Defaults to `standard` if undefined.",
-      ),
-    allowImmediateReapply: z.boolean().optional().default(false).meta({
-      deprecated: true,
-      description: "Deprecated: Use `reapplicationTimeframe` instead.",
-    }),
-    flagForFraud: z
-      .boolean()
-      .optional()
-      .describe(
-        "Whether to flag the partner for fraud review by the Dub team. Cannot be combined with `reapplicationTimeframe: instant`.",
-      ),
-    flagForFraudReason: z
-      .string()
-      .max(MAX_FRAUD_REASON_LENGTH)
-      .optional()
-      .transform((s) => {
-        const t = s?.trim();
-        return t === "" ? undefined : t;
-      })
-      .describe(
-        "The reason for flagging the partner for fraud. Required when flagForFraud is true.",
-      ),
-  })
-  .superRefine((data, ctx) => {
-    const reapplicationTimeframe = data.allowImmediateReapply
-      ? "instant"
-      : data.reapplicationTimeframe;
-
-    if (reapplicationTimeframe === "instant" && data.flagForFraud) {
-      ctx.addIssue({
-        code: "custom",
-        message:
-          "Cannot flag for fraud when allowing the partner to reapply immediately.",
-        path: ["flagForFraud"],
-      });
-    }
-    if (
-      data.flagForFraud &&
-      (!data.flagForFraudReason || !data.flagForFraudReason.trim())
-    ) {
-      ctx.addIssue({
-        code: "custom",
-        message: "Fraud reason is required when flagging for fraud.",
-        path: ["flagForFraudReason"],
-      });
-    }
-  });
+export const rejectPartnerSchema = z.object({
+  partnerId: z.string().describe("The ID of the partner to reject."),
+  rejectionReason: z
+    .enum(ProgramApplicationRejectionReason)
+    .optional()
+    .describe(
+      "The reason for rejecting the partner application. This will be shared with the partner via email.",
+    ),
+  rejectionNote: z
+    .string()
+    .max(PROGRAM_APPLICATION_REJECTION_NOTE_MAX_LENGTH)
+    .optional()
+    .transform((s) => {
+      const t = s?.trim();
+      return t === "" ? undefined : t;
+    })
+    .describe(
+      "Additional details about the rejection. This will be shared with the partner via email.",
+    ),
+  reapplicationTimeframe: z
+    .enum(["instant", "standard", "never"])
+    .default("standard")
+    .describe(
+      "The mode for reapplying for the program. `instant`: The partner can reapply immediately. `standard`: The partner can reapply after 30 days. `never`: The partner can never reapply for the program. Defaults to `standard` if undefined.",
+    ),
+  flagForFraud: z
+    .boolean()
+    .optional()
+    .describe(
+      "Whether to flag the partner for fraud review by the Dub team. Cannot be combined with `reapplicationTimeframe: instant`.",
+    ),
+  flagForFraudReason: z
+    .string()
+    .max(MAX_FRAUD_REASON_LENGTH)
+    .optional()
+    .transform((s) => {
+      const t = s?.trim();
+      return t === "" ? undefined : t;
+    })
+    .describe(
+      "The reason for flagging the partner for fraud. Required when flagForFraud is true.",
+    ),
+});
 
 export const bulkRejectPartnersSchema = z.object({
   workspaceId: z.string(),

--- a/apps/web/tests/partners/applications/approve-reject-partner-application.test.ts
+++ b/apps/web/tests/partners/applications/approve-reject-partner-application.test.ts
@@ -45,7 +45,7 @@ describe.sequential(
           partnerId,
           rejectionReason: "other",
           rejectionNote: "e2e: first rejection",
-          allowImmediateReapply: false,
+          reapplicationTimeframe: "standard" as const,
         },
       });
       expect(rejectStatus).toEqual(200);
@@ -57,7 +57,7 @@ describe.sequential(
           partnerId,
           rejectionReason: "other",
           rejectionNote: "e2e: should fail",
-          allowImmediateReapply: false,
+          reapplicationTimeframe: "standard" as const,
         },
       });
       expect(duplicateRejectStatus).toEqual(400);

--- a/apps/web/ui/modals/reject-partner-application-modal.tsx
+++ b/apps/web/ui/modals/reject-partner-application-modal.tsx
@@ -18,6 +18,7 @@ import {
   InfoTooltip,
   Modal,
   Switch,
+  ToggleGroup,
   useKeyboardShortcut,
 } from "@dub/ui";
 import { cn } from "@dub/utils";
@@ -41,6 +42,21 @@ const REJECTION_REASON_COMBO_OPTIONS: ComboboxOption[] =
     label: getProgramApplicationRejectionReasonLabel(value),
   }));
 
+const REAPPLICATION_TIMEFRAME_OPTIONS = [
+  { value: "instant", label: "Immediate" },
+  { value: "standard", label: "30 days" },
+  { value: "never", label: "Never" },
+] as const;
+
+const REAPPLICATION_TIMEFRAME_DESCRIPTIONS: Record<
+  (typeof REAPPLICATION_TIMEFRAME_OPTIONS)[number]["value"],
+  string
+> = {
+  instant: "The partner can reapply immediately.",
+  standard: "The partner can reapply after 30 days.",
+  never: "The partner can never reapply for the program.",
+};
+
 interface RejectPartnerApplicationModalProps {
   showRejectPartnerApplicationModal: boolean;
   setShowRejectPartnerApplicationModal: Dispatch<SetStateAction<boolean>>;
@@ -60,13 +76,17 @@ export function RejectPartnerApplicationModal({
   confirmShortcutOptions,
 }: RejectPartnerApplicationModalProps) {
   const { id: workspaceId } = useWorkspace();
-  const allowImmediateReapplyOutcomeRef = useRef(false);
+  const reapplicationTimeframeOutcomeRef = useRef<
+    "instant" | "standard" | "never"
+  >("standard");
 
   const [selectedReason, setSelectedReason] = useState<ComboboxOption | null>(
     null,
   );
   const [rejectionNote, setRejectionNote] = useState("");
-  const [allowImmediateReapply, setAllowImmediateReapply] = useState(false);
+  const [reapplicationTimeframe, setReapplicationTimeframe] = useState<
+    "instant" | "standard" | "never"
+  >("standard");
   const [flagForFraud, setFlagForFraud] = useState(false);
   const [flagForFraudReason, setFlagForFraudReason] = useState("");
   const fraudReasonFieldId = useId();
@@ -76,7 +96,7 @@ export function RejectPartnerApplicationModal({
     if (!showRejectPartnerApplicationModal) {
       setSelectedReason(null);
       setRejectionNote("");
-      setAllowImmediateReapply(false);
+      setReapplicationTimeframe("standard");
       setFlagForFraud(false);
       setFlagForFraudReason("");
     }
@@ -87,9 +107,11 @@ export function RejectPartnerApplicationModal({
     {
       onSuccess: async () => {
         toast.success(
-          allowImmediateReapplyOutcomeRef.current
+          reapplicationTimeframeOutcomeRef.current === "instant"
             ? `Application rejected — ${partner.email} can reapply immediately.`
-            : `Partner ${partner.email} has been rejected from your program.`,
+            : reapplicationTimeframeOutcomeRef.current === "never"
+              ? `Partner ${partner.email} has been rejected and cannot reapply.`
+              : `Partner ${partner.email} has been rejected from your program.`,
         );
         setShowRejectPartnerApplicationModal(false);
         await onConfirm?.();
@@ -108,12 +130,12 @@ export function RejectPartnerApplicationModal({
       return;
     }
 
-    allowImmediateReapplyOutcomeRef.current = allowImmediateReapply;
+    reapplicationTimeframeOutcomeRef.current = reapplicationTimeframe;
 
     await rejectPartnerApplication({
       workspaceId,
       partnerId: partner.id,
-      allowImmediateReapply,
+      reapplicationTimeframe,
       ...(flagForFraud
         ? { flagForFraud: true, flagForFraudReason: flagForFraudReason.trim() }
         : {}),
@@ -129,7 +151,7 @@ export function RejectPartnerApplicationModal({
     rejectPartnerApplication,
     selectedReason,
     rejectionNote,
-    allowImmediateReapply,
+    reapplicationTimeframe,
     flagForFraud,
     flagForFraudReason,
   ]);
@@ -229,35 +251,33 @@ export function RejectPartnerApplicationModal({
           </div>
 
           <div>
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                <span
-                  className={cn(
-                    "text-sm font-medium text-neutral-900",
-                    flagForFraud && "text-neutral-400",
-                  )}
-                >
-                  Allow partner to reapply immediately
-                </span>
-                <InfoTooltip content="This will skip the 30 day waiting period and allow the partner to resubmit another application." />
-              </div>
-              <Switch
-                checked={allowImmediateReapply}
-                disabled={isPending || flagForFraud}
-                disabledTooltip={
-                  flagForFraud
-                    ? 'Turn off "Flag partner for potential fraud" to allow immediate reapply.'
-                    : undefined
+            <label className="block text-sm font-medium text-neutral-900">
+              Reapplication timeframe
+            </label>
+            <ToggleGroup
+              className="mt-1.5 flex w-full items-center gap-1 rounded-md border border-neutral-200 bg-neutral-100 p-1"
+              optionClassName="h-8 flex flex-1 items-center justify-center rounded-md text-sm normal-case"
+              indicatorClassName="bg-white"
+              options={[...REAPPLICATION_TIMEFRAME_OPTIONS]}
+              selected={reapplicationTimeframe}
+              selectAction={(value) => {
+                if (isPending) {
+                  return;
                 }
-                fn={(checked: boolean) => {
-                  setAllowImmediateReapply(checked);
-                  if (checked) {
-                    setFlagForFraud(false);
-                    setFlagForFraudReason("");
-                  }
-                }}
-              />
-            </div>
+                const timeframe = value as "instant" | "standard" | "never";
+                if (timeframe === "instant" && flagForFraud) {
+                  return;
+                }
+                setReapplicationTimeframe(timeframe);
+                if (timeframe === "instant") {
+                  setFlagForFraud(false);
+                  setFlagForFraudReason("");
+                }
+              }}
+            />
+            <p className="mt-1.5 text-xs text-neutral-500">
+              {REAPPLICATION_TIMEFRAME_DESCRIPTIONS[reapplicationTimeframe]}
+            </p>
           </div>
 
           <div>
@@ -270,16 +290,16 @@ export function RejectPartnerApplicationModal({
               </div>
               <Switch
                 checked={flagForFraud}
-                disabled={isPending || allowImmediateReapply}
+                disabled={isPending || reapplicationTimeframe === "instant"}
                 disabledTooltip={
-                  allowImmediateReapply
-                    ? 'Turn off "Allow partner to reapply immediately" to flag for fraud.'
+                  reapplicationTimeframe === "instant"
+                    ? 'Select a reapplication option other than "Immediate" to flag for fraud.'
                     : undefined
                 }
                 fn={(checked: boolean) => {
                   setFlagForFraud(checked);
                   if (checked) {
-                    setAllowImmediateReapply(false);
+                    setReapplicationTimeframe("standard");
                   }
                 }}
               />

--- a/packages/email/src/templates/partner-application-rejected.tsx
+++ b/packages/email/src/templates/partner-application-rejected.tsx
@@ -14,6 +14,8 @@ import {
 } from "@react-email/components";
 import { Footer } from "../components/footer";
 
+type ReapplicationTimeframe = "instant" | "standard" | "never";
+
 export default function PartnerApplicationRejected({
   partner = {
     name: "John",
@@ -26,7 +28,7 @@ export default function PartnerApplicationRejected({
   },
   rejectionReason,
   additionalNotes,
-  canReapplyImmediately = false,
+  reapplicationTimeframe = "standard",
 }: {
   partner: {
     name: string;
@@ -39,7 +41,7 @@ export default function PartnerApplicationRejected({
   };
   rejectionReason?: string | null;
   additionalNotes?: string | null;
-  canReapplyImmediately?: boolean;
+  reapplicationTimeframe?: ReapplicationTimeframe;
 }) {
   const reason = rejectionReason?.trim();
   const notes = additionalNotes?.trim();
@@ -48,7 +50,7 @@ export default function PartnerApplicationRejected({
     <Html>
       <Head />
       <Preview>
-        {canReapplyImmediately
+        {reapplicationTimeframe === "instant"
           ? `Program status update — you can submit a new application to ${program.name}`
           : `Program status update — your application to join ${program.name} was not approved`}
       </Preview>
@@ -72,18 +74,14 @@ export default function PartnerApplicationRejected({
             <Text className="text-sm leading-6 text-neutral-600">
               After reviewing your application, we&apos;ve decided not to
               approve you at this time.
-              {canReapplyImmediately ? (
-                <>
-                  {" "}
-                  You&apos;re welcome to submit a new application whenever
-                  you&apos;re ready.
-                </>
-              ) : (
-                <> You will be able to re-apply in 30 days.</>
-              )}
+              {reapplicationTimeframe === "instant"
+                ? " You can submit a new application whenever you're ready."
+                : reapplicationTimeframe === "standard"
+                  ? " You will be able to re-apply in 30 days."
+                  : null}
             </Text>
 
-            {canReapplyImmediately ? (
+            {reapplicationTimeframe === "instant" ? (
               <Section className="my-8 mt-8">
                 <Link
                   href={`${PARTNERS_DOMAIN}/apply/${program.slug}`}
@@ -110,7 +108,7 @@ export default function PartnerApplicationRejected({
               </Text>
             ) : null}
 
-            {canReapplyImmediately ? null : (
+            {reapplicationTimeframe === "instant" ? null : (
               <Text className="text-sm leading-6 text-neutral-600">
                 {program.supportEmail ? (
                   <>

--- a/packages/prisma/schema/message.prisma
+++ b/packages/prisma/schema/message.prisma
@@ -20,11 +20,11 @@ model Message {
   createdAt   DateTime  @default(now())
   updatedAt   DateTime  @updatedAt
 
-  program           Program             @relation(fields: [programId], references: [id], onDelete: Cascade)
-  partner           Partner?            @relation(fields: [partnerId], references: [id], onDelete: Cascade)
-  senderUser        User                @relation(fields: [senderUserId], references: [id], onDelete: Cascade)
-  senderPartner     Partner?            @relation("SenderPartner", fields: [senderPartnerId], references: [id], onDelete: Cascade)
-  emails            NotificationEmail[]
+  program       Program             @relation(fields: [programId], references: [id], onDelete: Cascade)
+  partner       Partner?            @relation(fields: [partnerId], references: [id], onDelete: Cascade)
+  senderUser    User                @relation(fields: [senderUserId], references: [id], onDelete: Cascade)
+  senderPartner Partner?            @relation("SenderPartner", fields: [senderPartnerId], references: [id], onDelete: Cascade)
+  emails        NotificationEmail[]
 
   @@index([programId, partnerId])
   @@index(partnerId)

--- a/packages/prisma/schema/partner.prisma
+++ b/packages/prisma/schema/partner.prisma
@@ -71,11 +71,11 @@ model Partner {
   cryptoWalletAddress          String?
 
   // timestamp fields
-  createdAt        DateTime  @default(now())
-  updatedAt        DateTime  @updatedAt
-  submittedAt      DateTime?
-  reviewedAt       DateTime?
-  trustedAt        DateTime?
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+  submittedAt DateTime?
+  reviewedAt  DateTime?
+  trustedAt   DateTime?
 
   // miscellaneous fields
   invoiceSettings     Json?

--- a/packages/prisma/schema/program.prisma
+++ b/packages/prisma/schema/program.prisma
@@ -97,6 +97,12 @@ model Program {
   @@index(addedToMarketplaceAt)
 }
 
+enum ReapplicationTimeframe {
+  instant
+  standard
+  never
+}
+
 model ProgramEnrollment {
   id               String                  @id @default(cuid())
   partnerId        String
@@ -131,12 +137,13 @@ model ProgramEnrollment {
   daysSinceLastConversion Int? // days since lastConversionAt
   consistencyScore        Int? // based on daysSinceLastConversion
 
-  createdAt                    DateTime             @default(now())
-  updatedAt                    DateTime             @updatedAt
+  createdAt                    DateTime               @default(now())
+  updatedAt                    DateTime               @updatedAt
   customerDataSharingEnabledAt DateTime?
   groupMoveDisabledAt          DateTime?
   bannedAt                     DateTime?
   bannedReason                 PartnerBannedReason?
+  reapplicationTimeframe       ReapplicationTimeframe @default(standard)
 
   partner            Partner                  @relation(fields: [partnerId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   program            Program                  @relation(fields: [programId], references: [id], onUpdate: Cascade, onDelete: Cascade)
@@ -179,6 +186,7 @@ model ProgramEnrollment {
   // other indexes
   @@index([programId, groupId])
   @@index([groupId, status])
+  @@index(status)
   @@index(clickRewardId)
   @@index(leadRewardId)
   @@index(saleRewardId)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Partner rejection workflow now offers three reapplication timeframe options (instant, standard, never) with updated modal UI and messaging.

* **Bug Fixes**
  * Fraud-flagging now correctly interacts with the instant timeframe and prevents invalid combinations.

* **Database**
  * Reapplication timeframe is persisted on enrollments; cleanup and rejection flows respect the selected timeframe.

* **Email**
  * Rejection emails now show timeframe-specific messaging and CTAs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dubinc/dub/pull/3931?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->