### PR TITLE
Bound eventQuantity to a positive integer with a max

### DIFF
--- a/apps/web/lib/zod/schemas/leads.ts
+++ b/apps/web/lib/zod/schemas/leads.ts
@@ -57,7 +57,7 @@ export const trackLeadRequestSchema = z.object({
     .number()
     .int()
     .positive()
-    .max(1000)
+    .max(100)
     .nullish()
     .describe(
       "The numerical value associated with this lead event (e.g., number of provisioned seats in a free trial). If defined as N, the lead event will be tracked N times.",

--- a/apps/web/lib/zod/schemas/leads.ts
+++ b/apps/web/lib/zod/schemas/leads.ts
@@ -55,6 +55,9 @@ export const trackLeadRequestSchema = z.object({
     ),
   eventQuantity: z
     .number()
+    .int()
+    .positive()
+    .max(1000)
     .nullish()
     .describe(
       "The numerical value associated with this lead event (e.g., number of provisioned seats in a free trial). If defined as N, the lead event will be tracked N times.",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Tightened lead event quantity validation to accept only whole numbers greater than zero, capped at **100**.
  - Prevents invalid quantities (non-integers or out-of-range values) from being submitted, improving overall input reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->