### PR TITLE
Add `isSoftDelete` prop to `deleteDiscountCodes`

### DIFF
--- a/apps/web/app/(ee)/api/cron/discount-codes/disable/route.ts
+++ b/apps/web/app/(ee)/api/cron/discount-codes/disable/route.ts
@@ -14,7 +14,7 @@ const inputSchema = z.object({
   provider: z.enum(DiscountProvider),
 });
 
-// POST /api/cron/discount-codes/delete
+// POST /api/cron/discount-codes/disable – disable a discount code from the provider (Stripe, Shopify, etc.)
 export const POST = withCron(async ({ rawBody }) => {
   const { provider, code, programId } = inputSchema.parse(JSON.parse(rawBody));
 

--- a/apps/web/app/(ee)/api/cron/partners/ban/route.ts
+++ b/apps/web/app/(ee)/api/cron/partners/ban/route.ts
@@ -138,7 +138,7 @@ export const POST = withCron(async ({ rawBody }) => {
     recordLink(links, { deleted: true }),
 
     // Queue discount code deletions
-    deleteDiscountCodes(discountCodes),
+    deleteDiscountCodes(discountCodes, { isSoftDelete: true }),
   ]);
 
   // Send email

--- a/apps/web/app/(ee)/api/cron/partners/deactivate/route.ts
+++ b/apps/web/app/(ee)/api/cron/partners/deactivate/route.ts
@@ -58,7 +58,7 @@ export const POST = withCron(async ({ rawBody }) => {
   const discountCodes = programEnrollments.flatMap(({ discountCodes }) =>
     discountCodes.map((dc) => dc),
   );
-  await deleteDiscountCodes(discountCodes);
+  await deleteDiscountCodes(discountCodes, { isSoftDelete: false });
   console.log("[bulkDeactivatePartners] Queued discount code deletions.");
 
   // Find the program

--- a/apps/web/app/(ee)/api/cron/partners/deactivate/route.ts
+++ b/apps/web/app/(ee)/api/cron/partners/deactivate/route.ts
@@ -58,7 +58,7 @@ export const POST = withCron(async ({ rawBody }) => {
   const discountCodes = programEnrollments.flatMap(({ discountCodes }) =>
     discountCodes.map((dc) => dc),
   );
-  await deleteDiscountCodes(discountCodes, { isSoftDelete: false });
+  await deleteDiscountCodes(discountCodes, { isSoftDelete: true });
   console.log("[bulkDeactivatePartners] Queued discount code deletions.");
 
   // Find the program

--- a/apps/web/app/(ee)/api/discount-codes/route.ts
+++ b/apps/web/app/(ee)/api/discount-codes/route.ts
@@ -11,6 +11,7 @@ import {
   DiscountCodeSchema,
   getDiscountCodesQuerySchema,
 } from "@/lib/zod/schemas/discount";
+import { APP_DOMAIN } from "@dub/utils";
 import { waitUntil } from "@vercel/functions";
 import { NextResponse } from "next/server";
 
@@ -108,7 +109,7 @@ export const POST = withWorkspace(
       if (duplicateByCode) {
         throw new DubApiError({
           code: "conflict",
-          message: `This discount code "${code}" is already in use by [${duplicateByCode.partner.email}](https://app.dub.co/${workspace.slug}/program/partners/${duplicateByCode.partner.id}). Please choose a different code.`,
+          message: `This discount code "${code}" is already in use by [${duplicateByCode.partner.email}](${APP_DOMAIN}/${workspace.slug}/program/partners/${duplicateByCode.partner.id}). Please choose a different code.`,
         });
       }
     }

--- a/apps/web/app/(ee)/api/discount-codes/route.ts
+++ b/apps/web/app/(ee)/api/discount-codes/route.ts
@@ -100,12 +100,15 @@ export const POST = withWorkspace(
             code,
           },
         },
+        include: {
+          partner: true,
+        },
       });
 
       if (duplicateByCode) {
         throw new DubApiError({
-          code: "bad_request",
-          message: `A discount with the code ${code} already exists in the program. Please choose a different code.`,
+          code: "conflict",
+          message: `This discount code "${code}" is already in use by [${duplicateByCode.partner.email}](https://app.dub.co/${workspace.slug}/program/partners/${duplicateByCode.partner.id}). Please choose a different code.`,
         });
       }
     }

--- a/apps/web/app/(ee)/api/partner-profile/programs/[programId]/links/route.ts
+++ b/apps/web/app/(ee)/api/partner-profile/programs/[programId]/links/route.ts
@@ -37,6 +37,7 @@ export const GET = withPartnerProfile(async ({ partner, params }) => {
     return {
       ...link,
       discountCode: discountCode?.code,
+      discountCodeDisabledAt: discountCode?.disabledAt ?? null,
     };
   });
 

--- a/apps/web/app/(ee)/api/stripe/integration/webhook/utils/attribute-via-promotion-code-id.ts
+++ b/apps/web/app/(ee)/api/stripe/integration/webhook/utils/attribute-via-promotion-code-id.ts
@@ -70,14 +70,21 @@ export async function attributeViaPromotionCodeId({
         code: promotionCode.code,
       },
     },
-    select: {
+    include: {
       link: true,
     },
   });
 
   if (!discountCode) {
     console.log(
-      `Couldn't find link associated with promotion code ${promotionCode.code}, skipping...`,
+      `Couldn't find discount code "${promotionCode.code}" in program "${workspace.defaultProgramId}", skipping...`,
+    );
+    return null;
+  }
+
+  if (discountCode.disabledAt) {
+    console.log(
+      `Discount code "${discountCode.code}" is disabled, skipping...`,
     );
     return null;
   }

--- a/apps/web/app/(ee)/partners.dub.co/(dashboard)/programs/[programSlug]/(enrolled)/links/partner-link-card.tsx
+++ b/apps/web/app/(ee)/partners.dub.co/(dashboard)/programs/[programSlug]/(enrolled)/links/partner-link-card.tsx
@@ -28,6 +28,7 @@ import {
   getApexDomain,
   getPrettyUrl,
   nFormatter,
+  PARTNERS_DOMAIN,
 } from "@dub/utils";
 import NumberFlow from "@number-flow/react";
 import Link from "next/link";
@@ -74,6 +75,19 @@ export function PartnerLinkCard({ link }: { link: PartnerProfileLinkProps }) {
   });
 
   const isDeactivated = programEnrollment?.status === "deactivated";
