### PR TITLE
Skip inactive coupons during import

### DIFF
--- a/apps/web/lib/rewardful/import-affiliate-coupons.ts
+++ b/apps/web/lib/rewardful/import-affiliate-coupons.ts
@@ -36,13 +36,19 @@ export async function importAffiliateCoupons(payload: RewardfulImportPayload) {
       page: currentPage,
     });
 
+    if (allAffiliateCoupons.length === 0) {
+      hasMore = false;
+      break;
+    }
+
     const activeAffiliateCoupons = allAffiliateCoupons.filter(
       (affiliateCoupon) => !affiliateCoupon.archived,
     );
 
     if (activeAffiliateCoupons.length === 0) {
-      hasMore = false;
-      break;
+      currentPage++;
+      processedBatches++;
+      continue;
     }
 
     const affiliateIds = activeAffiliateCoupons.map(

--- a/apps/web/lib/rewardful/import-affiliate-coupons.ts
+++ b/apps/web/lib/rewardful/import-affiliate-coupons.ts
@@ -32,16 +32,20 @@ export async function importAffiliateCoupons(payload: RewardfulImportPayload) {
   let processedBatches = 0;
 
   while (hasMore && processedBatches < REWARDFUL_MAX_BATCHES) {
-    const affiliateCoupons = await rewardfulApi.listAffiliateCoupons({
+    const allAffiliateCoupons = await rewardfulApi.listAffiliateCoupons({
       page: currentPage,
     });
 
-    if (affiliateCoupons.length === 0) {
+    const activeAffiliateCoupons = allAffiliateCoupons.filter(
+      (affiliateCoupon) => !affiliateCoupon.archived,
+    );
+
+    if (activeAffiliateCoupons.length === 0) {
       hasMore = false;
       break;
     }
 
-    const affiliateIds = affiliateCoupons.map(
+    const affiliateIds = activeAffiliateCoupons.map(
       (affiliateCoupon) => affiliateCoupon.affiliate_id,
     );
 
@@ -59,7 +63,7 @@ export async function importAffiliateCoupons(payload: RewardfulImportPayload) {
     );
 
     // Find the coupons that have a partner account created on Dub
-    const filteredCoupons = affiliateCoupons.filter(
+    const filteredCoupons = activeAffiliateCoupons.filter(
       (affiliateCoupon) => filteredPartners[affiliateCoupon.affiliate_id],
     );
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Affiliate coupon imports now skip archived coupons and only bring in active offers.
  * Sync pagination is improved: it no longer stops when a page contains no active coupons.
  * Affiliate/coupon matching now uses active coupons only, reducing the chance of using outdated discount codes during syncing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->