### PR TITLE
Add custom sales range to earnings calculator

### DIFF
--- a/apps/web/lib/zod/schemas/program-lander.ts
+++ b/apps/web/lib/zod/schemas/program-lander.ts
@@ -64,6 +64,8 @@ export const programLanderEarningsCalculatorBlockSchema =
     data: z.object({
       productPrice: z.number().describe("Average product price in cents"),
       billingPeriod: z.enum(["monthly", "yearly", "one-time"]).optional(),
+      minSales: z.number().int().min(1).optional(),
+      maxSales: z.number().int().min(1).optional(),
     }),
   });
 

--- a/apps/web/ui/partners/groups/design/lander/modals/earnings-calculator-block-modal.tsx
+++ b/apps/web/ui/partners/groups/design/lander/modals/earnings-calculator-block-modal.tsx
@@ -63,6 +63,8 @@ function EarningsCalculatorBlockModalInner({
         ? defaultValues.productPrice / 100
         : undefined,
       billingPeriod: defaultValues?.billingPeriod ?? "monthly",
+      minSales: defaultValues?.minSales,
+      maxSales: defaultValues?.maxSales,
     },
   });
 
@@ -84,6 +86,8 @@ function EarningsCalculatorBlockModalInner({
               onSubmit({
                 ...data,
                 productPrice: Number(data.productPrice) * 100,
+                minSales: data.minSales || undefined,
+                maxSales: data.maxSales || undefined,
               });
             })(e);
           }}
