### PR TITLE
Standardize partner invite checks and enhance AI personalization

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/invite-network-partner-sheet.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/invite-network-partner-sheet.tsx
@@ -4,18 +4,22 @@ import { getProgramNetworkInviteEmailDefaults } from "@/lib/network/get-program-
 import useProgram from "@/lib/swr/use-program";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { NetworkPartnerProps } from "@/lib/types";
+import { GroupSelector } from "@/ui/partners/groups/group-selector";
 import { PartnerAvatar } from "@/ui/partners/partner-avatar";
-import { Sheet } from "@dub/ui";
+import { TrustedPartnerBadge } from "@/ui/partners/trusted-partner-badge";
+import { AnimatedSizeContainer, Sheet } from "@dub/ui";
+import { Globe } from "@dub/ui/icons";
+import { COUNTRIES, cn } from "@dub/utils";
+import { ChevronDown } from "lucide-react";
 import { useAction } from "next-safe-action/hooks";
 import { Dispatch, SetStateAction, useMemo, useState } from "react";
-import { useForm } from "react-hook-form";
+import { UseFormRegisterReturn, useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { EmailContent, InviteEmailPreview } from "./invite-email-preview";
 import {
-  GroupField,
   InviteSheetFooter,
   InviteSheetHeader,
-  ShortLinkField,
+  ShortLinkInput,
 } from "./invite-sheet-ui";
 
 interface InviteNetworkPartnerSheetProps {
@@ -181,37 +185,17 @@ function InviteNetworkPartnerSheetContent({
 
       <div className="flex-1 overflow-y-auto">
         <div className="p-6">
-          <div className="grid grid-cols-1 gap-6">
-            <div className="flex items-center gap-3 rounded-xl border border-neutral-200 bg-neutral-50 p-4">
-              <PartnerAvatar partner={partner} className="size-10 shrink-0" />
-              <div className="min-w-0">
-                <p className="truncate text-sm font-semibold text-neutral-900">
-                  {partner.name}
-                </p>
-                {partner.companyName && (
-                  <p className="truncate text-xs text-neutral-500">
-                    {partner.companyName}
-                  </p>
-                )}
-              </div>
-            </div>
-
-            <div>
-              <GroupField
-                selectedGroupId={watch("groupId")}
-                setSelectedGroupId={(groupId) => {
-                  setValue("groupId", groupId, {
-                    shouldDirty: true,
-                  });
-                }}
-              />
-            </div>
-
-            <ShortLinkField
-              domain={program?.domain ?? undefined}
-              registration={register("username")}
-            />
-          </div>
+          <NetworkPartnerInviteDetails
+            partner={partner}
+            domain={program?.domain ?? undefined}
+            selectedGroupId={watch("groupId") ?? null}
+            setSelectedGroupId={(groupId) => {
+              setValue("groupId", groupId, {
+                shouldDirty: true,
+              });
+            }}
+            usernameRegistration={register("username")}
+          />
 
           <InviteEmailPreview
             emailContent={emailContent || defaultEmailContent}
@@ -241,6 +225,120 @@ function InviteNetworkPartnerSheetContent({
         isSubmitDisabled={isEditingEmail || isGeneratingEmail}
       />
     </form>
+  );
+}
+
+function NetworkPartnerInviteDetails({
+  partner,
+  domain,
+  selectedGroupId,
+  setSelectedGroupId,
+  usernameRegistration,
+}: {
+  partner: NetworkPartnerProps;
+  domain?: string;
+  selectedGroupId: string | null;
+  setSelectedGroupId: (groupId: string) => void;
+  usernameRegistration: UseFormRegisterReturn;
+}) {
+  const [showLinkSettings, setShowLinkSettings] = useState(false);
+  const countryLabel = partner.country
+    ? COUNTRIES[partner.country] ?? partner.country
+    : "Planet Earth";
+
+  return (
+    <div className="mb-6 space-y-3">
+      <div className="overflow-hidden rounded-xl border border-neutral-200 bg-white">
+        <div className="bg-neutral-50 p-4">
+          <div className="flex items-center gap-4">
+            <div className="relative w-fit shrink-0">
+              <PartnerAvatar
+                partner={partner}
+                className="size-12 border border-neutral-100"
+              />
+              {partner.networkStatus === "trusted" && (
+                <TrustedPartnerBadge size="large" />
+              )}
+            </div>
+            <div className="min-w-0">
+              <p className="truncate text-sm font-semibold text-neutral-900">
+                {partner.name}
+              </p>
+              {partner.companyName && (
+                <p className="truncate text-xs text-neutral-500">
+                  {partner.companyName}
+                </p>
+              )}
+              <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs font-medium text-neutral-500">
+                <div className="flex min-w-0 items-center gap-1.5">
+                  {partner.country ? (
+                    <img
+                      alt={`Flag of ${countryLabel}`}
+                      src={`https://flag.vercel.app/m/${partner.country}.svg`}
+                      className="size-3.5 shrink-0 rounded-full"
+                    />
+                  ) : (
+                    <Globe className="size-3.5 shrink-0" />
+                  )}
+                  <span className="truncate">{countryLabel}</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="grid gap-2 border-t border-neutral-200 p-4 sm:grid-cols-[120px_minmax(0,1fr)] sm:items-center">
+          <label className="text-sm font-medium text-neutral-900">Group</label>
+          <GroupSelector
+            selectedGroupId={selectedGroupId}
+            setSelectedGroupId={setSelectedGroupId}
+            buttonProps={{
+              className: cn(
+                "h-9 w-full justify-start border-neutral-300 px-3 transition-none",
+                "data-[state=open]:border-neutral-500 data-[state=open]:ring-1 data-[state=open]:ring-neutral-500",
+                "focus:border-neutral-500 focus:ring-1 focus:ring-neutral-500",
+              ),
+            }}
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-col px-3">
+        <button
+          type="button"
+          className="flex w-fit items-center gap-2 text-sm text-neutral-600 transition-colors hover:text-neutral-900"
+          aria-expanded={showLinkSettings}
+          aria-label={`${showLinkSettings ? "Hide" : "Show"} short link settings`}
+          onClick={() => setShowLinkSettings((show) => !show)}
+        >
+          <span>
+            Short Link Settings{" "}
+            <span className="text-neutral-500">(optional)</span>
+          </span>
+          <ChevronDown
+            className={cn(
+              "size-4 shrink-0 transition-transform duration-75",
+              showLinkSettings && "rotate-180",
+            )}
+          />
+        </button>
+
+        <AnimatedSizeContainer height className="flex flex-col">
+          {showLinkSettings && (
+            <div className="mt-3">
+              <label htmlFor="username" className="sr-only">
+                Custom short link slug
+              </label>
+              <ShortLinkInput
+                domain={domain}
+                registration={usernameRegistration}
+                placeholder="custom-slug"
+              />
+            </div>
+          )}
+        </AnimatedSizeContainer>
+      </div>
+    </div>
   );
 }
 

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/invite-sheet-ui.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/invite-sheet-ui.tsx
@@ -62,6 +62,34 @@ export function InviteSheetFooter({
   );
 }
 
+export function ShortLinkInput({
+  domain,
+  registration,
+  id = "username",
+  placeholder = "johndoe",
+}: {
+  domain?: string;
+  registration: UseFormRegisterReturn;
+  id?: string;
+  placeholder?: string;
+}) {
+  return (
+    <div className="flex">
+      <span className="inline-flex items-center rounded-l-md border border-r-0 border-neutral-300 bg-neutral-50 px-3 text-neutral-500 sm:text-sm">
+        {domain}
+      </span>
+      <input
+        {...registration}
+        type="text"
+        id={id}
+        className="block w-full rounded-r-md border-neutral-300 text-neutral-900 placeholder-neutral-400 focus:border-neutral-500 focus:outline-none focus:ring-neutral-500 sm:text-sm"
+        placeholder={placeholder}
+        autoComplete="off"
+      />
+    </div>
+  );
+}
+
 export function ShortLinkField({
   domain,
   registration,
@@ -80,18 +108,8 @@ export function ShortLinkField({
         </label>
       </div>
 
-      <div className="mt-2 flex">
-        <span className="inline-flex items-center rounded-l-md border border-r-0 border-neutral-300 bg-neutral-50 px-3 text-neutral-500 sm:text-sm">
-          {domain}
-        </span>
-        <input
-          {...registration}
-          type="text"
-          id="username"
-          className="block w-full rounded-r-md border-neutral-300 text-neutral-900 placeholder-neutral-400 focus:border-neutral-500 focus:outline-none focus:ring-neutral-500 sm:text-sm"
-          placeholder="johndoe"
-          autoComplete="off"
-        />
+      <div className="mt-2">
+        <ShortLinkInput domain={domain} registration={registration} />
       </div>
     </div>
   );

--- a/apps/web/lib/actions/partners/invite-partner-from-network.ts
+++ b/apps/web/lib/actions/partners/invite-partner-from-network.ts
@@ -54,6 +54,9 @@ export const invitePartnerFromNetworkAction = authActionClient
       prisma.partner.findFirst({
         where: {
           id: partnerId,
+          networkStatus: {
+            in: ["approved", "trusted"],
+          },
           programs: {
             none: {
               programId,
@@ -62,6 +65,10 @@ export const invitePartnerFromNetworkAction = authActionClient
         },
       }),
     ]);
+
+    if (!program.partnerNetworkEnabledAt) {
+      throw new Error("Partner network is not enabled for this program.");
+    }
 
     if (!partner || !partner.email)
       throw new Error("Partner not found or already enrolled in this program.");

--- a/apps/web/lib/ai/generate-partner-network-invite-email.ts
+++ b/apps/web/lib/ai/generate-partner-network-invite-email.ts
@@ -168,11 +168,12 @@ Come up with a specific subject line that is likely to make the recipient open t
 - Mention the selected platform by name, summarize the channel description/content space in plain language when available, and connect that audience back to the program's customers.
 - If the selected channel has no description, infer the content space from the partner description, industry interests, sales channels, platform type, and identifier. Do not say "channel description".
 - Pick the angle most relevant to the program's customer base. Avoid generic phrases like "resonates well with our customers" unless you make the connection specific.
-- Adapt the content to fit the program + partner, but keep the overall length the same.
-- If Program.partnerEarningsClaim is present and non-null, you should mention it once in the body, naturally and without changing the meaning.
+- Adapt the content to fit the program + partner.
+- If Program.partnerEarningsClaim is present and non-null, mention it once in the body naturally, without altering the claim.
 - If Program.partnerEarningsClaim is missing or null, do not mention earnings, payouts, top partners, or partner performance.
 - Never name specific partners, imply guaranteed future earnings, mention payouts, or invent amounts when using Program.partnerEarningsClaim.
 - 80 words maximum. Plain text only: no markdown, links, bold, or em dashes.
+- Reference statistics about the partner naturally. For example: Instead of saying "You have 273K subscribers", it's more natural to say "over 250K subscribers".
 - Only make claims supported by the program and partner data provided.
 - Do not mention rewards, discounts, or bounties; the template displays them below the body.
 - Do not imply the sender watched, read, or reviewed any specific content.
@@ -186,7 +187,7 @@ Subject: Acme + Jordan?
 
 Title: Jordan, we'd love to have you!
 
-Content:
+Content Example (note: add Program.partnerEarningsClaim when present, value-add, and natural):
 "Hey Jordan,
 
 I'm David with Acme. I came across your YouTube channel and liked how you make productivity and work systems feel practical. A lot of Acme users are trying to get better at the same kinds of workflows, so I thought there might be a good fit here.


### PR DESCRIPTION
1. refresh top of partner invite email sheet
<img width="418" height="313" alt="image" src="https://github.com/user-attachments/assets/fff60094-6ab6-4640-bbbd-9f07ab9e8d58" />

2. add inite-send gate to match new ai-personalization gate
4. enhance ai-personalization prompt

## Testing
Tested on local, confirmed shortlinks still work, confirmed AI personalization still functioning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved invite network partner sheet with partner avatar badge, country flag display, a redesigned group selector, and an optional, collapsible “Short Link Settings” section.

* **Bug Fixes**
  * Ensured invites from the partner network only use approved or trusted partners.
  * Added a runtime guard to stop partner-network invitations when the program isn’t enabled.

* **Refactor**
  * Moved partner invite details into a dedicated, reusable UI component.
  * Introduced a reusable short link input and updated the sheet to use it.
  * Refined partner invite email generation rules for clearer earnings claim handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->