### PR TITLE
PartnerReferralLink email variable

### DIFF
--- a/apps/web/app/(ee)/api/campaigns/[campaignId]/preview/route.ts
+++ b/apps/web/app/(ee)/api/campaigns/[campaignId]/preview/route.ts
@@ -5,6 +5,7 @@ import { getProgramOrThrow } from "@/lib/api/programs/get-program-or-throw";
 import { parseRequestBody } from "@/lib/api/utils";
 import { renderCampaignEmailHTML } from "@/lib/api/workflows/render-campaign-email-html";
 import { withWorkspace } from "@/lib/auth";
+import { constructPartnerReferralLink } from "@/lib/partner-referrals/utils";
 import { TiptapNode } from "@/lib/types";
 import { CampaignSchema } from "@/lib/zod/schemas/campaigns";
 import { sendBatchEmail } from "@dub/email";
@@ -89,6 +90,10 @@ export const POST = withWorkspace(
                 PartnerName: "Partner",
                 PartnerEmail: "partner@acme.com",
                 PartnerLink: "https://acme.com/partner",
+                PartnerReferralLink: constructPartnerReferralLink({
+                  partner: { username: "partner-username" },
+                  program: { slug: program.slug },
+                }),
               },
             }),
           },

--- a/apps/web/app/(ee)/api/cron/campaigns/broadcast/route.ts
+++ b/apps/web/app/(ee)/api/cron/campaigns/broadcast/route.ts
@@ -2,6 +2,7 @@ import { validateCampaignFromAddress } from "@/lib/api/campaigns/validate-campai
 import { createId } from "@/lib/api/create-id";
 import { handleAndReturnErrorResponse } from "@/lib/api/errors";
 import { renderCampaignEmailHTML } from "@/lib/api/workflows/render-campaign-email-html";
+import { constructPartnerReferralLink } from "@/lib/partner-referrals/utils";
 import { qstash } from "@/lib/cron";
 import { verifyQstashSignature } from "@/lib/cron/verify-qstash";
 import { TiptapNode } from "@/lib/types";
@@ -166,6 +167,7 @@ export async function POST(req: Request) {
             id: true,
             name: true,
             email: true,
+            username: true,
             users: {
               where: {
                 notificationPreferences: {
@@ -259,6 +261,10 @@ export async function POST(req: Request) {
                     PartnerEmail: partnerUser.partner.email,
                     PartnerLink:
                       partnerUser.enrollment.links?.[0]?.shortLink ?? null,
+                    PartnerReferralLink: constructPartnerReferralLink({
+                      partner: partnerUser.partner,
+                      program: { slug: program.slug },
+                    }),
                   },
                 }),
               },

--- a/apps/web/lib/api/workflows/execute-send-campaign-workflow.ts
+++ b/apps/web/lib/api/workflows/execute-send-campaign-workflow.ts
@@ -1,4 +1,5 @@
 import { evaluateWorkflowConditions } from "@/lib/api/workflows/evaluate-workflow-conditions";
+import { constructPartnerReferralLink } from "@/lib/partner-referrals/utils";
 import { aggregatePartnerLinksStats } from "@/lib/partners/aggregate-partner-links-stats";
 import {
   CampaignTriggerCondition,
@@ -176,6 +177,10 @@ export const executeSendCampaignWorkflow = async ({
                 PartnerEmail: partnerUser.partner.email,
                 PartnerLink:
                   partnerUser.enrollment.links?.[0]?.shortLink ?? null,
+                PartnerReferralLink: constructPartnerReferralLink({
+                  partner: partnerUser.partner,
+                  program: { slug: program.slug },
+                }),
               },
             }),
           },

--- a/apps/web/lib/api/workflows/interpolate-email-template.ts
+++ b/apps/web/lib/api/workflows/interpolate-email-template.ts
@@ -42,7 +42,7 @@ function partnerLinkToAnchorOrText(raw: string): string {
  *
  * **Output**
  * - `PartnerName`, `PartnerEmail`, etc.: HTML-escaped (treat as plain text; no raw HTML).
- * - `PartnerLink`: valid `http:` / `https:` URL → clickable `<a>`; else escaped text.
+ * - `PartnerLink`, `PartnerReferralLink`: valid `http:` / `https:` URL → clickable `<a>`; else escaped text.
  *
  * @param text - HTML string containing `{{VariableName}}` or `{{Name | fallback}}`
  * @param variables - Map of template variable names to values
@@ -69,7 +69,7 @@ export function interpolateEmailTemplate({
     (_, key, fallback) => {
       const value = variables[key];
       const resolved = value != null ? String(value) : fallback?.trim() ?? "";
-      if (key === "PartnerLink") {
+      if (key === "PartnerLink" || key === "PartnerReferralLink") {
         return partnerLinkToAnchorOrText(resolved);
       }
       return escapeHtml(resolved);

--- a/apps/web/lib/zod/schemas/campaigns.ts
+++ b/apps/web/lib/zod/schemas/campaigns.ts
@@ -14,6 +14,7 @@ export const EMAIL_TEMPLATE_VARIABLES = [
   "PartnerName",
   "PartnerEmail",
   "PartnerLink",
+  "PartnerReferralLink",
 ] as const;
 
 export const CAMPAIGN_WORKFLOW_ATTRIBUTE_CONFIG: Record<

--- a/apps/web/tests/misc/interpolate-email-template.test.ts
+++ b/apps/web/tests/misc/interpolate-email-template.test.ts
@@ -66,4 +66,18 @@ describe("interpolateEmailTemplate", () => {
       }),
     ).toBe("Hi &lt;script&gt;alert(1)&lt;/script&gt;");
   });
+
+  it("renders PartnerReferralLink as a clickable anchor for https URLs", () => {
+    expect(
+      interpolateEmailTemplate({
+        text: "Refer partners: {{PartnerReferralLink}}",
+        variables: {
+          PartnerReferralLink:
+            "https://partners.dub.co/acme/apply?via=johndoe-a1b2",
+        },
+      }),
+    ).toBe(
+      'Refer partners: <a href="https://partners.dub.co/acme/apply?via=johndoe-a1b2" target="_blank" rel="noopener noreferrer">https://partners.dub.co/acme/apply?via=johndoe-a1b2</a>',
+    );
+  });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Campaign emails now support a new `PartnerReferralLink` template variable that dynamically generates partner-specific referral links. These links render as clickable anchors in emails across preview, broadcast, and workflow systems.

* **Tests**
  * Added test coverage verifying the new template variable renders correctly as clickable anchors with appropriate link attributes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dubinc/dub/pull/3934?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->