### PR TITLE
Allow shared tremendous email across partners

### DIFF
--- a/apps/web/app/(ee)/api/embed/referrals/tremendous/send-otp/route.ts
+++ b/apps/web/app/(ee)/api/embed/referrals/tremendous/send-otp/route.ts
@@ -75,30 +75,16 @@ export const POST = withReferralsEmbedToken(
       });
     }
 
-    const [partner, duplicatePartner] = await prisma.$transaction([
-      prisma.partner.findUniqueOrThrow({
-        where: {
-          id: partnerId,
-        },
-        select: {
-          id: true,
-          country: true,
-          defaultPayoutMethod: true,
-        },
-      }),
-
-      prisma.partner.findFirst({
-        where: {
-          tremendousEmail: email,
-          id: {
-            not: partnerId,
-          },
-        },
-        select: {
-          id: true,
-        },
-      }),
-    ]);
+    const partner = await prisma.partner.findUniqueOrThrow({
+      where: {
+        id: partnerId,
+      },
+      select: {
+        id: true,
+        country: true,
+        defaultPayoutMethod: true,
+      },
+    });
 
     if (
       partner.country &&
@@ -114,14 +100,6 @@ export const POST = withReferralsEmbedToken(
       throw new DubApiError({
         code: "bad_request",
         message: "You already have a payout method connected.",
-      });
-    }
-
-    if (duplicatePartner) {
-      throw new DubApiError({
-        code: "conflict",
-        message:
-          "Unable to save partner details. Please verify the email address and try again.",
       });
     }
 

--- a/apps/web/app/(ee)/api/embed/referrals/tremendous/verify-otp/route.ts
+++ b/apps/web/app/(ee)/api/embed/referrals/tremendous/verify-otp/route.ts
@@ -73,30 +73,16 @@ export const POST = withReferralsEmbedToken(
       });
     }
 
-    const [partner, duplicatePartner] = await prisma.$transaction([
-      prisma.partner.findUniqueOrThrow({
-        where: {
-          id: partnerId,
-        },
-        select: {
-          id: true,
-          country: true,
-          defaultPayoutMethod: true,
-        },
-      }),
-
-      prisma.partner.findFirst({
-        where: {
-          tremendousEmail: email,
-          id: {
-            not: partnerId,
-          },
-        },
-        select: {
-          id: true,
-        },
-      }),
-    ]);
+    const partner = await prisma.partner.findUniqueOrThrow({
+      where: {
+        id: partnerId,
+      },
+      select: {
+        id: true,
+        country: true,
+        defaultPayoutMethod: true,
+      },
+    });
 
     if (
       partner.country &&
@@ -112,14 +98,6 @@ export const POST = withReferralsEmbedToken(
       throw new DubApiError({
         code: "bad_request",
         message: "You already have a payout method connected.",
-      });
-    }
-
-    if (duplicatePartner) {
-      throw new DubApiError({
-        code: "conflict",
-        message:
-          "Unable to save partner details. Please verify the email address and try again.",
       });
     }
 

--- a/apps/web/prisma/schema/partner.prisma
+++ b/apps/web/prisma/schema/partner.prisma
@@ -70,7 +70,7 @@ model Partner {
   stripeRecipientId            String?              @unique
   payoutMethodHash             String?
   cryptoWalletAddress          String?
-  tremendousEmail              String?              @unique
+  tremendousEmail              String?
 
   // timestamp fields
   createdAt   DateTime  @default(now())
@@ -119,6 +119,7 @@ model Partner {
   @@index(cryptoWalletAddress)
   @@index(identityVerifiedAt)
   @@index(referredByPartnerId)
+  @@index(tremendousEmail)
   @@fulltext([email, name, companyName]) // For full-text search
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Tremendous payout OTP sending and verification by removing conflict blocking tied to duplicate payout emails, while preserving the existing eligibility, rate-limit, and token validation checks.
  * Improved reliability when partners share the same Tremendous payout email—OTP flows continue as long as all validations pass.
* **Database**
  * Updated the Partner payout email constraint to no longer enforce global uniqueness, adding an index for faster lookup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->