### PR TITLE
Preserve %2B in query strings for cloaked links

### DIFF
--- a/apps/web/app/cloaked/[url]/page.tsx
+++ b/apps/web/app/cloaked/[url]/page.tsx
@@ -5,11 +5,45 @@ import {
 } from "@dub/utils";
 import { getMetaTags } from "app/api/links/metatags/utils";
 
+function getCloakedDestinationUrl(routeParam: string): string {
+  const url =
+    routeParam.includes("://") || !routeParam.includes("%")
+      ? routeParam
+      : decodeURIComponent(routeParam);
+
+  const queryIndex = url.indexOf("?");
+  if (queryIndex === -1) {
+    return url;
+  }
+
+  const base = url.slice(0, queryIndex);
+  const query = url.slice(queryIndex + 1);
+
+  const normalizedQuery = query
+    .split("&")
+    .filter(Boolean)
+    .map((pair) => {
+      const eqIndex = pair.indexOf("=");
+      if (eqIndex === -1) {
+        return pair;
+      }
+
+      const key = pair.slice(0, eqIndex);
+      const rawValue = pair.slice(eqIndex + 1);
+      const value = decodeURIComponent(rawValue.replace(/\+/g, "%2B"));
+
+      return `${key}=${encodeURIComponent(value)}`;
+    })
+    .join("&");
+
+  return normalizedQuery ? `${base}?${normalizedQuery}` : base;
+}
+
 export async function generateMetadata(props: {
   params: Promise<{ url: string }>;
 }) {
   const params = await props.params;
-  const url = decodeURIComponent(params.url); // key can potentially be encoded
+  const url = getCloakedDestinationUrl(params.url);
 
   const metatags = await getMetaTags(url);
   const apexDomain = getApexDomain(url);
@@ -27,7 +61,7 @@ export default async function CloakedPage(props: {
   params: Promise<{ url: string }>;
 }) {
   const params = await props.params;
-  const url = decodeURIComponent(params.url);
+  const url = getCloakedDestinationUrl(params.url);
 
   return <iframe src={url} className="min-h-screen w-full border-none" />;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of cloaked destination URLs so links with query parameters are parsed and normalized more reliably.
  * Fixed URL decoding behavior to better preserve the base path while correctly handling spaces and encoded query values.
  * Updated metadata and embedded content loading to use the same normalized destination URL for more consistent page behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->