### PR TITLE
Remove @default(cuid()) from Prisma models that always receive explicit IDs

### DIFF
--- a/packages/prisma/schema/application.prisma
+++ b/packages/prisma/schema/application.prisma
@@ -6,7 +6,7 @@ enum ProgramApplicationRejectionReason {
 }
 
 model ProgramApplication {
-  id              String                             @id @default(cuid())
+  id              String                             @id
   programId       String
   groupId         String?
   name            String

--- a/packages/prisma/schema/bounty.prisma
+++ b/packages/prisma/schema/bounty.prisma
@@ -30,7 +30,7 @@ enum BountySubmissionFrequency {
 }
 
 model Bounty {
-  id                        String                     @id @default(cuid())
+  id                        String                     @id
   programId                 String
   workflowId                String?                    @unique
   name                      String
@@ -72,7 +72,7 @@ model BountyGroup {
 }
 
 model BountySubmission {
-  id                        String                           @id @default(cuid())
+  id                        String                           @id
   programId                 String
   partnerId                 String
   bountyId                  String

--- a/packages/prisma/schema/campaign.prisma
+++ b/packages/prisma/schema/campaign.prisma
@@ -18,7 +18,7 @@ enum CampaignStatus {
 }
 
 model Campaign {
-  id              String              @id @default(cuid())
+  id              String              @id
   programId       String
   workflowId      String?             @unique
   userId          String

--- a/packages/prisma/schema/commission.prisma
+++ b/packages/prisma/schema/commission.prisma
@@ -17,7 +17,7 @@ enum CommissionType {
 }
 
 model Commission {
-  id                 String           @id @default(cuid())
+  id                 String           @id
   programId          String
   partnerId          String
   rewardId           String?

--- a/packages/prisma/schema/customer.prisma
+++ b/packages/prisma/schema/customer.prisma
@@ -1,5 +1,5 @@
 model Customer {
-  id               String  @id @default(cuid())
+  id               String  @id
   name             String?
   email            String?
   avatar           String? @db.Text

--- a/packages/prisma/schema/dashboard.prisma
+++ b/packages/prisma/schema/dashboard.prisma
@@ -1,5 +1,5 @@
 model Dashboard {
-  id String @id @default(cuid())
+  id String @id
 
   link   Link?   @relation(fields: [linkId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   linkId String? @unique

--- a/packages/prisma/schema/discount.prisma
+++ b/packages/prisma/schema/discount.prisma
@@ -4,7 +4,7 @@ enum DiscountProvider {
 }
 
 model Discount {
-  id                     String           @id @default(cuid())
+  id                     String           @id
   programId              String
   amount                 Int              @default(0)
   type                   RewardStructure  @default(percentage)
@@ -26,7 +26,7 @@ model Discount {
 }
 
 model DiscountCode {
-  id         String   @id @default(cuid())
+  id         String   @id
   code       String
   programId  String
   discountId String?

--- a/packages/prisma/schema/domain.prisma
+++ b/packages/prisma/schema/domain.prisma
@@ -69,7 +69,7 @@ enum EmailDomainStatus {
 }
 
 model EmailDomain {
-  id             String            @id @default(cuid())
+  id             String            @id
   workspaceId    String
   programId      String
   slug           String            @unique

--- a/packages/prisma/schema/folder.prisma
+++ b/packages/prisma/schema/folder.prisma
@@ -15,7 +15,7 @@ enum FolderUserRole {
 }
 
 model Folder {
-  id          String             @id @default(cuid())
+  id          String             @id
   name        String
   description String?            @db.Text
   projectId   String

--- a/packages/prisma/schema/fraud.prisma
+++ b/packages/prisma/schema/fraud.prisma
@@ -14,7 +14,7 @@ enum FraudRuleType {
 }
 
 model FraudRule {
-  id         String        @id @default(cuid())
+  id         String        @id
   programId  String
   type       FraudRuleType
   config     Json?         @db.Json
@@ -28,7 +28,7 @@ model FraudRule {
 }
 
 model FraudEventGroup {
-  id               String           @id @default(cuid())
+  id               String           @id
   programId        String
   partnerId        String
   type             FraudRuleType
@@ -54,7 +54,7 @@ model FraudEventGroup {
 }
 
 model FraudEvent {
-  id                String   @id @default(cuid())
+  id                String   @id
   fraudEventGroupId String
   programId         String
   partnerId         String

--- a/packages/prisma/schema/group.prisma
+++ b/packages/prisma/schema/group.prisma
@@ -5,7 +5,7 @@ enum PartnerLinkStructure {
 }
 
 model PartnerGroup {
-  id                           String               @id @default(cuid())
+  id                           String               @id
   programId                    String
   name                         String
   slug                         String
@@ -50,7 +50,7 @@ model PartnerGroup {
 }
 
 model PartnerGroupDefaultLink {
-  id        String   @id @default(cuid())
+  id        String   @id
   programId String
   groupId   String? // can be null for soft-deleted default links
   domain    String

--- a/packages/prisma/schema/invoice.prisma
+++ b/packages/prisma/schema/invoice.prisma
@@ -18,7 +18,7 @@ enum PaymentMethod {
 }
 
 model Invoice {
-  id                   String            @id @default(cuid())
+  id                   String            @id
   programId            String?
   workspaceId          String
   number               String?           @unique // This starts with the customer's unique invoicePrefix

--- a/packages/prisma/schema/lead.prisma
+++ b/packages/prisma/schema/lead.prisma
@@ -9,7 +9,7 @@ enum SubmittedLeadStatus {
 }
 
 model SubmittedLead {
-  id         String              @id @default(cuid())
+  id         String              @id
   programId  String
   partnerId  String
   customerId String?

--- a/packages/prisma/schema/link.prisma
+++ b/packages/prisma/schema/link.prisma
@@ -1,5 +1,5 @@
 model Link {
-  id              String    @id @default(cuid())
+  id              String    @id
   domain          String // domain of the link (e.g. dub.sh) – also stored on Redis
   key             String // key of the link (e.g. /github) – also stored on Redis
   url             String    @db.LongText // target url (e.g. https://github.com/dubinc/dub) – also stored on Redis

--- a/packages/prisma/schema/message.prisma
+++ b/packages/prisma/schema/message.prisma
@@ -4,7 +4,7 @@ enum MessageType {
 }
 
 model Message {
-  id        String @id @default(cuid())
+  id        String @id
   programId String
   partnerId String
 

--- a/packages/prisma/schema/network.prisma
+++ b/packages/prisma/schema/network.prisma
@@ -40,7 +40,7 @@ model ProgramSimilarity {
 }
 
 model DiscoveredPartner {
-  id        String @id @default(cuid())
+  id        String @id
   programId String
   partnerId String
 

--- a/packages/prisma/schema/oauth.prisma
+++ b/packages/prisma/schema/oauth.prisma
@@ -1,5 +1,5 @@
 model OAuthApp {
-  id                  String  @id @default(cuid())
+  id                  String  @id
   integrationId       String  @unique
   clientId            String  @unique
   hashedClientSecret  String

--- a/packages/prisma/schema/payout.prisma
+++ b/packages/prisma/schema/payout.prisma
@@ -14,7 +14,7 @@ enum PayoutMode {
 }
 
 model Payout {
-  id                  String               @id @default(cuid())
+  id                  String               @id
   programId           String
   partnerId           String
   invoiceId           String?

--- a/packages/prisma/schema/postback.prisma
+++ b/packages/prisma/schema/postback.prisma
@@ -4,7 +4,7 @@ enum PostbackReceiver {
 }
 
 model Postback {
-  id         String           @id @default(cuid())
+  id         String           @id
   partnerId  String
   name       String
   url        String           @db.LongText

--- a/packages/prisma/schema/program.prisma
+++ b/packages/prisma/schema/program.prisma
@@ -25,7 +25,7 @@ enum ProgramPayoutMode {
 }
 
 model Program {
-  id                 String            @id @default(cuid())
+  id                 String            @id
   workspaceId        String
   defaultFolderId    String
   defaultGroupId     String
@@ -104,7 +104,7 @@ enum ReapplicationTimeframe {
 }
 
 model ProgramEnrollment {
-  id               String                  @id @default(cuid())
+  id               String                  @id
   partnerId        String
   programId        String
   tenantId         String?

--- a/packages/prisma/schema/reward.prisma
+++ b/packages/prisma/schema/reward.prisma
@@ -11,7 +11,7 @@ enum RewardStructure {
 }
 
 model Reward {
-  id                 String          @id @default(cuid())
+  id                 String          @id
   programId          String?
   description        String?
   tooltipDescription String?         @db.Text

--- a/packages/prisma/schema/tag.prisma
+++ b/packages/prisma/schema/tag.prisma
@@ -1,5 +1,5 @@
 model Tag {
-  id        String    @id @default(cuid())
+  id        String    @id
   name      String
   color     String    @default("blue")
   createdAt DateTime  @default(now())
@@ -26,7 +26,7 @@ model LinkTag {
 }
 
 model PartnerTag {
-  id        String   @id @default(cuid())
+  id        String   @id
   programId String?
   name      String
   createdAt DateTime @default(now())

--- a/packages/prisma/schema/utm.prisma
+++ b/packages/prisma/schema/utm.prisma
@@ -1,5 +1,5 @@
 model UtmTemplate {
-  id   String @id @default(cuid())
+  id   String @id
   name String
 
   // Parameters

--- a/packages/prisma/schema/webhook.prisma
+++ b/packages/prisma/schema/webhook.prisma
@@ -7,7 +7,7 @@ enum WebhookReceiver {
 }
 
 model Webhook {
-  id                  String          @id @default(cuid())
+  id                  String          @id
   projectId           String
   installationId      String? // indicates which integration installation added the webhook
   receiver            WebhookReceiver @default(user)

--- a/packages/prisma/schema/workflow.prisma
+++ b/packages/prisma/schema/workflow.prisma
@@ -10,7 +10,7 @@ enum WorkflowTrigger {
 }
 
 model Workflow {
-  id                String          @id @default(cuid())
+  id                String          @id
   programId         String
   name              String?
   trigger           WorkflowTrigger

--- a/packages/prisma/schema/workspace.prisma
+++ b/packages/prisma/schema/workspace.prisma
@@ -6,7 +6,7 @@ enum PlanPeriod {
 }
 
 model Project {
-  id               String  @id @default(cuid())
+  id               String  @id
   name             String
   slug             String  @unique
   logo             String?


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated how record IDs are handled across many parts of the platform: new records now require an explicitly provided identifier instead of receiving one automatically during creation.
  * This change affects creation flows for a wide range of entities, helping standardize how records are created and referenced across the product.
  * Existing records are unaffected, but any custom creation workflows may need to provide IDs when submitting new entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->