### PR TITLE
Reward update emails to active enrollments

### DIFF
--- a/apps/web/app/(ee)/api/cron/rewards/process/route.ts
+++ b/apps/web/app/(ee)/api/cron/rewards/process/route.ts
@@ -6,7 +6,10 @@ import {
 import { isStaleRewardVersion } from "@/lib/api/rewards/reward-version";
 import { withCron } from "@/lib/cron/with-cron";
 import { prisma } from "@/lib/prisma";
-import { INACTIVE_ENROLLMENT_STATUSES } from "@/lib/zod/schemas/partners";
+import {
+  ACTIVE_ENROLLMENT_STATUSES,
+  INACTIVE_ENROLLMENT_STATUSES,
+} from "@/lib/zod/schemas/partners";
 import { REWARD_EVENT_COLUMN_MAPPING } from "@/lib/zod/schemas/rewards";
 import { Prisma } from "@prisma/client";
 import { logAndRespond } from "../../utils";
@@ -113,6 +116,7 @@ export const POST = withCron(async ({ rawBody }) => {
     },
     select: {
       id: true,
+      status: true,
       partner: {
         select: {
           users: {
@@ -161,9 +165,9 @@ export const POST = withCron(async ({ rawBody }) => {
     }
 
     if (shouldNotify) {
-      const users = programEnrollments.flatMap(({ partner }) =>
-        partner.users.map(({ user }) => user),
-      );
+      const users = programEnrollments
+        .filter(({ status }) => ACTIVE_ENROLLMENT_STATUSES.includes(status))
+        .flatMap(({ partner }) => partner.users.map(({ user }) => user));
 
       await notifyPartnerRewardChange({
         action: event,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reward-change notifications are now limited to partners with active enrollment status.
  * Improved the selection of notified users so inactive enrollments no longer receive updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->