### PR TITLE
Remove `af_ua` and `af_ip` params for AppsFlyer links

### DIFF
--- a/apps/web/lib/integrations/appsflyer/constants.ts
+++ b/apps/web/lib/integrations/appsflyer/constants.ts
@@ -14,16 +14,6 @@ export const APPSFLYER_HARDCODED_PARAMETERS = [
     value: "{dub_id}",
     description: "Dub click ID",
   },
-  {
-    key: "af_ua",
-    value: "{userAgent}",
-    description: "User agent",
-  },
-  {
-    key: "af_ip",
-    value: "{ipAddress}",
-    description: "IP address",
-  },
 ];
 
 export const APPSFLYER_REQUIRED_PARAMETERS = [

--- a/apps/web/lib/middleware/utils/get-final-url.ts
+++ b/apps/web/lib/middleware/utils/get-final-url.ts
@@ -68,12 +68,6 @@ export const getFinalUrl = (
       urlObj.searchParams.set("clickid", clickId);
     }
 
-    urlObj.searchParams.set("af_ua", ua);
-
-    if (ip) {
-      urlObj.searchParams.set("af_ip", ip);
-    }
-
     // set dynamic params (if not exist)
     if (!urlObj.searchParams.has("c") && via) {
       urlObj.searchParams.set("c", via);

--- a/apps/web/tests/redirects/index.test.ts
+++ b/apps/web/tests/redirects/index.test.ts
@@ -183,11 +183,9 @@ describe.runIf(env.CI)("Link Redirects", async () => {
   test("appsflyer tracking url", async () => {
     const response = await fetch(`${h.baseUrl}/appsflyer`, fetchOptions);
 
-    // location to include clickid, af_siteid, af_ip, af_ua query params
+    // location to include clickid, af_siteid query params
     expect(response.headers.get("location")).toMatch(/pid=dubinc_int/);
     expect(response.headers.get("location")).toMatch(/clickid=[a-zA-Z0-9]+/);
-    expect(response.headers.get("location")).toMatch(/af_ua=.+/);
-    expect(response.headers.get("location")).toMatch(/af_ip=[a-zA-Z0-9.]+/);
     expect(response.headers.get("x-powered-by")).toBe(poweredBy);
     expect(response.status).toBe(302);
   });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Streamlined AppsFlyer tracking URL construction by removing specific query parameters from the final tracking URLs generated during redirects. This simplifies the tracking mechanism while maintaining essential tracking functionality.

* **Tests**
  * Updated AppsFlyer tracking URL tests to reflect parameter removals and ensure correct verification of tracking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->