### PR TITLE
AI support chat slack threading

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -115,9 +115,6 @@ DUB_SLACK_HOOK_LINKS=
 # Slack Dub Support integration
 DUB_SLACK_ASSISTANT_BOT_TOKEN=
 
-# Slack channel ID that mirrors AI support chat conversations
-DUB_SLACK_SUPPORT_CHAT_CHANNEL_ID=
-
 # Used for background jobs
 # Get your ngrok URL here: https://ngrok.com/
 NEXT_PUBLIC_NGROK_URL=

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -115,6 +115,9 @@ DUB_SLACK_HOOK_LINKS=
 # Slack Dub Support integration
 DUB_SLACK_ASSISTANT_BOT_TOKEN=
 
+# Slack channel ID that mirrors AI support chat conversations
+DUB_SLACK_SUPPORT_CHAT_CHANNEL_ID=
+
 # Used for background jobs
 # Get your ngrok URL here: https://ngrok.com/
 NEXT_PUBLIC_NGROK_URL=

--- a/apps/web/app/api/ai/support-chat/route.ts
+++ b/apps/web/app/api/ai/support-chat/route.ts
@@ -64,39 +64,37 @@ export const POST = withSession(async ({ req, session }) => {
     return new Response("Don't DDoS me pls 🥺", { status: 429 });
   }
 
-  const slackChannel = process.env.DUB_SLACK_SUPPORT_CHAT_CHANNEL_ID;
+  const slackChannel = "C0BECQ3GNKH";
   let slackThreadTs = incomingSlackThreadTs;
   let slackUserPostPromise: Promise<string | undefined> | undefined;
 
-  if (slackChannel) {
-    const latestUserText =
-      messages[messages.length - 1].parts
-        ?.filter((p): p is { type: "text"; text: string } => p.type === "text")
-        .map((p) => p.text)
-        .join("\n\n") ?? "";
-    const userLabel = session.user.name || session.user.email || "Unknown user";
+  const latestUserText =
+    messages[messages.length - 1].parts
+      ?.filter((p): p is { type: "text"; text: string } => p.type === "text")
+      .map((p) => p.text)
+      .join("\n\n") ?? "";
+  const userLabel = session.user.name || session.user.email || "Unknown user";
 
-    if (!slackThreadTs) {
-      slackUserPostPromise = postSupportChatMessage({
-        channel: slackChannel,
-        text: [
-          `:speech_balloon: *New AI Support Chat*`,
-          ...getAccountContextLines(globalContext),
-          `${userLabel} (${session.user.email})`,
-          "",
-          `${userLabel}: ${latestUserText}`,
-        ].join("\n"),
-      }).then((ts) => {
-        if (ts) slackThreadTs = ts;
-        return ts;
-      });
-    } else {
-      slackUserPostPromise = postSupportChatMessage({
-        channel: slackChannel,
-        threadTs: slackThreadTs,
-        text: `*${userLabel}:* ${latestUserText}`,
-      });
-    }
+  if (!slackThreadTs) {
+    slackUserPostPromise = postSupportChatMessage({
+      channel: slackChannel,
+      text: [
+        `:speech_balloon: *New AI Support Chat*`,
+        ...getAccountContextLines(globalContext),
+        `${userLabel} (${session.user.email})`,
+        "",
+        `${userLabel}: ${latestUserText}`,
+      ].join("\n"),
+    }).then((ts) => {
+      if (ts) slackThreadTs = ts;
+      return ts;
+    });
+  } else {
+    slackUserPostPromise = postSupportChatMessage({
+      channel: slackChannel,
+      threadTs: slackThreadTs,
+      text: `*${userLabel}:* ${latestUserText}`,
+    });
   }
 
   const result = streamText({

--- a/apps/web/app/api/ai/support-chat/route.ts
+++ b/apps/web/app/api/ai/support-chat/route.ts
@@ -162,7 +162,7 @@ const postSupportChatMessage = async ({
       text: text.slice(0, 3000),
       unfurl_links: false,
     });
-    return (res.ts as string | undefined) ?? threadTs;
+    return threadTs ?? (res.ts as string | undefined);
   } catch (e) {
     console.error("[Slack] Failed to post support chat message", e);
     return threadTs;

--- a/apps/web/app/api/ai/support-chat/route.ts
+++ b/apps/web/app/api/ai/support-chat/route.ts
@@ -118,7 +118,7 @@ export const POST = withSession(async ({ req, session }) => {
         await postSupportChatMessage({
           channel: slackChannel,
           threadTs: slackThreadTs,
-          text: `*Dub AI:* ${text}`,
+          text: `*Dub AI:*\n${markdownToSlackMrkdwn(text)}`,
         });
       }
     },
@@ -170,3 +170,13 @@ const getAccountContextLines = (globalContext?: GlobalChatContext) => {
 
   return [globalContext?.chatLocation ?? "Unknown context"];
 };
+
+const markdownToSlackMrkdwn = (text: string) =>
+  text
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, "<$2|$1>")
+    .replace(/\*\*([^*]+)\*\*/g, "*$1*")
+    .replace(/__([^_]+)__/g, "*$1*")
+    .replace(/~~([^~]+)~~/g, "~$1~")
+    .replace(/^#{1,6}\s+(.+)$/gm, "*$1*")
+    .replace(/^[*+]\s+/gm, "- ")
+    .trim();

--- a/apps/web/app/api/ai/support-chat/route.ts
+++ b/apps/web/app/api/ai/support-chat/route.ts
@@ -68,12 +68,23 @@ export const POST = withSession(async ({ req, session }) => {
   let slackThreadTs = incomingSlackThreadTs;
   let slackUserPostPromise: Promise<string | undefined> | undefined;
 
-  const latestUserText =
-    messages[messages.length - 1].parts
-      ?.filter((p): p is { type: "text"; text: string } => p.type === "text")
-      .map((p) => p.text)
-      .join("\n\n") ?? "";
+  const latestParts = Array.isArray(messages[messages.length - 1].parts)
+    ? messages[messages.length - 1].parts
+    : [];
+  const latestUserText = latestParts
+    .filter(
+      (p): p is { type: "text"; text: string } =>
+        p != null &&
+        typeof p === "object" &&
+        p.type === "text" &&
+        typeof p.text === "string",
+    )
+    .map((p) => p.text)
+    .join("\n\n");
   const userLabel = session.user.name || session.user.email || "Unknown user";
+  const safeUserText = escapeSlackMrkdwn(latestUserText);
+  const safeUserLabel = escapeSlackMrkdwn(userLabel);
+  const safeUserEmail = escapeSlackMrkdwn(session.user.email);
 
   if (!slackThreadTs) {
     slackUserPostPromise = postSupportChatMessage({
@@ -81,9 +92,9 @@ export const POST = withSession(async ({ req, session }) => {
       text: [
         `:speech_balloon: *New AI Support Chat*`,
         ...getAccountContextLines(globalContext),
-        `${userLabel} (${session.user.email})`,
+        `${safeUserLabel} (${safeUserEmail})`,
         "",
-        `${userLabel}: ${latestUserText}`,
+        `${safeUserLabel}: ${safeUserText}`,
       ].join("\n"),
     }).then((ts) => {
       if (ts) slackThreadTs = ts;
@@ -93,7 +104,7 @@ export const POST = withSession(async ({ req, session }) => {
     slackUserPostPromise = postSupportChatMessage({
       channel: slackChannel,
       threadTs: slackThreadTs,
-      text: `*${userLabel}:* ${latestUserText}`,
+      text: `*${safeUserLabel}:* ${safeUserText}`,
     });
   }
 
@@ -128,7 +139,7 @@ export const POST = withSession(async ({ req, session }) => {
       await postSupportChatMessage({
         channel: slackChannel,
         threadTs,
-        text: `*Dub AI:*\n${markdownToSlackMrkdwn(text)}`,
+        text: `*Dub AI:*\n${markdownToSlackMrkdwn(escapeSlackMrkdwn(text))}`,
       });
     },
   });
@@ -169,18 +180,25 @@ const postSupportChatMessage = async ({
   }
 };
 
+const escapeSlackMrkdwn = (text: string) =>
+  text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
 const getAccountContextLines = (globalContext?: GlobalChatContext) => {
   if (globalContext?.selectedWorkspace) {
     const { name, slug } = globalContext.selectedWorkspace;
-    return [`:briefcase: *Workspace* - ${name} (${slug})`];
+    return [
+      `:briefcase: *Workspace* - ${escapeSlackMrkdwn(name)} (${escapeSlackMrkdwn(slug)})`,
+    ];
   }
 
   if (globalContext?.selectedProgram) {
     const { name, slug } = globalContext.selectedProgram;
-    return [`:handshake: *Partners* - ${name} (${slug})`];
+    return [
+      `:handshake: *Partners* - ${escapeSlackMrkdwn(name)} (${escapeSlackMrkdwn(slug)})`,
+    ];
   }
 
-  return [globalContext?.chatLocation ?? "Unknown context"];
+  return [escapeSlackMrkdwn(globalContext?.chatLocation ?? "Unknown context")];
 };
 
 const markdownToSlackMrkdwn = (text: string) =>

--- a/apps/web/app/api/ai/support-chat/route.ts
+++ b/apps/web/app/api/ai/support-chat/route.ts
@@ -9,6 +9,7 @@ import { getProgramPerformanceTool } from "@/lib/ai/get-program-performance";
 import { getWorkspaceDetailsTool } from "@/lib/ai/get-workspace-details";
 import { requestSupportTicketTool } from "@/lib/ai/request-support-ticket";
 import { withSession } from "@/lib/auth";
+import { getSlackClient } from "@/lib/slack/client";
 import { ratelimit } from "@/lib/upstash/ratelimit";
 import { anthropic } from "@ai-sdk/anthropic";
 import { convertToModelMessages, stepCountIs, streamText, UIMessage } from "ai";
@@ -44,11 +45,50 @@ export const POST = withSession(async ({ req, session }) => {
   }
   const ticketDetails: string | undefined = body.ticketDetails?.slice(0, 4982);
 
+  if (
+    body.slackThreadTs !== undefined &&
+    (typeof body.slackThreadTs !== "string" || body.slackThreadTs.length > 64)
+  ) {
+    return new Response("Invalid slackThreadTs", { status: 400 });
+  }
+  const incomingSlackThreadTs: string | undefined = body.slackThreadTs;
+
   const { success } = await ratelimit(5, "30 s").limit(
     `support-chat:${session.user.id}`,
   );
   if (!success) {
     return new Response("Don't DDoS me pls 🥺", { status: 429 });
+  }
+
+  const slackChannel = process.env.DUB_SLACK_SUPPORT_CHAT_CHANNEL_ID;
+  let slackThreadTs = incomingSlackThreadTs;
+
+  if (slackChannel) {
+    const latestUserText =
+      messages[messages.length - 1].parts
+        ?.filter((p): p is { type: "text"; text: string } => p.type === "text")
+        .map((p) => p.text)
+        .join("\n\n") ?? "";
+    const userLabel = session.user.name || session.user.email || "Unknown user";
+
+    if (!slackThreadTs) {
+      slackThreadTs = await postSupportChatMessage({
+        channel: slackChannel,
+        text: [
+          `:speech_balloon: *New AI Support Chat*`,
+          ...getAccountContextLines(globalContext),
+          `${userLabel} (${session.user.email})`,
+          "",
+          `${userLabel}: ${latestUserText}`,
+        ].join("\n"),
+      });
+    } else {
+      await postSupportChatMessage({
+        channel: slackChannel,
+        threadTs: slackThreadTs,
+        text: `*${userLabel}:* ${latestUserText}`,
+      });
+    }
   }
 
   const result = streamText({
@@ -73,7 +113,60 @@ export const POST = withSession(async ({ req, session }) => {
         ticketDetails,
       }),
     },
+    onFinish: async ({ text }) => {
+      if (slackChannel && slackThreadTs && text) {
+        await postSupportChatMessage({
+          channel: slackChannel,
+          threadTs: slackThreadTs,
+          text: `*Dub AI:* ${text}`,
+        });
+      }
+    },
   });
 
-  return result.toUIMessageStreamResponse();
+  return result.toUIMessageStreamResponse({
+    messageMetadata: ({ part }) => {
+      if (part.type === "start" && slackThreadTs) {
+        return { slackThreadTs };
+      }
+    },
+  });
 });
+
+const postSupportChatMessage = async ({
+  channel,
+  threadTs,
+  text,
+}: {
+  channel: string;
+  threadTs?: string;
+  text: string;
+}): Promise<string | undefined> => {
+  try {
+    const slack = getSlackClient();
+    const res = await slack.chat.postMessage({
+      channel,
+      thread_ts: threadTs,
+      text: text.slice(0, 3000),
+      unfurl_links: false,
+    });
+    return (res.ts as string | undefined) ?? threadTs;
+  } catch (e) {
+    console.error("[Slack] Failed to post support chat message", e);
+    return threadTs;
+  }
+};
+
+const getAccountContextLines = (globalContext?: GlobalChatContext) => {
+  if (globalContext?.selectedWorkspace) {
+    const { name, slug } = globalContext.selectedWorkspace;
+    return [`:briefcase: *Workspace* - ${name} (${slug})`];
+  }
+
+  if (globalContext?.selectedProgram) {
+    const { name, slug } = globalContext.selectedProgram;
+    return [`:handshake: *Partners* - ${name} (${slug})`];
+  }
+
+  return [globalContext?.chatLocation ?? "Unknown context"];
+};

--- a/apps/web/app/api/ai/support-chat/route.ts
+++ b/apps/web/app/api/ai/support-chat/route.ts
@@ -21,6 +21,10 @@ export const POST = withSession(async ({ req, session }) => {
     globalContext?: GlobalChatContext;
   };
 
+  if (!Array.isArray(messages) || messages.length === 0) {
+    return new Response("Invalid messages", { status: 400 });
+  }
+
   const MAX_ATTACHMENTS = 5;
   const MAX_ATTACHMENT_ID_LENGTH = 128;
   const rawAttachmentIds = body.attachmentIds;
@@ -62,6 +66,7 @@ export const POST = withSession(async ({ req, session }) => {
 
   const slackChannel = process.env.DUB_SLACK_SUPPORT_CHAT_CHANNEL_ID;
   let slackThreadTs = incomingSlackThreadTs;
+  let slackUserPostPromise: Promise<string | undefined> | undefined;
 
   if (slackChannel) {
     const latestUserText =
@@ -72,7 +77,7 @@ export const POST = withSession(async ({ req, session }) => {
     const userLabel = session.user.name || session.user.email || "Unknown user";
 
     if (!slackThreadTs) {
-      slackThreadTs = await postSupportChatMessage({
+      slackUserPostPromise = postSupportChatMessage({
         channel: slackChannel,
         text: [
           `:speech_balloon: *New AI Support Chat*`,
@@ -81,9 +86,12 @@ export const POST = withSession(async ({ req, session }) => {
           "",
           `${userLabel}: ${latestUserText}`,
         ].join("\n"),
+      }).then((ts) => {
+        if (ts) slackThreadTs = ts;
+        return ts;
       });
     } else {
-      await postSupportChatMessage({
+      slackUserPostPromise = postSupportChatMessage({
         channel: slackChannel,
         threadTs: slackThreadTs,
         text: `*${userLabel}:* ${latestUserText}`,
@@ -114,19 +122,25 @@ export const POST = withSession(async ({ req, session }) => {
       }),
     },
     onFinish: async ({ text }) => {
-      if (slackChannel && slackThreadTs && text) {
-        await postSupportChatMessage({
-          channel: slackChannel,
-          threadTs: slackThreadTs,
-          text: `*Dub AI:*\n${markdownToSlackMrkdwn(text)}`,
-        });
-      }
+      if (!slackChannel || !text || !slackUserPostPromise) return;
+
+      const threadTs = await slackUserPostPromise;
+      if (!threadTs) return;
+
+      await postSupportChatMessage({
+        channel: slackChannel,
+        threadTs,
+        text: `*Dub AI:*\n${markdownToSlackMrkdwn(text)}`,
+      });
     },
   });
 
   return result.toUIMessageStreamResponse({
     messageMetadata: ({ part }) => {
-      if (part.type === "start" && slackThreadTs) {
+      if (part.type === "start" && incomingSlackThreadTs) {
+        return { slackThreadTs: incomingSlackThreadTs };
+      }
+      if (part.type === "finish" && slackThreadTs) {
         return { slackThreadTs };
       }
     },

--- a/apps/web/ui/support/chat-interface.tsx
+++ b/apps/web/ui/support/chat-interface.tsx
@@ -141,6 +141,16 @@ export function ChatInterface({
     }
   };
 
+  const getSlackThreadTs = () => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const meta = (messages[i] as any).metadata as
+        | { slackThreadTs?: string }
+        | undefined;
+      if (meta?.slackThreadTs) return meta.slackThreadTs;
+    }
+    return undefined;
+  };
+
   const handleSend = (text?: string) => {
     const messageText = text ?? input;
     if (!messageText.trim() || status === "streaming" || !canChat) return;
@@ -154,6 +164,7 @@ export function ChatInterface({
               effectiveAccountType === "partner" ? "partners" : "app",
             accountType: effectiveAccountType,
           },
+          slackThreadTs: getSlackThreadTs(),
         },
       },
     );
@@ -175,6 +186,7 @@ export function ChatInterface({
               effectiveAccountType === "partner" ? "partners" : "app",
             accountType: effectiveAccountType,
           },
+          slackThreadTs: getSlackThreadTs(),
           ...(attachmentIds.length ? { attachmentIds } : {}),
           ...(details ? { ticketDetails: details } : {}),
         },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support chat conversations can now continue in a linked Slack thread, keeping context together across sends and escalations.
  * Assistant responses are delivered to Slack with Slack-friendly formatting.
* **Bug Fixes**
  * Strengthened request validation for chat messages and Slack thread references.
  * The UI now tracks and sends the latest linked thread timestamp so subsequent messages attach to the correct thread.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->