### PR TITLE
Changed message attachment error toast

### DIFF
--- a/apps/web/ui/shared/message-input.tsx
+++ b/apps/web/ui/shared/message-input.tsx
@@ -130,6 +130,22 @@ export function MessageInput({
       if (!onAddFiles) return;
 
       const fileArray = Array.from(files);
+      const allowedFileTypeSet = allowedFileTypes
+        ? new Set(allowedFileTypes)
+        : null;
+      const supportedFiles = allowedFileTypeSet
+        ? fileArray.filter((file) => allowedFileTypeSet.has(file.type))
+        : fileArray;
+      const unsupportedFiles = allowedFileTypeSet
+        ? fileArray.filter((file) => !allowedFileTypeSet.has(file.type))
+        : [];
+
+      if (unsupportedFiles.length > 0 && allowedFileTypes) {
+        toast.error(getUnsupportedFileTypeMessage(allowedFileTypes));
+      }
+
+      if (supportedFiles.length === 0) return;
+
       const remaining = maxAttachments - attachments.length;
 
       if (remaining <= 0) {
@@ -137,14 +153,14 @@ export function MessageInput({
         return;
       }
 
-      const filesToAdd = fileArray.slice(0, remaining);
-      if (fileArray.length > remaining) {
+      const filesToAdd = supportedFiles.slice(0, remaining);
+      if (supportedFiles.length > remaining) {
         toast.error(`Maximum ${maxAttachments} attachments per message`);
       }
 
       onAddFiles(filesToAdd);
     },
-    [onAddFiles, attachments.length, maxAttachments],
+    [onAddFiles, attachments.length, maxAttachments, allowedFileTypes],
   );
 
   const handleDragEvent = useCallback((e: DragEvent) => {
@@ -346,6 +362,25 @@ export function MessageInput({
       )}
     </div>
   );
+}
+
+function getUnsupportedFileTypeMessage(allowedFileTypes: readonly string[]) {
+  const allowedLabels = formatList(
+    allowedFileTypes.map((type) => getAttachmentTypeLabel(type)),
+  );
+
+  return `File type not supported. Upload a ${allowedLabels}.`;
+}
+
+function formatList(items: string[]) {
+  const uniqueItems = Array.from(new Set(items));
+
+  if (uniqueItems.length <= 1) return uniqueItems[0] || "supported";
+  if (uniqueItems.length === 2) return uniqueItems.join(" or ");
+
+  return `${uniqueItems.slice(0, -1).join(", ")}, or ${
+    uniqueItems[uniqueItems.length - 1]
+  }`;
 }
 
 function AttachmentChip({

--- a/apps/web/ui/shared/message-input.tsx
+++ b/apps/web/ui/shared/message-input.tsx
@@ -365,6 +365,10 @@ export function MessageInput({
 }
 
 function getUnsupportedFileTypeMessage(allowedFileTypes: readonly string[]) {
+  if (allowedFileTypes.length === 0) {
+    return "File type not supported.";
+  }
+
   const allowedLabels = formatList(
     allowedFileTypes.map((type) => getAttachmentTypeLabel(type)),
   );
@@ -375,7 +379,7 @@ function getUnsupportedFileTypeMessage(allowedFileTypes: readonly string[]) {
 function formatList(items: string[]) {
   const uniqueItems = Array.from(new Set(items));
 
-  if (uniqueItems.length <= 1) return uniqueItems[0] || "supported";
+  if (uniqueItems.length <= 1) return uniqueItems[0] || "";
   if (uniqueItems.length === 2) return uniqueItems.join(" or ");
 
   return `${uniqueItems.slice(0, -1).join(", ")}, or ${


### PR DESCRIPTION
- Add client-side validation for unsupported message attachment file types before upload
- Replace raw Zod validation errors with a clear toast: File type not supported. Upload a PNG, JPG, WEBP, or PDF.
- Apply the attachment limit only after filtering unsupported files, so valid files are not skipped when mixed with invalid ones

### After
<img width="806" height="180" alt="CleanShot 2026-06-11 at 16 34 55@2x" src="https://github.com/user-attachments/assets/c5c658b9-d2e3-410d-800d-9f0c378f403e" />

### Before
<img width="729" height="230" alt="CleanShot 2026-06-11 at 16 40 34@2x" src="https://github.com/user-attachments/assets/74fd5808-ecdb-4c99-ac16-38fcc3bcd67f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file attachment validation to reject unsupported formats and show a clear error toast listing allowed types.
  * Enforced attachment limits: only supported files are added and users are notified when the maximum number of attachments would be exceeded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->