### PR TITLE
Fix cross-program ban metadata and backfill existing events

### DIFF
--- a/apps/web/app/(ee)/api/admin/fraud-alerts/[id]/route.ts
+++ b/apps/web/app/(ee)/api/admin/fraud-alerts/[id]/route.ts
@@ -75,6 +75,11 @@ export const PATCH = withAdmin(
             partnerId: true,
             bannedReason: true,
             bannedAt: true,
+            application: {
+              select: {
+                reviewedAt: true,
+              },
+            },
           },
         },
       },
@@ -106,7 +111,10 @@ export const PATCH = withAdmin(
             partnerId: programEnrollment.partnerId,
             programId: programEnrollment.programId,
             bannedReason: programEnrollment.bannedReason ?? "fraud",
-            bannedAt: programEnrollment.bannedAt ?? createdAt,
+            bannedAt:
+              programEnrollment.bannedAt ??
+              programEnrollment.application?.reviewedAt ??
+              createdAt,
           }),
         ),
       ),

--- a/apps/web/app/(ee)/api/admin/fraud-alerts/[id]/route.ts
+++ b/apps/web/app/(ee)/api/admin/fraud-alerts/[id]/route.ts
@@ -24,13 +24,8 @@ export const PATCH = withAdmin(
       where: {
         id,
       },
-      include: {
-        programEnrollment: {
-          select: {
-            bannedAt: true,
-            bannedReason: true,
-          },
-        },
+      select: {
+        partnerId: true,
       },
     });
 
@@ -73,6 +68,7 @@ export const PATCH = withAdmin(
       },
       select: {
         id: true,
+        createdAt: true,
         programEnrollment: {
           select: {
             programId: true,
@@ -105,12 +101,12 @@ export const PATCH = withAdmin(
 
     waitUntil(
       Promise.allSettled(
-        pendingFraudAlerts.map(({ programEnrollment }) =>
+        pendingFraudAlerts.map(({ programEnrollment, createdAt }) =>
           reportCrossProgramBanToNetwork({
             partnerId: programEnrollment.partnerId,
             programId: programEnrollment.programId,
-            bannedReason: programEnrollment.bannedReason,
-            bannedAt: programEnrollment.bannedAt,
+            bannedReason: programEnrollment.bannedReason ?? "fraud",
+            bannedAt: programEnrollment.bannedAt ?? createdAt,
           }),
         ),
       ),

--- a/apps/web/scripts/misc/backfill-cross-program-ban-metadata.ts
+++ b/apps/web/scripts/misc/backfill-cross-program-ban-metadata.ts
@@ -1,0 +1,72 @@
+import "dotenv-flow/config";
+
+import { prisma } from "@/lib/prisma";
+import { chunk } from "@dub/utils";
+import { Prisma } from "@prisma/client";
+
+// There are around 85+ fraud events that don't have the banned reason or banned at metadata.
+
+async function main() {
+  const fraudEvents = await prisma.fraudEvent.findMany({
+    where: {
+      fraudEventGroup: {
+        type: "partnerCrossProgramBan",
+      },
+      metadata: {
+        path: "$.bannedAt",
+        equals: Prisma.JsonNull,
+      },
+      AND: {
+        metadata: {
+          path: "$.bannedReason",
+          equals: Prisma.JsonNull,
+        },
+      },
+    },
+    select: {
+      id: true,
+      createdAt: true,
+      metadata: true,
+    },
+    orderBy: {
+      createdAt: "desc",
+    },
+  });
+
+  console.log(`Found ${fraudEvents.length} fraud events to backfill`);
+
+  console.table(fraudEvents);
+
+  if (fraudEvents.length === 0) {
+    return;
+  }
+
+  const chunks = chunk(fraudEvents, 10);
+
+  for (const [index, batch] of chunks.entries()) {
+    await prisma.$transaction(
+      batch.map((event) =>
+        prisma.fraudEvent.update({
+          where: {
+            id: event.id,
+          },
+          data: {
+            metadata: {
+              ...(event.metadata as Record<string, unknown>),
+              bannedReason: "fraud",
+              bannedAt: event.createdAt,
+            },
+          },
+        }),
+      ),
+    );
+
+    console.log(
+      `Updated batch ${index + 1} of ${chunks.length} (${batch.length} fraud events)`,
+    );
+  }
+
+  console.log(`Updated ${fraudEvents.length} fraud events`);
+}
+
+main();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-program ban reporting to reliably pick the most accurate available ban reason and timestamp when some alert details are missing.
  * Enhanced pending fraud alert processing to include the alert creation date to ensure consistent reporting.

* **Chores**
  * Added a maintenance backfill script to populate missing ban metadata on existing fraud records, improving consistency for future reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->