### PR TITLE
Fix duplicate cancellation feedback emails

### DIFF
--- a/apps/web/app/(ee)/api/stripe/webhook/customer-subscription-deleted.ts
+++ b/apps/web/app/(ee)/api/stripe/webhook/customer-subscription-deleted.ts
@@ -15,7 +15,10 @@ import AdvancedPlanDowngradeNotice from "@dub/email/templates/advanced-plan-down
 import { prisma } from "@dub/prisma";
 import { capitalize, FREE_PLAN, log } from "@dub/utils";
 import Stripe from "stripe";
-import { sendCancellationFeedback } from "./utils/send-cancellation-feedback";
+import {
+  CANCELLATION_FEEDBACK_EMAIL_TYPE,
+  sendCancellationFeedback,
+} from "./utils/send-cancellation-feedback";
 import { updateWorkspacePlan } from "./utils/update-workspace-plan";
 
 export async function customerSubscriptionDeleted(
@@ -175,6 +178,7 @@ export async function customerSubscriptionDeleted(
       }),
 
     sendCancellationFeedback({
+      workspace,
       owners: workspaceUsers,
     }),
 
@@ -202,6 +206,14 @@ export async function customerSubscriptionDeleted(
       hashedKeys: workspace.restrictedTokens.map(({ hashedKey }) => hashedKey),
     }),
   ]);
+
+  // Reset cancellation feedback dedupe so a future resubscribe + cancel can send again
+  await prisma.sentEmail.deleteMany({
+    where: {
+      projectId: workspace.id,
+      type: CANCELLATION_FEEDBACK_EMAIL_TYPE,
+    },
+  });
 
   // Update the webhooks cache
   const webhooks = await prisma.webhook.findMany({

--- a/apps/web/app/(ee)/api/stripe/webhook/customer-subscription-updated.ts
+++ b/apps/web/app/(ee)/api/stripe/webhook/customer-subscription-updated.ts
@@ -107,6 +107,7 @@ export async function customerSubscriptionUpdated(
     const cancelReason = updatedSubscription.cancellation_details?.feedback;
 
     await sendCancellationFeedback({
+      workspace,
       owners,
       reason: cancelReason,
     });

--- a/apps/web/app/(ee)/api/stripe/webhook/utils/send-cancellation-feedback.ts
+++ b/apps/web/app/(ee)/api/stripe/webhook/utils/send-cancellation-feedback.ts
@@ -1,6 +1,9 @@
 import { isBlacklistedEmail } from "@/lib/edge-config";
 import { sendEmail } from "@dub/email";
+import { prisma } from "@dub/prisma";
 import Stripe from "stripe";
+
+export const CANCELLATION_FEEDBACK_EMAIL_TYPE = "cancellationFeedbackEmail";
 
 const cancellationReasonMap = {
   customer_service: "you had a bad experience with our customer service",
@@ -13,15 +16,33 @@ const cancellationReasonMap = {
 };
 
 export async function sendCancellationFeedback({
+  workspace,
   owners,
   reason,
 }: {
+  workspace: {
+    id: string;
+  };
   owners: {
     name: string | null;
     email: string | null;
   }[];
   reason?: Stripe.Subscription.CancellationDetails.Feedback | null;
 }) {
+  const alreadySent = await prisma.sentEmail.findFirst({
+    where: {
+      projectId: workspace.id,
+      type: CANCELLATION_FEEDBACK_EMAIL_TYPE,
+    },
+  });
+
+  if (alreadySent) {
+    console.log(
+      `Cancellation feedback email already sent for workspace ${workspace.id}, skipping...`,
+    );
+    return;
+  }
+
   const isBlacklistedCancellation = await isBlacklistedEmail(
     owners.filter(({ email }) => email).map(({ email }) => email!),
   );
@@ -30,6 +51,13 @@ export async function sendCancellationFeedback({
     console.log("Blacklisted cancellation, skipping feedback email...");
     return;
   }
+
+  await prisma.sentEmail.create({
+    data: {
+      projectId: workspace.id,
+      type: CANCELLATION_FEEDBACK_EMAIL_TYPE,
+    },
+  });
 
   const reasonText = reason ? cancellationReasonMap[reason] : "";
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate cancellation-feedback emails by ensuring feedback is sent idempotently per workspace.
  * Deleting a subscription now clears prior feedback records so follow-up notifications won't resend.
  * Subscription updates now correctly associate workspace context to avoid sending duplicate cancellation notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->