### PR TITLE
Message attachment style adjustments

### DIFF
--- a/apps/web/app/(ee)/api/network/partners/count/route.ts
+++ b/apps/web/app/(ee)/api/network/partners/count/route.ts
@@ -7,7 +7,6 @@ import { getDefaultProgramIdOrThrow } from "@/lib/api/programs/get-default-progr
 import { withWorkspace } from "@/lib/auth";
 import { getNetworkPartnersCountQuerySchema } from "@/lib/zod/schemas/partner-network";
 import { prisma } from "@dub/prisma";
-import { PlatformType, Prisma } from "@dub/prisma/client";
 import { NextResponse } from "next/server";
 
 // GET /api/network/partners/count - get the number of available partners in the network
@@ -31,21 +30,13 @@ export const GET = withWorkspace(
       });
     }
 
-    const {
-      partnerIds,
-      status,
-      groupBy,
-      country,
-      starred,
-      platform,
-      subscribers,
-    } = getNetworkPartnersCountQuerySchema.parse(searchParams);
+    const { partnerIds, status, groupBy, country, starred, platform } =
+      getNetworkPartnersCountQuerySchema.parse(searchParams);
 
     const listingParts = partnerNetworkListingParts({
       partnerIds,
       country,
       platform,
-      subscribers,
     });
 
     const commonWhere = partnerWhereFromListingParts(listingParts);
@@ -161,119 +152,6 @@ export const GET = withWorkspace(
       });
 
       return NextResponse.json(countries);
-    } else if (groupBy === "platform") {
-      // Build platform filter for PartnerPlatform
-      const platformPlatformFilter: Prisma.PartnerPlatformWhereInput = {
-        verifiedAt: { not: null },
-        ...(subscribers === "<5000" && {
-          subscribers: { lt: 5000 },
-        }),
-        ...(subscribers === "5000-25000" && {
-          subscribers: { gte: 5000, lt: 25000 },
-        }),
-        ...(subscribers === "25000-100000" && {
-          subscribers: { gte: 25000, lt: 100000 },
-        }),
-        ...(subscribers === "100000+" && {
-          subscribers: { gte: 100000 },
-        }),
-      };
-
-      const mergedPlatformsSome: Prisma.PartnerPlatformWhereInput =
-        listingParts.listingPlatformSome
-          ? { AND: [listingParts.listingPlatformSome, platformPlatformFilter] }
-          : platformPlatformFilter;
-
-      const partnerWhere: Prisma.PartnerWhereInput = {
-        ...listingParts.listingPartnerBase,
-        ...statusWhereForFacet,
-        platforms: {
-          some: mergedPlatformsSome,
-        },
-      };
-
-      // Get all partners matching the criteria with their platforms
-      const partners = await prisma.partner.findMany({
-        where: partnerWhere,
-        select: {
-          id: true,
-          platforms: {
-            where: mergedPlatformsSome,
-            select: {
-              type: true,
-            },
-          },
-        },
-      });
-
-      // Group by platform type and count distinct partners
-      const platformCountsMap = new Map<PlatformType, Set<string>>();
-
-      for (const partner of partners) {
-        for (const platform of partner.platforms) {
-          if (!platformCountsMap.has(platform.type)) {
-            platformCountsMap.set(platform.type, new Set());
-          }
-          platformCountsMap.get(platform.type)!.add(partner.id);
-        }
-      }
-
-      const platformCounts = Array.from(platformCountsMap.entries())
-        .map(([type, partnerIds]) => ({
-          platform: type,
-          _count: partnerIds.size,
-        }))
-        .sort((a, b) => b._count - a._count);
-
-      return NextResponse.json(platformCounts);
-    } else if (groupBy === "subscribers") {
-      // Get counts by subscriber ranges (only verified platforms)
-      const subscriberRanges = [
-        { label: "<5000", min: 0, max: 4999 },
-        { label: "5000-25000", min: 5000, max: 24999 },
-        { label: "25000-100000", min: 25000, max: 99999 },
-        { label: "100000+", min: 100000, max: null },
-      ];
-
-      const subscriberCounts = await Promise.all(
-        subscriberRanges.map(async (range) => {
-          const rangePlatformSome: Prisma.PartnerPlatformWhereInput = {
-            verifiedAt: { not: null },
-            ...(range.max !== null
-              ? {
-                  subscribers: { gte: range.min, lt: range.max + 1 },
-                }
-              : {
-                  subscribers: { gte: range.min },
-                }),
-            ...(platform && { type: platform }),
-          };
-
-          const mergedPlatformsSome: Prisma.PartnerPlatformWhereInput =
-            listingParts.listingPlatformSome
-              ? {
-                  AND: [listingParts.listingPlatformSome, rangePlatformSome],
-                }
-              : rangePlatformSome;
-
-          const where: Prisma.PartnerWhereInput = {
-            ...listingParts.listingPartnerBase,
-            ...statusWhereForFacet,
-            platforms: {
-              some: mergedPlatformsSome,
-            },
-          };
-
-          const count = await prisma.partner.count({ where });
-
-          return {
-            subscribers: range.label,
-            _count: count,
-          };
-        }),
-      );
-
-      return NextResponse.json(subscriberCounts);
     }
 
     throw new Error("Invalid groupBy");

