### PR TITLE
fix: do not fail shortlink creation when the og:image is not publicly hosted

### DIFF
--- a/apps/web/app/api/links/metatags/utils.ts
+++ b/apps/web/app/api/links/metatags/utils.ts
@@ -1,5 +1,8 @@
 import { recordMetatags } from "@/lib/upstash";
-import { linkPreviewImageBase64PrefixRegex } from "@/lib/zod/schemas/images";
+import {
+  linkPreviewImageBase64PrefixRegex,
+  publicHostedImageSchema,
+} from "@/lib/zod/schemas/images";
 import { fetchWithTimeout, isValidUrl } from "@dub/utils";
 import { waitUntil } from "@vercel/functions";
 import he from "he";
@@ -75,10 +78,12 @@ export const getRelativeUrl = (url: string, imageUrl: string) => {
   } catch {
     return null;
   }
-  if (
-    /^https?:\/\//i.test(resolved) ||
-    linkPreviewImageBase64PrefixRegex.test(resolved)
-  ) {
+  if (linkPreviewImageBase64PrefixRegex.test(resolved)) {
+    return resolved;
+  }
+  // Apply the same image rule as link creation so a scraped preview can't block it:
+  // publicHostedImageSchema drops non-public hosts (localhost, IPs) that can't be proxied.
+  if (publicHostedImageSchema.safeParse(resolved).success) {
     return resolved;
   }
   return null;

--- a/apps/web/lib/zod/schemas/images.ts
+++ b/apps/web/lib/zod/schemas/images.ts
@@ -80,7 +80,10 @@ export const uploadedImageSchema = z
   .transform((v) => v || null);
 
 export const publicHostedImageSchema = z
-  .httpUrl({ error: "Image URL must start with http:// or https://" })
+  .httpUrl({
+    error:
+      "Image must be a publicly accessible http:// or https:// URL (localhost and IP addresses aren't allowed).",
+  })
   .trim();
 
 /** Coerce unusable preview strings (e.g. data:favicons) to null before create/update link validation. */

--- a/apps/web/tests/misc/metatags-relative-url.test.ts
+++ b/apps/web/tests/misc/metatags-relative-url.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { getRelativeUrl } from "../../app/api/links/metatags/utils";
+
+const PAGE = "https://example.com/blog/post";
+
+describe("getRelativeUrl (metatags image resolution)", () => {
+  it("keeps publicly-hosted absolute image URLs", () => {
+    expect(getRelativeUrl(PAGE, "https://cdn.example.com/og.jpg")).toBe(
+      "https://cdn.example.com/og.jpg",
+    );
+    expect(getRelativeUrl(PAGE, "http://images.example.com/og.png")).toBe(
+      "http://images.example.com/og.png",
+    );
+  });
+
+  it("resolves relative image URLs against the page origin", () => {
+    expect(getRelativeUrl(PAGE, "/og.jpg")).toBe("https://example.com/og.jpg");
+  });
+
+  it("keeps inline base64 images", () => {
+    const dataUrl =
+      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+    expect(getRelativeUrl(PAGE, dataUrl)).toBe(dataUrl);
+  });
+
+  // Regression: preview sites with a misconfigured Next.js metadataBase ship
+  // og:image as http://localhost:3000/...; the scraper must drop these since
+  // they can't be proxied and previously broke link creation.
+  it("drops images on localhost / loopback / private hosts", () => {
+    expect(
+      getRelativeUrl(PAGE, "http://localhost:3000/images/og.jpg"),
+    ).toBeNull();
+    expect(getRelativeUrl(PAGE, "http://127.0.0.1:3000/og.jpg")).toBeNull();
+    expect(getRelativeUrl(PAGE, "http://foo/og.jpg")).toBeNull();
+  });
+
+  it("returns null for empty or non-http(s) image values", () => {
+    expect(getRelativeUrl(PAGE, "")).toBeNull();
+    expect(getRelativeUrl(PAGE, "ftp://files.example.com/og.jpg")).toBeNull();
+  });
+});

--- a/apps/web/ui/links/link-builder/use-link-builder-submit.tsx
+++ b/apps/web/ui/links/link-builder/use-link-builder-submit.tsx
@@ -134,7 +134,12 @@ export function useLinkBuilderSubmit({
             }
             const message = error.message.toLowerCase();
 
-            if (message.includes("key"))
+            // Image errors contain the word "URL" but have no field of their own,
+            // so match "image" before the "url" branch below; otherwise they'd
+            // attach to the destination URL field instead of the form root.
+            if (message.includes("image"))
+              setError("root", { message: error.message });
+            else if (message.includes("key"))
               setError("key", { message: error.message });
             else if (message.includes("url"))
               setError("url", { message: error.message });


### PR DESCRIPTION
Currently, shortlink creation will fail if the `og:image` link provided is not publicly hosted.  It also provides an incorrect error message to the user.  

reproduction steps:
1) use a URL where the og:image is (incorrectly) providing a private image (example: `https://2427ba57-caa6-4e2f-cc6e-08decd85c78b.preview.dealjoy.dev/`)
2) attempt to create link, error message will appear

<img width="1534" height="784" alt="image" src="https://github.com/user-attachments/assets/a5635e48-2d2d-4b48-8cf9-ebb5c430b2e1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened metatag image URL handling to return null for invalid or non-proxyable hosts, and to reject unsafe URLs (including localhost and private/IP hosts).
  * Updated image URL validation messaging to clearly state only publicly accessible HTTP/HTTPS URLs are allowed.
  * Improved form error attribution so image-related failures surface as form-level errors.
* **Tests**
  * Added coverage for image URL resolution, data URL preservation, and rejection of unsupported schemes/hosts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->