### PR TITLE
Require owner or member role for partner tag actions

### DIFF
--- a/apps/web/lib/actions/partners/tags/create-partner-tag.ts
+++ b/apps/web/lib/actions/partners/tags/create-partner-tag.ts
@@ -9,6 +9,7 @@ import {
 import { prisma } from "@dub/prisma";
 import { INFINITY_NUMBER } from "@dub/utils";
 import { authActionClient } from "../../safe-action";
+import { throwIfNoPermission } from "../../throw-if-no-permission";
 
 // Create a partner tag
 export const createPartnerTagAction = authActionClient
@@ -17,21 +18,25 @@ export const createPartnerTagAction = authActionClient
     const { workspace } = ctx;
     const { name } = parsedInput;
 
+    throwIfNoPermission({
+      role: workspace.role,
+      requiredRoles: ["owner", "member"],
+    });
+
     const programId = getDefaultProgramIdOrThrow(workspace);
 
-    const partnerTagsLimit = (
-      workspace as unknown as { partnerTagsLimit: number }
-    ).partnerTagsLimit;
-
-    if (partnerTagsLimit < INFINITY_NUMBER) {
+    if (workspace.partnerTagsLimit < INFINITY_NUMBER) {
       const existingCount = await prisma.partnerTag.count({
-        where: { programId },
+        where: {
+          programId,
+        },
       });
-      if (existingCount >= partnerTagsLimit) {
+
+      if (existingCount >= workspace.partnerTagsLimit) {
         throw new Error(
-          partnerTagsLimit === 0
+          workspace.partnerTagsLimit === 0
             ? "Partner tags are not available on your plan. Upgrade to create partner tags."
-            : `You've reached the maximum of ${partnerTagsLimit} partner tags per program on your plan. Upgrade to Advanced or Enterprise for unlimited partner tags.`,
+            : `You've reached the maximum of ${workspace.partnerTagsLimit} partner tags per program on your plan. Upgrade to Advanced or Enterprise for unlimited partner tags.`,
         );
       }
     }

--- a/apps/web/lib/actions/partners/tags/delete-partner-tag.ts
+++ b/apps/web/lib/actions/partners/tags/delete-partner-tag.ts
@@ -4,6 +4,7 @@ import { getDefaultProgramIdOrThrow } from "@/lib/api/programs/get-default-progr
 import { markPartnerTagDeleted } from "@/lib/api/tags/mark-partner-tag-deleted";
 import { deletePartnerTagSchema } from "@/lib/zod/schemas/partner-tags";
 import { authActionClient } from "../../safe-action";
+import { throwIfNoPermission } from "../../throw-if-no-permission";
 
 // Delete a partner tag
 export const deletePartnerTagAction = authActionClient
@@ -11,6 +12,11 @@ export const deletePartnerTagAction = authActionClient
   .action(async ({ parsedInput, ctx }) => {
     const { workspace } = ctx;
     const { partnerTagId } = parsedInput;
+
+    throwIfNoPermission({
+      role: workspace.role,
+      requiredRoles: ["owner", "member"],
+    });
 
     const programId = getDefaultProgramIdOrThrow(workspace);
 

--- a/apps/web/lib/actions/partners/tags/update-partner-tag.ts
+++ b/apps/web/lib/actions/partners/tags/update-partner-tag.ts
@@ -4,6 +4,7 @@ import { getDefaultProgramIdOrThrow } from "@/lib/api/programs/get-default-progr
 import { updatePartnerTagSchema } from "@/lib/zod/schemas/partner-tags";
 import { prisma } from "@dub/prisma";
 import { authActionClient } from "../../safe-action";
+import { throwIfNoPermission } from "../../throw-if-no-permission";
 
 // Update a partner tag
 export const updatePartnerTagAction = authActionClient
@@ -11,6 +12,11 @@ export const updatePartnerTagAction = authActionClient
   .action(async ({ parsedInput, ctx }) => {
     const { workspace } = ctx;
     const { partnerTagId, name } = parsedInput;
+
+    throwIfNoPermission({
+      role: workspace.role,
+      requiredRoles: ["owner", "member"],
+    });
 
     const programId = getDefaultProgramIdOrThrow(workspace);
 

--- a/apps/web/lib/actions/partners/tags/update-program-partner-tags.ts
+++ b/apps/web/lib/actions/partners/tags/update-program-partner-tags.ts
@@ -8,6 +8,7 @@ import { updatePartnerTagsSchema } from "@/lib/zod/schemas/partner-tags";
 import { prisma } from "@dub/prisma";
 import { waitUntil } from "@vercel/functions";
 import { authActionClient } from "../../safe-action";
+import { throwIfNoPermission } from "../../throw-if-no-permission";
 
 const PARTNER_LINKS_TINYBIRD_BATCH_SIZE = 500;
 
@@ -21,6 +22,11 @@ export const updateProgramPartnerTagsAction = authActionClient
       addTagIds: addTagIdsInput,
       removeTagIds: removeTagIdsInput,
     } = parsedInput;
+
+    throwIfNoPermission({
+      role: workspace.role,
+      requiredRoles: ["owner", "member"],
+    });
 
     const partnerIds = [...new Set(partnerIdsInput)];
     const addTagIds = [...new Set(addTagIdsInput ?? [])];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Added authorization checks to all partner tag operations (create, delete, update, and program assignment) to ensure only workspace owners and members can perform these actions. Permission validation now occurs before any database modifications are made.

* **Bug Fixes**
  * Improved partner tag limit calculation to use workspace configuration directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->