### PR TITLE
Upfront quota for yearly plans

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/billing/plan-usage.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/billing/plan-usage.tsx
@@ -284,7 +284,9 @@ export default function PlanUsage() {
                   : capitalize(plan)}{" "}
                 Plan
               </span>
-              <Badge variant="gray">{capitalize(planPeriod)}</Badge>
+              {planPeriod && (
+                <Badge variant="gray">{capitalize(planPeriod)}</Badge>
+              )}
             </h2>
             {billingStart && billingEnd && (
               <p className="mt-1.5 text-balance text-sm font-medium leading-normal text-neutral-700">

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/billing/upgrade/adjust-usage-row.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/billing/upgrade/adjust-usage-row.tsx
@@ -3,9 +3,11 @@ import { Button, Grid, Slider } from "@dub/ui";
 import {
   BUSINESS_PLAN,
   ENTERPRISE_PLAN,
+  PlanPeriod,
   SELF_SERVE_PAID_PLANS,
   cn,
   getPlanDetails,
+  getPlanLimitForPeriod,
 } from "@dub/utils";
 import NumberFlow from "@number-flow/react";
 import { motion } from "motion/react";
@@ -13,9 +15,11 @@ import { useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 
 export function AdjustUsageRow({
+  planPeriod,
   onEventsUsageChange,
   onLinksUsageChange,
 }: {
+  planPeriod: PlanPeriod;
   onEventsUsageChange: (value: number) => void;
   onLinksUsageChange: (value: number) => void;
 }) {
@@ -34,8 +38,16 @@ export function AdjustUsageRow({
         )}
       >
         <div className="grid grid-cols-1 gap-10 p-6 lg:grid-cols-2">
-          <UsageSlider type="links" onChange={onLinksUsageChange} />
-          <UsageSlider type="events" onChange={onEventsUsageChange} />
+          <UsageSlider
+            type="links"
+            planPeriod={planPeriod}
+            onChange={onLinksUsageChange}
+          />
+          <UsageSlider
+            type="events"
+            planPeriod={planPeriod}
+            onChange={onEventsUsageChange}
+          />
         </div>
       </motion.div>
       <div className="relative flex items-center justify-center overflow-hidden rounded-b-[12px] py-2">
@@ -60,12 +72,15 @@ export function AdjustUsageRow({
 
 function UsageSlider({
   type,
+  planPeriod,
   onChange,
 }: {
   type: "links" | "events";
+  planPeriod: PlanPeriod;
   onChange: (value: number) => void;
 }) {
   const workspace = useWorkspace();
+  const { planPeriod: workspacePlanPeriod } = workspace;
 
   const limitKey = { events: "clicks" }[type] ?? type;
   const workspaceLimitKey = { events: "usageLimit", links: "linksLimit" }[type];
@@ -108,41 +123,55 @@ function UsageSlider({
     }
 
     const currentLimit = workspace[workspaceLimitKey];
+    const monthlyCurrentLimit =
+      workspacePlanPeriod === "yearly" ? currentLimit / 12 : currentLimit;
+
     return usageSteps.reduce((prev, curr) =>
-      Math.abs(curr - currentLimit) < Math.abs(prev - currentLimit)
+      Math.abs(curr - monthlyCurrentLimit) < Math.abs(prev - monthlyCurrentLimit)
         ? curr
         : prev,
     );
-  }, [usageSteps, workspace, workspaceLimitKey]);
+  }, [usageSteps, workspace, workspaceLimitKey, workspacePlanPeriod]);
 
   const [selectedValue, setSelectedValue] = useState<number | null>(null);
+  const monthlySelectedValue = selectedValue ?? defaultValue;
 
   useEffect(() => {
-    onChange(selectedValue ?? defaultValue);
-  }, [selectedValue, defaultValue, onChange]);
+    onChange(monthlySelectedValue);
+  }, [monthlySelectedValue, onChange]);
 
   if (usageSteps.length < 2) return null;
+
+  const monthlyWorkspaceLimit =
+    workspacePlanPeriod === "yearly"
+      ? workspace[workspaceLimitKey] / 12
+      : workspace[workspaceLimitKey];
 
   return (
     <div className="flex flex-col">
       <span className="text-content-default text-sm font-medium">
         {
           {
-            events: "Events tracked per month",
-            links: "Links created per month",
+            events: `Events tracked per ${planPeriod === "yearly" ? "year" : "month"}`,
+            links: `Links created per ${planPeriod === "yearly" ? "year" : "month"}`,
           }[type]
         }
       </span>
       <span className="text-content-emphasis text-lg font-semibold">
-        <NumberFlow value={selectedValue ?? defaultValue} />
-        {workspace[workspaceLimitKey] === (selectedValue ?? defaultValue) && (
+        <NumberFlow
+          value={getPlanLimitForPeriod({
+            limit: monthlySelectedValue,
+            planPeriod,
+          })}
+        />
+        {monthlyWorkspaceLimit === monthlySelectedValue && (
           <span className="animate-fade-in"> (current plan)</span>
         )}
       </span>
 
       <div className="mt-1">
         <Slider
-          value={usageSteps.indexOf(selectedValue ?? defaultValue)}
+          value={usageSteps.indexOf(monthlySelectedValue)}
           min={0}
           max={usageSteps.length - 1}
           onChange={(idx) => setSelectedValue(usageSteps[idx])}

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/billing/upgrade/adjust-usage-row.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/billing/upgrade/adjust-usage-row.tsx
@@ -7,6 +7,7 @@ import {
   SELF_SERVE_PAID_PLANS,
   cn,
   getPlanDetails,
+  getMonthlyLimitFromPeriod,
   getPlanLimitForPeriod,
 } from "@dub/utils";
 import NumberFlow from "@number-flow/react";
@@ -123,8 +124,10 @@ function UsageSlider({
     }
 
     const currentLimit = workspace[workspaceLimitKey];
-    const monthlyCurrentLimit =
-      workspacePlanPeriod === "yearly" ? currentLimit / 12 : currentLimit;
+    const monthlyCurrentLimit = getMonthlyLimitFromPeriod({
+      limit: currentLimit,
+      planPeriod: workspacePlanPeriod,
+    });
 
     return usageSteps.reduce((prev, curr) =>
       Math.abs(curr - monthlyCurrentLimit) < Math.abs(prev - monthlyCurrentLimit)
@@ -142,10 +145,10 @@ function UsageSlider({
 
   if (usageSteps.length < 2) return null;
 
-  const monthlyWorkspaceLimit =
-    workspacePlanPeriod === "yearly"
-      ? workspace[workspaceLimitKey] / 12
-      : workspace[workspaceLimitKey];
+  const monthlyWorkspaceLimit = getMonthlyLimitFromPeriod({
+    limit: workspace[workspaceLimitKey],
+    planPeriod: workspacePlanPeriod,
+  });
 
   return (
     <div className="flex flex-col">

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/billing/upgrade/page.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/billing/upgrade/page.tsx
@@ -334,6 +334,7 @@ export default function WorkspaceBillingUpgradePage() {
             <div className="bg-bg-muted border-subtle absolute inset-x-0 -top-2.5 bottom-0 rounded-b-[12px] border" />
 
             <AdjustUsageRow
+              planPeriod={period}
               onEventsUsageChange={(value) => setEventsUsage(value)}
               onLinksUsageChange={(value) => setLinksUsage(value)}
             />
@@ -350,6 +351,7 @@ export default function WorkspaceBillingUpgradePage() {
               features={section.features}
               mobilePlanIndex={mobilePlanIndex}
               plans={plans}
+              planPeriod={period}
             />
           ))}
         </div>
@@ -404,9 +406,11 @@ function BillingCompareSection({
   features,
   mobilePlanIndex,
   plans,
+  planPeriod,
 }: (typeof PRICING_PLAN_COMPARE_FEATURES)[number] & {
   mobilePlanIndex: number;
   plans: { plan: PlanDetails; planTier: number }[];
+  planPeriod: "monthly" | "yearly";
 }) {
   const [isExpanded, setIsExpanded] = useState(true);
   const { defaultProgramId } = useWorkspace();
@@ -520,6 +524,7 @@ function BillingCompareSection({
                             ? (text({
                                 id,
                                 plan,
+                                planPeriod,
                               }) as React.ReactNode)
                             : text}
                         </As>

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/billing/upgrade/page.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/billing/upgrade/page.tsx
@@ -8,6 +8,7 @@ import { PageWidthWrapper } from "@/ui/layout/page-width-wrapper";
 import { usePartnersUpgradeModal } from "@/ui/partners/partners-upgrade-modal";
 import { UpgradePlanButton } from "@/ui/workspaces/upgrade-plan-button";
 import {
+  Badge,
   ChartLine,
   Check,
   CircleQuestion,
@@ -18,6 +19,7 @@ import {
   Icon,
   Plug2,
   ToggleGroup,
+  useMediaQuery,
   Users2,
 } from "@dub/ui";
 import {
@@ -121,6 +123,8 @@ export default function WorkspaceBillingUpgradePage() {
     [recommendedPlan],
   );
 
+  const { isMobile } = useMediaQuery();
+
   return (
     <PageContent
       title={
@@ -140,12 +144,20 @@ export default function WorkspaceBillingUpgradePage() {
           <ToggleGroup
             options={[
               { label: "Monthly", value: "monthly" },
-              { label: "Yearly (Save 17%)", value: "yearly" },
+              {
+                label: "Yearly",
+                badge: (
+                  <Badge variant="blueGradient" className="py-0 text-xs">
+                    {isMobile ? "10% off" : "10% discount + 12x usage upfront"}
+                  </Badge>
+                ),
+                value: "yearly",
+              },
             ]}
             selected={period}
             selectAction={(option) => setPeriod(option as "monthly" | "yearly")}
             className="rounded-lg border-neutral-300 bg-neutral-100 p-0.5"
-            optionClassName="text-xs text-neutral-800 data-[selected=true]:text-neutral-800 px-3 sm:px-5 py-2 leading-none"
+            optionClassName="text-xs normal-case text-neutral-800 data-[selected=true]:text-neutral-800 px-3 h-8 leading-none"
             indicatorClassName="bg-white border-neutral-200 rounded-md"
           />
         </div>

--- a/apps/web/app/app.dub.co/(onboarding)/onboarding/(steps)/plan/plan-selector.tsx
+++ b/apps/web/app/app.dub.co/(onboarding)/onboarding/(steps)/plan/plan-selector.tsx
@@ -16,7 +16,7 @@ import {
   BUSINESS_PLAN,
   cn,
   ENTERPRISE_PLAN,
-  PRICING_PLAN_MAIN_FEATURES,
+  getPricingPlanMainFeatures,
   PRICING_PLAN_TAGLINES,
   PRO_PLAN,
 } from "@dub/utils";
@@ -81,7 +81,7 @@ export function PlanSelector({ product }: { product: OnboardingProduct }) {
         >
           {plans.map((plan) => {
             const features =
-              PRICING_PLAN_MAIN_FEATURES[product][plan.name] || [];
+              getPricingPlanMainFeatures(period)[product][plan.name] || [];
 
             return (
               <div

--- a/apps/web/app/app.dub.co/(onboarding)/onboarding/(steps)/plan/plan-selector.tsx
+++ b/apps/web/app/app.dub.co/(onboarding)/onboarding/(steps)/plan/plan-selector.tsx
@@ -32,16 +32,19 @@ export function PlanSelector({ product }: { product: OnboardingProduct }) {
       : [PRO_PLAN, BUSINESS_PLAN, ADVANCED_PLAN];
 
   const [period, setPeriod] = useState<"monthly" | "yearly">("monthly");
+
   const [mobilePlanIndex, setMobilePlanIndex] = useState(() => {
     const defaultPlanName = product === "partners" ? "Advanced" : "Business";
     return Math.max(
       0,
-      plans.findIndex((plan) => plan.name === defaultPlanName),
+      plans.findIndex(
+        (plan) => plan.name.toLowerCase() === defaultPlanName.toLowerCase(),
+      ),
     );
   });
 
   return (
-    <div className="flex flex-col items-center gap-4 [container-type:inline-size]">
+    <div className="flex flex-col items-center gap-4">
       <ToggleGroup
         options={[
           { label: "Monthly", value: "monthly" },
@@ -61,10 +64,10 @@ export function PlanSelector({ product }: { product: OnboardingProduct }) {
         optionClassName="text-xs normal-case text-neutral-800 data-[selected=true]:text-neutral-800 px-3 h-8 leading-none"
         indicatorClassName="bg-white border-neutral-200 rounded-md"
       />
-      <div className="overflow-hidden max-lg:rounded-lg">
+      <div className="w-full overflow-hidden max-lg:rounded-lg [container-type:inline-size]">
         <div
           className={cn(
-            "mx-auto grid max-w-[calc(var(--cols)*342px)] grid-cols-[repeat(var(--cols),1fr)]",
+            "grid max-w-[calc(var(--cols)*342px)] grid-cols-[repeat(var(--cols),1fr)] lg:mx-auto",
 
             // Mobile
             "max-lg:w-[calc(var(--cols)*100cqw+(var(--cols)-1)*32px)] max-lg:max-w-none max-lg:translate-x-[calc(-1*var(--index)*(100cqw+32px))] max-lg:gap-x-8 max-lg:transition-transform",
@@ -82,7 +85,7 @@ export function PlanSelector({ product }: { product: OnboardingProduct }) {
 
             return (
               <div
-                key={plan.name}
+                key={`${product}-${plan.name}`}
                 className={cn(
                   "flex flex-col border-y border-l border-neutral-200 bg-white first:rounded-l-lg last:rounded-r-lg last:border-r",
                   "max-lg:overflow-hidden max-lg:rounded-lg max-lg:border-0 max-lg:ring-1 max-lg:ring-inset max-lg:ring-neutral-200",

--- a/apps/web/app/app.dub.co/(onboarding)/onboarding/(steps)/plan/plan-selector.tsx
+++ b/apps/web/app/app.dub.co/(onboarding)/onboarding/(steps)/plan/plan-selector.tsx
@@ -5,11 +5,10 @@ import { UpgradePlanButton } from "@/ui/workspaces/upgrade-plan-button";
 import {
   Badge,
   Button,
-  CalendarRefresh,
   Check,
   DubProductIcon,
   PLAN_FEATURE_ICONS,
-  Switch,
+  ToggleGroup,
   Tooltip,
 } from "@dub/ui";
 import {
@@ -42,7 +41,26 @@ export function PlanSelector({ product }: { product: OnboardingProduct }) {
   });
 
   return (
-    <div className="[container-type:inline-size]">
+    <div className="flex flex-col items-center gap-4 [container-type:inline-size]">
+      <ToggleGroup
+        options={[
+          { label: "Monthly", value: "monthly" },
+          {
+            label: "Yearly",
+            badge: (
+              <Badge variant="blueGradient" className="py-0 text-xs">
+                10% discount + 12x usage upfront
+              </Badge>
+            ),
+            value: "yearly",
+          },
+        ]}
+        selected={period}
+        selectAction={(option) => setPeriod(option as "monthly" | "yearly")}
+        className="w-fit rounded-lg border-neutral-300 bg-neutral-100 p-0.5"
+        optionClassName="text-xs normal-case text-neutral-800 data-[selected=true]:text-neutral-800 px-3 h-8 leading-none"
+        indicatorClassName="bg-white border-neutral-200 rounded-md"
+      />
       <div className="overflow-hidden max-lg:rounded-lg">
         <div
           className={cn(
@@ -113,44 +131,11 @@ export function PlanSelector({ product }: { product: OnboardingProduct }) {
                           <span className="text-sm text-neutral-400">
                             {" "}
                             per month
+                            {period === "yearly" && ", billed yearly"}
                           </span>
                         </>
                       )}
                     </div>
-                    {plan.name === "Enterprise" ? (
-                      <div className="mt-4 flex items-center gap-1.5 text-neutral-400">
-                        <CalendarRefresh className="size-4 shrink-0" />
-                        <span className="text-sm font-medium">
-                          Tailored pricing terms
-                        </span>
-                      </div>
-                    ) : (
-                      <label className="mt-4 flex items-center gap-1.5">
-                        <Switch
-                          checked={period === "yearly"}
-                          fn={(checked) =>
-                            setPeriod(checked ? "yearly" : "monthly")
-                          }
-                          trackDimensions="radix-state-checked:bg-black focus-visible:ring-black/20 w-7 h-4"
-                          thumbDimensions="size-3"
-                          thumbTranslate="translate-x-3"
-                        />
-                        <div className="flex items-center gap-1 text-sm font-medium text-neutral-600">
-                          <span>Billed yearly</span>
-                          <Badge
-                            variant="outline"
-                            size="sm"
-                            className={cn(
-                              "animate-in fade-in-0 slide-in-from-right-2 duration-150",
-                              period === "monthly" &&
-                                "-translate-x-2 opacity-0",
-                            )}
-                          >
-                            Save 17%
-                          </Badge>
-                        </div>
-                      </label>
-                    )}
                   </div>
 
                   <p className="min-h-10 text-sm text-neutral-600">

--- a/apps/web/ui/modals/manage-usage-modal.tsx
+++ b/apps/web/ui/modals/manage-usage-modal.tsx
@@ -1,7 +1,14 @@
 import { clientAccessCheck } from "@/lib/client-access-check";
 import { isEligibleForTrial } from "@/lib/stripe/is-eligible-for-trial";
 import useWorkspace from "@/lib/swr/use-workspace";
-import { CursorRays, Hyperlink, Modal, Slider, ToggleGroup } from "@dub/ui";
+import {
+  Badge,
+  CursorRays,
+  Hyperlink,
+  Modal,
+  Slider,
+  ToggleGroup,
+} from "@dub/ui";
 import {
   DUB_TRIAL_PERIOD_DAYS,
   ENTERPRISE_PLAN,
@@ -126,7 +133,12 @@ function ManageUsageModalContent({ type }: ManageUsageModalProps) {
               { value: "monthly", label: "Monthly" },
               {
                 value: "yearly",
-                label: "Yearly (Save 17%)",
+                label: "Yearly",
+                badge: (
+                  <Badge variant="blueGradient" className="py-0 text-xs">
+                    10% discount + 12x usage upfront
+                  </Badge>
+                ),
               },
             ]}
             className="flex overflow-hidden rounded-lg bg-transparent p-0.5"

--- a/apps/web/ui/modals/manage-usage-modal.tsx
+++ b/apps/web/ui/modals/manage-usage-modal.tsx
@@ -12,9 +12,12 @@ import {
 import {
   DUB_TRIAL_PERIOD_DAYS,
   ENTERPRISE_PLAN,
+  PlanPeriod,
   SELF_SERVE_PAID_PLANS,
   capitalize,
   cn,
+  getPlanLimitForPeriod,
+  getPlanPeriodSuffix,
   getSuggestedPlan,
   isDowngradePlan,
 } from "@dub/utils";
@@ -67,19 +70,46 @@ function ManageUsageModalContent({ type }: ManageUsageModalProps) {
   const defaultValue = useMemo(() => {
     const currentLimit =
       workspace[{ events: "usageLimit", links: "linksLimit" }[type]];
+    const monthlyCurrentLimit =
+      planPeriod === "yearly" ? currentLimit / 12 : currentLimit;
+
     return usageSteps.reduce((prev, curr) =>
-      Math.abs(curr - currentLimit) < Math.abs(prev - currentLimit)
+      Math.abs(curr - monthlyCurrentLimit) <
+      Math.abs(prev - monthlyCurrentLimit)
         ? curr
         : prev,
     );
-  }, [usageSteps, workspace]);
+  }, [usageSteps, workspace, type, planPeriod]);
 
   const [selectedValue, setSelectedValue] = useState<number | null>(null);
-  const [period, setPeriod] = useState<"monthly" | "yearly">("monthly");
+  const [period, setPeriod] = useState<PlanPeriod>(
+    planPeriod === "yearly" ? "yearly" : "monthly",
+  );
+
+  const monthlySelectedValue = selectedValue ?? defaultValue;
+
+  const getLimitInPeriod = useCallback(
+    ({
+      limit,
+      storedPeriod,
+      targetPeriod,
+    }: {
+      limit: number;
+      storedPeriod?: string | null;
+      targetPeriod: PlanPeriod;
+    }) => {
+      const monthlyLimit = storedPeriod === "yearly" ? limit / 12 : limit;
+      return getPlanLimitForPeriod({
+        limit: monthlyLimit,
+        planPeriod: targetPeriod,
+      });
+    },
+    [],
+  );
 
   const { plan: suggestedPlan, planTier: suggestedPlanTier } = getSuggestedPlan(
     {
-      [type]: selectedValue ?? defaultValue,
+      [type]: monthlySelectedValue,
     },
   );
 
@@ -109,18 +139,21 @@ function ManageUsageModalContent({ type }: ManageUsageModalProps) {
         <p className="text-content-default text-sm font-medium">
           {
             {
-              events: "Events tracked per month",
-              links: "Links created per month",
+              events: `Events tracked per ${period === "yearly" ? "year" : "month"}`,
+              links: `Links created per ${period === "yearly" ? "year" : "month"}`,
             }[type]
           }
         </p>
         <NumberFlow
-          value={selectedValue ?? defaultValue}
+          value={getPlanLimitForPeriod({
+            limit: monthlySelectedValue,
+            planPeriod: period,
+          })}
           className="text-content-emphasis mb-4 text-lg font-semibold"
         />
 
         <Slider
-          value={usageSteps.indexOf(selectedValue ?? defaultValue)}
+          value={usageSteps.indexOf(monthlySelectedValue)}
           min={0}
           max={usageSteps.length - 1}
           onChange={(idx) => setSelectedValue(usageSteps[idx])}
@@ -217,15 +250,39 @@ function ManageUsageModalContent({ type }: ManageUsageModalProps) {
               {[
                 {
                   icon: CursorRays,
-                  value: suggestedPlan.limits.clicks,
-                  label: `total tracked events/mo`,
-                  difference: suggestedPlan.limits.clicks - (usageLimit ?? 0),
+                  value: getPlanLimitForPeriod({
+                    limit: suggestedPlan.limits.clicks,
+                    planPeriod: period,
+                  }),
+                  label: `total tracked events${getPlanPeriodSuffix({ planPeriod: period })}`,
+                  difference:
+                    getPlanLimitForPeriod({
+                      limit: suggestedPlan.limits.clicks,
+                      planPeriod: period,
+                    }) -
+                    getLimitInPeriod({
+                      limit: usageLimit ?? 0,
+                      storedPeriod: planPeriod,
+                      targetPeriod: period,
+                    }),
                 },
                 {
                   icon: Hyperlink,
-                  value: suggestedPlan.limits.links,
-                  label: `new links/mo`,
-                  difference: suggestedPlan.limits.links - (linksLimit ?? 0),
+                  value: getPlanLimitForPeriod({
+                    limit: suggestedPlan.limits.links,
+                    planPeriod: period,
+                  }),
+                  label: `new links${getPlanPeriodSuffix({ planPeriod: period })}`,
+                  difference:
+                    getPlanLimitForPeriod({
+                      limit: suggestedPlan.limits.links,
+                      planPeriod: period,
+                    }) -
+                    getLimitInPeriod({
+                      limit: linksLimit ?? 0,
+                      storedPeriod: planPeriod,
+                      targetPeriod: period,
+                    }),
                 },
               ].map(({ icon: Icon, value, label, difference }) => (
                 <div

--- a/apps/web/ui/modals/manage-usage-modal.tsx
+++ b/apps/web/ui/modals/manage-usage-modal.tsx
@@ -16,6 +16,7 @@ import {
   SELF_SERVE_PAID_PLANS,
   capitalize,
   cn,
+  getMonthlyLimitFromPeriod,
   getPlanLimitForPeriod,
   getPlanPeriodSuffix,
   getSuggestedPlan,
@@ -70,8 +71,10 @@ function ManageUsageModalContent({ type }: ManageUsageModalProps) {
   const defaultValue = useMemo(() => {
     const currentLimit =
       workspace[{ events: "usageLimit", links: "linksLimit" }[type]];
-    const monthlyCurrentLimit =
-      planPeriod === "yearly" ? currentLimit / 12 : currentLimit;
+    const monthlyCurrentLimit = getMonthlyLimitFromPeriod({
+      limit: currentLimit,
+      planPeriod,
+    });
 
     return usageSteps.reduce((prev, curr) =>
       Math.abs(curr - monthlyCurrentLimit) <
@@ -98,9 +101,11 @@ function ManageUsageModalContent({ type }: ManageUsageModalProps) {
       storedPeriod?: string | null;
       targetPeriod: PlanPeriod;
     }) => {
-      const monthlyLimit = storedPeriod === "yearly" ? limit / 12 : limit;
       return getPlanLimitForPeriod({
-        limit: monthlyLimit,
+        limit: getMonthlyLimitFromPeriod({
+          limit,
+          planPeriod: storedPeriod,
+        }),
         planPeriod: targetPeriod,
       });
     },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dub/utils",
   "description": "Utility functions and constants for Dub",
-  "version": "0.1.62",
+  "version": "0.1.64",
   "sideEffects": false,
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",

--- a/packages/utils/src/constants/index.ts
+++ b/packages/utils/src/constants/index.ts
@@ -20,6 +20,7 @@ export * from "./stablecoin-supported-countries";
 export * from "./tremendous-supported-countries";
 
 // pricing copy & values
+export * from "./pricing/plan-period-utils";
 export * from "./pricing/pricing-plan-compare-features";
 export * from "./pricing/pricing-plan-main-features";
 export * from "./pricing/pricing-plan-taglines";

--- a/packages/utils/src/constants/pricing/plan-period-utils.ts
+++ b/packages/utils/src/constants/pricing/plan-period-utils.ts
@@ -12,6 +12,16 @@ export function getPlanLimitForPeriod({
   return planPeriod === "yearly" ? limit * YEARLY_USAGE_MULTIPLIER : limit;
 }
 
+export function getMonthlyLimitFromPeriod({
+  limit,
+  planPeriod = "monthly",
+}: {
+  limit: number;
+  planPeriod?: PlanPeriod | string | null;
+}) {
+  return planPeriod === "yearly" ? limit / YEARLY_USAGE_MULTIPLIER : limit;
+}
+
 export function getPlanPeriodSuffix({
   planPeriod = "monthly",
   isUnlimited = false,

--- a/packages/utils/src/constants/pricing/plan-period-utils.ts
+++ b/packages/utils/src/constants/pricing/plan-period-utils.ts
@@ -1,0 +1,24 @@
+export type PlanPeriod = "monthly" | "yearly";
+
+const YEARLY_USAGE_MULTIPLIER = 12;
+
+export function getPlanLimitForPeriod({
+  limit,
+  planPeriod = "monthly",
+}: {
+  limit: number;
+  planPeriod?: PlanPeriod;
+}) {
+  return planPeriod === "yearly" ? limit * YEARLY_USAGE_MULTIPLIER : limit;
+}
+
+export function getPlanPeriodSuffix({
+  planPeriod = "monthly",
+  isUnlimited = false,
+}: {
+  planPeriod?: PlanPeriod;
+  isUnlimited?: boolean;
+}) {
+  if (isUnlimited) return "";
+  return planPeriod === "yearly" ? "/year" : "/month";
+}

--- a/packages/utils/src/constants/pricing/pricing-plan-compare-features.tsx
+++ b/packages/utils/src/constants/pricing/pricing-plan-compare-features.tsx
@@ -1,6 +1,11 @@
 import { ReactNode } from "react";
 import { nFormatter } from "../../functions/nformatter";
 import { INFINITY_NUMBER } from "../misc";
+import {
+  getPlanLimitForPeriod,
+  getPlanPeriodSuffix,
+  PlanPeriod,
+} from "./plan-period-utils";
 import { PLANS } from "./pricing-plans";
 
 export const PRICING_PLAN_COMPARE_FEATURES: {
@@ -9,7 +14,11 @@ export const PRICING_PLAN_COMPARE_FEATURES: {
   features: {
     text:
       | string
-      | ((d: { id: string; plan: (typeof PLANS)[number] }) => ReactNode);
+      | ((d: {
+          id: string;
+          plan: (typeof PLANS)[number];
+          planPeriod?: PlanPeriod;
+        }) => ReactNode);
     href?: string;
     check?:
       | boolean
@@ -28,15 +37,23 @@ export const PRICING_PLAN_COMPARE_FEATURES: {
     href: "https://dub.co/links",
     features: [
       {
-        text: ({ plan }) => (
+        text: ({ plan, planPeriod = "monthly" }) => (
           <>
             <strong>
               {plan.name === "Enterprise"
                 ? "Unlimited"
-                : nFormatter(plan.limits.links)}
+                : nFormatter(
+                    getPlanLimitForPeriod({
+                      limit: plan.limits.links,
+                      planPeriod,
+                    }),
+                  )}
             </strong>{" "}
             new links
-            {plan.name === "Enterprise" ? "" : "/mo"}
+            {getPlanPeriodSuffix({
+              planPeriod,
+              isUnlimited: plan.name === "Enterprise",
+            })}
           </>
         ),
       },
@@ -165,7 +182,7 @@ export const PRICING_PLAN_COMPARE_FEATURES: {
           advanced: true,
           enterprise: true,
         },
-        text: ({ id, plan }) =>
+        text: ({ id, plan, planPeriod = "monthly" }) =>
           id === "free" || id === "pro" ? (
             "No partner payouts"
           ) : (
@@ -173,10 +190,18 @@ export const PRICING_PLAN_COMPARE_FEATURES: {
               <strong>
                 {plan.name === "Enterprise"
                   ? "Unlimited"
-                  : `$${nFormatter(plan.limits.payouts / 100)}`}
+                  : `$${nFormatter(
+                      getPlanLimitForPeriod({
+                        limit: plan.limits.payouts,
+                        planPeriod,
+                      }) / 100,
+                    )}`}
               </strong>{" "}
               partner payouts
-              {plan.name === "Enterprise" ? "" : "/mo"}
+              {getPlanPeriodSuffix({
+                planPeriod,
+                isUnlimited: plan.name === "Enterprise",
+              })}
             </>
           ),
       },
@@ -389,15 +414,23 @@ export const PRICING_PLAN_COMPARE_FEATURES: {
         href: "https://dub.co/help/article/dub-analytics",
       },
       {
-        text: ({ plan }) => (
+        text: ({ plan, planPeriod = "monthly" }) => (
           <>
             <strong>
               {plan.name === "Enterprise"
                 ? "Unlimited"
-                : nFormatter(plan.limits.clicks)}
+                : nFormatter(
+                    getPlanLimitForPeriod({
+                      limit: plan.limits.clicks,
+                      planPeriod,
+                    }),
+                  )}
             </strong>{" "}
             tracked events
-            {plan.name === "Enterprise" ? "" : "/mo"}
+            {getPlanPeriodSuffix({
+              planPeriod,
+              isUnlimited: plan.name === "Enterprise",
+            })}
           </>
         ),
         href: "https://dub.co/help/article/dub-analytics-limits",

--- a/packages/utils/src/constants/pricing/pricing-plan-main-features.ts
+++ b/packages/utils/src/constants/pricing/pricing-plan-main-features.ts
@@ -1,5 +1,10 @@
 import { ReactNode } from "react";
 import { nFormatter } from "../../functions/nformatter";
+import {
+  getPlanLimitForPeriod,
+  getPlanPeriodSuffix,
+  PlanPeriod,
+} from "./plan-period-utils";
 import { PLANS } from "./pricing-plans";
 
 type Plan = (typeof PLANS)[number];
@@ -17,7 +22,10 @@ type HeroFeature = {
       };
 };
 
-const getLinksStandards = (plan: Plan): HeroFeature[] => {
+const getLinksStandards = (
+  plan: Plan,
+  planPeriod: PlanPeriod = "monthly",
+): HeroFeature[] => {
   return [
     // Tracked events
     {
@@ -25,7 +33,12 @@ const getLinksStandards = (plan: Plan): HeroFeature[] => {
       text:
         plan.name === "Enterprise"
           ? "Unlimited tracked events"
-          : `${nFormatter(plan.limits.clicks)} tracked events/mo`,
+          : `${nFormatter(
+              getPlanLimitForPeriod({
+                limit: plan.limits.clicks,
+                planPeriod,
+              }),
+            )} tracked events${getPlanPeriodSuffix({ planPeriod })}`,
     },
     // New links
     {
@@ -33,7 +46,12 @@ const getLinksStandards = (plan: Plan): HeroFeature[] => {
       text:
         plan.name === "Enterprise"
           ? "Unlimited new links"
-          : `${nFormatter(plan.limits.links)} new links/mo`,
+          : `${nFormatter(
+              getPlanLimitForPeriod({
+                limit: plan.limits.links,
+                planPeriod,
+              }),
+            )} new links${getPlanPeriodSuffix({ planPeriod })}`,
     },
     ...(plan.name !== "Enterprise"
       ? [
@@ -46,13 +64,21 @@ const getLinksStandards = (plan: Plan): HeroFeature[] => {
   ];
 };
 
-const getPartnersStandards = (plan: Plan): HeroFeature[] => [
+const getPartnersStandards = (
+  plan: Plan,
+  planPeriod: PlanPeriod = "monthly",
+): HeroFeature[] => [
   {
     id: "payouts",
     text:
       plan.name === "Enterprise"
         ? "Unlimited partner payouts"
-        : `$${nFormatter(plan.limits.payouts / 100)} partner payouts/mo`,
+        : `$${nFormatter(
+            getPlanLimitForPeriod({
+              limit: plan.limits.payouts,
+              planPeriod,
+            }) / 100,
+          )} partner payouts${getPlanPeriodSuffix({ planPeriod })}`,
     tooltip: {
       title:
         "Send payouts to your partners with 1-click (or automate it completely) – all across the world.",
@@ -62,12 +88,17 @@ const getPartnersStandards = (plan: Plan): HeroFeature[] => [
   },
 ];
 
-export const PRICING_PLAN_MAIN_FEATURES = {
+export const getPricingPlanMainFeatures = (
+  planPeriod: PlanPeriod = "monthly",
+) => ({
   links: {
     Pro: [
       {
         features: [
-          ...getLinksStandards(PLANS.find((p) => p.name === "Pro")!),
+          ...getLinksStandards(
+            PLANS.find((p) => p.name === "Pro")!,
+            planPeriod,
+          ),
           {
             id: "advanced",
             text: "Advanced link features",
@@ -112,7 +143,10 @@ export const PRICING_PLAN_MAIN_FEATURES = {
     Business: [
       {
         features: [
-          ...getLinksStandards(PLANS.find((p) => p.name === "Business")!),
+          ...getLinksStandards(
+            PLANS.find((p) => p.name === "Business")!,
+            planPeriod,
+          ),
           {
             id: "conversions",
             text: "Conversion tracking",
@@ -159,7 +193,10 @@ export const PRICING_PLAN_MAIN_FEATURES = {
     Advanced: [
       {
         features: [
-          ...getLinksStandards(PLANS.find((p) => p.name === "Advanced")!),
+          ...getLinksStandards(
+            PLANS.find((p) => p.name === "Advanced")!,
+            planPeriod,
+          ),
           {
             id: "api",
             text: "Elevated API rate limits",
@@ -178,7 +215,10 @@ export const PRICING_PLAN_MAIN_FEATURES = {
     Enterprise: [
       {
         features: [
-          ...getLinksStandards(PLANS.find((p) => p.name === "Enterprise")!),
+          ...getLinksStandards(
+            PLANS.find((p) => p.name === "Enterprise")!,
+            planPeriod,
+          ),
           {
             id: "sso",
             text: "SSO/SAML",
@@ -199,7 +239,10 @@ export const PRICING_PLAN_MAIN_FEATURES = {
     Business: [
       {
         features: [
-          ...getPartnersStandards(PLANS.find((p) => p.name === "Business")!),
+          ...getPartnersStandards(
+            PLANS.find((p) => p.name === "Business")!,
+            planPeriod,
+          ),
           {
             id: "basicrewards",
             text: "Basic reward structures",
@@ -270,7 +313,10 @@ export const PRICING_PLAN_MAIN_FEATURES = {
     Advanced: [
       {
         features: [
-          ...getPartnersStandards(PLANS.find((p) => p.name === "Advanced")!),
+          ...getPartnersStandards(
+            PLANS.find((p) => p.name === "Advanced")!,
+            planPeriod,
+          ),
           {
             id: "flexiblerewards",
             text: "Advanced reward structures",
@@ -339,7 +385,10 @@ export const PRICING_PLAN_MAIN_FEATURES = {
     Enterprise: [
       {
         features: [
-          ...getPartnersStandards(PLANS.find((p) => p.name === "Enterprise")!),
+          ...getPartnersStandards(
+            PLANS.find((p) => p.name === "Enterprise")!,
+            planPeriod,
+          ),
           {
             id: "volume",
             text: "Volume discounts",
@@ -392,4 +441,4 @@ export const PRICING_PLAN_MAIN_FEATURES = {
       },
     ],
   },
-};
+});

--- a/packages/utils/src/constants/pricing/pricing-plans.tsx
+++ b/packages/utils/src/constants/pricing/pricing-plans.tsx
@@ -53,80 +53,91 @@ export type PlanDetails = {
 };
 
 const LEGACY_PRO_PRICE_IDS = [
-  "price_1LodNLAlJJEpqkPVQSrt33Lc", // old monthly
-  "price_1LodNLAlJJEpqkPVRxUyCQgZ", // old yearly
-  "price_1OTcQBAlJJEpqkPViGtGEsbb", // new monthly (test)
-  "price_1OYJeBAlJJEpqkPVLjTsjX0E", // new monthly (prod)
-  "price_1OTcQBAlJJEpqkPVYlCMqdLL", // new yearly (test)
-  "price_1OYJeBAlJJEpqkPVnPGEZeb0", // new yearly (prod)
+  "price_1LodNLAlJJEpqkPVQSrt33Lc", // monthly 2023
+  "price_1LodNLAlJJEpqkPVRxUyCQgZ", // yearly 2023
+  "price_1OTcQBAlJJEpqkPViGtGEsbb", // monthly 2024 (test)
+  "price_1OYJeBAlJJEpqkPVLjTsjX0E", // monthly 2024 (prod)
+  "price_1OTcQBAlJJEpqkPVYlCMqdLL", // yearly 2024 (test)
+  "price_1OYJeBAlJJEpqkPVnPGEZeb0", // yearly 2024 (prod)
 ];
 
 const PRO_TIER_PRICE_IDS = {
   2: [
-    "price_1SQtg3AlJJEpqkPVVhDSyd9u", // yearly (prod)
-    "price_1SQtg3AlJJEpqkPVNHYhTRy7", // monthly (prod)
-    "price_1SQ8hiAlJJEpqkPVIy8pfvAC", // yearly (test)
-    "price_1SQ8gwAlJJEpqkPVb78Oc9Yc", // monthly (test)
+    "price_1SQtg3AlJJEpqkPVVhDSyd9u", // yearly 2025 (prod)
+    "price_1SQtg3AlJJEpqkPVNHYhTRy7", // monthly 2025 (prod)
+    "price_1SQ8hiAlJJEpqkPVIy8pfvAC", // yearly 2025 (test)
+    "price_1TrQKGAlJJEpqkPVXz5gGere", // monthly 2025 (test)
+    "price_", // yearly 2026 (prod)
+    "price_1TrOzqAlJJEpqkPVXBwEbPo4", // yearly 2026 (test)
   ],
 };
 
-// 2025 pricing
 const NEW_PRO_PRICE_IDS = [
-  "price_1R8XtyAlJJEpqkPV5WZ4c0jF", //  yearly
-  "price_1R8XtEAlJJEpqkPV4opVvVPq", // monthly
-  "price_1R8XxZAlJJEpqkPVqGi0wOqD", // yearly (test),
-  "price_1R7oeBAlJJEpqkPVh6q5q3h8", // monthly (test),
+  "price_1R8XtyAlJJEpqkPV5WZ4c0jF", //  yearly 2025
+  "price_1R8XtEAlJJEpqkPV4opVvVPq", // monthly 2025 (prod)
+  "price_1R8XxZAlJJEpqkPVqGi0wOqD", // yearly 2025 (test),
+  "price_1R7oeBAlJJEpqkPVh6q5q3h8", // monthly 2025 (test),
+  "price_", // yearly 2026 (prod)
+  "price_1TrOyDAlJJEpqkPVxoOc1eet", // yearly 2026 (test)
   ...Object.values(PRO_TIER_PRICE_IDS).flat(),
 ];
 
 const LEGACY_BUSINESS_PRICE_IDS = [
-  "price_1LodLoAlJJEpqkPV9rD0rlNL", // old monthly
-  "price_1LodLoAlJJEpqkPVJdwv5zrG", // oldest yearly
-  "price_1OZgmnAlJJEpqkPVOj4kV64R", // old yearly
-  "price_1OzNlmAlJJEpqkPV7s9HXNAC", // new monthly (test)
-  "price_1OzNmXAlJJEpqkPVYO89lTdx", // new yearly (test)
-  "price_1OzOFIAlJJEpqkPVJxzc9irl", // new monthly (prod)
-  "price_1OzOXMAlJJEpqkPV9ERrjjbw", // new yearly (prod)
+  "price_1LodLoAlJJEpqkPV9rD0rlNL", // monthly 2023
+  "price_1OZgmnAlJJEpqkPVOj4kV64R", // yearly 2023
+  "price_1OzNlmAlJJEpqkPV7s9HXNAC", // monthly 2024 (test)
+  "price_1OzNmXAlJJEpqkPVYO89lTdx", // yearly 2024 (test)
+  "price_1OzOFIAlJJEpqkPVJxzc9irl", // monthly 2024 (prod)
+  "price_1OzOXMAlJJEpqkPV9ERrjjbw", // yearly 2024 (prod)
 ];
 
 const BUSINESS_TIER_PRICE_IDS = {
   2: [
-    "price_1SQtdxAlJJEpqkPV4kNkRHZr", // yearly (prod)
-    "price_1SQtdxAlJJEpqkPV7cvJTv4g", // monthly (prod)
-    "price_1SQ8iwAlJJEpqkPVEGmKd6Lg", // yearly (test)
-    "price_1SQ8iSAlJJEpqkPVQ5crmBtF", // monthly (test)
+    "price_1SQtdxAlJJEpqkPV4kNkRHZr", // yearly 2025 (prod)
+    "price_1SQtdxAlJJEpqkPV7cvJTv4g", // monthly 2025 (prod)
+    "price_1SQ8iwAlJJEpqkPVEGmKd6Lg", // yearly 2025 (test)
+    "price_1TrQMNAlJJEpqkPVREg73wkW", // monthly 2025 (test)
+    "price_", // yearly 2026 (prod)
+    "price_1TrQGrAlJJEpqkPVmBqGRdsP", // yearly 2026 (test)
   ],
 };
 
-// 2025 pricing
 export const NEW_BUSINESS_PRICE_IDS = [
-  "price_1R3j01AlJJEpqkPVXuG1eNzm", //  yearly
-  "price_1R6JedAlJJEpqkPVMUkfjch4", // monthly
-  "price_1R8XypAlJJEpqkPVdjzOcYUC", // yearly (test),
-  "price_1R7ofLAlJJEpqkPV3MlgDpyx", // monthly (test),
+  "price_1R3j01AlJJEpqkPVXuG1eNzm", //  yearly 2025 (prod)
+  "price_1R6JedAlJJEpqkPVMUkfjch4", // monthly 2025 (prod)
+  "price_1R8XypAlJJEpqkPVdjzOcYUC", // yearly 2025 (test),
+  "price_1R7ofLAlJJEpqkPV3MlgDpyx", // monthly 2025 (test),
+  "price_", // yearly 2026 (prod)
+  "price_1TrQBOAlJJEpqkPVCOGYIwVy", // yearly 2026 (test)
   ...Object.values(BUSINESS_TIER_PRICE_IDS).flat(),
 ];
 
 const ADVANCED_TIER_PRICE_IDS = {
   2: [
-    "price_1SQtg6AlJJEpqkPVAJdrStq7", // yearly (prod)
-    "price_1SQtg6AlJJEpqkPVaZNisQdm", // monthly (prod)
-    "price_1SQ8jlAlJJEpqkPV6EanvSXl", // yearly (test)
-    "price_1SQ8jJAlJJEpqkPVIwY9QZSP", // monthly (test)
+    "price_1SQtg6AlJJEpqkPVAJdrStq7", // yearly 2025 (prod)
+    "price_1SQtg6AlJJEpqkPVaZNisQdm", // monthly 2025 (prod)
+    "price_1SQ8jlAlJJEpqkPV6EanvSXl", // yearly 2025 (test)
+    "price_1TrQU1AlJJEpqkPVmgLd5cR1", // monthly 2025 (test)
+    "price_", // yearly 2026 (prod)
+    "price_1TrQTSAlJJEpqkPV1cqueTie", // yearly 2026 (test)
   ],
   3: [
-    "price_1SQtg8AlJJEpqkPVvQVU7uQ3", // yearly (prod)
-    "price_1SQtg8AlJJEpqkPV4Nks8MkS", // monthly (prod)
-    "price_1SQ8lqAlJJEpqkPVzBaioV3I", // yearly (test)
-    "price_1SQ8lOAlJJEpqkPVz2R8SRss", // monthly (test)
+    "price_1SQtg8AlJJEpqkPVvQVU7uQ3", // yearly 2025 (prod)
+    "price_1SQtg8AlJJEpqkPV4Nks8MkS", // monthly 2025 (prod)
+    "price_1SQ8lqAlJJEpqkPVzBaioV3I", // yearly 2025 (test)
+    "price_1TrQXfAlJJEpqkPV7RXjqb74", // monthly 2025 (test)
+    "price_", // yearly 2026 (prod)
+    "price_1TrQXMAlJJEpqkPVIzWw9iHW", // yearly 2026 (test)
   ],
 };
 
 const ADVANCED_PRICE_IDS = [
-  "price_1R8Xw4AlJJEpqkPV6nwdink9", //  yearly
-  "price_1R3j0qAlJJEpqkPVkfGNXRwb", // monthly
-  "price_1R8XztAlJJEpqkPVnHmIU2tf", // yearly (test),
-  "price_1R7ofzAlJJEpqkPV0L2TwyJo", // monthly (test),
+  "price_1R8Xw4AlJJEpqkPV6nwdink9", //  yearly 2025 (prod)
+  "price_1R3j0qAlJJEpqkPVkfGNXRwb", // monthly 2025 (prod)
+  "price_1R8XztAlJJEpqkPVnHmIU2tf", // yearly 2025 (test),
+  "price_1R7ofzAlJJEpqkPV0L2TwyJo", // monthly 2025 (test),
+  "price_", // yearly 2026 (prod)
+  "price_1TrQN3AlJJEpqkPVqX1Rt9el", // yearly 2026 (test)
   ...Object.values(ADVANCED_TIER_PRICE_IDS).flat(),
 ];
 
@@ -159,7 +170,7 @@ export const PLANS: PlanDetails[] = [
     name: "Pro",
     price: {
       monthly: 30,
-      yearly: 25,
+      yearly: 27,
       ids: [...LEGACY_PRO_PRICE_IDS, ...NEW_PRO_PRICE_IDS],
     },
     limits: {
@@ -183,7 +194,7 @@ export const PLANS: PlanDetails[] = [
       2: {
         price: {
           monthly: 60,
-          yearly: 50,
+          yearly: 54,
           ids: PRO_TIER_PRICE_IDS[2],
         },
         limits: {
@@ -250,7 +261,7 @@ export const PLANS: PlanDetails[] = [
     name: "Business",
     price: {
       monthly: 90,
-      yearly: 75,
+      yearly: 81,
       ids: [...LEGACY_BUSINESS_PRICE_IDS, ...NEW_BUSINESS_PRICE_IDS],
     },
     limits: {
@@ -274,7 +285,7 @@ export const PLANS: PlanDetails[] = [
       2: {
         price: {
           monthly: 180,
-          yearly: 150,
+          yearly: 162,
           ids: BUSINESS_TIER_PRICE_IDS[2],
         },
         limits: {
@@ -360,7 +371,7 @@ export const PLANS: PlanDetails[] = [
     name: "Advanced",
     price: {
       monthly: 300,
-      yearly: 250,
+      yearly: 270,
       ids: ADVANCED_PRICE_IDS,
     },
     limits: {
@@ -384,7 +395,7 @@ export const PLANS: PlanDetails[] = [
       2: {
         price: {
           monthly: 600,
-          yearly: 500,
+          yearly: 540,
           ids: ADVANCED_TIER_PRICE_IDS[2],
         },
         limits: {
@@ -395,7 +406,7 @@ export const PLANS: PlanDetails[] = [
       3: {
         price: {
           monthly: 900,
-          yearly: 750,
+          yearly: 810,
           ids: ADVANCED_TIER_PRICE_IDS[3],
         },
         limits: {

--- a/packages/utils/src/constants/pricing/pricing-plans.tsx
+++ b/packages/utils/src/constants/pricing/pricing-plans.tsx
@@ -67,7 +67,7 @@ const PRO_TIER_PRICE_IDS = {
     "price_1SQtg3AlJJEpqkPVNHYhTRy7", // monthly 2025 (prod)
     "price_1SQ8hiAlJJEpqkPVIy8pfvAC", // yearly 2025 (test)
     "price_1TrQKGAlJJEpqkPVXz5gGere", // monthly 2025 (test)
-    "price_", // yearly 2026 (prod)
+    "price_1TrSHvAlJJEpqkPVOv8okJ4L", // yearly 2026 (prod)
     "price_1TrOzqAlJJEpqkPVXBwEbPo4", // yearly 2026 (test)
   ],
 };
@@ -77,7 +77,7 @@ const NEW_PRO_PRICE_IDS = [
   "price_1R8XtEAlJJEpqkPV4opVvVPq", // monthly 2025 (prod)
   "price_1R8XxZAlJJEpqkPVqGi0wOqD", // yearly 2025 (test),
   "price_1R7oeBAlJJEpqkPVh6q5q3h8", // monthly 2025 (test),
-  "price_", // yearly 2026 (prod)
+  "price_1TrSHYAlJJEpqkPVtJ0mnJMQ", // yearly 2026 (prod)
   "price_1TrOyDAlJJEpqkPVxoOc1eet", // yearly 2026 (test)
   ...Object.values(PRO_TIER_PRICE_IDS).flat(),
 ];
@@ -97,7 +97,7 @@ const BUSINESS_TIER_PRICE_IDS = {
     "price_1SQtdxAlJJEpqkPV7cvJTv4g", // monthly 2025 (prod)
     "price_1SQ8iwAlJJEpqkPVEGmKd6Lg", // yearly 2025 (test)
     "price_1TrQMNAlJJEpqkPVREg73wkW", // monthly 2025 (test)
-    "price_", // yearly 2026 (prod)
+    "price_1TrSJkAlJJEpqkPVtUyuZ7Z2", // yearly 2026 (prod)
     "price_1TrQGrAlJJEpqkPVmBqGRdsP", // yearly 2026 (test)
   ],
 };
@@ -107,7 +107,7 @@ export const NEW_BUSINESS_PRICE_IDS = [
   "price_1R6JedAlJJEpqkPVMUkfjch4", // monthly 2025 (prod)
   "price_1R8XypAlJJEpqkPVdjzOcYUC", // yearly 2025 (test),
   "price_1R7ofLAlJJEpqkPV3MlgDpyx", // monthly 2025 (test),
-  "price_", // yearly 2026 (prod)
+  "price_1TrSIiAlJJEpqkPVUNjLPUxY", // yearly 2026 (prod)
   "price_1TrQBOAlJJEpqkPVCOGYIwVy", // yearly 2026 (test)
   ...Object.values(BUSINESS_TIER_PRICE_IDS).flat(),
 ];
@@ -118,7 +118,7 @@ const ADVANCED_TIER_PRICE_IDS = {
     "price_1SQtg6AlJJEpqkPVaZNisQdm", // monthly 2025 (prod)
     "price_1SQ8jlAlJJEpqkPV6EanvSXl", // yearly 2025 (test)
     "price_1TrQU1AlJJEpqkPVmgLd5cR1", // monthly 2025 (test)
-    "price_", // yearly 2026 (prod)
+    "price_1TrSKzAlJJEpqkPVHkhc8cUx", // yearly 2026 (prod)
     "price_1TrQTSAlJJEpqkPV1cqueTie", // yearly 2026 (test)
   ],
   3: [
@@ -126,7 +126,7 @@ const ADVANCED_TIER_PRICE_IDS = {
     "price_1SQtg8AlJJEpqkPV4Nks8MkS", // monthly 2025 (prod)
     "price_1SQ8lqAlJJEpqkPVzBaioV3I", // yearly 2025 (test)
     "price_1TrQXfAlJJEpqkPV7RXjqb74", // monthly 2025 (test)
-    "price_", // yearly 2026 (prod)
+    "price_1TrSLRAlJJEpqkPVOHrNc2hI", // yearly 2026 (prod)
     "price_1TrQXMAlJJEpqkPVIzWw9iHW", // yearly 2026 (test)
   ],
 };
@@ -136,7 +136,7 @@ const ADVANCED_PRICE_IDS = [
   "price_1R3j0qAlJJEpqkPVkfGNXRwb", // monthly 2025 (prod)
   "price_1R8XztAlJJEpqkPVnHmIU2tf", // yearly 2025 (test),
   "price_1R7ofzAlJJEpqkPV0L2TwyJo", // monthly 2025 (test),
-  "price_", // yearly 2026 (prod)
+  "price_1TrSKLAlJJEpqkPV2QG2AFUQ", // yearly 2026 (prod)
   "price_1TrQN3AlJJEpqkPVqX1Rt9el", // yearly 2026 (test)
   ...Object.values(ADVANCED_TIER_PRICE_IDS).flat(),
 ];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated plan selection, upgrade, and usage management to be fully billing-period aware (monthly vs yearly), including period-specific limit formatting and suffixes.
  * Improved upgrade and usage sliders/modals so suggested values and “usage impact” are recalculated for the selected period.
  * Refreshed the yearly billing UI with discount/upfront messaging and better mobile responsiveness.
  * Updated pricing plan feature text and displayed limits to match the selected period.
  * Updated yearly pricing for select plans and tiers.

* **Bug Fixes**
  * Billing-period badges no longer render when no billing period is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->