### PR TITLE
Fix Android Play Store fallback for in-app webviews

### DIFF
--- a/apps/web/app/app.dub.co/(deeplink)/deeplink/[domain]/[[...key]]/action-button.tsx
+++ b/apps/web/app/app.dub.co/(deeplink)/deeplink/[domain]/[[...key]]/action-button.tsx
@@ -30,6 +30,10 @@ export function DeepLinkActionButton({
       `${link.shortLink}${searchParamsString ? `?${searchParamsString}` : ""}`,
     );
 
+    const fallback = `${link.shortLink}?skip_deeplink_preview=1${
+      searchParamsString ? `&${searchParamsString}` : ""
+    }`;
+
     // Firefox on Android has a known bug where S.browser_fallback_url always
     // wins over launching the installed app (mozilla/fenix#23397), so we keep
     // the plain https:// path for Firefox users to avoid regressing them.
@@ -37,9 +41,6 @@ export function DeepLinkActionButton({
     if (platform === "android" && androidPackageName && !isFirefox) {
       const url = new URL(link.shortLink);
       const userQuery = searchParamsString ? `?${searchParamsString}` : "";
-      const fallback = `${link.shortLink}?skip_deeplink_preview=1${
-        searchParamsString ? `&${searchParamsString}` : ""
-      }`;
       const extras = [
         `scheme=${url.protocol.replace(":", "")}`,
         `package=${androidPackageName}`,
@@ -47,11 +48,25 @@ export function DeepLinkActionButton({
         "end",
       ].join(";");
 
+      // In-app webviews (e.g. Facebook, Instagram) don't honor the intent's
+      // S.browser_fallback_url when the app isn't installed – they just show
+      // "page can't be loaded". So we set a timer to navigate to the fallback
+      // ourselves. If the intent dispatches, the webview is backgrounded
+      // (visibilitychange → hidden) and we cancel before it fires.
+      const timer = window.setTimeout(() => {
+        window.location.href = fallback;
+      }, 1500);
+      document.addEventListener("visibilitychange", () => {
+        if (document.visibilityState === "hidden") {
+          clearTimeout(timer);
+        }
+      });
+
       window.location.href = `intent://${url.host}${url.pathname}${userQuery}#Intent;${extras}`;
       return;
     }
 
-    window.location.href = `${link.shortLink}?skip_deeplink_preview=1${searchParamsString ? `&${searchParamsString}` : ""}`;
+    window.location.href = fallback;
   };
 
   return (

--- a/apps/web/app/app.dub.co/(deeplink)/deeplink/[domain]/[[...key]]/action-button.tsx
+++ b/apps/web/app/app.dub.co/(deeplink)/deeplink/[domain]/[[...key]]/action-button.tsx
@@ -53,14 +53,17 @@ export function DeepLinkActionButton({
       // "page can't be loaded". So we set a timer to navigate to the fallback
       // ourselves. If the intent dispatches, the webview is backgrounded
       // (visibilitychange → hidden) and we cancel before it fires.
-      const timer = window.setTimeout(() => {
-        window.location.href = fallback;
-      }, 1500);
-      document.addEventListener("visibilitychange", () => {
+      const onVisibilityChange = () => {
         if (document.visibilityState === "hidden") {
           clearTimeout(timer);
+          document.removeEventListener("visibilitychange", onVisibilityChange);
         }
-      });
+      };
+      const timer = window.setTimeout(() => {
+        document.removeEventListener("visibilitychange", onVisibilityChange);
+        window.location.href = fallback;
+      }, 1500);
+      document.addEventListener("visibilitychange", onVisibilityChange);
 
       window.location.href = `intent://${url.host}${url.pathname}${userQuery}#Intent;${extras}`;
       return;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unified fallback URL for deep links so all navigation branches use the same fallback.
  * On Android, intent paths include the unified fallback and a short timeout that redirects if the intent doesn't take over; the timeout is cleared when the page becomes hidden.
  * Other browsers (including Firefox on Android) now consistently navigate to the same fallback URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->