### PR TITLE
[DRAFT] Tinybird TYPE ENDPOINT definitions and add missing metadata

### DIFF
--- a/packages/tinybird/pipes/all_stats.pipe
+++ b/packages/tinybird/pipes/all_stats.pipe
@@ -7,5 +7,4 @@ SQL >
         (SELECT COUNT(timestamp) FROM dub_click_events_mv) AS clicks,
         (SELECT COUNT(timestamp) + 42036155 FROM dub_links_metadata) AS links,
         (SELECT SUM(amount) FROM dub_sale_events_mv) AS sales
-
-
+TYPE ENDPOINT

--- a/packages/tinybird/pipes/coordinates_all.pipe
+++ b/packages/tinybird/pipes/coordinates_all.pipe
@@ -92,5 +92,4 @@ SQL >
             )
         ORDER BY
             timestamp DESC
-
-
+TYPE ENDPOINT

--- a/packages/tinybird/pipes/coordinates_sales.pipe
+++ b/packages/tinybird/pipes/coordinates_sales.pipe
@@ -22,5 +22,4 @@ SQL >
             AND city != 'Ashburn'
         ORDER BY timestamp DESC
         LIMIT 500
-
-
+TYPE ENDPOINT

--- a/packages/tinybird/pipes/dub_links_metadata_pipe.pipe
+++ b/packages/tinybird/pipes/dub_links_metadata_pipe.pipe
@@ -21,6 +21,7 @@ SQL >
        partner_group_id,
        folder_id,
        tag_ids,
+       partner_tag_ids,
        tenant_id,
        created_at,
        deleted
@@ -28,5 +29,4 @@ SQL >
 
 TYPE materialized
 DATASOURCE dub_links_metadata_latest
-
 

--- a/packages/tinybird/pipes/get_api_log_by_id.pipe
+++ b/packages/tinybird/pipes/get_api_log_by_id.pipe
@@ -20,3 +20,4 @@ SQL >
         id = {{ String(id) }}
         AND workspace_id = {{ String(workspaceId) }}
     LIMIT 1
+TYPE ENDPOINT

--- a/packages/tinybird/pipes/get_api_logs.pipe
+++ b/packages/tinybird/pipes/get_api_logs.pipe
@@ -31,3 +31,4 @@ SQL >
     ORDER BY timestamp DESC
     LIMIT {{ Int32(limit, 100) }}
     OFFSET {{ Int32(offset, 0) }}
+TYPE ENDPOINT

--- a/packages/tinybird/pipes/get_api_logs_count.pipe
+++ b/packages/tinybird/pipes/get_api_logs_count.pipe
@@ -49,3 +49,4 @@ SQL >
         {% if defined(groupBy) and groupBy == 'routePattern' %} count_by_route_pattern
         {% else %} count
         {% end %}
+TYPE ENDPOINT

--- a/packages/tinybird/pipes/get_audit_logs.pipe
+++ b/packages/tinybird/pipes/get_audit_logs.pipe
@@ -24,5 +24,4 @@ SQL >
                 {% if defined(workspaceId) %} AND workspace_id = {{ String(workspaceId) }} {% end %}
                 {% if defined(programId) %} AND program_id = {{ String(programId) }} {% end %}
             ORDER BY timestamp DESC
-
-
+TYPE ENDPOINT

--- a/packages/tinybird/pipes/get_click_event.pipe
+++ b/packages/tinybird/pipes/get_click_event.pipe
@@ -16,5 +16,4 @@ SQL >
             }}
         ORDER BY timestamp DESC
         LIMIT 1
-
-
+TYPE ENDPOINT

--- a/packages/tinybird/pipes/get_framer_lead_events.pipe
+++ b/packages/tinybird/pipes/get_framer_lead_events.pipe
@@ -7,5 +7,4 @@ SQL >
         WHERE 
           link_id IN {{ Array(linkIds, 'String', ['link_1JWRSXGRTN95H1YCKTC5BM41B','link_1JWQHXN0Y1QBR7X07YQ6MHWTZ']) }}
           AND customer_id IN {{ Array(customerIds, 'String', ['cus_1JWTHSGTT67WY9NK98QSFJ3M4','cus_1JWTQS8S008Q3VTB8ZRG7AE3W']) }}
