### PR TITLE
Update free trial users' limit

### DIFF
--- a/packages/utils/src/constants/pricing/trial-limits.ts
+++ b/packages/utils/src/constants/pricing/trial-limits.ts
@@ -11,7 +11,7 @@ export const TRIAL_LIMITS = {
   groups: 5,
   networkInvites: 0,
   partners: 50,
-  users: 5,
+  users: 3,
   ai: 100,
   api: 120,
   analyticsApi: 2,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the trial user limit from 5 to 3 users. Trial accounts will now be restricted to a maximum of 3 users per workspace during the trial period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->