### PR TITLE
Fix invite teammates form stuck in loading state on error

### DIFF
--- a/apps/web/ui/workspaces/invite-teammates-form.tsx
+++ b/apps/web/ui/workspaces/invite-teammates-form.tsx
@@ -110,7 +110,8 @@ export function InviteTeammatesForm({
               throw error;
             }
 
-            const message = error?.message ?? "Something went wrong";
+            const message =
+              error?.message ?? "Failed to send invites. Please try again.";
 
             toast.error(message);
             throw new Error(message);

--- a/apps/web/ui/workspaces/invite-teammates-form.tsx
+++ b/apps/web/ui/workspaces/invite-teammates-form.tsx
@@ -67,13 +67,15 @@ export function InviteTeammatesForm({
         onSubmit={handleSubmit(async (data) => {
           const teammates = data.teammates.filter(({ email }) => email);
 
-          const response = await fetch(`/api/workspaces/${id}/invites`, {
+          const rawResponse = await fetch(`/api/workspaces/${id}/invites`, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ teammates }),
           });
 
-          if (response.ok) {
+          const response = await rawResponse.json();
+
+          if (rawResponse.ok) {
             await mutatePrefix(`/api/workspaces/${id}/invites`);
             toast.success(`${pluralize("Invitation", teammates.length)} sent!`);
 
@@ -85,15 +87,14 @@ export function InviteTeammatesForm({
 
             onSuccess?.();
           } else {
-            const body = await response.json().catch(() => null);
-            const error = body?.error;
+            const { code, message } = response.error;
 
-            if (trialActive && error?.code === "exceeded_limit") {
+            if (trialActive && code === "exceeded_limit") {
               openTrialLimitModal("users");
-              throw error;
+              throw new Error(message);
             }
 
-            if (error?.message?.includes("upgrade")) {
+            if (message.includes("upgrade")) {
               if (trialActive) {
                 openTrialLimitModal("users");
               } else {
@@ -107,11 +108,8 @@ export function InviteTeammatesForm({
                   { duration: 4000 },
                 );
               }
-              throw error;
+              throw new Error(message);
             }
-
-            const message =
-              error?.message ?? "Failed to send invites. Please try again.";
 
             toast.error(message);
             throw new Error(message);

--- a/apps/web/ui/workspaces/invite-teammates-form.tsx
+++ b/apps/web/ui/workspaces/invite-teammates-form.tsx
@@ -34,7 +34,7 @@ export function InviteTeammatesForm({
   invites?: Invite[];
   className?: string;
 }) {
-  const { id, slug, plan, usersLimit, trialEndsAt } = useWorkspace();
+  const { id, plan, usersLimit, trialEndsAt } = useWorkspace();
   const { isMobile } = useMediaQuery();
   const { queryParams } = useRouterStuff();
   const { openTrialLimitModal, TrialLimitActivateModal } =
@@ -66,16 +66,17 @@ export function InviteTeammatesForm({
       <form
         onSubmit={handleSubmit(async (data) => {
           const teammates = data.teammates.filter(({ email }) => email);
-          const res = await fetch(`/api/workspaces/${id}/invites`, {
+
+          const response = await fetch(`/api/workspaces/${id}/invites`, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ teammates }),
           });
 
-          if (res.ok) {
+          if (response.ok) {
             await mutatePrefix(`/api/workspaces/${id}/invites`);
-
             toast.success(`${pluralize("Invitation", teammates.length)} sent!`);
+
             queryParams({
               set: {
                 status: "invited",
@@ -84,12 +85,14 @@ export function InviteTeammatesForm({
 
             onSuccess?.();
           } else {
-            const body = await res.json().catch(() => null);
+            const body = await response.json().catch(() => null);
             const error = body?.error;
+
             if (trialActive && error?.code === "exceeded_limit") {
               openTrialLimitModal("users");
-              return;
+              throw error;
             }
+
             if (error?.message?.includes("upgrade")) {
               if (trialActive) {
                 openTrialLimitModal("users");
@@ -104,10 +107,13 @@ export function InviteTeammatesForm({
                   { duration: 4000 },
                 );
               }
-              return;
+              throw error;
             }
-            toast.error(error?.message ?? "Something went wrong");
-            if (error) throw error;
+
+            const message = error?.message ?? "Something went wrong";
+
+            toast.error(message);
+            throw new Error(message);
           }
         })}
         className={cn("flex flex-col gap-8 text-left", className)}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved invite flow error handling: clearer messages shown on failure and appropriate error dialogs for trial-limit and upgrade-related cases.
  * Trial-limit cases now open the trial-limit modal when limits are exceeded.
  * Success path consistently shows success feedback and updates the URL/status to reflect invited state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->