### PR TITLE
Allow disabling risk detection per partner enrollment

### DIFF
--- a/apps/web/app/(ee)/api/workflows/create-partner-commission/route.ts
+++ b/apps/web/app/(ee)/api/workflows/create-partner-commission/route.ts
@@ -433,7 +433,6 @@ async function stepRunSideEffects(
     skipWorkflow,
     clickEvent,
     isFirstConversion,
-    userId,
     triggerAggregateDueCommissions,
   } = input;
 
@@ -556,7 +555,10 @@ async function stepRunSideEffects(
       detectAndRecordFraudEvent({
         program: { id: programId },
         partner: pick(programEnrollment.partner, ["id", "email", "name"]),
-        programEnrollment: pick(programEnrollment, ["status"]),
+        programEnrollment: pick(programEnrollment, [
+          "status",
+          "riskDetectionDisabledAt",
+        ]),
         customer: {
           ...pick(commission.customer, ["id", "email", "name"]),
           // only pass along isFirstConversion if it's a boolean

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/messages/[partnerId]/page-client.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/messages/[partnerId]/page-client.tsx
@@ -22,17 +22,18 @@ import { ChevronLeft } from "@dub/ui/icons";
 import { cn } from "@dub/utils";
 import { useAction } from "next-safe-action/hooks";
 import Link from "next/link";
-import { redirect, useParams } from "next/navigation";
+import { redirect, useParams, useSearchParams } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
 import { v4 as uuid } from "uuid";
 
 export function ProgramMessagesPartnerPageClient() {
-  const { id: workspaceId, slug: workspaceSlug } = useWorkspace();
-
-  const { partnerId } = useParams() as { partnerId: string };
   const { user } = useUser();
   const { program } = useProgram();
+  const searchParams = useSearchParams();
+  const { partnerId } = useParams<{ partnerId: string }>();
+  const { id: workspaceId, slug: workspaceSlug } = useWorkspace();
+
   const {
     partner: enrolledPartner,
     error: enrolledPartnerError,
@@ -85,6 +86,8 @@ export function ProgramMessagesPartnerPageClient() {
   const [isRightPanelOpen, setIsRightPanelOpen] = useState(true);
 
   if (errorMessages) redirect(`/${workspaceSlug}/program/messages`);
+
+  const defaultMessage = decodeURIComponent(searchParams.get("message") || "");
 
   return (
     <div
@@ -141,6 +144,7 @@ export function ProgramMessagesPartnerPageClient() {
             currentUserId={user?.id || ""}
             program={program}
             partner={partner}
+            defaultValue={defaultMessage}
             onSendMessage={async (message) => {
               const createdAt = new Date();
 

--- a/apps/web/lib/actions/fraud/resolve-fraud-group.ts
+++ b/apps/web/lib/actions/fraud/resolve-fraud-group.ts
@@ -12,7 +12,7 @@ export const resolveFraudGroupAction = authActionClient
   .inputSchema(resolveFraudGroupSchema)
   .action(async ({ ctx, parsedInput }) => {
     const { workspace, user } = ctx;
-    const { groupId, resolutionReason } = parsedInput;
+    const { groupId, resolutionReason, disableRiskDetection } = parsedInput;
 
     throwIfNoPermission({
       role: workspace.role,
@@ -60,6 +60,20 @@ export const resolveFraudGroupAction = authActionClient
           partnerId: fraudGroup.partnerId,
           userId: user.id,
           text: resolutionReason,
+        },
+      });
+    }
+
+    if (disableRiskDetection) {
+      await prisma.programEnrollment.update({
+        where: {
+          partnerId_programId: {
+            partnerId: fraudGroup.partnerId,
+            programId,
+          },
+        },
+        data: {
+          riskDetectionDisabledAt: new Date(),
         },
       });
     }

--- a/apps/web/lib/actions/partners/update-partner-enrollment.ts
+++ b/apps/web/lib/actions/partners/update-partner-enrollment.ts
@@ -19,6 +19,7 @@ const updatePartnerEnrollmentSchema = z.object({
   tenantId: z.string().nullable(),
   customerDataSharingEnabledAt: z.coerce.date().nullable(),
   groupMoveDisabledAt: z.coerce.date().nullable(),
+  riskDetectionDisabledAt: z.coerce.date().nullable(),
 });
 
 // Update a partner's program enrollment data
@@ -31,6 +32,7 @@ export const updatePartnerEnrollmentAction = authActionClient
       tenantId,
       customerDataSharingEnabledAt,
       groupMoveDisabledAt,
+      riskDetectionDisabledAt,
     } = parsedInput;
 
     throwIfNoPermission({
@@ -77,6 +79,7 @@ export const updatePartnerEnrollmentAction = authActionClient
           tenantId,
           customerDataSharingEnabledAt,
           groupMoveDisabledAt,
+          riskDetectionDisabledAt,
         },
         include: {
           links: {

--- a/apps/web/lib/api/fraud/detect-record-fraud-event.ts
+++ b/apps/web/lib/api/fraud/detect-record-fraud-event.ts
@@ -28,6 +28,14 @@ export async function detectAndRecordFraudEvent(context: FraudEventContext) {
     return;
   }
 
+  // Skip if risk detection is disabled
+  if (programEnrollment.riskDetectionDisabledAt) {
+    console.info(
+      `[detectAndRecordFraudEvent] Risk detection is disabled for this partner, skipping...`,
+    );
+    return;
+  }
+
   // Get program-specific rule overrides
   const programRules = await prisma.fraudRule.findMany({
     where: {

--- a/apps/web/lib/zod/schemas/fraud.ts
+++ b/apps/web/lib/zod/schemas/fraud.ts
@@ -99,6 +99,7 @@ export const resolveFraudGroupSchema = z.object({
     )
     .nullable()
     .default(null),
+  disableRiskDetection: z.boolean().default(false),
 });
 
 export const bulkResolveFraudGroupsSchema = z.object({

--- a/apps/web/lib/zod/schemas/programs.ts
+++ b/apps/web/lib/zod/schemas/programs.ts
@@ -199,6 +199,7 @@ export const ProgramEnrollmentSchema = z.object({
   application: ProgramEnrollmentApplicationSchema.nullish().describe(
     "Linked program application, including review outcome when applicable.",
   ),
+  riskDetectionDisabledAt: z.date().nullable(),
 });
 
 export const ProgramInviteSchema = z.object({

--- a/apps/web/lib/zod/schemas/schemas.ts
+++ b/apps/web/lib/zod/schemas/schemas.ts
@@ -12,6 +12,7 @@ export const fraudEventContext = z.object({
   }),
   programEnrollment: ProgramEnrollmentSchema.pick({
     status: true,
+    riskDetectionDisabledAt: true,
   }),
   customer: z.object({
     id: z.string(),

--- a/apps/web/ui/messages/messages-panel.tsx
+++ b/apps/web/ui/messages/messages-panel.tsx
@@ -28,6 +28,7 @@ export function MessagesPanel({
   partner,
   onSendMessage,
   placeholder,
+  defaultValue,
   error,
   footerSlot,
 }: {
@@ -38,6 +39,7 @@ export function MessagesPanel({
   partner?: Pick<PartnerProps, "name">;
   onSendMessage: (message: string) => void;
   placeholder?: string;
+  defaultValue?: string;
   error?: any;
   /** When set, replaces the message composer (e.g. read-only enrollment states). */
   footerSlot?: ReactNode;
@@ -243,6 +245,7 @@ export function MessagesPanel({
                 placeholder={personalizedPlaceholder}
                 onSendMessage={sendMessage}
                 autoFocus={!isMobile}
+                defaultValue={defaultValue}
               />
             </div>
           )}

--- a/apps/web/ui/partners/fraud-risks/request-details-banner.tsx
+++ b/apps/web/ui/partners/fraud-risks/request-details-banner.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { getPlanCapabilities } from "@/lib/plan-capabilities";
+import useWorkspace from "@/lib/swr/use-workspace";
+import { FraudGroupProps } from "@/lib/types";
+import { FraudRuleType } from "@dub/prisma/client";
+import { Button, Msgs } from "@dub/ui";
+import Link from "next/link";
+
+export function RequestDetailsBanner({
+  fraudGroup,
+}: {
+  fraudGroup: FraudGroupProps;
+}) {
+  const { slug, plan } = useWorkspace();
+  const { canMessagePartners } = getPlanCapabilities(plan);
+
+  if (
+    !canMessagePartners ||
+    fraudGroup.type !== FraudRuleType.paidTrafficDetected
+  ) {
+    return null;
+  }
+
+  const { partner } = fraudGroup;
+
+  const message = `Hi ${partner.name},
+  
+We noticed paid advertising traffic tied to recent referral activity from your account.
+
+Could you share dashboard screenshots that contain the campaign name, keywords or targeting, and the landing page URL so we can review it?
+
+Thanks!`;
+
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-lg bg-blue-50 px-4 py-2.5">
+      <p className="text-sm font-medium text-blue-900">
+        <span className="font-semibold">Recommended:</span> Request paid traffic
+        details from the partner
+      </p>
+      <Link
+        href={`/${slug}/program/messages/${partner.id}?message=${encodeURIComponent(message)}`}
+        target="_blank"
+      >
+        <Button
+          variant="primary"
+          icon={<Msgs className="size-4" />}
+          text="Request details"
+          className="h-8 shrink-0 rounded-lg px-3 text-sm"
+        />
+      </Link>
+    </div>
+  );
+}

--- a/apps/web/ui/partners/fraud-risks/resolve-fraud-group-modal.tsx
+++ b/apps/web/ui/partners/fraud-risks/resolve-fraud-group-modal.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/lib/zod/schemas/fraud";
 import { PartnerAvatar } from "@/ui/partners/partner-avatar";
 import { MaxCharactersCounter } from "@/ui/shared/max-characters-counter";
-import { Button, Modal } from "@dub/ui";
+import { Button, Modal, Switch } from "@dub/ui";
 import { cn, pluralize } from "@dub/utils";
 import { useAction } from "next-safe-action/hooks";
 import {
@@ -50,6 +50,8 @@ function ResolveFraudGroupModal({
     },
   });
 
+  const [disableRiskDetection, setDisableRiskDetection] = useState(false);
+
   const {
     register,
     handleSubmit,
@@ -72,9 +74,10 @@ function ResolveFraudGroupModal({
         workspaceId,
         groupId: fraudGroup.id,
         resolutionReason: data.resolutionReason,
+        disableRiskDetection,
       });
     },
-    [executeAsync, fraudGroup.id, workspaceId],
+    [executeAsync, fraudGroup.id, workspaceId, disableRiskDetection],
   );
 
   const { partner } = fraudGroup;
@@ -134,6 +137,27 @@ function ResolveFraudGroupModal({
                 maxLength={MAX_RESOLUTION_REASON_LENGTH}
                 {...register("resolutionReason")}
               />
+            </div>
+          </div>
+
+          <div>
+            <div className="flex items-start gap-3">
+              <Switch
+                fn={setDisableRiskDetection}
+                checked={disableRiskDetection}
+                trackDimensions="w-8 h-4"
+                thumbDimensions="w-3 h-3"
+                thumbTranslate="translate-x-4"
+              />
+              <div className="flex flex-col gap-1.5">
+                <h3 className="text-sm font-medium leading-none text-neutral-700">
+                  Exclude from risk monitoring
+                </h3>
+                <p className="text-xs text-neutral-500">
+                  Future risk events won't be generated for this partner. This
+                  can be changed anytime in the partner's advanced settings.
+                </p>
+              </div>
             </div>
           </div>
         </div>

--- a/apps/web/ui/partners/fraud-risks/risk-review-sheet.tsx
+++ b/apps/web/ui/partners/fraud-risks/risk-review-sheet.tsx
@@ -30,6 +30,7 @@ import { AssociatedCommissionsTable } from "./associated-commissions-table";
 import { FraudEventsTableWrapper } from "./fraud-events-tables";
 import { useMarkAllAsFraudModal } from "./mark-all-as-fraud-modal";
 import { PartnerCrossProgramSummary } from "./partner-cross-program-summary";
+import { RequestDetailsBanner } from "./request-details-banner";
 import { useResolveFraudGroupModal } from "./resolve-fraud-group-modal";
 import { ResolvedRiskEventsTable } from "./resolved-risk-events-table";
 
@@ -237,6 +238,11 @@ function RiskReviewSheetContent({
                   {fraudRuleInfo.description}
                 </span>
               </div>
+
+              {fraudGroup.type === FraudRuleType.paidTrafficDetected &&
+                fraudGroup.status === "pending" && (
+                  <RequestDetailsBanner fraudGroup={fraudGroup} />
+                )}
 
               <FraudEventsTableWrapper fraudGroup={fraudGroup} />
             </div>

--- a/apps/web/ui/partners/partner-advanced-settings-modal.tsx
+++ b/apps/web/ui/partners/partner-advanced-settings-modal.tsx
@@ -25,6 +25,7 @@ type FormData = {
   tenantId: string | null;
   customerDataSharingEnabledAt: Date | null;
   groupMoveDisabledAt: Date | null;
+  riskDetectionDisabledAt: Date | null;
 };
 
 function PartnerAdvancedSettingsModal({
@@ -36,7 +37,11 @@ function PartnerAdvancedSettingsModal({
   setShowPartnerAdvancedSettingsModal: Dispatch<SetStateAction<boolean>>;
   partner: Pick<
     EnrolledPartnerExtendedProps,
-    "id" | "tenantId" | "customerDataSharingEnabledAt" | "groupMoveDisabledAt"
+    | "id"
+    | "tenantId"
+    | "customerDataSharingEnabledAt"
+    | "groupMoveDisabledAt"
+    | "riskDetectionDisabledAt"
   >;
 }) {
   const { id: workspaceId, plan } = useWorkspace();
@@ -48,6 +53,10 @@ function PartnerAdvancedSettingsModal({
 
   const [hasGroupMoveDisabled, setHasGroupMoveDisabled] = useState(
     !!partner.groupMoveDisabledAt,
+  );
+
+  const [hasRiskDetectionDisabled, setHasRiskDetectionDisabled] = useState(
+    !!partner.riskDetectionDisabledAt,
   );
 
   const { executeAsync } = useAction(updatePartnerEnrollmentAction, {
@@ -69,6 +78,7 @@ function PartnerAdvancedSettingsModal({
       tenantId: partner.tenantId,
       customerDataSharingEnabledAt: partner.customerDataSharingEnabledAt,
       groupMoveDisabledAt: partner.groupMoveDisabledAt ?? null,
+      riskDetectionDisabledAt: partner.riskDetectionDisabledAt ?? null,
     },
   });
 
@@ -83,6 +93,14 @@ function PartnerAdvancedSettingsModal({
   const handleGroupMoveDisabledToggle = (checked: boolean) => {
     setHasGroupMoveDisabled(checked);
     setValue("groupMoveDisabledAt", checked ? new Date() : null, {
+      shouldDirty: true,
+      shouldValidate: true,
+    });
+  };
+
+  const handleRiskDetectionDisabledToggle = (checked: boolean) => {
+    setHasRiskDetectionDisabled(checked);
+    setValue("riskDetectionDisabledAt", checked ? new Date() : null, {
       shouldDirty: true,
       shouldValidate: true,
     });
@@ -107,6 +125,7 @@ function PartnerAdvancedSettingsModal({
             tenantId: data.tenantId || null,
             customerDataSharingEnabledAt: data.customerDataSharingEnabledAt,
             groupMoveDisabledAt: data.groupMoveDisabledAt,
+            riskDetectionDisabledAt: data.riskDetectionDisabledAt,
           });
 
           if (result?.serverError || result?.validationErrors) {
@@ -194,6 +213,26 @@ function PartnerAdvancedSettingsModal({
               </div>
             </div>
           )}
+
+          <div className="mt-6">
+            <div className="flex items-start gap-3">
+              <Switch
+                fn={handleRiskDetectionDisabledToggle}
+                checked={hasRiskDetectionDisabled}
+                trackDimensions="w-8 h-4"
+                thumbDimensions="w-3 h-3"
+                thumbTranslate="translate-x-4"
+              />
+              <div className="flex flex-col gap-1.5">
+                <h3 className="text-sm font-medium leading-none text-neutral-700">
+                  Exclude from risk monitoring
+                </h3>
+                <p className="text-xs text-neutral-500">
+                  Future risk events won't be generated for this partner.
+                </p>
+              </div>
+            </div>
+          </div>
         </div>
 
         <div className="flex items-center justify-end gap-2 border-t border-neutral-200 bg-neutral-50 px-4 py-5 sm:px-6">

--- a/packages/email/src/templates/unresolved-fraud-events-summary.tsx
+++ b/packages/email/src/templates/unresolved-fraud-events-summary.tsx
@@ -77,7 +77,7 @@ export default function UnresolvedFraudEventsSummary({
   return (
     <Html>
       <Head />
-      <Preview>Fraud detection events</Preview>
+      <Preview>Risk events</Preview>
       <Tailwind>
         <Body className="mx-auto my-auto bg-white font-sans">
           <Container className="mx-auto my-8 max-w-[600px] px-8 py-8">
@@ -86,13 +86,14 @@ export default function UnresolvedFraudEventsSummary({
             </Section>
 
             <Heading className="mx-0 my-8 p-0 text-lg font-medium text-black">
-              Fraud detection events
+              Risk events
             </Heading>
 
             <Text className="text-sm text-neutral-600">
-              Here are your detected fraud and risk events reported for{" "}
+              Here are your detected risk events reported for{" "}
               <strong>{todayDate}</strong> for the{" "}
-              <strong>{program.name}</strong> program.
+              <strong>{program.name}</strong> program. These risk events will
+              automatically expire in 30 days if not resolved.
             </Text>
 
             <Section className="my-6 rounded-xl border border-solid border-neutral-200 bg-white p-0">
@@ -100,6 +101,7 @@ export default function UnresolvedFraudEventsSummary({
                 const isLastDisplayedItem =
                   index === displayedGroups.length - 1;
                 const shouldShowBottomBorder = !isLastDisplayedItem;
+
                 return (
                   <Row
                     key={group.id}

--- a/packages/prisma/schema/program.prisma
+++ b/packages/prisma/schema/program.prisma
@@ -144,6 +144,7 @@ model ProgramEnrollment {
   bannedAt                     DateTime?
   bannedReason                 PartnerBannedReason?
   reapplicationTimeframe       ReapplicationTimeframe @default(standard)
+  riskDetectionDisabledAt      DateTime?
 
   partner            Partner                  @relation(fields: [partnerId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   program            Program                  @relation(fields: [programId], references: [id], onUpdate: Cascade, onDelete: Cascade)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Partners can now be excluded from risk monitoring through advanced settings or fraud resolution workflows.
  * Pre-populated messaging support enables links to messaging interfaces with default message content.
  * Added "Request details" banner for paid traffic fraud detection events to streamline partner communication.

* **Documentation**
  * Updated fraud event email terminology to refer to "Risk events" instead of "Fraud detection events."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->