### PR TITLE
Use Dub workspace stripeId for Acme domain renewals

### DIFF
--- a/apps/web/app/(ee)/api/cron/domains/renewal-payments/route.ts
+++ b/apps/web/app/(ee)/api/cron/domains/renewal-payments/route.ts
@@ -133,16 +133,19 @@ export async function GET(req: Request) {
 
       // If Acme workspace, use Dub workspace stripeId
       if (workspace.id === ACME_WORKSPACE_ID) {
-        workspace = await prisma.project.findUniqueOrThrow({
+        const dubWorkspace = await prisma.project.findUniqueOrThrow({
           where: {
             id: DUB_WORKSPACE_ID,
           },
           select: {
-            id: true,
             stripeId: true,
-            invoicePrefix: true,
           },
         });
+
+        workspace = {
+          ...workspace,
+          stripeId: dubWorkspace.stripeId,
+        };
 
         console.log(
           `Using Dub workspace stripeId for Acme workspace domains...`,

--- a/apps/web/app/(ee)/api/cron/domains/renewal-payments/route.ts
+++ b/apps/web/app/(ee)/api/cron/domains/renewal-payments/route.ts
@@ -4,7 +4,7 @@ import { verifyVercelSignature } from "@/lib/cron/verify-vercel";
 import { createPaymentIntent } from "@/lib/stripe/create-payment-intent";
 import { prisma } from "@dub/prisma";
 import { Invoice, Project, RegisteredDomain } from "@dub/prisma/client";
-import { log } from "@dub/utils";
+import { ACME_WORKSPACE_ID, DUB_WORKSPACE_ID, log } from "@dub/utils";
 import { addDays, endOfDay, startOfDay } from "date-fns";
 import { NextResponse } from "next/server";
 
@@ -129,7 +129,25 @@ export async function GET(req: Request) {
 
     // Create payment intent for each invoice
     for (const invoice of invoices) {
-      const { workspace } = groupedByWorkspace[invoice.workspaceId];
+      let { workspace } = groupedByWorkspace[invoice.workspaceId];
+
+      // If Acme workspace, use Dub workspace stripeId
+      if (workspace.id === ACME_WORKSPACE_ID) {
+        workspace = await prisma.project.findUniqueOrThrow({
+          where: {
+            id: DUB_WORKSPACE_ID,
+          },
+          select: {
+            id: true,
+            stripeId: true,
+            invoicePrefix: true,
+          },
+        });
+
+        console.log(
+          `Using Dub workspace stripeId for Acme workspace domains...`,
+        );
+      }
 
       if (!workspace.stripeId) {
         console.log(`Workspace ${workspace.id} has no stripeId, skipping...`);
@@ -137,7 +155,7 @@ export async function GET(req: Request) {
       }
 
       const res = await createPaymentIntent({
-        stripeId: workspace.stripeId!,
+        stripeId: workspace.stripeId,
         amount: invoice.total,
         invoiceId: invoice.id,
         statementDescriptor: "DUB.CO DOMAIN RENEWAL",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved domain renewal payment processing to use the correct workspace-specific Stripe identifier when creating payment intents.
  * Added additional runtime safeguards to skip invoice processing when the resolved Stripe identifier is missing, reducing avoidable payment failures and retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->