### PR TITLE
No categories placeholder on network partner cards

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/network/network-partner-card.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/network/network-partner-card.tsx
@@ -490,7 +490,6 @@ function ListRow({
       setIsReady(false);
   }, [entry]);
 
-  if (items && items.length === 0) return null;
   return (
     <div
       ref={containerRef}
@@ -532,7 +531,7 @@ function ListRow({
           ) : (
             <div className="flex h-7 w-fit items-center rounded-full border border-dashed border-neutral-300 bg-neutral-50 px-2">
               <span className="text-content-subtle text-xs opacity-60">
-                Not specified
+                No categories
               </span>
             </div>
           )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a rendering issue where empty lists would not display the fallback UI correctly.
  * Updated the empty state message to "No categories" for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->