### PR TITLE
Sort partners "Referred by" filter by count

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/use-partner-filters.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/use-partner-filters.tsx
@@ -365,11 +365,15 @@ export function usePartnerFilters(
               options:
                 referredByCount && referredByPartners
                   ? referredByCount
+                      .filter(({ referredByPartnerId }) =>
+                        referredByPartners.some(
+                          (p) => p.id === referredByPartnerId,
+                        ),
+                      )
                       .map(({ referredByPartnerId, _count }) => {
                         const partner = referredByPartners.find(
                           (p) => p.id === referredByPartnerId,
-                        );
-                        if (!partner) return null;
+                        )!;
 
                         return {
                           value: referredByPartnerId,
@@ -387,7 +391,6 @@ export function usePartnerFilters(
                           right: nFormatter(_count, { full: true }),
                         };
                       })
-                      .filter((option) => option !== null)
                   : null,
             },
           ]

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/use-partner-filters.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/use-partner-filters.tsx
@@ -246,17 +246,9 @@ export function usePartnerFilters(
   });
 
   const { referredByPartners } = useReferredByPartnerFilterOptions({
-    search: selectedFilter === "referredByPartnerId" ? debouncedSearch : "",
+    referredByCount,
     enabled: enabledFilters.includes("referredByPartnerId"),
   });
-
-  const referredByCountMap = useMemo(
-    () =>
-      new Map(
-        referredByCount?.map((r) => [r.referredByPartnerId, r._count]) ?? [],
-      ),
-    [referredByCount],
-  );
 
   const filters = useMemo(
     () => [
@@ -371,23 +363,32 @@ export function usePartnerFilters(
                 enabledFilters.includes(m.filterKey),
               ),
               options:
-                referredByPartners?.map(({ id, name, image }) => {
-                  const count = referredByCountMap.get(id);
-                  return {
-                    value: id,
-                    label: name,
-                    icon: (
-                      <img
-                        src={image || `${OG_AVATAR_URL}${id}`}
-                        alt={`${name} avatar`}
-                        className="size-4 rounded-full"
-                      />
-                    ),
-                    ...(count !== undefined && {
-                      right: nFormatter(count, { full: true }),
-                    }),
-                  };
-                }) ?? null,
+                referredByCount && referredByPartners
+                  ? referredByCount
+                      .map(({ referredByPartnerId, _count }) => {
+                        const partner = referredByPartners.find(
+                          (p) => p.id === referredByPartnerId,
+                        );
+                        if (!partner) return null;
+
+                        return {
+                          value: referredByPartnerId,
+                          label: partner.name,
+                          icon: (
+                            <img
+                              src={
+                                partner.image ||
+                                `${OG_AVATAR_URL}${referredByPartnerId}`
+                              }
+                              alt={`${partner.name} avatar`}
+                              className="size-4 rounded-full"
+                            />
+                          ),
+                          right: nFormatter(_count, { full: true }),
+                        };
+                      })
+                      .filter((option) => option !== null)
+                  : null,
             },
           ]
         : []),
@@ -445,7 +446,7 @@ export function usePartnerFilters(
       statusCount,
       countriesCount,
       referredByPartners,
-      referredByCountMap,
+      referredByCount,
     ],
   );
 
@@ -760,17 +761,26 @@ function usePartnerTagFilterOptions({
 }
 
 function useReferredByPartnerFilterOptions({
-  search,
+  referredByCount,
   enabled = true,
 }: {
-  search: string;
+  referredByCount?:
+    | {
+        referredByPartnerId: string;
+        _count: number;
+      }[]
+    | undefined;
   enabled?: boolean;
 }) {
   const { searchParamsObj } = useRouterStuff();
 
+  const partnerIds = referredByCount?.map((r) => r.referredByPartnerId) ?? [];
+
   const { partners, loading: partnersLoading } = usePartners({
-    query: { search },
-    enabled,
+    query: {
+      partnerIds: partnerIds.length ? partnerIds : undefined,
+    },
+    enabled: enabled && partnerIds.length > 0,
   });
 
   const { partners: selectedPartners } = usePartners({
@@ -784,6 +794,7 @@ function useReferredByPartnerFilterOptions({
 
   const result = useMemo(() => {
     if (
+      !referredByCount ||
       partnersLoading ||
       (searchParamsObj.referredByPartnerId &&
         ![...(selectedPartners ?? []), ...(partners ?? [])].some(
@@ -800,6 +811,7 @@ function useReferredByPartnerFilterOptions({
         ?.map((sp) => ({ ...sp, hideDuringSearch: true })) ?? []),
     ] as (EnrolledPartnerProps & { hideDuringSearch?: boolean })[];
   }, [
+    referredByCount,
     partnersLoading,
     partners,
     selectedPartners,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the “Referred by” filter to build its options from referral counts, resulting in more accurate partner name and avatar display.
  * Omit or hide “Referred by” entries when the corresponding partner details can’t be resolved, reducing incomplete results.
  * Made “Referred by” search behavior more consistent during loading, including handling of the currently selected partner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->