### PR TITLE
Add support for discount code restrictions

### DIFF
--- a/apps/web/lib/discounts/discount-provider-stripe.ts
+++ b/apps/web/lib/discounts/discount-provider-stripe.ts
@@ -161,7 +161,8 @@ function createStripeDiscountProvider() {
             coupon: discount.couponId,
             code: currentCode.toUpperCase(),
             restrictions: {
-              first_time_transaction: true,
+              first_time_transaction:
+                settings.discountCodeRestrictions.firstTimeTransaction,
             },
           },
           {

--- a/apps/web/lib/integrations/stripe/schema.ts
+++ b/apps/web/lib/integrations/stripe/schema.ts
@@ -1,6 +1,7 @@
 import * as z from "zod/v4";
 
 export const stripeIntegrationSettingsSchema = z.object({
+  stripeMode: z.enum(["live", "test", "sandbox"]).optional().default("live"),
   freeTrials: z
     .object({
       enabled: z
@@ -15,5 +16,11 @@ export const stripeIntegrationSettingsSchema = z.object({
         ),
     })
     .nullish(),
-  stripeMode: z.enum(["live", "test", "sandbox"]).optional().default("live"),
+  discountCodeRestrictions: z
+    .object({
+      firstTimeTransaction: z.boolean().default(true),
+    })
+    .default({
+      firstTimeTransaction: true,
+    }),
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stripe discount code restrictions are now configurable through integration settings, allowing you to control whether codes are limited to first-time transactions (defaults to enabled).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dubinc/dub/pull/3955?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->