### PR TITLE
Fix: Adding Comments to Partner Network Partners throws error

### DIFF
--- a/apps/web/app/(ee)/api/messages/route.ts
+++ b/apps/web/app/(ee)/api/messages/route.ts
@@ -1,3 +1,4 @@
+import { partnerReachableByProgramWhereInput } from "@/lib/api/partners/partner-reachable-by-program-where-input";
 import { getDefaultProgramIdOrThrow } from "@/lib/api/programs/get-default-program-id-or-throw";
 import { withWorkspace } from "@/lib/auth";
 import {
@@ -26,11 +27,7 @@ export const GET = withWorkspace(
         ? {
             id: partnerId,
             // Partner is either approved or trusted in the partner network, enrolled in the program, or already has a message with the program
-            OR: [
-              { networkStatus: { in: ["approved", "trusted"] } },
-              { programs: { some: { programId } } },
-              { messages: { some: { programId } } },
-            ],
+            ...partnerReachableByProgramWhereInput(programId),
           }
         : {
             // Partner has messages with the program

--- a/apps/web/lib/actions/partners/create-partner-comment.ts
+++ b/apps/web/lib/actions/partners/create-partner-comment.ts
@@ -1,7 +1,8 @@
 "use server";
 
+import { DubApiError } from "@/lib/api/errors";
+import { partnerReachableByProgramWhereInput } from "@/lib/api/partners/partner-reachable-by-program-where-input";
 import { getDefaultProgramIdOrThrow } from "@/lib/api/programs/get-default-program-id-or-throw";
-import { getProgramEnrollmentOrThrow } from "@/lib/api/programs/get-program-enrollment-or-throw";
 import { prisma } from "@dub/prisma";
 import {
   PartnerCommentSchema,
@@ -24,11 +25,23 @@ export const createPartnerCommentAction = authActionClient
 
     const programId = getDefaultProgramIdOrThrow(workspace);
 
-    await getProgramEnrollmentOrThrow({
-      partnerId,
-      programId,
-      include: {},
+    // Allow commenting on partners that are enrolled in the program OR
+    // discoverable via the partner network, so the team can discuss a partner
+    // (e.g. whether to invite them) before they're enrolled.
+    const partner = await prisma.partner.findFirst({
+      where: {
+        id: partnerId,
+        ...partnerReachableByProgramWhereInput(programId),
+      },
+      select: { id: true },
     });
+
+    if (!partner) {
+      throw new DubApiError({
+        code: "not_found",
+        message: "Partner not found.",
+      });
+    }
 
     const comment = await prisma.partnerComment.create({
       data: {

--- a/apps/web/lib/actions/partners/message-partner.ts
+++ b/apps/web/lib/actions/partners/message-partner.ts
@@ -3,6 +3,7 @@
 import { createId } from "@/lib/api/create-id";
 import { DubApiError } from "@/lib/api/errors";
 import { getNetworkInvitesUsage } from "@/lib/api/partners/get-network-invites-usage";
+import { partnerReachableByProgramWhereInput } from "@/lib/api/partners/partner-reachable-by-program-where-input";
 import { getDefaultProgramIdOrThrow } from "@/lib/api/programs/get-default-program-id-or-throw";
 import { qstash } from "@/lib/cron";
 import { getPlanCapabilities } from "@/lib/plan-capabilities";
@@ -46,27 +47,7 @@ export const messagePartnerAction = authActionClient
     const { _count, programs } = await prisma.partner.findFirstOrThrow({
       where: {
         id: partnerId,
-        OR: [
-          {
-            networkStatus: {
-              in: ["approved", "trusted"],
-            },
-          },
-          {
-            programs: {
-              some: {
-                programId,
-              },
-            },
-          },
-          {
-            messages: {
-              some: {
-                programId,
-              },
-            },
-          },
-        ],
+        ...partnerReachableByProgramWhereInput(programId),
       },
       include: {
         _count: {

--- a/apps/web/lib/api/partners/partner-reachable-by-program-where-input.ts
+++ b/apps/web/lib/api/partners/partner-reachable-by-program-where-input.ts
@@ -1,0 +1,17 @@
+import { Prisma } from "@dub/prisma/client";
+
+/**
+ * Prisma `where` input for partners reachable by a program: approved/trusted
+ * in the partner network, enrolled in the program, or already has a message
+ * thread with the program. Spread into a `prisma.partner` query alongside an
+ * `id` filter; callers are still responsible for action-specific authorization.
+ */
+export const partnerReachableByProgramWhereInput = (
+  programId: string,
+): Prisma.PartnerWhereInput => ({
+  OR: [
+    { networkStatus: { in: ["approved", "trusted"] } },
+    { programs: { some: { programId } } },
+    { messages: { some: { programId } } },
+  ],
+});


### PR DESCRIPTION
**Bug**: if a Program attempts to add a comment to a Partner while browsing the Partner Network, the backend rejects this comment and the UI throws an error because the Add Comment API requires program enrollment.

This functionality would be useful to Program teams evaluating partners/strategizing on outreach and should be allowed.  _If this behavior is intentional - fix would be to instead remove the add comment panel._

This PR updates the create partner comment API to allow this, as well as a light refactor to avoid duplicate query code in several places.

### **Before:**
<img width="1822" height="1185" alt="image" src="https://github.com/user-attachments/assets/02e859dc-c8c1-4c7d-8d0f-0e407471303e" />

### **After:**
<img width="1180" height="500" alt="image" src="https://github.com/user-attachments/assets/b10fa10d-2122-452e-b756-8dce4bd16ac8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated partner eligibility logic used across messaging, partner lookup, and commenting flows to ensure consistent behavior.
  * Shared eligibility checks now power partner selection for outreach and comment creation, reducing duplication.
  * Comment creation now validates partner reachability using the shared check before saving.
  * No changes to user-visible permissions or messaging workflows; sending messages, commenting, and partner discovery remain the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->