### PR TITLE
Adding copy link action to link page

### DIFF
--- a/apps/web/ui/links/short-link-input.tsx
+++ b/apps/web/ui/links/short-link-input.tsx
@@ -9,12 +9,14 @@ import {
   ArrowTurnRight2,
   ButtonTooltip,
   Combobox,
+  Copy,
   LinkedIn,
   LoadingCircle,
   Magic,
   PenWriting,
   Tooltip,
   Twitter,
+  useCopyToClipboard,
   useKeyboardShortcut,
 } from "@dub/ui";
 import {
@@ -90,6 +92,7 @@ export const ShortLinkInput = forwardRef<HTMLInputElement, ShortLinkInputProps>(
 
     const [lockKey, setLockKey] = useState(existingLink);
     const [generatingRandomKey, setGeneratingRandomKey] = useState(false);
+    const [, copyToClipboard] = useCopyToClipboard();
 
     const [keyError, setKeyError] = useState<string | null>(null);
     const error = keyError || errorProp;
@@ -196,6 +199,12 @@ export const ShortLinkInput = forwardRef<HTMLInputElement, ShortLinkInputProps>(
         pretty: true,
       });
     }, [key, domain]);
+    const shortLinkToCopy = useMemo(() => {
+      return linkConstructor({
+        key,
+        domain,
+      });
+    }, [key, domain]);
 
     return (
       <div>
@@ -208,17 +217,34 @@ export const ShortLinkInput = forwardRef<HTMLInputElement, ShortLinkInputProps>(
             {existingLinkProps?.disabledAt && <DisabledLinkTooltip />}
           </label>
           {lockKey ? (
-            <button
-              className="flex h-6 items-center space-x-2 text-sm text-neutral-500 transition-all duration-75 hover:text-black active:scale-95"
-              type="button"
-              onClick={() => {
-                window.confirm(
-                  "Editing an existing short link could potentially break existing links. Are you sure you want to continue?",
-                ) && setLockKey(false);
-              }}
-            >
-              <PenWriting className="size-3.5" />
-            </button>
+            <div className="flex items-center gap-1">
+              <ButtonTooltip
+                tooltipProps={{
+                  content: "Edit link",
+                }}
+                onClick={() => {
+                  window.confirm(
+                    "Editing an existing short link could potentially break existing links. Are you sure you want to continue?",
+                  ) && setLockKey(false);
+                }}
+              >
+                <span className="sr-only">Edit short link</span>
+                <PenWriting className="size-3.5" />
+              </ButtonTooltip>
+              <ButtonTooltip
+                tooltipProps={{
+                  content: "Copy link",
+                }}
+                onClick={() => {
+                  toast.promise(copyToClipboard(shortLinkToCopy), {
+                    success: "Link copied to clipboard",
+                  });
+                }}
+                disabled={!shortLinkToCopy}
+              >
+                <Copy className="size-3.5" />
+              </ButtonTooltip>
+            </div>
           ) : (
             <div className="flex items-center gap-1">
               <ButtonTooltip


### PR DESCRIPTION
- Added a `Copy link` action above the input
- Added a missing `Edit link` tooltip to the edit button
- Keeping the top-right button, as it's still good to have it as the primary action

https://github.com/user-attachments/assets/9eeaf0a3-42c9-4c78-be5f-65d0f2792df4



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to copy short-link URLs while editing an existing link.
  * Redesigned the link editing interface with separate actions for unlocking edit mode and copying the generated short link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->