### PR TITLE
Reducing the default toast time

### DIFF
--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -10,7 +10,7 @@ export default function RootProviders({ children }: { children: ReactNode }) {
     <TooltipProvider>
       <PlausibleProvider enabled>
         <KeyboardShortcutProvider>
-          <Toaster className="pointer-events-auto" closeButton />
+          <Toaster className="pointer-events-auto" closeButton duration={3000} />
           {children}
         </KeyboardShortcutProvider>
       </PlausibleProvider>


### PR DESCRIPTION
If no duration is set on `providers.tsx` the global toast time is 4s. Adding duration prop to the `toaster` to 3000 to change to 3s

## After -> 3 seconds
https://github.com/user-attachments/assets/76b9e749-4265-4660-89d1-c2f36612799a

## Before 4 seconds
https://github.com/user-attachments/assets/c2b39e9c-1b14-4fa6-bcb8-50cacf81642b



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated toast notification timing to auto-dismiss after 3 seconds for improved user experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dubinc/dub/pull/3948?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->