### PR TITLE
Temporarily hide bounty performance chart

### DIFF
--- a/apps/web/app/(ee)/app.dub.co/embed/referrals/bounties/detail.tsx
+++ b/apps/web/app/(ee)/app.dub.co/embed/referrals/bounties/detail.tsx
@@ -22,7 +22,6 @@ import {
   BountyEndDate,
   BountyRewardsTable,
 } from "../../../../partners.dub.co/(dashboard)/programs/[programSlug]/(enrolled)/bounties/bounty-card";
-import { EmbedBountyPerformanceSection } from "./performance-section";
 import { EmbedBountySubmissionDetail } from "./submission-detail";
 import { EmbedBountySubmissionForm } from "./submission-form";
 import { EmbedBountySubmissionsTable } from "./submissions-table";
@@ -166,12 +165,13 @@ export function EmbedBountyDetail({
             </div>
           </div>
 
-          {bounty.type === "performance" ? (
-            <EmbedBountyPerformanceSection
-              bounty={bounty}
-              programEnrollment={programEnrollment}
-            />
-          ) : (
+          {bounty.type === "performance" ? null : (
+            // (
+            //   <EmbedBountyPerformanceSection
+            //     bounty={bounty}
+            //     programEnrollment={programEnrollment}
+            //   />
+            // )
             <EmbedBountySubmissionsTable
               bounty={bounty}
               onSubmit={(periodNumber) =>

--- a/apps/web/app/(ee)/partners.dub.co/(dashboard)/programs/[programSlug]/(enrolled)/bounties/[bountyId]/page-client.tsx
+++ b/apps/web/app/(ee)/partners.dub.co/(dashboard)/programs/[programSlug]/(enrolled)/bounties/[bountyId]/page-client.tsx
@@ -18,7 +18,6 @@ import {
   PartnerBountyCard,
   PartnerBountyCardSkeleton,
 } from "../bounty-card";
-import { BountyPerformanceSection } from "./bounty-performance-section";
 import { BountySubmissionsTable } from "./bounty-submissions-table";
 
 export function PartnerBountyPageClient() {
@@ -77,9 +76,10 @@ export function PartnerBountyPageClient() {
                 </div>
               </div>
 
-              {bounty.type === "performance" ? (
-                <BountyPerformanceSection bounty={bounty} />
-              ) : (
+              {bounty.type === "performance" ? null : (
+                // (
+                //   <BountyPerformanceSection bounty={bounty} />
+                // )
                 <BountySubmissionsTable bounty={bounty} />
               )}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled rendering of performance bounty detail sections in embedded and dashboard views. Submission-type bounties continue to display normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->