### PR TITLE
Add 5 minute delay for card Stripe payout enqueues

### DIFF
--- a/apps/web/app/(ee)/api/cron/payouts/charge-succeeded/queue-stripe-payouts.ts
+++ b/apps/web/app/(ee)/api/cron/payouts/charge-succeeded/queue-stripe-payouts.ts
@@ -145,10 +145,6 @@ export async function queueStripePayouts({
             // x-slack-ref: https://dub.slack.com/archives/C074P7LMV9C/p1758776038825219?thread_ts=1758769780.982089&cid=C074P7LMV9C
             ...(paymentMethod === "card" && { chargeId }),
           },
-          // 5 minutes delay to give some buffer for the card charge to settle fully
-          ...(paymentMethod === "card" && {
-            delay: "5m",
-          }),
         });
       }),
     );

--- a/apps/web/app/(ee)/api/cron/payouts/charge-succeeded/queue-stripe-payouts.ts
+++ b/apps/web/app/(ee)/api/cron/payouts/charge-succeeded/queue-stripe-payouts.ts
@@ -145,6 +145,10 @@ export async function queueStripePayouts({
             // x-slack-ref: https://dub.slack.com/archives/C074P7LMV9C/p1758776038825219?thread_ts=1758769780.982089&cid=C074P7LMV9C
             ...(paymentMethod === "card" && { chargeId }),
           },
+          // 5 minutes delay to give some buffer for the card charge to settle fully
+          ...(paymentMethod === "card" && {
+            delay: "5m",
+          }),
         });
       }),
     );

--- a/apps/web/app/(ee)/api/cron/payouts/charge-succeeded/utils.ts
+++ b/apps/web/app/(ee)/api/cron/payouts/charge-succeeded/utils.ts
@@ -24,8 +24,7 @@ export async function scheduleDelayedPayouts({
   invoice: Pick<Invoice, "id">;
   executeAt: Date;
 }) {
-  // Add 5 minutes to the executeAt time to give some buffer for the card charge to settle fully
-  const scheduleTimeMs = executeAt.getTime() + 5 * 60 * 1000;
+  const scheduleTimeMs = executeAt.getTime();
 
   const delaySeconds = Math.max(
     0,
@@ -34,7 +33,7 @@ export async function scheduleDelayedPayouts({
 
   const qstashResponse = await qstash.publishJSON({
     url: `${APP_DOMAIN_WITH_NGROK}/api/cron/payouts/charge-succeeded`,
-    delay: delaySeconds,
+    delay: delaySeconds + 5 * 60, // 5 minutes delay to give some buffer for the card charge to settle fully
     deduplicationId: `retry-delayed-payouts-${invoice.id}`, // The deduplication window is 10 minutes
     flowControl: {
       key: invoice.id,

--- a/apps/web/app/(ee)/api/cron/payouts/charge-succeeded/utils.ts
+++ b/apps/web/app/(ee)/api/cron/payouts/charge-succeeded/utils.ts
@@ -24,7 +24,8 @@ export async function scheduleDelayedPayouts({
   invoice: Pick<Invoice, "id">;
   executeAt: Date;
 }) {
-  const scheduleTimeMs = executeAt.getTime();
+  // Add 5 minutes to the executeAt time to give some buffer for the card charge to settle fully
+  const scheduleTimeMs = executeAt.getTime() + 5 * 60 * 1000;
 
   const delaySeconds = Math.max(
     0,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of delayed payout scheduling by adding a small additional buffer before execution, helping ensure payouts are triggered slightly later than before and reducing the likelihood of timing-related issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->