### PR TITLE
Revalidate apply page cache synchronously

### DIFF
--- a/apps/web/lib/actions/partners/update-program.ts
+++ b/apps/web/lib/actions/partners/update-program.ts
@@ -67,22 +67,20 @@ export const updateProgramAction = authActionClient
     }
 
     waitUntil(
-      (async () => {
-        await recordAuditLog({
-          workspaceId: workspace.id,
-          programId: program.id,
-          action: "program.updated",
-          description: `Program ${program.name} updated`,
-          actor: user,
-          targets: [
-            {
-              type: "program",
-              id: program.id,
-              metadata: updatedProgram,
-            },
-          ],
-        });
-      })(),
+      recordAuditLog({
+        workspaceId: workspace.id,
+        programId: program.id,
+        action: "program.updated",
+        description: `Program ${program.name} updated`,
+        actor: user,
+        targets: [
+          {
+            type: "program",
+            id: program.id,
+            metadata: updatedProgram,
+          },
+        ],
+      }),
     );
 
     return {

--- a/apps/web/lib/actions/partners/update-program.ts
+++ b/apps/web/lib/actions/partners/update-program.ts
@@ -62,6 +62,10 @@ export const updateProgramAction = authActionClient
       },
     });
 
+    if (updatedProgram.termsUrl !== program.termsUrl) {
+      revalidatePath(`/partners.dub.co/${program.slug}/apply`);
+    }
+
     waitUntil(
       (async () => {
         await recordAuditLog({
@@ -78,10 +82,6 @@ export const updateProgramAction = authActionClient
             },
           ],
         });
-
-        if (updatedProgram.termsUrl !== program.termsUrl) {
-          revalidatePath(`/partners.dub.co/${program.slug}/apply`);
-        }
       })(),
     );
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Program terms updates now trigger immediate revalidation of the program application page so changes appear promptly in the interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dubinc/dub/pull/3959?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->