### PR TITLE
Add rate limiting to password-protected link verification

### DIFF
--- a/apps/web/app/password/[linkId]/action.ts
+++ b/apps/web/app/password/[linkId]/action.ts
@@ -41,18 +41,13 @@ export async function verifyPassword(_prevState: any, data: FormData) {
     const linkKey = `verify-password:${linkId}`;
 
     const [ipLimit, linkLimit] = await Promise.all([
-      ratelimit(IP_ATTEMPTS, ATTEMPTS_WINDOW).getRemaining(ipKey),
-      ratelimit(LINK_ATTEMPTS, ATTEMPTS_WINDOW).getRemaining(linkKey),
-    ]);
-
-    if (ipLimit.remaining <= 0 || linkLimit.remaining <= 0) {
-      return { error: "Don't DDoS me pls 🥺" };
-    }
-
-    await Promise.all([
       ratelimit(IP_ATTEMPTS, ATTEMPTS_WINDOW).limit(ipKey),
       ratelimit(LINK_ATTEMPTS, ATTEMPTS_WINDOW).limit(linkKey),
     ]);
+
+    if (!ipLimit.success || !linkLimit.success) {
+      return { error: "Don't DDoS me pls 🥺" };
+    }
   }
 
   return { error: "Invalid password" };

--- a/apps/web/app/password/[linkId]/action.ts
+++ b/apps/web/app/password/[linkId]/action.ts
@@ -1,7 +1,14 @@
 "use server";
 
+import { shouldApplyRateLimit } from "@/lib/api/environment";
+import { getIP } from "@/lib/api/utils/get-ip";
 import { prismaEdge } from "@/lib/prisma/edge";
+import { ratelimit } from "@/lib/upstash";
 import { cookies } from "next/headers";
+
+const IP_ATTEMPTS = 10;
+const LINK_ATTEMPTS = 100;
+const ATTEMPTS_WINDOW = "10 m";
 
 export async function verifyPassword(_prevState: any, data: FormData) {
   const linkId = data.get("linkId") as string;
@@ -15,19 +22,38 @@ export async function verifyPassword(_prevState: any, data: FormData) {
   if (!link) {
     return { error: "Link not found" };
   }
+
   const { password: realPassword } = link;
 
   const validPassword = password === realPassword;
 
   if (validPassword) {
-    // if the password is valid, set the cookie
     (await cookies()).set(`dub_password_${link.id}`, password, {
       path: `/${link.key}`,
       httpOnly: true,
       secure: true,
     });
     return true;
-  } else {
-    return { error: "Invalid password" };
   }
+
+  if (shouldApplyRateLimit) {
+    const ipKey = `verify-password:${linkId}:${await getIP()}`;
+    const linkKey = `verify-password:${linkId}`;
+
+    const [ipLimit, linkLimit] = await Promise.all([
+      ratelimit(IP_ATTEMPTS, ATTEMPTS_WINDOW).getRemaining(ipKey),
+      ratelimit(LINK_ATTEMPTS, ATTEMPTS_WINDOW).getRemaining(linkKey),
+    ]);
+
+    if (ipLimit.remaining <= 0 || linkLimit.remaining <= 0) {
+      return { error: "Don't DDoS me pls 🥺" };
+    }
+
+    await Promise.all([
+      ratelimit(IP_ATTEMPTS, ATTEMPTS_WINDOW).limit(ipKey),
+      ratelimit(LINK_ATTEMPTS, ATTEMPTS_WINDOW).limit(linkKey),
+    ]);
+  }
+
+  return { error: "Invalid password" };
 }

--- a/apps/web/app/password/[linkId]/action.ts
+++ b/apps/web/app/password/[linkId]/action.ts
@@ -1,14 +1,9 @@
 "use server";
 
 import { shouldApplyRateLimit } from "@/lib/api/environment";
-import { getIP } from "@/lib/api/utils/get-ip";
 import { prismaEdge } from "@/lib/prisma/edge";
 import { ratelimit } from "@/lib/upstash";
 import { cookies } from "next/headers";
-
-const IP_ATTEMPTS = 10;
-const LINK_ATTEMPTS = 100;
-const ATTEMPTS_WINDOW = "10 m";
 
 export async function verifyPassword(_prevState: any, data: FormData) {
   const linkId = data.get("linkId") as string;
@@ -37,15 +32,11 @@ export async function verifyPassword(_prevState: any, data: FormData) {
   }
 
   if (shouldApplyRateLimit) {
-    const ipKey = `verify-password:${linkId}:${await getIP()}`;
-    const linkKey = `verify-password:${linkId}`;
+    const { success } = await ratelimit(30, "10 m").limit(
+      `verify-password:${linkId}`,
+    );
 
-    const [ipLimit, linkLimit] = await Promise.all([
-      ratelimit(IP_ATTEMPTS, ATTEMPTS_WINDOW).limit(ipKey),
-      ratelimit(LINK_ATTEMPTS, ATTEMPTS_WINDOW).limit(linkKey),
-    ]);
-
-    if (!ipLimit.success || !linkLimit.success) {
+    if (!success) {
       return { error: "Don't DDoS me pls 🥺" };
     }
   }

--- a/apps/web/app/password/[linkId]/form.tsx
+++ b/apps/web/app/password/[linkId]/form.tsx
@@ -54,7 +54,9 @@ export default function PasswordForm() {
         </div>
         {state.error && (
           <p className="mt-2 text-sm text-red-600" id="slug-error">
-            Incorrect password
+            {state.error === "Invalid password"
+              ? "Incorrect password"
+              : state.error}
           </p>
         )}
       </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Password-protected links now set a session cookie after a successful password check, so returning visitors aren’t repeatedly prompted.

* **Bug Fixes**
  * Invalid password messaging is more accurate: the UI shows “Incorrect password” only for the standard invalid-password case, and otherwise displays the provided error text.
  * Added optional rate limiting for repeated invalid password attempts, returning a DDoS-prevention error when limits are exceeded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->