### PR TITLE
Skip instead of failing discount cron on Stripe permission errors

### DIFF
--- a/apps/web/app/(ee)/api/cron/discount-codes/create/route.ts
+++ b/apps/web/app/(ee)/api/cron/discount-codes/create/route.ts
@@ -99,6 +99,7 @@ export const POST = withCron(async ({ rawBody }) => {
     // Eg: This application does not have the required permissions for this endpoint on account 'acct_xxx'.
     // Having the 'read_write' scope would allow this request to continue.
     if (
+      error instanceof Error &&
       error.message.includes(
         "This application does not have the required permissions",
       )

--- a/apps/web/app/(ee)/api/cron/discount-codes/create/route.ts
+++ b/apps/web/app/(ee)/api/cron/discount-codes/create/route.ts
@@ -96,6 +96,16 @@ export const POST = withCron(async ({ rawBody }) => {
       );
     }
 
+    // Eg: This application does not have the required permissions for this endpoint on account 'acct_xxx'.
+    // Having the 'read_write' scope would allow this request to continue.
+    if (
+      error.message.includes(
+        "This application does not have the required permissions",
+      )
+    ) {
+      return logAndRespond(error.message, { logLevel: "warn" });
+    }
+
     throw error;
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for discount code creation: specific permission errors are now logged as warnings and handled gracefully to reduce unnecessary failures and improve observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->