### PR TITLE
constructPartnerLink for {{PartnerLink}} in campaign emails

### DIFF
--- a/apps/web/app/(ee)/api/cron/campaigns/broadcast/route.ts
+++ b/apps/web/app/(ee)/api/cron/campaigns/broadcast/route.ts
@@ -4,6 +4,7 @@ import { handleAndReturnErrorResponse } from "@/lib/api/errors";
 import { renderCampaignEmailHTML } from "@/lib/api/workflows/render-campaign-email-html";
 import { qstash } from "@/lib/cron";
 import { verifyQstashSignature } from "@/lib/cron/verify-qstash";
+import { constructPartnerLink } from "@/lib/partners/construct-partner-link";
 import { prisma } from "@/lib/prisma";
 import { TiptapNode } from "@/lib/types";
 import { ACTIVE_ENROLLMENT_STATUSES } from "@/lib/zod/schemas/partners";
@@ -155,9 +156,12 @@ export async function POST(req: Request) {
       },
       select: {
         id: true,
+        partnerGroup: { select: { linkStructure: true } },
         links: {
           select: {
             shortLink: true,
+            key: true,
+            url: true,
           },
           orderBy: { id: "asc" },
         },
@@ -258,7 +262,10 @@ export async function POST(req: Request) {
                     PartnerName: partnerUser.partner.name,
                     PartnerEmail: partnerUser.partner.email,
                     PartnerLink:
-                      partnerUser.enrollment.links?.[0]?.shortLink ?? null,
+                      constructPartnerLink({
+                        group: partnerUser.enrollment.partnerGroup,
+                        link: partnerUser.enrollment.links?.[0],
+                      }) || null,
                   },
                 }),
               },

--- a/apps/web/app/(ee)/api/cron/campaigns/broadcast/route.ts
+++ b/apps/web/app/(ee)/api/cron/campaigns/broadcast/route.ts
@@ -156,14 +156,20 @@ export async function POST(req: Request) {
       },
       select: {
         id: true,
-        partnerGroup: { select: { linkStructure: true } },
+        partnerGroup: {
+          select: {
+            linkStructure: true,
+          },
+        },
         links: {
           select: {
             shortLink: true,
             key: true,
             url: true,
           },
-          orderBy: { id: "asc" },
+          orderBy: {
+            id: "asc",
+          },
         },
         partner: {
           select: {

--- a/apps/web/lib/api/workflows/execute-send-campaign-workflow.ts
+++ b/apps/web/lib/api/workflows/execute-send-campaign-workflow.ts
@@ -215,25 +215,6 @@ export const executeSendCampaignWorkflow = async ({
   }
 };
 
-const enrollmentLinksForEmail = {
-  select: { shortLink: true, key: true, url: true },
-  orderBy: { id: "asc" as const },
-};
-
-const enrollmentLinksForWorkflowStats = {
-  select: {
-    shortLink: true,
-    key: true,
-    url: true,
-    clicks: true,
-    leads: true,
-    conversions: true,
-    sales: true,
-    saleAmount: true,
-  },
-  orderBy: { id: "asc" as const },
-};
-
 const includePartnerUsers = {
   partner: {
     include: {
@@ -244,8 +225,21 @@ const includePartnerUsers = {
       },
     },
   },
-  partnerGroup: { select: { linkStructure: true } },
-  links: enrollmentLinksForEmail,
+  partnerGroup: {
+    select: {
+      linkStructure: true,
+    },
+  },
+  links: {
+    select: {
+      shortLink: true,
+      key: true,
+      url: true,
+    },
+    orderBy: {
+      id: "asc" as const,
+    },
+  },
 } satisfies Prisma.ProgramEnrollmentInclude;
 
 async function getProgramEnrollments({
@@ -284,7 +278,23 @@ async function getProgramEnrollments({
       include: {
         ...includePartnerUsers,
         ...(isPartnerLinkStatsAttribute
-          ? { links: enrollmentLinksForWorkflowStats }
+          ? {
+              links: {
+                select: {
+                  shortLink: true,
+                  key: true,
+                  url: true,
+                  clicks: true,
+                  leads: true,
+                  conversions: true,
+                  sales: true,
+                  saleAmount: true,
+                },
+                orderBy: {
+                  id: "asc",
+                },
+              },
+            }
           : {}),
       },
     });

--- a/apps/web/lib/api/workflows/execute-send-campaign-workflow.ts
+++ b/apps/web/lib/api/workflows/execute-send-campaign-workflow.ts
@@ -1,5 +1,6 @@
 import { evaluateWorkflowConditions } from "@/lib/api/workflows/evaluate-workflow-conditions";
 import { aggregatePartnerLinksStats } from "@/lib/partners/aggregate-partner-links-stats";
+import { constructPartnerLink } from "@/lib/partners/construct-partner-link";
 import { prisma } from "@/lib/prisma";
 import {
   CampaignTriggerCondition,
@@ -175,7 +176,10 @@ export const executeSendCampaignWorkflow = async ({
                 PartnerName: partnerUser.partner.name,
                 PartnerEmail: partnerUser.partner.email,
                 PartnerLink:
-                  partnerUser.enrollment.links?.[0]?.shortLink ?? null,
+                  constructPartnerLink({
+                    group: partnerUser.enrollment.partnerGroup,
+                    link: partnerUser.enrollment.links?.[0],
+                  }) || null,
               },
             }),
           },
@@ -212,13 +216,15 @@ export const executeSendCampaignWorkflow = async ({
 };
 
 const enrollmentLinksForEmail = {
-  select: { shortLink: true },
+  select: { shortLink: true, key: true, url: true },
   orderBy: { id: "asc" as const },
 };
 
 const enrollmentLinksForWorkflowStats = {
   select: {
     shortLink: true,
+    key: true,
+    url: true,
     clicks: true,
     leads: true,
     conversions: true,
@@ -238,6 +244,7 @@ const includePartnerUsers = {
       },
     },
   },
+  partnerGroup: { select: { linkStructure: true } },
   links: enrollmentLinksForEmail,
 } satisfies Prisma.ProgramEnrollmentInclude;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Campaign emails now generate partner links more reliably by deriving the link format from the recipient’s partner group settings and available enrollment link details.
* **Bug Fixes**
  * Email templates now render the correct partner link in more scenarios, using the full link information instead of relying only on the first link’s short value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->