### PR TITLE
Add per-customer label to sale spend limits and fix currency display

### DIFF
--- a/apps/web/ui/partners/format-reward-description.ts
+++ b/apps/web/ui/partners/format-reward-description.ts
@@ -55,7 +55,7 @@ export function formatRewardDescription(
   let description = parts.join(" ");
 
   if (spendLimitParts && reward.spendLimitInterval) {
-    description += `, with a ${spendLimitParts.amount} ${formatSpendLimitIntervalLabel(reward.spendLimitInterval)} limit`;
+    description += `, with a ${spendLimitParts.amount} ${formatSpendLimitIntervalLabel(reward.spendLimitInterval)} limit ${reward.event === "sale" ? "per customer" : ""}`;
   }
 
   return description;

--- a/apps/web/ui/partners/program-reward-description.tsx
+++ b/apps/web/ui/partners/program-reward-description.tsx
@@ -84,6 +84,7 @@ export function ProgramRewardDescription({
             ))}
 
           <ProgramRewardSpendLimit
+            event={reward.event}
             spendLimitAmount={reward.spendLimitAmount}
             spendLimitInterval={reward.spendLimitInterval}
           />

--- a/apps/web/ui/partners/program-reward-spend-limit.tsx
+++ b/apps/web/ui/partners/program-reward-spend-limit.tsx
@@ -1,6 +1,6 @@
 import { RewardProps } from "@/lib/types";
 import { currencyFormatter } from "@dub/utils";
-import { RewardSpendLimitInterval } from "@prisma/client";
+import { EventType, RewardSpendLimitInterval } from "@prisma/client";
 
 export function getSpendLimitDescriptionParts({
   spendLimitAmount,
@@ -22,9 +22,11 @@ export function getSpendLimitDescriptionParts({
 }
 
 export function ProgramRewardSpendLimit({
+  event,
   spendLimitAmount,
   spendLimitInterval,
 }: {
+  event: EventType;
   spendLimitAmount?: number | null;
   spendLimitInterval?: RewardSpendLimitInterval | null;
 }) {
@@ -37,7 +39,7 @@ export function ProgramRewardSpendLimit({
     return null;
   }
 
-  return ` up to ${parts.amount} ${parts.interval}`;
+  return ` up to ${parts.amount} ${parts.interval} ${event === "sale" ? "per customer" : ""}`;
 }
 
 export function buildCommissionDescription({

--- a/apps/web/ui/partners/rewards/add-edit-reward-sheet.tsx
+++ b/apps/web/ui/partners/rewards/add-edit-reward-sheet.tsx
@@ -37,7 +37,7 @@ import {
   useLocalStorage,
   useRouterStuff,
 } from "@dub/ui";
-import { capitalize, cn, pluralize } from "@dub/utils";
+import { capitalize, cn, currencyFormatter, pluralize } from "@dub/utils";
 import { EventType, RewardStructure } from "@prisma/client";
 import { motion } from "motion/react";
 import { useAction } from "next-safe-action/hooks";
@@ -572,7 +572,13 @@ function RewardSheetContent({
                                   text={
                                     spendLimitAmount != null &&
                                     !isNaN(spendLimitAmount)
-                                      ? `$${spendLimitAmount}`
+                                      ? currencyFormatter(
+                                          spendLimitAmount * 100,
+                                          {
+                                            trailingZeroDisplay:
+                                              "stripIfInteger",
+                                          },
+                                        )
                                       : "amount"
                                   }
                                   invalid={


### PR DESCRIPTION
<img width="1136" height="840" alt="CleanShot 2026-06-22 at 9  52 48@2x" src="https://github.com/user-attachments/assets/4d7d6d3f-fa59-4599-92e5-29065f1a95f0" />

<img width="1362" height="286" alt="CleanShot 2026-06-22 at 9  53 03@2x" src="https://github.com/user-attachments/assets/5dd0ea4f-386c-4e90-b5d3-764bd15e61b3" />

<img width="2578" height="526" alt="CleanShot 2026-06-22 at 9  53 15@2x" src="https://github.com/user-attachments/assets/c8cc9c3d-3f0c-4c28-aead-c6c861a99c2e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Spend-limit descriptions for sales-based rewards now explicitly state the limit is applied **“per customer.”**
  * Spend-limit amounts in the rewards add/edit experience now use consistent currency formatting (including handling of trailing zeros) for a cleaner, more accurate display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->