### PR TITLE
Batch commission paid updates in stripe transfer

### DIFF
--- a/apps/web/app/(ee)/api/paypal/webhook/payouts-item-succeeded.ts
+++ b/apps/web/app/(ee)/api/paypal/webhook/payouts-item-succeeded.ts
@@ -1,5 +1,7 @@
 import { trackCommissionStatusUpdate } from "@/lib/api/commissions/track-commission-update-activity-log";
 import { prisma } from "@dub/prisma";
+import { chunk, log } from "@dub/utils";
+import { waitUntil } from "@vercel/functions";
 import { payoutsItemSchema } from "./utils";
 
 export async function payoutsItemSucceeded(event: any) {
@@ -50,33 +52,53 @@ export async function payoutsItemSucceeded(event: any) {
     },
   });
 
-  await Promise.all([
-    prisma.payout.update({
-      where: {
-        id: payout.id,
-      },
-      data: {
-        paypalTransferId: payoutItemId,
-        status: "completed",
-        paidAt: payout.paidAt ?? new Date(), // preserve the paidAt if it already exists
-        failureReason: null,
-      },
-    }),
-
-    prisma.commission.updateMany({
-      where: {
-        payoutId: payout.id,
-      },
-      data: {
-        status: "paid",
-      },
-    }),
-  ]);
-
-  await trackCommissionStatusUpdate({
-    workspaceId: payout.program.workspaceId,
-    programId: payout.program.id,
-    commissions,
-    newStatus: "paid",
+  await prisma.payout.update({
+    where: {
+      id: payout.id,
+    },
+    data: {
+      paypalTransferId: payoutItemId,
+      status: "completed",
+      paidAt: payout.paidAt ?? new Date(), // preserve the paidAt if it already exists
+      failureReason: null,
+    },
   });
+
+  const commissionIds = commissions.map((c) => c.id);
+
+  let totalUpdatedCommissions = 0;
+  for (const commissionIdsBatch of chunk(commissionIds, 250)) {
+    try {
+      const { count } = await prisma.commission.updateMany({
+        where: {
+          id: {
+            in: commissionIdsBatch,
+          },
+        },
+        data: {
+          status: "paid",
+        },
+      });
+
+      totalUpdatedCommissions += count;
+      console.log(
+        `Marked ${totalUpdatedCommissions}/${commissionIds.length} commissions as paid`,
+      );
+    } catch (error) {
+      await log({
+        message: `[PayPal payoutsItemSucceeded] Failed to mark commissions as paid for payouts ${payoutId}: ${error.message}`,
+        type: "errors",
+        mention: true,
+      });
+    }
+  }
+
+  waitUntil(
+    trackCommissionStatusUpdate({
+      workspaceId: payout.program.workspaceId,
+      programId: payout.program.id,
+      commissions,
+      newStatus: "paid",
+    }),
+  );
 }

--- a/apps/web/lib/partners/create-stablecoin-payout.ts
+++ b/apps/web/lib/partners/create-stablecoin-payout.ts
@@ -6,7 +6,9 @@ import { prisma } from "@dub/prisma";
 import { PartnerPayoutMethod, Prisma } from "@dub/prisma/client";
 import {
   APP_DOMAIN_WITH_NGROK,
+  chunk,
   currencyFormatter,
+  log,
   prettyPrint,
 } from "@dub/utils";
 import { waitUntil } from "@vercel/functions";
@@ -254,32 +256,50 @@ export const createStablecoinPayout = async ({
     },
   });
 