+
+  const discountCodeSection = link.discountCode ? (
+    <div className="hidden items-center gap-1.5 rounded-xl border border-neutral-200 py-1 pl-2 pr-1 sm:flex">
+      <span className="text-sm leading-none text-neutral-500">
+        Discount code
+      </span>
+      <DiscountCodeBadge
+        code={link.discountCode}
+        disabledAt={link.discountCodeDisabledAt}
+        disabledTooltip={`This discount code was disabled by the program. [Contact the program owner](${PARTNERS_DOMAIN}/messages/${programEnrollment?.program.slug}) if you need a new code.`}
+      />
+    </div>
+  ) : null;
 
   return (
     <CardList.Card
@@ -153,20 +167,14 @@ export function PartnerLinkCard({ link }: { link: PartnerProfileLinkProps }) {
                   </StatusBadge>
                 );
               })()}
-            {link.discountCode && (
-              <Tooltip
-                content={
-                  "This program supports discount code tracking. Copy the code to use it in podcasts, videos, etc. [Learn more](https://dub.co/help/article/dual-sided-incentives)"
-                }
-              >
-                <div className="hidden items-center gap-1.5 rounded-xl border border-neutral-200 py-1 pl-2 pr-1 sm:flex">
-                  <span className="text-sm leading-none text-neutral-500">
-                    Discount code
-                  </span>
-                  <DiscountCodeBadge code={link.discountCode} />
-                </div>
-              </Tooltip>
-            )}
+            {discountCodeSection &&
+              (link.discountCodeDisabledAt ? (
+                discountCodeSection
+              ) : (
+                <Tooltip content="This program supports discount code tracking. Copy the code to use it in podcasts, videos, etc. [Learn more](https://dub.co/help/article/dual-sided-incentives)">
+                  {discountCodeSection}
+                </Tooltip>
+              ))}
             {displayOption === "cards" && <StatsBadge link={link} />}
             <Controls link={link} />
           </div>

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/[partnerId]/links/page.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/[partnerId]/links/page.tsx
@@ -333,7 +333,12 @@ const PartnerDiscountCodes = ({
       {
         id: "code",
         header: "Code",
-        cell: ({ row }) => <DiscountCodeBadge code={row.original.code} />,
+        cell: ({ row }) => (
+          <DiscountCodeBadge
+            code={row.original.code}
+            disabledAt={row.original.disabledAt}
+          />
+        ),
       },
       {
         id: "shortLink",

--- a/apps/web/lib/discounts/delete-discount-code.ts
+++ b/apps/web/lib/discounts/delete-discount-code.ts
@@ -30,7 +30,23 @@ export async function deleteDiscountCodes(
     return;
   }
 
-  if (!isSoftDelete) {
+  if (isSoftDelete) {
+    // Soft delete the discount codes from the database (mark them as disabled)
+    const disabledDiscountCodes = await prisma.discountCode.updateMany({
+      where: {
+        id: {
+          in: discountCodes.map(({ id }) => id),
+        },
+      },
+      data: {
+        disabledAt: new Date(),
+      },
+    });
+
+    console.log(
+      `[deleteDiscountCodes] Disabled ${disabledDiscountCodes.count} discount codes.`,
+    );
+  } else {
     // Delete the discount codes from the database
     const deletedDiscountCodes = await prisma.discountCode.deleteMany({
       where: {

--- a/apps/web/lib/discounts/delete-discount-code.ts
+++ b/apps/web/lib/discounts/delete-discount-code.ts
@@ -17,6 +17,7 @@ type DeleteDiscountCodesParams = Pick<
 // 4. When a partner is moved to a different group
 export async function deleteDiscountCodes(
   input: (DeleteDiscountCodesParams | null | undefined)[],
+  { isSoftDelete = false }: { isSoftDelete?: boolean } = {},
 ) {
   const discountCodes = input.filter(
     (dc): dc is NonNullable<typeof dc> => dc != null,
@@ -29,18 +30,20 @@ export async function deleteDiscountCodes(
     return;
   }
 
-  // Delete the discount codes from the database
-  const deletedDiscountCodes = await prisma.discountCode.deleteMany({
-    where: {
-      id: {
-        in: discountCodes.map(({ id }) => id),
+  if (!isSoftDelete) {
+    // Delete the discount codes from the database
+    const deletedDiscountCodes = await prisma.discountCode.deleteMany({
+      where: {
+        id: {
+          in: discountCodes.map(({ id }) => id),
+        },
       },
-    },
-  });
+    });
 
-  console.log(
-    `[deleteDiscountCodes] Deleted ${deletedDiscountCodes.count} discount codes.`,
-  );
+    console.log(
+      `[deleteDiscountCodes] Deleted ${deletedDiscountCodes.count} discount codes.`,
+    );
+  }
 
   // Only enqueue external-provider cleanup for codes whose provider is known.
   // Orphaned codes (discount relation is null) still get deleted locally above
@@ -63,7 +66,7 @@ export async function deleteDiscountCodes(
   for (const chunkOfCodes of chunks) {
     await enqueueBatchJobs(
       chunkOfCodes.map((discountCode) => ({
-        url: `${APP_DOMAIN_WITH_NGROK}/api/cron/discount-codes/delete`,
+        url: `${APP_DOMAIN_WITH_NGROK}/api/cron/discount-codes/disable`,
         method: "POST",
         queueName: "delete-discount-code",
         body: {

--- a/apps/web/lib/zod/schemas/discount.ts
+++ b/apps/web/lib/zod/schemas/discount.ts
@@ -62,6 +62,12 @@ export const DiscountCodeSchema = z.object({
   discountId: z.string().nullable(),
   partnerId: z.string(),
   linkId: z.string(),
+  disabledAt: z.coerce
+    .date()
+    .nullish()
+    .describe(
+      "When this discount code was disabled, which happens when a partner is banned or deactivated.",
+    ),
 });
 
 export const createDiscountCodeSchema = z.object({

--- a/apps/web/lib/zod/schemas/partner-profile.ts
+++ b/apps/web/lib/zod/schemas/partner-profile.ts
@@ -100,6 +100,7 @@ export const PartnerProfileLinkSchema = LinkSchema.pick({
   createdAt: z.string().or(z.date()),
   partnerGroupDefaultLinkId: z.string().nullish(),
   discountCode: z.string().nullable().default(null),
+  discountCodeDisabledAt: z.coerce.date().nullable().default(null),
 });
 
 export const PartnerProfileCustomerSchema = CustomerEnrichedSchema.pick({

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -129,7 +129,7 @@
     "remark-gfm": "^4.0.0",
     "sanitize-html": "^2.17.0",
     "shiki": "^1.14.1",
-    "sonner": "^1.4.41",
+    "sonner": "^2.0.7",
     "streamdown": "^2.3.0",
     "stripe": "^18.2.0",
     "svix": "^1.76.1",

--- a/apps/web/prisma/schema/discount.prisma
+++ b/apps/web/prisma/schema/discount.prisma
@@ -34,6 +34,7 @@ model DiscountCode {
   linkId     String   @unique
   createdAt  DateTime @default(now())
   updatedAt  DateTime @updatedAt
+  disabledAt DateTime?
 
   program           Program            @relation(fields: [programId], references: [id], onDelete: Cascade)
   discount          Discount?          @relation(fields: [discountId], references: [id], onDelete: SetNull)

--- a/apps/web/ui/modals/add-discount-code-modal.tsx
+++ b/apps/web/ui/modals/add-discount-code-modal.tsx
@@ -18,7 +18,8 @@ import { toast } from "sonner";
 import { useDebounce } from "use-debounce";
 import * as z from "zod/v4";
 import { ERROR_MAP } from "../partners/constants";
-import { X } from "../shared/icons";
+import { CustomToast } from "../shared/custom-toast";
+import { AlertCircleFill, X } from "../shared/icons";
 import { UpgradeRequiredToast } from "../shared/upgrade-required-toast";
 
 type FormData = z.infer<typeof createDiscountCodeSchema>;
@@ -87,28 +88,30 @@ const AddDiscountCodeModal = ({
         toast.success("Discount code created and copied to clipboard!");
       },
       onError: (error) => {
-        if (error) {
-          const code = Object.keys(ERROR_MAP).find((key) =>
-            error.startsWith(key),
-          );
+        const code = Object.keys(ERROR_MAP).find((key) =>
+          error.startsWith(key),
+        );
 
-          if (code) {
-            const { title, ctaLabel, ctaUrl } = ERROR_MAP[code];
-            const message = error.replace(`${code}: `, "");
+        if (code) {
+          const { title, ctaLabel, ctaUrl } = ERROR_MAP[code];
+          const message = error.replace(`${code}: `, "");
 
-            toast.custom(() => (
-              <UpgradeRequiredToast
-                title={title}
-                message={message}
-                ctaLabel={ctaLabel}
-                ctaUrl={ctaUrl}
-              />
-            ));
-            return;
-          }
+          toast.custom(() => (
+            <UpgradeRequiredToast
+              title={title}
+              message={message}
+              ctaLabel={ctaLabel}
+              ctaUrl={ctaUrl}
+            />
+          ));
+          return;
+        } else if (error.includes("already in use")) {
+          toast.custom(() => (
+            <CustomToast icon={AlertCircleFill}>{error}</CustomToast>
+          ));
+        } else {
+          toast.error(error);
         }
-
-        toast.error(error);
       },
     });
   };

--- a/apps/web/ui/partners/discounts/discount-code-badge.tsx
+++ b/apps/web/ui/partners/discounts/discount-code-badge.tsx
@@ -1,65 +1,68 @@
-import { StatusBadge, Tag, Tooltip, useCopyToClipboard } from "@dub/ui";
+import { Tag, Tooltip, useCopyToClipboard } from "@dub/ui";
 import { cn } from "@dub/utils";
 import { toast } from "sonner";
 
 export function DiscountCodeBadge({
   code,
   disabledAt,
+  disabledTooltip = "This discount code was disabled because the partner was banned or deactivated. To re-enable it, delete this code and create a new one.",
 }: {
   code: string;
   disabledAt?: Date | string | null;
+  disabledTooltip?: string;
 }) {
   const [copied, copyToClipboard] = useCopyToClipboard();
   const isDisabled = !!disabledAt;
 
-  return (
-    <div className="flex items-center gap-2">
-      <button
-        type="button"
+  const content = (
+    <>
+      <Tag
         className={cn(
-          "group/discountcode relative flex w-fit cursor-copy items-center gap-1 rounded-lg px-2 py-1",
-          "transition-colors duration-150",
-          copied && "cursor-default",
-          isDisabled
-            ? "bg-neutral-200/80 line-through hover:bg-neutral-200/80 hover:no-underline"
-            : "bg-green-200 hover:bg-green-300/80",
+          "size-3",
+          isDisabled ? "text-neutral-500" : "text-green-700",
         )}
-        onClick={() =>
-          copyToClipboard(code, {
-            onSuccess: () => {
-              toast.success("Copied discount code to clipboard");
-            },
-          })
-        }
+        strokeWidth={1.5}
+      />
+      <div
+        className={cn(
+          "text-xs font-medium",
+          isDisabled
+            ? "text-neutral-500 line-through"
+            : "text-green-700 decoration-dotted underline-offset-2 transition-colors group-hover/discountcode:underline",
+        )}
       >
-        <Tag
-          className={cn(
-            "size-3",
-            isDisabled ? "text-neutral-500" : "text-green-700",
-          )}
-          strokeWidth={1.5}
-        />
-        <div
-          className={cn(
-            "text-xs font-medium decoration-dotted underline-offset-2 transition-colors group-hover/discountcode:underline",
-            isDisabled ? "text-neutral-600" : "text-green-700",
-          )}
-        >
-          {code}
+        {code}
+      </div>
+    </>
+  );
+
+  if (isDisabled) {
+    return (
+      <Tooltip content={disabledTooltip}>
+        <div className="flex w-fit cursor-help items-center gap-1 rounded-lg bg-neutral-100 px-2 py-1">
+          {content}
         </div>
-      </button>
-      {isDisabled && (
-        <Tooltip content="This discount code was disabled because the partner was banned or deactivated. To re-enable it, delete this code and create a new one.">
-          <StatusBadge
-            variant="neutral"
-            size="sm"
-            icon={null}
-            className="cursor-help"
-          >
-            Disabled
-          </StatusBadge>
-        </Tooltip>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      className={cn(
+        "group/discountcode relative flex w-fit cursor-copy items-center gap-1 rounded-lg bg-green-200 px-2 py-1",
+        "transition-colors duration-150 hover:bg-green-300/80",
+        copied && "cursor-default",
       )}
-    </div>
+      onClick={() =>
+        copyToClipboard(code, {
+          onSuccess: () => {
+            toast.success("Copied discount code to clipboard");
+          },
+        })
+      }
+    >
+      {content}
+    </button>
   );
 }

--- a/apps/web/ui/partners/discounts/discount-code-badge.tsx
+++ b/apps/web/ui/partners/discounts/discount-code-badge.tsx
@@ -1,29 +1,65 @@
-import { Tag, useCopyToClipboard } from "@dub/ui";
+import { StatusBadge, Tag, Tooltip, useCopyToClipboard } from "@dub/ui";
 import { cn } from "@dub/utils";
 import { toast } from "sonner";
 
-export function DiscountCodeBadge({ code }: { code: string }) {
+export function DiscountCodeBadge({
+  code,
+  disabledAt,
+}: {
+  code: string;
+  disabledAt?: Date | string | null;
+}) {
   const [copied, copyToClipboard] = useCopyToClipboard();
+  const isDisabled = !!disabledAt;
+
   return (
-    <button
-      type="button"
-      className={cn(
-        "group/discountcode relative flex w-fit cursor-copy items-center gap-1 rounded-lg bg-green-200 px-2 py-1",
-        "transition-colors duration-150 hover:bg-green-300/80",
-        copied && "cursor-default",
+    <div className="flex items-center gap-2">
+      <button
+        type="button"
+        className={cn(
+          "group/discountcode relative flex w-fit cursor-copy items-center gap-1 rounded-lg px-2 py-1",
+          "transition-colors duration-150",
+          copied && "cursor-default",
+          isDisabled
+            ? "bg-neutral-200/80 line-through hover:bg-neutral-200/80 hover:no-underline"
+            : "bg-green-200 hover:bg-green-300/80",
+        )}
+        onClick={() =>
+          copyToClipboard(code, {
+            onSuccess: () => {
+              toast.success("Copied discount code to clipboard");
+            },
+          })
+        }
+      >
+        <Tag
+          className={cn(
+            "size-3",
+            isDisabled ? "text-neutral-500" : "text-green-700",
+          )}
+          strokeWidth={1.5}
+        />
+        <div
+          className={cn(
+            "text-xs font-medium decoration-dotted underline-offset-2 transition-colors group-hover/discountcode:underline",
+            isDisabled ? "text-neutral-600" : "text-green-700",
+          )}
+        >
+          {code}
+        </div>
+      </button>
+      {isDisabled && (
+        <Tooltip content="This discount code was disabled because the partner was banned or deactivated. To re-enable it, delete this code and create a new one.">
+          <StatusBadge
+            variant="neutral"
+            size="sm"
+            icon={null}
+            className="cursor-help"
+          >
+            Disabled
+          </StatusBadge>
+        </Tooltip>
       )}
-      onClick={() =>
-        copyToClipboard(code, {
-          onSuccess: () => {
-            toast.success("Copied discount code to clipboard");
-          },
-        })
-      }
-    >
-      <Tag className="size-3 text-green-700" strokeWidth={1.5} />
-      <div className="text-xs font-medium text-green-700 decoration-dotted underline-offset-2 transition-colors group-hover/discountcode:underline">
-        {code}
-      </div>
-    </button>
+    </div>
   );
 }

--- a/apps/web/ui/shared/custom-toast.tsx
+++ b/apps/web/ui/shared/custom-toast.tsx
@@ -1,4 +1,4 @@
-import ReactMarkdown from "react-markdown";
+import { MarkdownDescription } from "./markdown-description";
 
 export function CustomToast({
   icon: Icon,
@@ -10,20 +10,9 @@ export function CustomToast({
   return (
     <div className="flex items-center gap-1.5 rounded-lg bg-white p-4 text-sm shadow-[0_4px_12px_#0000001a]">
       {Icon && <Icon className="size-[18px] shrink-0 text-black" />}
-      <ReactMarkdown
-        className="text-[13px] font-medium text-neutral-900"
-        components={{
-          a: ({ node, ...props }) => (
-            <a
-              {...props}
-              target="_blank"
-              className="text-neutral-500 underline transition-colors hover:text-neutral-800"
-            />
-          ),
-        }}
-      >
+      <MarkdownDescription className="text-[13px] font-medium text-neutral-900">
         {children}
-      </ReactMarkdown>
+      </MarkdownDescription>
     </div>
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -366,8 +366,8 @@ importers:
         specifier: ^1.14.1
         version: 1.14.1
       sonner:
-        specifier: ^1.4.41
-        version: 1.4.41(react-dom@19.1.3(react@19.1.3))(react@19.1.3)
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.1.3(react@19.1.3))(react@19.1.3)
       streamdown:
         specifier: ^2.3.0
         version: 2.3.0(react-dom@19.1.3(react@19.1.3))(react@19.1.3)
@@ -672,7 +672,7 @@ importers:
     dependencies:
       '@hubspot/cli':
         specifier: ^7.6.2
-        version: 7.6.2(@babel/core@7.28.4)(@types/node@18.11.9)(@types/react-dom@19.1.9(@types/react@19.1.15))(@types/react@19.1.15)(encoding@0.1.13)(prettier@3.6.2)(rollup@4.52.5)(styled-components@6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.27.0)(typescript@5.6.2)(vite@5.4.8(@types/node@18.11.9)(terser@5.27.0))
+        version: 7.6.2(@babel/core@7.24.5)(@types/node@18.11.9)(@types/react-dom@19.1.9(@types/react@19.1.15))(@types/react@19.1.15)(encoding@0.1.13)(prettier@3.6.2)(rollup@4.52.5)(styled-components@6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.27.0)(typescript@5.6.2)(vite@5.4.8(@types/node@18.11.9)(terser@5.27.0))
     devDependencies:
       '@types/node':
         specifier: 18.11.9
@@ -11964,6 +11964,12 @@ packages:
       react: ^18.0.0
       react-dom: ^18.0.0
 
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+
   source-map-js@1.2.0:
     resolution: {integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==}
     engines: {node: '>=0.10.0'}
@@ -14502,9 +14508,9 @@ snapshots:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.28.4)':
+  '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.27.1
     optional: true
 
@@ -15334,7 +15340,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@hubspot/cli@7.6.2(@babel/core@7.28.4)(@types/node@18.11.9)(@types/react-dom@19.1.9(@types/react@19.1.15))(@types/react@19.1.15)(encoding@0.1.13)(prettier@3.6.2)(rollup@4.52.5)(styled-components@6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.27.0)(typescript@5.6.2)(vite@5.4.8(@types/node@18.11.9)(terser@5.27.0))':
+  '@hubspot/cli@7.6.2(@babel/core@7.24.5)(@types/node@18.11.9)(@types/react-dom@19.1.9(@types/react@19.1.15))(@types/react@19.1.15)(encoding@0.1.13)(prettier@3.6.2)(rollup@4.52.5)(styled-components@6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.27.0)(typescript@5.6.2)(vite@5.4.8(@types/node@18.11.9)(terser@5.27.0))':
     dependencies:
       '@hubspot/local-dev-lib': 3.19.1
       '@hubspot/project-parsing-lib': 0.8.6(@hubspot/local-dev-lib@3.19.1)
@@ -15365,7 +15371,7 @@ snapshots:
       yargs: 17.7.2
       yargs-parser: 21.1.1
     optionalDependencies:
-      '@hubspot/cms-dev-server': 1.0.38(@babel/core@7.28.4)(@types/node@18.11.9)(@types/react-dom@19.1.9(@types/react@19.1.15))(@types/react@19.1.15)(encoding@0.1.13)(prettier@3.6.2)(rollup@4.52.5)(styled-components@6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.27.0)
+      '@hubspot/cms-dev-server': 1.0.38(@babel/core@7.24.5)(@types/node@18.11.9)(@types/react-dom@19.1.9(@types/react@19.1.15))(@types/react@19.1.15)(encoding@0.1.13)(prettier@3.6.2)(rollup@4.52.5)(styled-components@6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.27.0)
       '@modelcontextprotocol/sdk': 1.13.3
     transitivePeerDependencies:
       - '@babel/core'
@@ -15403,7 +15409,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
     optional: true
 
-  '@hubspot/cms-dev-server@1.0.38(@babel/core@7.28.4)(@types/node@18.11.9)(@types/react-dom@19.1.9(@types/react@19.1.15))(@types/react@19.1.15)(encoding@0.1.13)(prettier@3.6.2)(rollup@4.52.5)(styled-components@6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.27.0)':
+  '@hubspot/cms-dev-server@1.0.38(@babel/core@7.24.5)(@types/node@18.11.9)(@types/react-dom@19.1.9(@types/react@19.1.15))(@types/react@19.1.15)(encoding@0.1.13)(prettier@3.6.2)(rollup@4.52.5)(styled-components@6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.27.0)':
     dependencies:
       '@babel/code-frame': 7.26.2
       '@babel/parser': 7.26.2
@@ -15430,7 +15436,7 @@ snapshots:
       '@vitejs/plugin-react': 4.7.0(vite@5.4.8(@types/node@18.11.9)(terser@5.27.0))
       ansi-to-html: 0.7.2
       babel-plugin-macros: 3.1.0
-      babel-plugin-styled-components: 2.1.4(@babel/core@7.28.4)(styled-components@6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      babel-plugin-styled-components: 2.1.4(@babel/core@7.24.5)(styled-components@6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       chalk: 5.4.1
       class-variance-authority: 0.7.0
       cli-progress: 3.12.0
@@ -15449,7 +15455,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       request: 2.88.2
       storybook: 8.6.14(prettier@3.6.2)
-      styled-jsx: 5.1.2(@babel/core@7.28.4)(babel-plugin-macros@3.1.0)(react@18.3.1)
+      styled-jsx: 5.1.2(@babel/core@7.24.5)(babel-plugin-macros@3.1.0)(react@18.3.1)
       tailwind-merge: 2.6.0
       tailwindcss-animate: 1.0.7
       typescript: 4.7.4
@@ -20478,11 +20484,11 @@ snapshots:
       resolve: 1.22.6
     optional: true
 
-  babel-plugin-styled-components@2.1.4(@babel/core@7.28.4)(styled-components@6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
+  babel-plugin-styled-components@2.1.4(@babel/core@7.24.5)(styled-components@6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
     dependencies:
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-module-imports': 7.25.9
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.24.5)
       lodash: 4.17.21
       picomatch: 2.3.1
       styled-components: 6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -27267,6 +27273,11 @@ snapshots:
       react: 19.1.3
       react-dom: 19.1.3(react@19.1.3)
 
+  sonner@2.0.7(react-dom@19.1.3(react@19.1.3))(react@19.1.3):
+    dependencies:
+      react: 19.1.3
+      react-dom: 19.1.3(react@19.1.3)
+
   source-map-js@1.2.0: {}
 
   source-map-js@1.2.1: {}
@@ -27566,12 +27577,12 @@ snapshots:
       tslib: 2.6.2
     optional: true
 
-  styled-jsx@5.1.2(@babel/core@7.28.4)(babel-plugin-macros@3.1.0)(react@18.3.1):
+  styled-jsx@5.1.2(@babel/core@7.24.5)(babel-plugin-macros@3.1.0)(react@18.3.1):
     dependencies:
       client-only: 0.0.1
       react: 18.3.1
     optionalDependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.24.5
       babel-plugin-macros: 3.1.0
     optional: true
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved partner ban/deactivation cron behavior by disabling discount codes (soft) instead of deleting them, and propagating the disabled state through Stripe attribution.
  * Added `disabledAt` support across the discount code lifecycle, schemas, and API responses, so disabled codes display and behave correctly.
  * Enhanced the duplicate discount-code API response with clearer conflict messaging tied to the relevant partner.
* **UI Improvements**
  * Updated discount-code badges, tooltips, and the discount codes table to reflect disabled status; improved “already in use” and toast error visuals.
* **Chores**
  * Updated the `sonner` dependency version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->