-
-
+TYPE ENDPOINT

--- a/packages/tinybird/pipes/get_import_error_logs.pipe
+++ b/packages/tinybird/pipes/get_import_error_logs.pipe
@@ -27,5 +27,4 @@ SQL >
                 }}
             ORDER BY timestamp DESC
             limit 5000
-
-
+TYPE ENDPOINT

--- a/packages/tinybird/pipes/get_lead_event.pipe
+++ b/packages/tinybird/pipes/get_lead_event.pipe
@@ -20,5 +20,4 @@ SQL >
         }}
         {% if defined(eventName) %} AND event_name = {{ eventName }} {% end %}
     ORDER BY timestamp DESC
-
-
+TYPE ENDPOINT

--- a/packages/tinybird/pipes/get_lead_events.pipe
+++ b/packages/tinybird/pipes/get_lead_events.pipe
@@ -8,5 +8,4 @@ SQL >
             true
             {% if defined(customerIds) %} AND customer_id IN {{ Array(customerIds, 'String') }} {% end %}
         ORDER BY timestamp DESC
-
-
+TYPE ENDPOINT

--- a/packages/tinybird/pipes/get_postback_events.pipe
+++ b/packages/tinybird/pipes/get_postback_events.pipe
@@ -20,5 +20,4 @@ SQL >
                 }}
                 ORDER BY timestamp DESC
                 limit 100
-
-
+TYPE ENDPOINT

--- a/packages/tinybird/pipes/get_webhook_events.pipe
+++ b/packages/tinybird/pipes/get_webhook_events.pipe
@@ -20,5 +20,4 @@ SQL >
                 }}
                 ORDER BY timestamp DESC
                 limit 100
-
-
+TYPE ENDPOINT

--- a/packages/tinybird/pipes/v2_customer_events.pipe
+++ b/packages/tinybird/pipes/v2_customer_events.pipe
@@ -160,5 +160,4 @@ SQL >
             )
         ORDER BY
             timestamp DESC, CASE event WHEN 'click' THEN 1 WHEN 'lead' THEN 2 WHEN 'sale' THEN 3 END DESC
-
-
+TYPE ENDPOINT

--- a/packages/tinybird/pipes/v2_top_programs.pipe
+++ b/packages/tinybird/pipes/v2_top_programs.pipe
@@ -174,5 +174,4 @@ SQL >
             {% elif eventType == 'composite' %} top_programs_composite
             {% else %} top_programs_sales
             {% end %}
-
-
+TYPE ENDPOINT

--- a/packages/tinybird/pipes/v3_count.pipe
+++ b/packages/tinybird/pipes/v3_count.pipe
@@ -318,5 +318,4 @@ FROM
     {% elif eventType == 'composite' %} count_composite
     {% else %} count_clicks
     {% end %}
-
-
+TYPE ENDPOINT

--- a/packages/tinybird/pipes/v3_events.pipe
+++ b/packages/tinybird/pipes/v3_events.pipe
@@ -322,5 +322,4 @@ FROM
     {% elif eventType == 'sales' %} sale_events
     {% else %} click_events
     {% end %}
-
-
+TYPE ENDPOINT

--- a/packages/tinybird/pipes/v3_group_by.pipe
+++ b/packages/tinybird/pipes/v3_group_by.pipe
@@ -493,5 +493,4 @@ FROM
     {% elif eventType == 'composite' %}group_by_composite
     {% else %} group_by_clicks
     {% end %}
-
-
+TYPE ENDPOINT

--- a/packages/tinybird/pipes/v3_group_by_link_country.pipe
+++ b/packages/tinybird/pipes/v3_group_by_link_country.pipe
@@ -22,5 +22,4 @@ SQL >
         ORDER BY
             link_id ASC,
             clicks DESC
-
-
+TYPE ENDPOINT

--- a/packages/tinybird/pipes/v3_group_by_link_metadata.pipe
+++ b/packages/tinybird/pipes/v3_group_by_link_metadata.pipe
@@ -296,5 +296,4 @@ FROM
     {% elif eventType == 'composite' %}group_by_link_metadata_composite
     {% else %} group_by_link_metadata_clicks
     {% end %}
-
-
+TYPE ENDPOINT

