### PR TITLE
Skip instead of throwing when transferable amount is below min withdrawal amount

### DIFF
--- a/apps/web/lib/partners/create-stablecoin-payout.ts
+++ b/apps/web/lib/partners/create-stablecoin-payout.ts
@@ -131,9 +131,10 @@ export const createStablecoinPayout = async ({
   );
 
   if (totalTransferableAmount < MIN_FORCE_WITHDRAWAL_AMOUNT_CENTS) {
-    throw new Error(
+    console.warn(
       `Total transferable amount (${currencyFormatter(totalTransferableAmount)}) for partner ${partner.email} is less than the minimum amount required for withdrawal (${currencyFormatter(MIN_FORCE_WITHDRAWAL_AMOUNT_CENTS)}). Skipping...`,
     );
+    return;
   }
 
   let withdrawalFee = 0;

--- a/apps/web/lib/partners/create-stablecoin-payout.ts
+++ b/apps/web/lib/partners/create-stablecoin-payout.ts
@@ -131,10 +131,16 @@ export const createStablecoinPayout = async ({
   );
 
   if (totalTransferableAmount < MIN_FORCE_WITHDRAWAL_AMOUNT_CENTS) {
-    console.warn(
-      `Total transferable amount (${currencyFormatter(totalTransferableAmount)}) for partner ${partner.email} is less than the minimum amount required for withdrawal (${currencyFormatter(MIN_FORCE_WITHDRAWAL_AMOUNT_CENTS)}). Skipping...`,
-    );
-    return;
+    const message = `Total transferable amount (${currencyFormatter(totalTransferableAmount)}) is less than the minimum amount required for withdrawal (${currencyFormatter(MIN_FORCE_WITHDRAWAL_AMOUNT_CENTS)}).`;
+
+    // For force-withdrawal action, throw so the error surfaces back to partners.
+    // Otherwise (e.g. cron-driven payouts) just log and skip silently.
+    if (forceWithdrawal) {
+      throw new Error(message);
+    } else {
+      console.warn(message);
+      return;
+    }
   }
 
   let withdrawalFee = 0;

--- a/apps/web/lib/partners/create-stripe-transfer.ts
+++ b/apps/web/lib/partners/create-stripe-transfer.ts
@@ -109,10 +109,16 @@ export const createStripeTransfer = async ({
   );
 
   if (totalTransferableAmount < MIN_FORCE_WITHDRAWAL_AMOUNT_CENTS) {
-    console.warn(
-      `Total transferable amount (${currencyFormatter(totalTransferableAmount)}) for partner ${partner.email} is less than the minimum amount required for withdrawal (${currencyFormatter(MIN_FORCE_WITHDRAWAL_AMOUNT_CENTS)}). Skipping...`,
-    );
-    return;
+    const message = `Total transferable amount (${currencyFormatter(totalTransferableAmount)}) is less than the minimum amount required for withdrawal (${currencyFormatter(MIN_FORCE_WITHDRAWAL_AMOUNT_CENTS)}).`;
+
+    // For force-withdrawal action, throw so the error surfaces back to partners.
+    // Otherwise (e.g. cron-driven payouts) just log and skip silently.
+    if (forceWithdrawal) {
+      throw new Error(message);
+    } else {
+      console.warn(message);
+      return;
+    }
   }
 
   let withdrawalFee = 0;

--- a/apps/web/lib/partners/create-stripe-transfer.ts
+++ b/apps/web/lib/partners/create-stripe-transfer.ts
@@ -109,9 +109,10 @@ export const createStripeTransfer = async ({
   );
 
   if (totalTransferableAmount < MIN_FORCE_WITHDRAWAL_AMOUNT_CENTS) {
-    throw new Error(
+    console.warn(
       `Total transferable amount (${currencyFormatter(totalTransferableAmount)}) for partner ${partner.email} is less than the minimum amount required for withdrawal (${currencyFormatter(MIN_FORCE_WITHDRAWAL_AMOUNT_CENTS)}). Skipping...`,
     );
+    return;
   }
 
   let withdrawalFee = 0;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Transfers and payouts below the minimum threshold now log a warning and are skipped by default to avoid spurious failures; when explicitly forced, the operation will raise an error instead. This applies to both fiat (Stripe) transfers and stablecoin payouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->