### PR TITLE
run prisma:generate before starting concurrent build processes

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "license": "AGPL-3.0-or-later",
   "scripts": {
-    "dev": "concurrently --kill-others \"pnpm prisma:generate && next dev --turbopack --port 8888\" \"pnpm prisma:generate && pnpm prisma:studio --browser none\"",
+    "dev": "pnpm prisma:generate && concurrently --kill-others \"next dev --turbopack --port 8888\" \"pnpm prisma:studio --browser none\"",
     "build": "pnpm prisma:generate && next build",
     "lint": "next lint",
     "start": "next start",


### PR DESCRIPTION
Fix issue with Prisma generated client failing complex queries

```
web:dev: [0] Invalid `prisma.$queryRaw()` invocation:
web:dev: [0]
web:dev: [0]
web:dev: [0] Raw query failed. Code: `1105`. Message: `unknown error: syntax error at position
```

## Pre-fix reproduction steps
How to reproduce the problem before this code change:

1. Go to partner network page (should be working if clean build / clean cache etc).  If not, stop server and manually run `pnpm --filter @dub/prisma generate`

If after this, you still can't get it working, clear your local caches:
```
# 1. Clear local generated Prisma clients
rm -rf node_modules/.prisma
rm -rf apps/web/node_modules/.prisma
rm -rf packages/prisma/node_modules/.prisma

# 2. Clear Next/Turbopack compiled cache
rm -rf apps/web/.next

# 3. Regenerate Prisma from this repo's schema
pnpm --filter @dub/prisma generate
```

2. Start server, go to partner network page, you should get results
3. Switch branch
4. Refresh page, you should see "failed to load partners" 
<img width="438" height="335" alt="image" src="https://github.com/user-attachments/assets/0c44f1b3-3e15-4b05-bb58-22478b4609cd" />

## Post-fix instructions
**With this fix**, if you start and stop server (`pnpm dev`) it will correctly generate ONE Prisma client with the latest schema before starting concurrent Next dev and Prisma Studio processes.  Previously, attempting to concurrently generate multiple prisma clients was problematic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized development environment setup by streamlining database initialization processes during local development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->