@@ -154,6 +158,98 @@ function EarningsCalculatorBlockModalInner({
                   </div>
                 </div>
 
+                <div>
+                  <label className="text-sm font-medium text-neutral-700">
+                    Sales range
+                  </label>
+
+                  <div className="mt-2 flex items-end gap-2">
+                    <div
+                      className={cn(
+                        "border-subtle flex h-10 min-w-0 flex-1 items-stretch overflow-hidden rounded-lg border bg-white",
+                        "transition-[border-color,box-shadow] duration-150 ease-out motion-reduce:transition-none",
+                        "focus-within:border-neutral-500 focus-within:ring-4 focus-within:ring-neutral-200",
+                        errors.minSales &&
+                          "border-red-600 focus-within:border-red-500 focus-within:ring-red-200",
+                      )}
+                    >
+                      <input
+                        id={`${id}-min-sales`}
+                        type="text"
+                        inputMode="numeric"
+                        autoComplete="off"
+                        aria-label="Minimum sales"
+                        placeholder="No min"
+                        className="min-w-0 flex-1 border-0 bg-transparent px-3 py-1 text-sm text-neutral-900 outline-none placeholder:text-neutral-400 focus:ring-0"
+                        {...register("minSales", {
+                          setValueAs: (v) => {
+                            if (v === "" || v == null) return undefined;
+                            const n = Number.parseInt(
+                              String(v).replace(/\D/g, ""),
+                              10,
+                            );
+                            return Number.isFinite(n) ? n : undefined;
+                          },
+                          min: 1,
+                          validate: (value, formValues) => {
+                            if (value == null || formValues.maxSales == null) {
+                              return true;
+                            }
+                            return (
+                              value <= formValues.maxSales ||
+                              "Must be less than or equal to max sales"
+                            );
+                          },
+                        })}
+                      />
+                    </div>
+
+                    <span className="shrink-0 pb-2.5 text-xs text-neutral-500">
+                      to
+                    </span>
+
+                    <div
+                      className={cn(
+                        "border-subtle flex h-10 min-w-0 flex-1 items-stretch overflow-hidden rounded-lg border bg-white",
+                        "transition-[border-color,box-shadow] duration-150 ease-out motion-reduce:transition-none",
+                        "focus-within:border-neutral-500 focus-within:ring-4 focus-within:ring-neutral-200",
+                        errors.maxSales &&
+                          "border-red-600 focus-within:border-red-500 focus-within:ring-red-200",
+                      )}
+                    >
+                      <input
+                        id={`${id}-max-sales`}
+                        type="text"
+                        inputMode="numeric"
+                        autoComplete="off"
+                        aria-label="Maximum sales"
+                        placeholder="No max"
+                        className="min-w-0 flex-1 border-0 bg-transparent px-3 py-1 text-sm text-neutral-900 outline-none placeholder:text-neutral-400 focus:ring-0"
+                        {...register("maxSales", {
+                          setValueAs: (v) => {
+                            if (v === "" || v == null) return undefined;
+                            const n = Number.parseInt(
+                              String(v).replace(/\D/g, ""),
+                              10,
+                            );
+                            return Number.isFinite(n) ? n : undefined;
+                          },
+                          min: 1,
+                          validate: (value, formValues) => {
+                            if (value == null || formValues.minSales == null) {
+                              return true;
+                            }
+                            return (
+                              value >= formValues.minSales ||
+                              "Must be greater than or equal to min sales"
+                            );
+                          },
+                        })}
+                      />
+                    </div>
+                  </div>
+                </div>
+
                 <div className="flex flex-col gap-2.5">
                   <div>
                     <span className="text-content-emphasis text-sm font-medium">
@@ -208,6 +304,8 @@ function Preview({
 }) {
   const productPrice = useWatch({ control, name: "productPrice" });
   const billingPeriod = useWatch({ control, name: "billingPeriod" });
+  const minSales = useWatch({ control, name: "minSales" });
+  const maxSales = useWatch({ control, name: "maxSales" });
 
   const { group } = useGroup();
 
@@ -222,6 +320,8 @@ function Preview({
           productPrice:
             Math.min(Math.max(productPrice || 0, 0), MAX_PRODUCT_PRICE) * 100,
           billingPeriod: billingPeriod ?? "monthly",
+          minSales: minSales || undefined,
+          maxSales: maxSales || undefined,
         },
       }}
       group={group}

--- a/apps/web/ui/partners/groups/design/lander/modals/earnings-calculator-block-modal.tsx
+++ b/apps/web/ui/partners/groups/design/lander/modals/earnings-calculator-block-modal.tsx
@@ -4,6 +4,7 @@ import useGroup from "@/lib/swr/use-group";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { programLanderEarningsCalculatorBlockSchema } from "@/lib/zod/schemas/program-lander";
 import {
+  AnimatedSizeContainer,
   Button,
   Modal,
   ToggleGroup,
@@ -11,8 +12,10 @@ import {
   useScrollProgress,
 } from "@dub/ui";
 import { cn } from "@dub/utils";
+import { ChevronDown } from "lucide-react";
+import { motion } from "motion/react";
 import Link from "next/link";
-import { Dispatch, SetStateAction, useId, useRef } from "react";
+import { Dispatch, SetStateAction, useId, useRef, useState } from "react";
 import type { Control } from "react-hook-form";
 import { Controller, useForm, useWatch } from "react-hook-form";
 import * as z from "zod/v4";
@@ -50,6 +53,10 @@ function EarningsCalculatorBlockModalInner({
   const { isMobile } = useMediaQuery();
 
   const { slug: workspaceSlug } = useWorkspace();
+
+  const [showAdvancedSettings, setShowAdvancedSettings] = useState(
+    () => defaultValues?.minSales != null || defaultValues?.maxSales != null,
+  );
 
   const {
     handleSubmit,
@@ -158,96 +165,125 @@ function EarningsCalculatorBlockModalInner({
                   </div>
                 </div>
 
-                <div>
-                  <label className="text-sm font-medium text-neutral-700">
-                    Sales range
-                  </label>
-
-                  <div className="mt-2 flex items-end gap-2">
-                    <div
-                      className={cn(
-                        "border-subtle flex h-10 min-w-0 flex-1 items-stretch overflow-hidden rounded-lg border bg-white",
-                        "transition-[border-color,box-shadow] duration-150 ease-out motion-reduce:transition-none",
-                        "focus-within:border-neutral-500 focus-within:ring-4 focus-within:ring-neutral-200",
-                        errors.minSales &&
-                          "border-red-600 focus-within:border-red-500 focus-within:ring-red-200",
-                      )}
+                <div className="flex flex-col">
+                  <button
+                    type="button"
+                    className="flex w-full items-center gap-2"
+                    onClick={() =>
+                      setShowAdvancedSettings(!showAdvancedSettings)
+                    }
+                  >
+                    <p className="text-sm text-neutral-600">
+                      {showAdvancedSettings ? "Hide" : "Show"} advanced settings
+                    </p>
+                    <motion.div
+                      animate={{ rotate: showAdvancedSettings ? 180 : 0 }}
+                      className="text-neutral-600"
                     >
-                      <input
-                        id={`${id}-min-sales`}
-                        type="text"
-                        inputMode="numeric"
-                        autoComplete="off"
-                        aria-label="Minimum sales"
-                        placeholder="No min"
-                        className="min-w-0 flex-1 border-0 bg-transparent px-3 py-1 text-sm text-neutral-900 outline-none placeholder:text-neutral-400 focus:ring-0"
-                        {...register("minSales", {
-                          setValueAs: (v) => {
-                            if (v === "" || v == null) return undefined;
-                            const n = Number.parseInt(
-                              String(v).replace(/\D/g, ""),
-                              10,
-                            );
-                            return Number.isFinite(n) ? n : undefined;
-                          },
-                          min: 1,
-                          validate: (value, formValues) => {
-                            if (value == null || formValues.maxSales == null) {
-                              return true;
-                            }
-                            return (
-                              value <= formValues.maxSales ||
-                              "Must be less than or equal to max sales"
-                            );
-                          },
-                        })}
-                      />
-                    </div>
+                      <ChevronDown className="size-4" />
+                    </motion.div>
+                  </button>
 
-                    <span className="shrink-0 pb-2.5 text-xs text-neutral-500">
-                      to
-                    </span>
+                  <AnimatedSizeContainer height className="flex flex-col">
+                    {showAdvancedSettings && (
+                      <div className="mt-2">
+                        <label className="text-sm font-medium text-neutral-700">
+                          Sales range
+                        </label>
+                        <div className="mt-2 flex items-end gap-2">
+                          <div
+                            className={cn(
+                              "border-subtle flex h-10 min-w-0 flex-1 items-stretch overflow-hidden rounded-lg border bg-white",
+                              "transition-[border-color,box-shadow] duration-150 ease-out motion-reduce:transition-none",
+                              "focus-within:border-neutral-500 focus-within:ring-4 focus-within:ring-neutral-200",
+                              errors.minSales &&
+                                "border-red-600 focus-within:border-red-500 focus-within:ring-red-200",
+                            )}
+                          >
+                            <input
+                              id={`${id}-min-sales`}
+                              type="text"
+                              inputMode="numeric"
+                              autoComplete="off"
+                              aria-label="Minimum sales"
+                              placeholder="No min"
+                              className="min-w-0 flex-1 border-0 bg-transparent px-3 py-1 text-sm text-neutral-900 outline-none placeholder:text-neutral-400 focus:ring-0"
+                              {...register("minSales", {
+                                setValueAs: (v) => {
+                                  if (v === "" || v == null) return undefined;
+                                  const n = Number.parseInt(
+                                    String(v).replace(/\D/g, ""),
+                                    10,
+                                  );
+                                  return Number.isFinite(n) ? n : undefined;
+                                },
+                                min: 1,
+                                validate: (value, formValues) => {
+                                  if (
+                                    value == null ||
+                                    formValues.maxSales == null
+                                  ) {
+                                    return true;
+                                  }
+                                  return (
+                                    value <= formValues.maxSales ||
+                                    "Must be less than or equal to max sales"
+                                  );
+                                },
+                              })}
+                            />
+                          </div>
 
-                    <div
-                      className={cn(
-                        "border-subtle flex h-10 min-w-0 flex-1 items-stretch overflow-hidden rounded-lg border bg-white",
-                        "transition-[border-color,box-shadow] duration-150 ease-out motion-reduce:transition-none",
-                        "focus-within:border-neutral-500 focus-within:ring-4 focus-within:ring-neutral-200",
-                        errors.maxSales &&
-                          "border-red-600 focus-within:border-red-500 focus-within:ring-red-200",
-                      )}
-                    >
-                      <input
-                        id={`${id}-max-sales`}
-                        type="text"
-                        inputMode="numeric"
-                        autoComplete="off"
-                        aria-label="Maximum sales"
-                        placeholder="No max"
-                        className="min-w-0 flex-1 border-0 bg-transparent px-3 py-1 text-sm text-neutral-900 outline-none placeholder:text-neutral-400 focus:ring-0"
-                        {...register("maxSales", {
-                          setValueAs: (v) => {
-                            if (v === "" || v == null) return undefined;
-                            const n = Number.parseInt(
-                              String(v).replace(/\D/g, ""),
-                              10,
-                            );
-                            return Number.isFinite(n) ? n : undefined;
-                          },
-                          min: 1,
-                          validate: (value, formValues) => {
-                            if (value == null || formValues.minSales == null) {
-                              return true;
-                            }
-                            return (
-                              value >= formValues.minSales ||
-                              "Must be greater than or equal to min sales"
-                            );
-                          },
-                        })}
-                      />
-                    </div>
-                  </div>
+                          <span className="shrink-0 pb-2.5 text-xs text-neutral-500">
+                            to
+                          </span>
+
+                          <div
+                            className={cn(
+                              "border-subtle flex h-10 min-w-0 flex-1 items-stretch overflow-hidden rounded-lg border bg-white",
+                              "transition-[border-color,box-shadow] duration-150 ease-out motion-reduce:transition-none",
+                              "focus-within:border-neutral-500 focus-within:ring-4 focus-within:ring-neutral-200",
+                              errors.maxSales &&
+                                "border-red-600 focus-within:border-red-500 focus-within:ring-red-200",
+                            )}
+                          >
+                            <input
+                              id={`${id}-max-sales`}
+                              type="text"
+                              inputMode="numeric"
+                              autoComplete="off"
+                              aria-label="Maximum sales"
+                              placeholder="No max"
+                              className="min-w-0 flex-1 border-0 bg-transparent px-3 py-1 text-sm text-neutral-900 outline-none placeholder:text-neutral-400 focus:ring-0"
+                              {...register("maxSales", {
+                                setValueAs: (v) => {
+                                  if (v === "" || v == null) return undefined;
+                                  const n = Number.parseInt(
+                                    String(v).replace(/\D/g, ""),
+                                    10,
+                                  );
+                                  return Number.isFinite(n) ? n : undefined;
+                                },
+                                min: 1,
+                                validate: (value, formValues) => {
+                                  if (
+                                    value == null ||
+                                    formValues.minSales == null
+                                  ) {
+                                    return true;
+                                  }
+                                  return (
+                                    value >= formValues.minSales ||
+                                    "Must be greater than or equal to min sales"
+                                  );
+                                },
+                              })}
+                            />
+                          </div>
+                        </div>
+                      </div>
+                    )}
+                  </AnimatedSizeContainer>
                 </div>
 
                 <div className="flex flex-col gap-2.5">

--- a/apps/web/ui/partners/lander/blocks/earnings-calculator-block.tsx
+++ b/apps/web/ui/partners/lander/blocks/earnings-calculator-block.tsx
@@ -27,7 +27,7 @@ export function EarningsCalculatorBlock({
 }) {
   const id = useId();
   const min = block.data.minSales ?? DEFAULT_SLIDER_MIN;
-  const max = block.data.maxSales ?? DEFAULT_SLIDER_MAX;
+  const max = block.data.maxSales ?? Math.max(DEFAULT_SLIDER_MAX, min);
   const sliderMin = max < min ? DEFAULT_SLIDER_MIN : min;
   const sliderMax = max < min ? DEFAULT_SLIDER_MAX : max;
   const [value, setValue] = useState(() =>

--- a/apps/web/ui/partners/lander/blocks/earnings-calculator-block.tsx
+++ b/apps/web/ui/partners/lander/blocks/earnings-calculator-block.tsx
@@ -5,15 +5,16 @@ import { GroupProps } from "@/lib/types";
 import { programLanderEarningsCalculatorBlockSchema } from "@/lib/zod/schemas/program-lander";
 import { InvoiceDollar } from "@dub/ui";
 import NumberFlow from "@number-flow/react";
-import { useId, useState } from "react";
+import { useEffect, useId, useState } from "react";
 import * as z from "zod/v4";
 import { formatRewardDescription } from "../../format-reward-description";
 import { BlockDescription } from "./block-description";
 import { BlockTitle } from "./block-title";
 import { WavePattern } from "./wave-pattern";
 
-const SLIDER_MIN = 1;
-const SLIDER_MAX = 50;
+const DEFAULT_SLIDER_MIN = 1;
+const DEFAULT_SLIDER_MAX = 50;
+const DEFAULT_SLIDER_VALUE = 10;
 
 export function EarningsCalculatorBlock({
   block,
@@ -25,7 +26,17 @@ export function EarningsCalculatorBlock({
   showTitleAndDescription?: boolean;
 }) {
   const id = useId();
-  const [value, setValue] = useState(10);
+  const min = block.data.minSales ?? DEFAULT_SLIDER_MIN;
+  const max = block.data.maxSales ?? DEFAULT_SLIDER_MAX;
+  const sliderMin = max < min ? DEFAULT_SLIDER_MIN : min;
+  const sliderMax = max < min ? DEFAULT_SLIDER_MAX : max;
+  const [value, setValue] = useState(() =>
+    Math.min(Math.max(DEFAULT_SLIDER_VALUE, sliderMin), sliderMax),
+  );
+
+  useEffect(() => {
+    setValue((current) => Math.min(Math.max(current, sliderMin), sliderMax));
+  }, [sliderMin, sliderMax]);
 
   if (!group?.saleReward) return null;
 
@@ -41,6 +52,10 @@ export function EarningsCalculatorBlock({
   );
 
   const displayEarnings = isYearly ? monthlyEarnings * 12 : monthlyEarnings;
+  const sliderProgress =
+    sliderMax === sliderMin
+      ? 100
+      : ((value - sliderMin) / (sliderMax - sliderMin)) * 100;
 
   return (
     <div className="space-y-5">
@@ -85,13 +100,13 @@ export function EarningsCalculatorBlock({
               id={`${id}-slider`}
               type="range"
               aria-labelledby={`${id}-label`}
-              min={SLIDER_MIN}
-              max={SLIDER_MAX}
+              min={sliderMin}
+              max={sliderMax}
               value={value}
               onChange={(e) => setValue(Number(e.target.value))}
               className="earnings-slider w-full"
               style={{
-                background: `linear-gradient(to right, #262626 ${((value - SLIDER_MIN) / (SLIDER_MAX - SLIDER_MIN)) * 100}%, #e5e5e5 ${((value - SLIDER_MIN) / (SLIDER_MAX - SLIDER_MIN)) * 100}%)`,
+                background: `linear-gradient(to right, #262626 ${sliderProgress}%, #e5e5e5 ${sliderProgress}%)`,
               }}
             />
             <div className="flex items-center gap-1">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional sales-range support to the earnings calculator, including minimum and maximum sales inputs.
  * The calculator slider now adapts to the selected sales range and updates its visual progress accordingly.
* **Bug Fixes**
  * Improved validation and normalization to keep sales-range bounds consistent (minimum ≤ maximum) and to treat empty inputs cleanly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->