### PR TITLE
Fix link builder (duplicate flow, simplify)

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/links/[...link]/page-client.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/links/[...link]/page-client.tsx
@@ -82,7 +82,7 @@ export function LinkPageClient() {
   );
 
   return link ? (
-    <LinkBuilderProvider props={link} workspace={workspace} modal={false}>
+    <LinkBuilderProvider props={link} modal={false}>
       <LinkBuilder link={link} />
     </LinkBuilderProvider>
   ) : (

--- a/apps/web/ui/links/link-builder/link-builder-header.tsx
+++ b/apps/web/ui/links/link-builder/link-builder-header.tsx
@@ -2,6 +2,7 @@ import { unsortedLinks } from "@/lib/folder/constants";
 import { getPlanCapabilities } from "@/lib/plan-capabilities";
 import useFolder from "@/lib/swr/use-folder";
 import useLinks from "@/lib/swr/use-links";
+import useWorkspace from "@/lib/swr/use-workspace";
 import { LinkProps } from "@/lib/types";
 import { FolderIcon } from "@/ui/folders/folder-icon";
 import { Combobox, LinkLogo } from "@dub/ui";
@@ -30,7 +31,8 @@ export function LinkBuilderHeader({
   onSelectLink?: (link: LinkProps) => void;
   className?: string;
 }>) {
-  const { props, workspace } = useLinkBuilderContext();
+  const { props } = useLinkBuilderContext();
+  const workspace = useWorkspace();
   const { isDirty } = useFormState();
 
   const [url, key, domain, folderId] = useWatch({

--- a/apps/web/ui/links/link-builder/link-builder-provider.tsx
+++ b/apps/web/ui/links/link-builder/link-builder-provider.tsx
@@ -1,5 +1,6 @@
+import useWorkspace from "@/lib/swr/use-workspace";
 import { ExpandedLinkProps } from "@/lib/types";
-import { DEFAULT_LINK_PROPS, PLANS } from "@dub/utils";
+import { DEFAULT_LINK_PROPS } from "@dub/utils";
 import {
   createContext,
   Dispatch,
@@ -15,14 +16,6 @@ export type LinkFormData = ExpandedLinkProps;
 export type LinkBuilderProps = {
   props?: ExpandedLinkProps;
   duplicateProps?: ExpandedLinkProps;
-  workspace: {
-    id?: string;
-    slug?: string;
-    plan?: string;
-    nextPlan?: (typeof PLANS)[number];
-    conversionEnabled?: boolean;
-    defaultProgramId?: string | null;
-  };
   modal: boolean;
 };
 
@@ -48,7 +41,7 @@ export function LinkBuilderProvider({
   children,
   ...rest
 }: PropsWithChildren<LinkBuilderProps>) {
-  const { plan, conversionEnabled } = rest.workspace || {};
+  const { plan, conversionEnabled } = useWorkspace();
 
   const [generatingMetatags, setGeneratingMetatags] = useState(
     Boolean(rest.props),

--- a/apps/web/ui/links/link-builder/use-link-builder-submit.tsx
+++ b/apps/web/ui/links/link-builder/use-link-builder-submit.tsx
@@ -1,4 +1,5 @@
 import { mutatePrefix } from "@/lib/swr/mutate";
+import useWorkspace from "@/lib/swr/use-workspace";
 import { UpgradeRequiredToast } from "@/ui/shared/upgrade-required-toast";
 import { Button, useCopyToClipboard } from "@dub/ui";
 import { useRouter } from "next/navigation";
@@ -14,7 +15,8 @@ export function useLinkBuilderSubmit({
   onSuccess?: (data: LinkFormData) => void;
 } = {}) {
   const router = useRouter();
-  const { workspace, props } = useLinkBuilderContext();
+  const { props } = useLinkBuilderContext();
+  const workspace = useWorkspace();
   const { getValues, setError } = useFormContext<LinkFormData>();
   const [, copyToClipboard] = useCopyToClipboard();
 

--- a/apps/web/ui/links/link-controls.tsx
+++ b/apps/web/ui/links/link-controls.tsx
@@ -20,7 +20,7 @@ import {
   QRCode,
   Trash,
 } from "@dub/ui/icons";
-import { cn, isDubDomain, nanoid } from "@dub/utils";
+import { cn, isDubDomain } from "@dub/utils";
 import { CopyPlus, FolderInput } from "lucide-react";
 import { useParams, useRouter } from "next/navigation";
 import { useCallback } from "react";
@@ -119,7 +119,7 @@ export function LinkControls({
     // @ts-expect-error
     duplicateProps: {
       ...propsToDuplicate,
-      key: nanoid(7),
+      key: propsToDuplicate.key + "-copy",
       clicks: 0,
     },
   });

--- a/apps/web/ui/modals/link-builder/index.tsx
+++ b/apps/web/ui/modals/link-builder/index.tsx
@@ -53,7 +53,6 @@ import { useFormContext, useWatch } from "react-hook-form";
 type LinkBuilderModalProps = {
   showLinkBuilder: boolean;
   setShowLinkBuilder: Dispatch<SetStateAction<boolean>>;
-  homepageDemo?: boolean;
 };
 
 export function LinkBuilder(props: LinkBuilderProps & LinkBuilderModalProps) {
@@ -63,7 +62,6 @@ export function LinkBuilder(props: LinkBuilderProps & LinkBuilderModalProps) {
 function LinkBuilderOuter({
   showLinkBuilder,
   setShowLinkBuilder,
-  homepageDemo,
   ...rest
 }: LinkBuilderProps & LinkBuilderModalProps) {
   return (
@@ -71,7 +69,6 @@ function LinkBuilderOuter({
       <LinkBuilderInner
         showLinkBuilder={showLinkBuilder}
         setShowLinkBuilder={setShowLinkBuilder}
-        homepageDemo={homepageDemo}
       />
     </LinkBuilderProvider>
   );
@@ -80,12 +77,10 @@ function LinkBuilderOuter({
 function LinkBuilderInner({
   showLinkBuilder,
   setShowLinkBuilder,
-  homepageDemo,
 }: LinkBuilderModalProps) {
   const searchParams = useSearchParams();
   const { queryParams } = useRouterStuff();
-  const { id: workspaceId, slug, flags } = useWorkspace();
-
+  const { id: workspaceId, slug } = useWorkspace();
   const { props, duplicateProps } = useLinkBuilderContext();
 
   const {
@@ -95,7 +90,7 @@ function LinkBuilderInner({
     formState: { isDirty, isSubmitting, isSubmitSuccessful },
   } = useFormContext<LinkFormData>();
 
-  const [domain, key] = useWatch({
+  const [domain, _key] = useWatch({
     control,
     name: ["domain", "key"],
   });
@@ -124,8 +119,14 @@ function LinkBuilderInner({
   });
 
   useEffect(() => {
+    console.log({ loading, primaryDomain, props, duplicateProps });
     // for a new link (no props or duplicateProps), set the domain to the primary domain
-    if (!loading && primaryDomain && !props && !duplicateProps) {
+    if (
+      !loading &&
+      primaryDomain &&
+      !props?.domain &&
+      !duplicateProps?.domain
+    ) {
       setValue("domain", primaryDomain, {
         shouldValidate: true,
         shouldDirty: false,
@@ -227,28 +228,20 @@ function LinkBuilderInner({
           </div>
           <div className="flex items-center justify-between gap-2 border-t border-neutral-100 bg-neutral-50 p-4">
             <LinkFeatureButtons />
-            {homepageDemo ? (
-              <Button
-                disabledTooltip="This is a demo link. You can't edit it."
-                text="Save changes"
-                className="h-8 w-fit"
-              />
-            ) : (
-              <Button
-                type="submit"
-                disabled={saveDisabled}
-                loading={isSubmitting || isSubmitSuccessful}
-                text={
-                  <span className="flex items-center gap-2">
-                    {props ? "Save changes" : "Create link"}
-                    <div className="rounded border border-white/20 p-1">
-                      <ArrowTurnLeft className="size-3.5" />
-                    </div>
-                  </span>
-                }
-                className="h-8 w-fit pl-2.5 pr-1.5"
-              />
-            )}
+            <Button
+              type="submit"
+              disabled={saveDisabled}
+              loading={isSubmitting || isSubmitSuccessful}
+              text={
+                <span className="flex items-center gap-2">
+                  {props ? "Save changes" : "Create link"}
+                  <div className="rounded border border-white/20 p-1">
+                    <ArrowTurnLeft className="size-3.5" />
+                  </div>
+                </span>
+              }
+              className="h-8 w-fit pl-2.5 pr-1.5"
+            />
           </div>
         </form>
       </Modal>
@@ -342,13 +335,10 @@ export function CreateLinkButton({
 export function useLinkBuilder({
   props,
   duplicateProps,
-  homepageDemo,
 }: {
   props?: ExpandedLinkProps;
   duplicateProps?: ExpandedLinkProps;
-  homepageDemo?: boolean;
 } = {}) {
-  const workspace = useWorkspace();
   const [showLinkBuilder, setShowLinkBuilder] = useState(false);
 
   const LinkBuilderCallback = useCallback(() => {
@@ -358,12 +348,10 @@ export function useLinkBuilder({
         setShowLinkBuilder={setShowLinkBuilder}
         props={props}
         duplicateProps={duplicateProps}
-        homepageDemo={homepageDemo}
-        workspace={workspace}
         modal={true}
       />
     );
-  }, [showLinkBuilder, workspace]);
+  }, [showLinkBuilder]);
 
   const CreateLinkButtonCallback = useCallback(
     (props?: CreateLinkButtonProps) => {

--- a/apps/web/ui/modals/link-builder/index.tsx
+++ b/apps/web/ui/modals/link-builder/index.tsx
@@ -119,7 +119,6 @@ function LinkBuilderInner({
   });
 
   useEffect(() => {
-    console.log({ loading, primaryDomain, props, duplicateProps });
     // for a new link (no props or duplicateProps), set the domain to the primary domain
     if (
       !loading &&

--- a/apps/web/ui/modals/tag-link-modal.tsx
+++ b/apps/web/ui/modals/tag-link-modal.tsx
@@ -34,7 +34,7 @@ function TagLinkModal(props: TagLinkModalProps) {
 }
 
 function TagLinkModalInner({ setShowTagLinkModal, links }: TagLinkModalProps) {
-  const { id: workspaceId, slug, plan } = useWorkspace();
+  const { id: workspaceId } = useWorkspace();
 
   const [updating, setUpdating] = useState(false);
 
@@ -91,10 +91,7 @@ function TagLinkModalInner({ setShowTagLinkModal, links }: TagLinkModalProps) {
   };
 
   return (
-    <LinkBuilderProvider
-      workspace={{ id: workspaceId, slug, plan }}
-      modal={true}
-    >
+    <LinkBuilderProvider modal={true}>
       <FormProvider {...form}>
         <div className="space-y-2 border-b border-neutral-200 p-4 sm:p-6">
           {links.length === 1 && (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Duplicate links now use a consistent "-copy" suffix for predictable names.
  * Link Builder modal simplified: submit action is unified and clearer.
  * Workspace handling centralized across Link Builder flows for more consistent capability checks.

* **Breaking Changes**
  * A previously exposed modal option/prop was removed from the Link Builder public API; integration code may need updating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->