### PR TITLE
Discount code empty state

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/[partnerId]/links/page.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/[partnerId]/links/page.tsx
@@ -17,6 +17,7 @@ import { useAddDiscountCodeModal } from "@/ui/modals/add-discount-code-modal";
 import { useAddPartnerLinkModal } from "@/ui/modals/add-partner-link-modal";
 import { DeleteDiscountCodeModal } from "@/ui/modals/delete-discount-code-modal";
 import { DiscountCodeBadge } from "@/ui/partners/discounts/discount-code-badge";
+import { ButtonLink } from "@/ui/placeholders/button-link";
 import { DiscountProvider } from "@dub/prisma/client";
 import {
   Button,
@@ -295,6 +296,9 @@ const PartnerDiscountCodes = ({
   partner: EnrolledPartnerExtendedProps;
 }) => {
   const { slug, stripeConnectId, shopifyStoreId } = useWorkspace();
+  const { group } = useGroup({
+    groupIdOrSlug: partner.groupId ?? undefined,
+  });
 
   const [selectedDiscountCode, setSelectedDiscountCode] =
     useState<DiscountCodeProps | null>(null);
@@ -416,6 +420,33 @@ const PartnerDiscountCodes = ({
     shopifyStoreId,
   ]);
 
+  const groupDiscount = group?.discount ?? partner.discount;
+
+  const discountCodeEmptyState = groupDiscount
+    ? {
+        description:
+          "Referral links apply your discount, and checkout codes are optional",
+        buttonText: "Learn more",
+        buttonHref: "https://dub.co/help/article/dual-sided-incentives",
+        buttonVariant: "outline" as const,
+        buttonClassName:
+          "border-transparent bg-neutral-200/60 hover:bg-neutral-200",
+        target: "_blank" as const,
+        rel: "noopener noreferrer",
+      }
+    : {
+        description:
+          "A customer discount is required before creating a discount code",
+        buttonText: "Group discounts",
+        buttonHref: group?.slug
+          ? `/${slug}/program/groups/${group.slug}/discounts`
+          : undefined,
+        buttonVariant: "secondary" as const,
+        buttonClassName: undefined,
+        target: undefined,
+        rel: undefined,
+      };
+
   return (
     <>
       <div className="flex items-end justify-between gap-4">
@@ -438,13 +469,29 @@ const PartnerDiscountCodes = ({
         </div>
       ) : !error && (!discountCodes || discountCodes.length === 0) ? (
         <div className="flex flex-col items-center justify-center gap-2 rounded-lg border border-neutral-200 bg-neutral-50 py-6">
-          <Tag className="mb-2 size-6 text-neutral-900" />
-          <h3 className="text-content-emphasis text-sm font-semibold leading-5">
-            No codes created
-          </h3>
-          <p className="text-content-default -mt-1 text-sm font-medium leading-5">
-            Create a discount code for each link
-          </p>
+          <div className="flex max-w-[300px] flex-col items-center gap-2 text-center">
+            <Tag className="mb-2 size-6 text-neutral-900" />
+            <h3 className="text-content-emphasis text-sm font-semibold leading-5">
+              No codes created
+            </h3>
+            <p className="text-content-default -mt-1 text-sm font-medium leading-5">
+              {discountCodeEmptyState.description}
+            </p>
+            {discountCodeEmptyState.buttonHref && (
+              <ButtonLink
+                href={discountCodeEmptyState.buttonHref}
+                target={discountCodeEmptyState.target}
+                rel={discountCodeEmptyState.rel}
+                variant={discountCodeEmptyState.buttonVariant}
+                className={cn(
+                  "mt-2 h-7 rounded-md px-3 text-sm font-medium",
+                  discountCodeEmptyState.buttonClassName,
+                )}
+              >
+                {discountCodeEmptyState.buttonText}
+              </ButtonLink>
+            )}
+          </div>
         </div>
       ) : error ? (
         <div className="flex justify-center py-16">

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/[partnerId]/links/page.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/[partnerId]/links/page.tsx
@@ -440,7 +440,7 @@ const PartnerDiscountCodes = ({
         buttonText: "Group discounts",
         buttonHref: group?.slug
           ? `/${slug}/program/groups/${group.slug}/discounts`
-          : undefined,
+          : `/${slug}/program/groups`,
         buttonVariant: "secondary" as const,
         buttonClassName: undefined,
         target: undefined,


### PR DESCRIPTION
Update the discount code empty state to provide more helpful context. 
- When the group has a reward, inform the user that the referral link still applies the discount. 
- When the group doesn't have a reward, it informs them to create one beforehand. 

Each provides a link to the group's discount code section or to learn more through the help docs.

https://github.com/user-attachments/assets/5caa3df4-0ed2-441a-aeab-93427a808c4a



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced empty state for partner discount codes with contextual guidance based on discount availability.
  * If a discount exists, message explains referral links apply the discount and shows a "Learn more" action to help docs.
  * If no discount exists, prompt to configure group/customer discounts and provide a direct action to the group discounts page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->