### PR TITLE
Fix nullable link date fields coercing to epoch in webhooks

### DIFF
--- a/apps/web/lib/webhook/sample-events/lead-created.json
+++ b/apps/web/lib/webhook/sample-events/lead-created.json
@@ -36,7 +36,7 @@
     "partnerId": "pn_cm0lcuvtz000xcutmqw4a7wi3",
     "programId": "prog_CYCu7IMAapjkRpTnr8F1azjN",
     "archived": false,
-    "expiresAt": "1970-01-01T00:00:00.000Z",
+    "expiresAt": null,
     "expiredUrl": null,
     "disabledAt": null,
     "password": null,

--- a/apps/web/lib/webhook/sample-events/link-clicked.json
+++ b/apps/web/lib/webhook/sample-events/link-clicked.json
@@ -27,7 +27,7 @@
     "partnerId": "pn_cm0lcuvtz000xcutmqw4a7wi3",
     "programId": "prog_CYCu7IMAapjkRpTnr8F1azjN",
     "archived": false,
-    "expiresAt": "1970-01-01T00:00:00.000Z",
+    "expiresAt": null,
     "expiredUrl": null,
     "disabledAt": null,
     "password": null,

--- a/apps/web/lib/webhook/sample-events/sale-created.json
+++ b/apps/web/lib/webhook/sample-events/sale-created.json
@@ -36,7 +36,7 @@
     "partnerId": "pn_cm0lcuvtz000xcutmqw4a7wi3",
     "programId": "prog_CYCu7IMAapjkRpTnr8F1azjN",
     "archived": false,
-    "expiresAt": "1970-01-01T00:00:00.000Z",
+    "expiresAt": null,
     "expiredUrl": null,
     "disabledAt": null,
     "password": null,

--- a/apps/web/lib/zod/schemas/links.ts
+++ b/apps/web/lib/zod/schemas/links.ts
@@ -861,11 +861,11 @@ export const linkEventSchema = LinkSchema.extend({
   // coerce date fields
   createdAt: z.coerce.date(),
   updatedAt: z.coerce.date(),
-  lastClicked: z.coerce.date(),
-  expiresAt: z.coerce.date(),
-  disabledAt: z.coerce.date(),
-  testCompletedAt: z.coerce.date(),
-  testStartedAt: z.coerce.date(),
+  lastClicked: z.coerce.date().nullable(),
+  expiresAt: z.coerce.date().nullable(),
+  disabledAt: z.coerce.date().nullable(),
+  testCompletedAt: z.coerce.date().nullable(),
+  testStartedAt: z.coerce.date().nullable(),
   // userId can be null
   userId: z.string().nullable(),
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated webhook sample data to use `null` for missing or unset link expiration and date fields.
  * Webhook payloads now better reflect real-world responses when link-related timestamps are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->