### PR TITLE
Fix folder default access level

### DIFF
--- a/apps/web/lib/zod/schemas/folders.ts
+++ b/apps/web/lib/zod/schemas/folders.ts
@@ -16,8 +16,10 @@ const folderAccessLevelSchema = z.enum(
 
 const workspaceFolderAccess = folderAccessLevelSchema
   .nullish()
-  .default(null)
-  .describe("The access level of the folder within the workspace.");
+  .default("write")
+  .describe(
+    "The workspace-level access level settings for the folder. Default is `write` which allows full access to the folder for all team members. The other options are `read` (view-only access) and `null` (no access) and are only available on Business plans and above.",
+  );
 
 export const folderUserRoleSchema = z
   .enum(Object.keys(FOLDER_USER_ROLE) as [FolderUserRole, ...FolderUserRole[]])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace folder access now defaults to **write** instead of no access, making newly configured folders immediately editable.
  * Updated the access-level guidance to clearly explain the available options: **write**, **read**, and **none**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->