--- a/apps/web/lib/messages/constants.ts
+++ b/apps/web/lib/messages/constants.ts
@@ -32,10 +32,3 @@ export const PREVIEWABLE_IMAGE_TYPES = new Set([
   "image/jpeg",
   "image/webp",
 ]);
-
-export const ATTACHMENT_MIME_TYPE_COLOR: Record<string, string> = {
-  "application/pdf": "bg-rose-600",
-  "image/png": "bg-blue-600",
-  "image/jpeg": "bg-blue-500",
-  "image/webp": "bg-blue-500",
-};

--- a/apps/web/lib/messages/constants.ts
+++ b/apps/web/lib/messages/constants.ts
@@ -34,7 +34,7 @@ export const PREVIEWABLE_IMAGE_TYPES = new Set([
 ]);
 
 export const ATTACHMENT_MIME_TYPE_COLOR: Record<string, string> = {
-  "application/pdf": "bg-red-600",
+  "application/pdf": "bg-rose-600",
   "image/png": "bg-blue-600",
   "image/jpeg": "bg-blue-500",
   "image/webp": "bg-blue-500",

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -7,6 +7,7 @@ const config: Pick<Config, "presets"> = {
       ...sharedConfig,
       content: [
         "./app/**/*.{js,ts,jsx,tsx}",
+        "./lib/**/*.{js,ts,jsx,tsx}",
         "./ui/**/*.{js,ts,jsx,tsx}",
         // h/t to https://www.willliu.com/blog/Why-your-Tailwind-styles-aren-t-working-in-your-Turborepo
         "../../packages/ui/src/**/*{.js,.ts,.jsx,.tsx}",

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -7,7 +7,6 @@ const config: Pick<Config, "presets"> = {
       ...sharedConfig,
       content: [
         "./app/**/*.{js,ts,jsx,tsx}",
-        "./lib/**/*.{js,ts,jsx,tsx}",
         "./ui/**/*.{js,ts,jsx,tsx}",
         // h/t to https://www.willliu.com/blog/Why-your-Tailwind-styles-aren-t-working-in-your-Turborepo
         "../../packages/ui/src/**/*{.js,.ts,.jsx,.tsx}",

--- a/apps/web/ui/messages/message-attachments.tsx
+++ b/apps/web/ui/messages/message-attachments.tsx
@@ -82,7 +82,7 @@ export function MessageFileAttachments({
             file.signedUrl && downloadFile(file.signedUrl, file.name)
           }
           className={cn(
-            "flex items-center gap-2 rounded-lg border border-neutral-200 bg-neutral-50 px-3 py-2 text-left transition-colors",
+            "flex items-center gap-3 rounded-lg border border-neutral-200 bg-neutral-50 p-1 pr-3 text-left transition-colors",
             file.signedUrl
               ? "hover:bg-neutral-100"
               : "cursor-default opacity-60",
@@ -97,7 +97,7 @@ export function MessageFileAttachments({
               {formatFileSize(file.size, 1)}
             </span>
           </div>
-          <div className="border-bg-subtle rounded-lg border bg-white px-3 py-2">
+          <div className="border-bg-subtle flex size-8 shrink-0 items-center justify-center rounded-lg border bg-white">
             <Download className="text-content-emphasis size-4 shrink-0" />
           </div>
         </button>
@@ -110,7 +110,7 @@ function FileTypeBadge({ type }: { type: string }) {
   return (
     <div
       className={cn(
-        "flex size-10 shrink-0 flex-col items-center justify-center gap-1 rounded-lg p-2 text-xs font-semibold uppercase text-white",
+        "flex size-12 shrink-0 flex-col items-center justify-center gap-0.5 rounded-md text-xs font-semibold uppercase text-white",
         ATTACHMENT_MIME_TYPE_COLOR[type] || "bg-neutral-500",
       )}
     >

--- a/apps/web/ui/messages/message-attachments.tsx
+++ b/apps/web/ui/messages/message-attachments.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { ATTACHMENT_MIME_TYPE_COLOR } from "@/lib/messages/constants";
 import { getAttachmentTypeLabel } from "@/lib/messages/utils";
 import { MessageAttachment } from "@/lib/types";
 import { formatFileSize } from "@dub/utils";
@@ -29,6 +28,13 @@ async function downloadFile(url: string, filename: string) {
     toast.error("Failed to download file. Please try again.");
   }
 }
+
+export const ATTACHMENT_MIME_TYPE_COLOR: Record<string, string> = {
+  "application/pdf": "bg-rose-600",
+  "image/png": "bg-blue-600",
+  "image/jpeg": "bg-blue-500",
+  "image/webp": "bg-blue-500",
+};
 
 export function MessageImageAttachments({
   attachments,

--- a/apps/web/ui/shared/message-input.tsx
+++ b/apps/web/ui/shared/message-input.tsx
@@ -392,7 +392,7 @@ function AttachmentChip({
   }
 
   return (
-    <div className="relative flex shrink-0 items-center gap-2 rounded-lg border border-neutral-200 bg-neutral-50 px-2 py-1.5">
+    <div className="relative flex h-14 shrink-0 items-center gap-3 rounded-lg border border-neutral-200 bg-neutral-50 p-1 pr-8">
       {attachment.uploading && (
         <div className="absolute inset-0 z-[1] flex items-center justify-center rounded-lg bg-white/80">
           <LoadingCircle className="size-4" />
@@ -401,19 +401,19 @@ function AttachmentChip({
 
       <div
         className={cn(
-          "flex size-8 shrink-0 flex-col items-center justify-center gap-0.5 rounded text-[8px] font-semibold uppercase text-white",
+          "flex size-12 shrink-0 flex-col items-center justify-center gap-0.5 rounded-md text-xs font-semibold uppercase text-white",
           ATTACHMENT_MIME_TYPE_COLOR[attachment.type] || "bg-neutral-500",
         )}
       >
-        <File className="size-2.5 shrink-0" />
+        <File className="size-3 shrink-0" />
         <span>{getAttachmentTypeLabel(attachment.type)}</span>
       </div>
 
-      <div className="flex max-w-[120px] flex-col">
-        <span className="truncate text-xs font-medium text-neutral-700">
+      <div className="flex min-w-0 max-w-[120px] flex-col">
+        <span className="truncate text-sm font-medium text-neutral-700">
           {attachment.name}
         </span>
-        <span className="text-[10px] text-neutral-400">
+        <span className="text-xs text-neutral-400">
           {formatFileSize(attachment.size, 1)}
         </span>
       </div>
@@ -421,7 +421,7 @@ function AttachmentChip({
       <button
         type="button"
         onClick={onRemove}
-        className="ml-1 rounded-full p-0.5 text-neutral-400 transition-colors hover:bg-neutral-200 hover:text-neutral-600"
+        className="absolute -right-1.5 -top-1.5 z-[2] flex size-5 items-center justify-center rounded-full border border-neutral-200 bg-white text-neutral-400 shadow-sm transition-colors hover:text-neutral-600"
       >
         <X className="size-3" />
       </button>
@@ -566,14 +566,11 @@ function MessageInputToolbar({
       }
       toolsEnd={
         onAttachClick ? (
-          <button
-            type="button"
+          <RichTextToolbarButton
+            icon={Paperclip}
+            label="Attach file"
             onClick={onAttachClick}
-            className="flex size-7 items-center justify-center rounded-md text-neutral-500 transition-colors hover:bg-neutral-100 hover:text-neutral-700"
-            title="Attach file"
-          >
-            <Paperclip className="size-4" />
-          </button>
+          />
         ) : undefined
       }
     />

--- a/apps/web/ui/shared/message-input.tsx
+++ b/apps/web/ui/shared/message-input.tsx
@@ -1,5 +1,4 @@
 import {
-  ATTACHMENT_MIME_TYPE_COLOR,
   MAX_ATTACHMENTS_PER_MESSAGE,
   MAX_MESSAGE_LENGTH,
 } from "@/lib/messages/constants";
@@ -33,6 +32,7 @@ import {
 } from "react";
 import { toast } from "sonner";
 import * as z from "zod/v4";
+import { ATTACHMENT_MIME_TYPE_COLOR } from "../messages/message-attachments";
 import { EmojiPicker } from "../shared/emoji-picker";
 
 export type PendingAttachment = Omit<


### PR DESCRIPTION
- Aligned the paper clip button to the rest of the button, and matched the size and styling as the others
- Set it so tailwind can pickup the other library colors that were being used in the designs (rose-600)
- PDF block
  - Moved the delete to the top right to match the image delete
  - Reduced the padding around the icon area
  - The sent document version match the design closer now
  - Also has the correct height. If the pdf was the only attachment it was a smaller height. When an image was added as well, it was taller.

<img width="3670" height="3266" alt="image" src="https://github.com/user-attachments/assets/3fbe2886-f2cd-4c16-adf5-73e0ae99c88d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated PDF attachment color for improved visual consistency.
  * Refined spacing, padding, and layout of attachment buttons, file-type badges, and attachment chips.
  * Switched attachment toolbar control to a standardized attach-file button.

* **Bug Fixes / Behavior**
  * Partner-count grouping no longer provides platform or subscriber-group facets; only status and country groupings remain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->