### PR TITLE
Show customer in new sale alert email

### DIFF
--- a/apps/web/lib/api/partners/notify-partner-commission.ts
+++ b/apps/web/lib/api/partners/notify-partner-commission.ts
@@ -8,6 +8,7 @@ import NewSaleAlertProgramOwner from "@dub/email/templates/new-sale-alert-progra
 import { prisma } from "@dub/prisma";
 import {
   Commission,
+  Customer,
   PartnerGroup,
   Program,
   Project,
@@ -28,8 +29,8 @@ export async function notifyPartnerCommission({
   workspace: Pick<Project, "id" | "slug" | "name">;
   commission: Pick<
     Commission,
-    "type" | "amount" | "earnings" | "partnerId" | "linkId"
-  >;
+    "type" | "amount" | "earnings" | "partnerId" | "linkId" | "customerId"
+  > & { customer?: Pick<Customer, "name" | "email"> | null };
   isFirstCommission?: boolean;
 }) {
   // Workspace owner emails are sent:
@@ -104,6 +105,24 @@ export async function notifyPartnerCommission({
     return;
   }
 
+  const customer =
+    shouldNotifyProgram && commission.customer
+      ? {
+          name: commission.customer.name,
+          email: commission.customer.email,
+        }
+      : shouldNotifyProgram && commission.customerId
+        ? await prisma.customer.findUnique({
+            where: {
+              id: commission.customerId,
+            },
+            select: {
+              name: true,
+              email: true,
+            },
+          })
+        : null;
+
   const data = {
     program: {
       name: program.name,
@@ -161,6 +180,7 @@ export async function notifyPartnerCommission({
                   email: user.email!,
                 },
                 workspace,
+                customer,
               }),
             }) as ResendEmailOptions,
         )

--- a/apps/web/lib/api/partners/notify-partner-commission.ts
+++ b/apps/web/lib/api/partners/notify-partner-commission.ts
@@ -30,7 +30,7 @@ export async function notifyPartnerCommission({
   commission: Pick<
     Commission,
     "type" | "amount" | "earnings" | "partnerId" | "linkId" | "customerId"
-  > & { customer?: Pick<Customer, "name" | "email"> | null };
+  > & { customer?: Pick<Customer, "id" | "name" | "email"> | null };
   isFirstCommission?: boolean;
 }) {
   // Workspace owner emails are sent:
@@ -105,24 +105,6 @@ export async function notifyPartnerCommission({
     return;
   }
 
-  const customer =
-    shouldNotifyProgram && commission.customer
-      ? {
-          name: commission.customer.name,
-          email: commission.customer.email,
-        }
-      : shouldNotifyProgram && commission.customerId
-        ? await prisma.customer.findUnique({
-            where: {
-              id: commission.customerId,
-            },
-            select: {
-              name: true,
-              email: true,
-            },
-          })
-        : null;
-
   const data = {
     program: {
       name: program.name,
@@ -180,7 +162,7 @@ export async function notifyPartnerCommission({
                   email: user.email!,
                 },
                 workspace,
-                customer,
+                customer: commission.customer,
               }),
             }) as ResendEmailOptions,
         )

--- a/apps/web/ui/partners/groups/design/lander/lander-ai-banner.tsx
+++ b/apps/web/ui/partners/groups/design/lander/lander-ai-banner.tsx
@@ -1,4 +1,4 @@
-import { generateLanderAction } from "@/lib/actions/partners/generate-lander";
+import { generateLanderAction } from "@/lib/ai/generate-lander";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { programLanderSimpleSchema } from "@/lib/zod/schemas/program-lander";
 import { X } from "@/ui/shared/icons";

--- a/apps/web/ui/partners/groups/design/lander/lander-preview-controls.tsx
+++ b/apps/web/ui/partners/groups/design/lander/lander-preview-controls.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { generateLanderAction } from "@/lib/actions/partners/generate-lander";
+import { generateLanderAction } from "@/lib/ai/generate-lander";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { programLanderSchema } from "@/lib/zod/schemas/program-lander";
 import { Button, LoadingSpinner, Sparkle3 } from "@dub/ui";

--- a/packages/email/src/templates/new-sale-alert-program-owner.tsx
+++ b/packages/email/src/templates/new-sale-alert-program-owner.tsx
@@ -1,4 +1,4 @@
-import { capitalize, currencyFormatter, DUB_WORDMARK } from "@dub/utils";
+import { currencyFormatter, DUB_WORDMARK } from "@dub/utils";
 import {
   Body,
   Column,
@@ -38,6 +38,7 @@ export default function NewSaleAlertProgramOwner({
     email: "steven@dub.co",
   },
   customer = {
+    id: "cus_1234567890",
     name: "Jane Smith",
     email: "jane@example.com",
   },
@@ -67,6 +68,7 @@ export default function NewSaleAlertProgramOwner({
     email: string | null;
   };
   customer?: {
+    id: string;
     name?: string | null;
     email?: string | null;
   } | null;
@@ -86,8 +88,6 @@ export default function NewSaleAlertProgramOwner({
     commission.amount - commission.earnings,
   );
 
-  const customerLabel = customer?.email ?? customer?.name ?? null;
-
   let formattedDueDate = "";
 
   if (group.holdingPeriodDays > 0) {
@@ -101,9 +101,7 @@ export default function NewSaleAlertProgramOwner({
     });
   }
 
-  const finalName = user.name
-    ? user.name.split(" ")[0]
-    : capitalize(user.email.split("@")[0]);
+  const customerLabel = customer?.name || customer?.email;
 
   return (
     <Html>
@@ -127,37 +125,39 @@ export default function NewSaleAlertProgramOwner({
             </Heading>
 
             <Text className="text-sm leading-6 text-neutral-600">
-              <strong>{program.name}</strong> earned a sale from a new customer
-              referred by{" "}
-              <strong>
+              <strong className="font-medium text-black">{program.name}</strong>{" "}
+              earned a sale from a new customer referred by{" "}
+              <Link
+                href={`https://app.dub.co/${workspace.slug}/program/partners/${partner.id}`}
+                className="font-medium text-black underline"
+              >
                 {partner.name
                   ? `${partner.name} (${partner.email})`
                   : partner.email}
-              </strong>
-              .
+              </Link>
+              :
             </Text>
 
             <Section className="my-8 w-full">
               <div className="rounded-lg">
-                {customerLabel && (
-                  <Row>
-                    <Column>
-                      <Text className="m-0 text-sm leading-6 text-neutral-600">
-                        Customer
-                      </Text>
-                    </Column>
-                    <Column align="right">
-                      <Text className="m-0 text-sm font-medium leading-6 text-neutral-600">
-                        {customerLabel}
-                      </Text>
-                    </Column>
-                  </Row>
-                )}
-
                 <Row>
                   <Column>
                     <Text className="m-0 text-sm leading-6 text-neutral-600">
-                      Sale amount
+                      {customerLabel ? (
+                        <>
+                          Payment from{" "}
+                          <Link
+                            href={`https://app.dub.co/${workspace.slug}/program/customers/${customer.id}`}
+                            className="font-medium text-black underline"
+                          >
+                            <strong className="font-medium text-black">
+                              {customerLabel}
+                            </strong>
+                          </Link>
+                        </>
+                      ) : (
+                        "Sale amount"
+                      )}
                     </Text>
                   </Column>
                   <Column align="right">
@@ -200,7 +200,10 @@ export default function NewSaleAlertProgramOwner({
             {formattedDueDate && (
               <Text className="text-sm leading-6 text-neutral-600">
                 Payment for this commission will be due on{" "}
-                <strong>{formattedDueDate}</strong>, as per this partner group's{" "}
+                <strong className="font-medium text-black">
+                  {formattedDueDate}
+                </strong>
+                , as per this partner group's{" "}
                 <Link
                   href="https://dub.co/help/article/partner-payouts#payout-holding-period"
                   className="font-semibold text-black underline"

--- a/packages/email/src/templates/new-sale-alert-program-owner.tsx
+++ b/packages/email/src/templates/new-sale-alert-program-owner.tsx
@@ -37,6 +37,10 @@ export default function NewSaleAlertProgramOwner({
     name: "Steven",
     email: "steven@dub.co",
   },
+  customer = {
+    name: "Jane Smith",
+    email: "jane@example.com",
+  },
   commission = {
     amount: 1330,
     earnings: 399,
@@ -62,6 +66,10 @@ export default function NewSaleAlertProgramOwner({
     name: string | null;
     email: string | null;
   };
+  customer?: {
+    name?: string | null;
+    email?: string | null;
+  } | null;
   commission: {
     amount: number;
     earnings: number;
@@ -77,6 +85,12 @@ export default function NewSaleAlertProgramOwner({
   const profitInDollars = currencyFormatter(
     commission.amount - commission.earnings,
   );
+
+  const customerLabel = customer
+    ? customer.name && customer.email
+      ? `${customer.name} (${customer.email})`
+      : customer.email ?? customer.name
+    : null;
 
   let formattedDueDate = "";
 
@@ -129,6 +143,21 @@ export default function NewSaleAlertProgramOwner({
 
             <Section className="my-8 w-full">
               <div className="rounded-lg">
+                {customerLabel && (
+                  <Row>
+                    <Column>
+                      <Text className="m-0 text-sm leading-6 text-neutral-600">
+                        Customer
+                      </Text>
+                    </Column>
+                    <Column align="right">
+                      <Text className="m-0 text-sm font-medium leading-6 text-neutral-600">
+                        {customerLabel}
+                      </Text>
+                    </Column>
+                  </Row>
+                )}
+
                 <Row>
                   <Column>
                     <Text className="m-0 text-sm leading-6 text-neutral-600">

--- a/packages/email/src/templates/new-sale-alert-program-owner.tsx
+++ b/packages/email/src/templates/new-sale-alert-program-owner.tsx
@@ -86,11 +86,7 @@ export default function NewSaleAlertProgramOwner({
     commission.amount - commission.earnings,
   );
 
-  const customerLabel = customer
-    ? customer.name && customer.email
-      ? `${customer.name} (${customer.email})`
-      : customer.email ?? customer.name
-    : null;
+  const customerLabel = customer?.email ?? customer?.name ?? null;
 
   let formattedDueDate = "";
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Partner commission sale alerts can now include optional customer context (id, name and/or email), improving clarity for program owners.
  * The program owner email now conditionally renders a “Payment from” customer link when customer details are present; otherwise it shows a “Sale amount” fallback.
  * Email due-date wording/formatting is updated for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->