--- a/packages/tinybird/pipes/v3_timeseries.pipe
+++ b/packages/tinybird/pipes/v3_timeseries.pipe
@@ -434,5 +434,4 @@ FROM
     {% elif eventType == 'composite' %} timeseries_composite
     {% else %} timeseries_clicks
     {% end %}
-
-
+TYPE ENDPOINT

--- a/packages/tinybird/pipes/v3_usage.pipe
+++ b/packages/tinybird/pipes/v3_usage.pipe
@@ -140,5 +140,4 @@ SQL >
 
     %
         SELECT * FROM {% if resource == 'events' %} usage_events {% else %} usage_links {% end %}
-
-
+TYPE ENDPOINT

--- a/packages/tinybird/pipes/v3_usage_latest.pipe
+++ b/packages/tinybird/pipes/v3_usage_latest.pipe
@@ -144,5 +144,4 @@ SQL >
 
     %
     SELECT * FROM {% if resource == 'events' %} usage_events {% else %} usage_links {% end %}
-
-
+TYPE ENDPOINT

--- a/packages/tinybird/pipes/v4_count.pipe
+++ b/packages/tinybird/pipes/v4_count.pipe
@@ -622,5 +622,4 @@ SQL >
         {% elif eventType == 'composite' %} count_composite
         {% else %} count_clicks
         {% end %}
-
-
+TYPE ENDPOINT

--- a/packages/tinybird/pipes/v4_events.pipe
+++ b/packages/tinybird/pipes/v4_events.pipe
@@ -632,5 +632,4 @@ SQL >
         {% elif eventType == 'sales' %} sale_events
         {% else %} click_events
         {% end %}
-
-
+TYPE ENDPOINT

--- a/packages/tinybird/pipes/v4_group_by.pipe
+++ b/packages/tinybird/pipes/v4_group_by.pipe
@@ -821,5 +821,4 @@ SQL >
         {% elif eventType == 'composite' %}group_by_composite
         {% else %} group_by_clicks
         {% end %}
-
-
+TYPE ENDPOINT

--- a/packages/tinybird/pipes/v4_group_by_link_metadata.pipe
+++ b/packages/tinybird/pipes/v4_group_by_link_metadata.pipe
@@ -587,5 +587,4 @@ SQL >
         {% elif eventType == 'composite' %}group_by_link_metadata_composite
         {% else %} group_by_link_metadata_clicks
         {% end %}
-
-
+TYPE ENDPOINT

--- a/packages/tinybird/pipes/v4_timeseries.pipe
+++ b/packages/tinybird/pipes/v4_timeseries.pipe
@@ -764,5 +764,4 @@ SQL >
         {% elif eventType == 'composite' %} timeseries_composite
         {% else %} timeseries_clicks
         {% end %}
-
-
+TYPE ENDPOINT


### PR DESCRIPTION
This PR has two fixes to address issues encountered during local dev onboarding:

1) TinyBird launched the new Forward Workspace, and it appears you can no longer create new Classic Tinybird workspaces moving forward.  I've updated the Dub docs to reflect this.  See [PR to update Dub Docs](https://github.com/dubinc/docs/pull/382) for full details on this issue.

`TYPE ENDPOINT` is supported by Tinybird Classic ([docs link](https://www.tinybird.co/docs/classic/cli/datafiles/pipe-files)) and required by Tinybird Forward to publish a `.pipe` as an API endpoint. This updates existing endpoint pipes to use the explicit endpoint type while leaving materialized pipes unchanged.  Classic inferred more from the workspace/UI while Forward workspaces are stricter about datafiles as source of truth.

2) Missing metadata on materialized pipe schema for `partner_tag_ids` in packages/tinybird/pipes/dub_links_metadata_pipe.pipe

**Testing**
- I was able to complete the full local environment setup and register clicks in TinyBird's clickhouse after making the changes in this PR to my local env.  

_NOTE:_ This was tested against a TinyBird **FORWARD** workspace, as I do not have the ability to create Classic workspaces.  Dub's prod environment is a Classic workspace AFAIK.

Someone with access to prod TinyBird will need to run:

`tb --cloud deployment create --check` [doc link](https://www.tinybird.co/docs/forward/development-workflow/manual-deployment)

and ensure that this does not make any material changes + test these changes against a TinyBird Classic Workspace running a Dub Dev environment




