### PR TITLE
Block pending partners from referrals embed

### DIFF
--- a/apps/web/app/(ee)/app.dub.co/embed/referrals/get-referrals-embed-data.ts
+++ b/apps/web/app/(ee)/app.dub.co/embed/referrals/get-referrals-embed-data.ts
@@ -143,6 +143,7 @@ export const getReferralsEmbedData = async (token: string) => {
     },
     programEnrollment: {
       createdAt: programEnrollment.createdAt,
+      status: programEnrollment.status,
     },
     group: {
       id: group.id,

--- a/apps/web/app/(ee)/app.dub.co/embed/referrals/page-client.tsx
+++ b/apps/web/app/(ee)/app.dub.co/embed/referrals/page-client.tsx
@@ -12,10 +12,16 @@ import {
 import { programEmbedSchema } from "@/lib/zod/schemas/program-embed";
 import { programResourcesSchema } from "@/lib/zod/schemas/program-resources";
 import { HeroBackground } from "@/ui/partners/hero-background";
+import { PartnerStatusBadges } from "@/ui/partners/partner-status-badges";
 import { ProgramRewardList } from "@/ui/partners/program-reward-list";
 import { ProgramRewardTerms } from "@/ui/partners/program-reward-terms";
 import { ThreeDots } from "@/ui/shared/icons";
-import { Partner, PlatformType, Program } from "@dub/prisma/client";
+import {
+  Partner,
+  PlatformType,
+  Program,
+  ProgramEnrollmentStatus,
+} from "@dub/prisma/client";
 import {
   Button,
   Check,
@@ -23,6 +29,7 @@ import {
   Copy,
   Directions,
   Popover,
+  StatusBadge,
   TabSelect,
   useCopyToClipboard,
   useLocalStorage,
@@ -66,7 +73,9 @@ type ReferralsEmbedData = {
     | "embedData"
     | "resources"
   >;
-  programEnrollment: Pick<ProgramEnrollmentProps, "createdAt">;
+  programEnrollment: Pick<ProgramEnrollmentProps, "createdAt"> & {
+    status: ProgramEnrollmentStatus;
+  };
   partner: Pick<Partner, "id" | "name" | "email">;
   partnerPlatforms: Array<{
     type: PlatformType;
@@ -169,6 +178,7 @@ export function ReferralsEmbedPageClient({
   );
 
   const activeBountiesCount = bounties.length;
+  const isPending = programEnrollment.status === "pending";
 
   const tabs = useMemo(
     () => [
@@ -225,6 +235,16 @@ export function ReferralsEmbedPageClient({
       bounties,
     ],
   );
+
+  if (isPending) {
+    return (
+      <ReferralsEmbedPending
+        programName={program.name}
+        themeOptions={themeOptions}
+        dynamicHeight={dynamicHeight}
+      />
+    );
+  }
 
   return (
     <ReferralsEmbedDataProvider value={embedData}>
@@ -367,6 +387,45 @@ export function ReferralsEmbedPageClient({
         </div>
       </div>
     </ReferralsEmbedDataProvider>
+  );
+}
+
+function ReferralsEmbedPending({
+  programName,
+  themeOptions,
+  dynamicHeight,
+}: {
+  programName: string;
+  themeOptions: ThemeOptions;
+  dynamicHeight: boolean;
+}) {
+  const badge = PartnerStatusBadges.pending;
+
+  return (
+    <div
+      style={{
+        backgroundColor: themeOptions.backgroundColor || "transparent",
+      }}
+      className={cn(
+        "flex flex-col items-center justify-center p-8 text-center",
+        !dynamicHeight && "min-h-screen",
+      )}
+    >
+      <StatusBadge
+        variant={badge.variant}
+        icon={badge.icon}
+        className="px-1.5 py-0.5"
+      >
+        {badge.label}
+      </StatusBadge>
+      <h2 className="text-content-default mt-4 text-base font-semibold">
+        Application in review
+      </h2>
+      <p className="text-content-subtle [&_strong]:text-content-default mt-2 max-w-sm text-balance text-sm font-medium [&_strong]:font-semibold">
+        You&apos;ll be notified when <strong>{programName}</strong> has finished
+        reviewing your application.
+      </p>
+    </div>
   );
 }
 

--- a/apps/web/app/(ee)/app.dub.co/embed/referrals/page-client.tsx
+++ b/apps/web/app/(ee)/app.dub.co/embed/referrals/page-client.tsx
@@ -9,6 +9,7 @@ import {
   ProgramEnrollmentProps,
   RewardProps,
 } from "@/lib/types";
+import { ACTIVE_ENROLLMENT_STATUSES } from "@/lib/zod/schemas/partners";
 import { programEmbedSchema } from "@/lib/zod/schemas/program-embed";
 import { programResourcesSchema } from "@/lib/zod/schemas/program-resources";
 import { HeroBackground } from "@/ui/partners/hero-background";
@@ -178,7 +179,9 @@ export function ReferralsEmbedPageClient({
   );
 
   const activeBountiesCount = bounties.length;
-  const isPending = programEnrollment.status === "pending";
+  const hasEmbedAccess = ACTIVE_ENROLLMENT_STATUSES.includes(
+    programEnrollment.status,
+  );
 
   const tabs = useMemo(
     () => [
@@ -236,9 +239,10 @@ export function ReferralsEmbedPageClient({
     ],
   );
 
-  if (isPending) {
+  if (!hasEmbedAccess) {
     return (
-      <ReferralsEmbedPending
+      <ReferralsEmbedUnapproved
+        status={programEnrollment.status}
         programName={program.name}
         themeOptions={themeOptions}
         dynamicHeight={dynamicHeight}
@@ -390,16 +394,19 @@ export function ReferralsEmbedPageClient({
   );
 }
 
-function ReferralsEmbedPending({
+function ReferralsEmbedUnapproved({
+  status,
   programName,
   themeOptions,
   dynamicHeight,
 }: {
+  status: ProgramEnrollmentStatus;
   programName: string;
   themeOptions: ThemeOptions;
   dynamicHeight: boolean;
 }) {
-  const badge = PartnerStatusBadges.pending;
+  const badge = PartnerStatusBadges[status];
+  const isPending = status === "pending";
 
   return (
     <div
@@ -419,11 +426,17 @@ function ReferralsEmbedPending({
         {badge.label}
       </StatusBadge>
       <h2 className="text-content-default mt-4 text-base font-semibold">
-        Application in review
+        {isPending ? "Application in review" : "Program unavailable"}
       </h2>
       <p className="text-content-subtle [&_strong]:text-content-default mt-2 max-w-sm text-balance text-sm font-medium [&_strong]:font-semibold">
-        You&apos;ll be notified when <strong>{programName}</strong> has finished
-        reviewing your application.
+        {isPending ? (
+          <>
+            You&apos;ll be notified when <strong>{programName}</strong> has
+            finished reviewing your application.
+          </>
+        ) : (
+          "You don't have access to this program."
+        )}
       </p>
     </div>
   );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Referral embed now shows explicit enrollment status views: an "Application in review" screen for pending enrollments (with program-specific messaging) and a "Program unavailable" screen for other non-active statuses. The normal embed interface appears only for active enrollments.
  * Embed now includes enrollment status in its data so the UI can decide which view to show.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->