### PR TITLE
invoice.paid webhook when discount has no promotion code

### DIFF
--- a/apps/web/app/(ee)/api/stripe/integration/webhook/invoice-paid.ts
+++ b/apps/web/app/(ee)/api/stripe/integration/webhook/invoice-paid.ts
@@ -482,8 +482,7 @@ async function resolvePromotionCodeIdFromInvoice({
   if (!discountWithPromotionCode) {
     return {
       promotionCodeId: null,
-      resolvePromotionCodeError:
-        "No promotion code found on invoice discounts (coupon applied directly)",
+      resolvePromotionCodeError: "No promotion code found on invoice discounts",
     };
   }
 

--- a/apps/web/app/(ee)/api/stripe/integration/webhook/invoice-paid.ts
+++ b/apps/web/app/(ee)/api/stripe/integration/webhook/invoice-paid.ts
@@ -455,9 +455,9 @@ async function resolvePromotionCodeIdFromInvoice({
     {
       stripeAccount: stripeAccountId,
     },
-  )) as Stripe.Invoice & {
+  )) as Omit<Stripe.Invoice, "discounts"> & {
     discounts: {
-      promotion_code: Stripe.PromotionCode;
+      promotion_code: Stripe.PromotionCode | null;
     }[];
   };
 
@@ -475,8 +475,20 @@ async function resolvePromotionCodeIdFromInvoice({
     };
   }
 
+  const discountWithPromotionCode = expandedInvoice.discounts.find((discount) =>
+    Boolean(discount?.promotion_code?.id),
+  );
+
+  if (!discountWithPromotionCode) {
+    return {
+      promotionCodeId: null,
+      resolvePromotionCodeError:
+        "No promotion code found on invoice discounts (coupon applied directly)",
+    };
+  }
+
   return {
-    promotionCodeId: expandedInvoice.discounts[0].promotion_code.id,
+    promotionCodeId: discountWithPromotionCode.promotion_code!.id,
     resolvePromotionCodeError: null,
   };
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Stripe invoice processing to correctly handle discounts that may not include promotion codes (e.g., coupons applied directly). Now detects promotion codes when present and returns clearer, specific messages when none are found, preventing billing errors and improving invoice reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->