### PR TITLE
Events export to use program startedAt

### DIFF
--- a/apps/web/app/(ee)/api/cron/export/events/workspace/route.ts
+++ b/apps/web/app/(ee)/api/cron/export/events/workspace/route.ts
@@ -24,6 +24,7 @@ const payloadSchema = eventsQuerySchema.extend({
     .pipe(z.string().array()),
   workspaceId: z.string(),
   userId: z.string(),
+  dataAvailableFrom: z.coerce.date().optional(),
 });
 
 // POST /api/cron/export/events/workspace - QStash worker for processing large event exports

--- a/apps/web/app/(ee)/api/events/export/route.ts
+++ b/apps/web/app/(ee)/api/events/export/route.ts
@@ -32,7 +32,7 @@ const exportQuerySchema = z
   })
   .passthrough();
 
-// GET /api/events/export – export events to CSV (with async support if >1000 events)
+// GET /api/events/export – export events to CSV (with async support if >1000 events)
 export const GET = withWorkspace(
   async ({ searchParams, workspace, session }) => {
     throwIfClicksUsageExceeded(workspace);
@@ -54,7 +54,7 @@ export const GET = withWorkspace(
     } = parsedParams;
 
     let programStartedAt: Date | null | undefined = null;
-    if (programId) {
+    if (programId && interval === "all") {
       const workspaceProgramId = getDefaultProgramIdOrThrow(workspace);
       if (programId !== workspaceProgramId) {
         throw new DubApiError({
@@ -69,7 +69,10 @@ export const GET = withWorkspace(
       programStartedAt = program.startedAt;
     }
 
-    const dataAvailableFrom = programStartedAt ?? workspace.createdAt;
+    const dataAvailableFrom =
+      programStartedAt && programStartedAt < workspace.createdAt
+        ? programStartedAt
+        : workspace.createdAt;
 
     let folderIdToVerify = getFirstFilterValue(folderId);
     if (!linkId && (externalId || (domain && key))) {
@@ -106,7 +109,7 @@ export const GET = withWorkspace(
 
     assertValidDateRangeForPlan({
       plan: workspace.plan,
-      dataAvailableFrom,
+      dataAvailableFrom: workspace.createdAt,
       interval,
       start,
       end,

--- a/apps/web/app/(ee)/api/events/export/route.ts
+++ b/apps/web/app/(ee)/api/events/export/route.ts
@@ -109,7 +109,7 @@ export const GET = withWorkspace(
 
     assertValidDateRangeForPlan({
       plan: workspace.plan,
-      dataAvailableFrom: workspace.createdAt,
+      dataAvailableFrom,
       interval,
       start,
       end,

--- a/apps/web/app/(ee)/api/events/export/route.ts
+++ b/apps/web/app/(ee)/api/events/export/route.ts
@@ -6,9 +6,13 @@ import { getFirstFilterValue } from "@/lib/analytics/filter-helpers";
 import { getAnalytics } from "@/lib/analytics/get-analytics";
 import { getEvents } from "@/lib/analytics/get-events";
 import { convertToCSV } from "@/lib/analytics/utils";
+import { DubApiError } from "@/lib/api/errors";
 import { getLinkOrThrow } from "@/lib/api/links/get-link-or-throw";
 import { throwIfClicksUsageExceeded } from "@/lib/api/links/usage-checks";
+import { getDefaultProgramIdOrThrow } from "@/lib/api/programs/get-default-program-id-or-throw";
+import { getProgramOrThrow } from "@/lib/api/programs/get-program-or-throw";
 import { assertValidDateRangeForPlan } from "@/lib/api/utils/assert-valid-date-range-for-plan";
+import { prefixWorkspaceId } from "@/lib/api/workspaces/workspace-id";
 import { withWorkspace } from "@/lib/auth";
 import { qstash } from "@/lib/cron";
 import { verifyFolderAccess } from "@/lib/folder/permissions";
@@ -46,7 +50,26 @@ export const GET = withWorkspace(
       key,
       linkId,
       externalId,
+      programId,
     } = parsedParams;
+
+    let programStartedAt: Date | null | undefined = null;
+    if (programId) {
+      const workspaceProgramId = getDefaultProgramIdOrThrow(workspace);
+      if (programId !== workspaceProgramId) {
+        throw new DubApiError({
+          code: "forbidden",
+          message: `Program ${programId} does not belong to workspace ${prefixWorkspaceId(workspace.id)}.`,
+        });
+      }
+      const program = await getProgramOrThrow({
+        workspaceId: workspace.id,
+        programId,
+      });
+      programStartedAt = program.startedAt;
+    }
+
+    const dataAvailableFrom = programStartedAt ?? workspace.createdAt;
 
     let folderIdToVerify = getFirstFilterValue(folderId);
     if (!linkId && (externalId || (domain && key))) {
@@ -83,7 +106,7 @@ export const GET = withWorkspace(
 
     assertValidDateRangeForPlan({
       plan: workspace.plan,
-      dataAvailableFrom: workspace.createdAt,
+      dataAvailableFrom,
       interval,
       start,
       end,
@@ -94,7 +117,7 @@ export const GET = withWorkspace(
       ...parsedParams,
       groupBy: "count",
       workspaceId: workspace.id,
-      dataAvailableFrom: workspace.createdAt,
+      dataAvailableFrom,
     });
 
     // Extract the count based on event type
@@ -114,6 +137,7 @@ export const GET = withWorkspace(
           ...searchParams,
           workspaceId: workspace.id,
           userId: session.user.id,
+          dataAvailableFrom: dataAvailableFrom.toISOString(),
         },
       });
 
@@ -125,6 +149,7 @@ export const GET = withWorkspace(
       event,
       workspaceId: workspace.id,
       limit: MAX_EVENTS_TO_EXPORT,
+      dataAvailableFrom,
     });
 
     const data = response.map((row) =>

--- a/apps/web/app/(ee)/api/events/export/route.ts
+++ b/apps/web/app/(ee)/api/events/export/route.ts
@@ -18,6 +18,7 @@ import { qstash } from "@/lib/cron";
 import { verifyFolderAccess } from "@/lib/folder/permissions";
 import { eventsQuerySchema } from "@/lib/zod/schemas/analytics";
 import { APP_DOMAIN_WITH_NGROK, capitalize } from "@dub/utils";
+import { min } from "date-fns";
 import { NextResponse } from "next/server";
 import * as z from "zod/v4";
 
@@ -69,10 +70,10 @@ export const GET = withWorkspace(
       programStartedAt = program.startedAt;
     }
 
-    const dataAvailableFrom =
-      programStartedAt && programStartedAt < workspace.createdAt
-        ? programStartedAt
-        : workspace.createdAt;
+    const dataAvailableFrom = min([
+      workspace.createdAt,
+      ...(programStartedAt ? [programStartedAt] : []),
+    ]);
 
     let folderIdToVerify = getFirstFilterValue(folderId);
     if (!linkId && (externalId || (domain && key))) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event exports can now accept an optional `programId` (when exporting across all intervals); the export uses the program’s start date to determine the earliest available data.
  * Exports now support an availability start date (`dataAvailableFrom`) to improve date-range accuracy, including for background exports.

* **Bug Fixes**
  * Prevent exporting with a `programId` that doesn’t match the workspace’s default program.
  * Background export jobs, event counting, and CSV generation now consistently respect the effective availability start date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->