-  await prisma.$transaction([
-    prisma.payout.updateMany({
-      where: {
-        id: {
-          in: payoutIds,
-        },
+  await prisma.payout.updateMany({
+    where: {
+      id: {
+        in: payoutIds,
       },
-      data: {
-        stripePayoutId: outboundPayment.id,
-        status: "sent",
-        paidAt: new Date(),
-        method: "stablecoin",
-      },
-    }),
+    },
+    data: {
+      stripePayoutId: outboundPayment.id,
+      status: "sent",
+      paidAt: new Date(),
+      method: "stablecoin",
+    },
+  });
 
-    prisma.commission.updateMany({
-      where: {
-        payoutId: {
-          in: payoutIds,
+  const commissionIds = commissions.map((c) => c.id);
+
+  let totalUpdatedCommissions = 0;
+  for (const commissionIdsBatch of chunk(commissionIds, 250)) {
+    try {
+      const { count } = await prisma.commission.updateMany({
+        where: {
+          id: {
+            in: commissionIdsBatch,
+          },
         },
-      },
-      data: {
-        status: "paid",
-      },
-    }),
-  ]);
+        data: {
+          status: "paid",
+        },
+      });
+
+      totalUpdatedCommissions += count;
+      console.log(
+        `Marked ${totalUpdatedCommissions}/${commissionIds.length} commissions as paid`,
+      );
+    } catch (error) {
+      await log({
+        message: `[createStablecoinPayout] Failed to mark commissions as paid for payouts ${payoutIds.join(
+          ", ",
+        )}: ${error.message}`,
+        type: "errors",
+        mention: true,
+      });
+    }
+  }
 
   waitUntil(
     Promise.allSettled([

--- a/apps/web/lib/partners/create-stripe-transfer.ts
+++ b/apps/web/lib/partners/create-stripe-transfer.ts
@@ -12,7 +12,9 @@ import { prisma } from "@dub/prisma";
 import { Prisma } from "@dub/prisma/client";
 import {
   APP_DOMAIN_WITH_NGROK,
+  chunk,
   currencyFormatter,
+  log,
   pluralize,
 } from "@dub/utils";
 import { waitUntil } from "@vercel/functions";
@@ -222,32 +224,45 @@ export const createStripeTransfer = async ({
     },
   });
 
-  await Promise.allSettled([
-    prisma.payout.updateMany({
-      where: {
-        id: {
-          in: payoutIds,
-        },
+  await prisma.payout.updateMany({
+    where: {
+      id: {
+        in: payoutIds,
       },
-      data: {
-        stripeTransferId: transfer.id,
-        status: "sent",
-        paidAt: new Date(),
-        method: "connect",
-      },
-    }),
+    },
+    data: {
+      stripeTransferId: transfer.id,
+      status: "sent",
+      paidAt: new Date(),
+      method: "connect",
+    },
+  });
 
-    prisma.commission.updateMany({
-      where: {
-        payoutId: {
-          in: payoutIds,
+  for (const commissionIdsBatch of chunk(
+    commissions.map((c) => c.id),
+    100,
+  )) {
+    try {
+      await prisma.commission.updateMany({
+        where: {
+          id: {
+            in: commissionIdsBatch,
+          },
         },
-      },
-      data: {
-        status: "paid",
-      },
-    }),
-  ]);
+        data: {
+          status: "paid",
+        },
+      });
+    } catch (error) {
+      await log({
+        message: `[createStripeTransfer] Failed to mark commissions as paid for payouts ${payoutIds.join(
+          ", ",
+        )}: ${error.message}`,
+        type: "errors",
+        mention: true,
+      });
+    }
+  }
 
   waitUntil(
     Promise.allSettled([

--- a/apps/web/lib/partners/create-stripe-transfer.ts
+++ b/apps/web/lib/partners/create-stripe-transfer.ts
@@ -238,10 +238,9 @@ export const createStripeTransfer = async ({
     },
   });
 
-  for (const commissionIdsBatch of chunk(
-    commissions.map((c) => c.id),
-    100,
-  )) {
+  const commissionIds = commissions.map((c) => c.id);
+
+  for (const commissionIdsBatch of chunk(commissionIds, 100)) {
     try {
       await prisma.commission.updateMany({
         where: {

--- a/apps/web/lib/partners/create-stripe-transfer.ts
+++ b/apps/web/lib/partners/create-stripe-transfer.ts
@@ -240,9 +240,10 @@ export const createStripeTransfer = async ({
 
   const commissionIds = commissions.map((c) => c.id);
 
-  for (const commissionIdsBatch of chunk(commissionIds, 100)) {
+  let totalUpdatedCommissions = 0;
+  for (const commissionIdsBatch of chunk(commissionIds, 250)) {
     try {
-      await prisma.commission.updateMany({
+      const { count } = await prisma.commission.updateMany({
         where: {
           id: {
             in: commissionIdsBatch,
@@ -252,6 +253,11 @@ export const createStripeTransfer = async ({
           status: "paid",
         },
       });
+
+      totalUpdatedCommissions += count;
+      console.log(
+        `Marked ${totalUpdatedCommissions}/${commissionIds.length} commissions as paid`,
+      );
     } catch (error) {
       await log({
         message: `[createStripeTransfer] Failed to mark commissions as paid for payouts ${payoutIds.join(

--- a/apps/web/scripts/payouts/backfill-completed-payout-commissions.ts
+++ b/apps/web/scripts/payouts/backfill-completed-payout-commissions.ts
@@ -1,0 +1,57 @@
+import { prisma } from "@dub/prisma";
+import { Prisma } from "@dub/prisma/client";
+import "dotenv-flow/config";
+
+const BATCH_SIZE = 1000;
+const DRY_RUN = process.env.DRY_RUN !== "false"; // default to dry-run for safety
+
+// Reconciles commissions that are stuck at "processed" even though their payout
+// is already "completed" (money has moved). Run via:
+//   pnpm script payouts/backfill-completed-payout-commissions
+// Set DRY_RUN=false to actually apply the updates.
+async function main() {
+  const where: Prisma.CommissionWhereInput = {
+    status: "processed",
+    payout: {
+      status: "completed",
+    },
+  };
+
+  const total = await prisma.commission.count({ where });
+  console.log(`${total} commissions to reconcile (DRY_RUN=${DRY_RUN})`);
+
+  if (DRY_RUN || total === 0) {
+    return;
+  }
+
+  let totalUpdated = 0;
+  while (true) {
+    const batch = await prisma.commission.findMany({
+      where,
+      select: { id: true },
+      take: BATCH_SIZE,
+    });
+
+    if (batch.length === 0) {
+      break;
+    }
+
+    const { count } = await prisma.commission.updateMany({
+      where: {
+        id: {
+          in: batch.map((c) => c.id),
+        },
+      },
+      data: {
+        status: "paid",
+      },
+    });
+
+    totalUpdated += count;
+    console.log(`Updated ${totalUpdated}/${total}...`);
+  }
+
+  console.log(`Done. Updated ${totalUpdated} commissions to "paid".`);
+}
+
+main();

--- a/apps/web/scripts/payouts/backfill-completed-payout-commissions.ts
+++ b/apps/web/scripts/payouts/backfill-completed-payout-commissions.ts
@@ -2,7 +2,7 @@ import { prisma } from "@dub/prisma";
 import { Prisma } from "@dub/prisma/client";
 import "dotenv-flow/config";
 
-const BATCH_SIZE = 1000;
+const BATCH_SIZE = 500;
 const DRY_RUN = process.env.DRY_RUN !== "false"; // default to dry-run for safety
 
 // Reconciles commissions that are stuck at "processed" even though their payout

--- a/packages/ui/src/tooltip.tsx
+++ b/packages/ui/src/tooltip.tsx
@@ -222,9 +222,7 @@ export function DynamicTooltipWrapper({
   tooltipProps?: TooltipProps;
 }) {
   return tooltipProps ? (
-    <Tooltip {...tooltipProps}>
-      <div className="w-fit">{children}</div>
-    </Tooltip>
+    <Tooltip {...tooltipProps}>{children}</Tooltip>
   ) : (
     children
   );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved stuck commission records when associated payouts complete; commissions now reliably transition to paid with improved per-batch error reporting.
  * Fixed tooltip rendering so UI children render without an extra wrapper, preventing layout shifts.

* **Refactor**
  * Payout/commission persistence moved to ordered updates with batched commission processing and progress logging for robustness.

* **Chores**
  * Added a backfill script to reconcile historical commission statuses (dry-run supported).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->