### PR TITLE
Bind email-change confirmation to the token's issued account

### DIFF
--- a/apps/web/app/app.dub.co/(auth)/auth/confirm-email-change/[token]/page.tsx
+++ b/apps/web/app/app.dub.co/(auth)/auth/confirm-email-change/[token]/page.tsx
@@ -81,6 +81,16 @@ const VerifyEmailChange = async ({ params, searchParams }: PageProps) => {
     ? partnerId
     : userId;
 
+  if (tokenFound.identifier !== identifier) {
+    return (
+      <EmptyState
+        icon={InputPassword}
+        title="Invalid Token"
+        description="This token is invalid or expired. Please request a new one."
+      />
+    );
+  }
+
   const data = await redis.get<{
     email: string;
     newEmail: string;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened email-change confirmation validation to prevent mismatched tokens from being processed.
  * Invalid or inconsistent tokens now show an “Invalid Token” state immediately instead of continuing the confirmation flow.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->