### PR TITLE
Show pending review on completed performance bounty badge

### DIFF
--- a/apps/web/ui/partners/bounties/bounty-status-badge.tsx
+++ b/apps/web/ui/partners/bounties/bounty-status-badge.tsx
@@ -10,6 +10,7 @@ interface BountyBadgeStateResult {
   status: "expired" | "expiring_soon" | "completed" | "new";
   endsAtFormatted: string | null;
   completedAtFormatted: string | null;
+  isPendingReview?: boolean;
 }
 
 function getBountyBadgeState(
@@ -57,6 +58,8 @@ function getBountyBadgeState(
 
   if (isCompleted) {
     const lastSubmission = bounty.submissions?.[0];
+    const isPendingReview =
+      bounty.type === "performance" && lastSubmission?.status === "submitted";
 
     return {
       status: "completed",
@@ -64,6 +67,7 @@ function getBountyBadgeState(
       completedAtFormatted: formatDate(lastSubmission?.completedAt ?? now, {
         month: "short",
       }),
+      isPendingReview,
     };
   }
 
@@ -88,7 +92,8 @@ export function BountyStatusBadge({ bounty }: { bounty: PartnerBountyProps }) {
     return null;
   }
 
-  const { status, endsAtFormatted, completedAtFormatted } = state;
+  const { status, endsAtFormatted, completedAtFormatted, isPendingReview } =
+    state;
 
   return (
     <div className="absolute left-2 top-2 z-10">
@@ -105,8 +110,9 @@ export function BountyStatusBadge({ bounty }: { bounty: PartnerBountyProps }) {
       )}
 
       {status === "completed" && completedAtFormatted && (
-        <StatusBadge variant="success" icon={null}>
+        <StatusBadge variant={isPendingReview ? "new" : "success"} icon={null}>
           Completed {completedAtFormatted}
+          {isPendingReview && " | Pending Review"}
         </StatusBadge>
       )}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Completed bounty badges now show a clearer “Pending Review” state when a submission has been sent but not yet reviewed.
  * Pending-review completed badges use a distinct visual style to make their status easier to spot.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->