### PR TITLE
Clear partner Stripe Connect data on revoked access error

### DIFF
--- a/apps/web/lib/partners/get-partner-bank-account.ts
+++ b/apps/web/lib/partners/get-partner-bank-account.ts
@@ -1,4 +1,6 @@
+import { prisma } from "@/lib/prisma";
 import { stripe } from "@/lib/stripe";
+import { waitUntil } from "@vercel/functions";
 import Stripe from "stripe";
 import * as z from "zod/v4";
 
@@ -21,14 +23,36 @@ export const bankAccountSchema = z
   .nullable();
 
 export const getPartnerBankAccount = async (stripeAccount: string) => {
-  const externalAccounts = (await stripe.accounts.listExternalAccounts(
-    stripeAccount,
-    {
-      object: "bank_account",
-    },
-  )) as Stripe.ApiList<Stripe.BankAccount>;
+  try {
+    const externalAccounts = await stripe.accounts.listExternalAccounts(
+      stripeAccount,
+      {
+        object: "bank_account",
+      },
+    );
 
-  return externalAccounts.data.length > 0
-    ? bankAccountSchema.parse(externalAccounts.data[0])
-    : null;
+    return externalAccounts.data.length > 0
+      ? bankAccountSchema.parse(externalAccounts.data[0])
+      : null;
+  } catch (error) {
+    const isApplicationAccessRevoked =
+      error instanceof Stripe.errors.StripeError &&
+      error.message.includes("Application access may have been revoked.");
+
+    if (isApplicationAccessRevoked) {
+      waitUntil(
+        prisma.partner.update({
+          where: {
+            stripeConnectId: stripeAccount,
+          },
+          data: {
+            stripeConnectId: null,
+            payoutMethodHash: null,
+          },
+        }),
+      );
+    }
+
+    return null;
+  }
 };

--- a/apps/web/lib/partners/get-partner-bank-account.ts
+++ b/apps/web/lib/partners/get-partner-bank-account.ts
@@ -40,17 +40,8 @@ export const getPartnerBankAccount = async (stripeAccount: string) => {
       error.message.includes("Application access may have been revoked.");
 
     if (isApplicationAccessRevoked) {
-      waitUntil(
-        prisma.partner.update({
-          where: {
-            stripeConnectId: stripeAccount,
-          },
-          data: {
-            stripeConnectId: null,
-            payoutMethodHash: null,
-          },
-        }),
-      );
+      // TODO: recompute payout state + reset payoutsEnabledAt / payoutMethodHash if needed
+      console.warn("No account connected – application access may have been revoked.")
     }
 
     return null;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of bank account retrieval when external payment access is unavailable.
  * If access to external payment data has been revoked, the app now handles the error safely and reports no bank account (with a warning).
  * When no external bank account is available, existing behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->