### PR TITLE
Enable Partners API on Business plan

### DIFF
--- a/apps/web/app/(ee)/api/bounties/[bountyId]/route.ts
+++ b/apps/web/app/(ee)/api/bounties/[bountyId]/route.ts
@@ -41,9 +41,6 @@ export const GET = withWorkspace(
   {
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],
@@ -279,9 +276,6 @@ export const PATCH = withWorkspace(
   {
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],
@@ -363,9 +357,6 @@ export const DELETE = withWorkspace(
   {
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/(ee)/api/bounties/[bountyId]/submissions/[submissionId]/approve/route.ts
+++ b/apps/web/app/(ee)/api/bounties/[bountyId]/submissions/[submissionId]/approve/route.ts
@@ -38,7 +38,7 @@ export const POST = withWorkspace(
     return NextResponse.json(approvedSubmission);
   },
   {
-    requiredPlan: ["advanced", "enterprise"],
+    requiredPlan: ["business", "advanced", "enterprise"],
     requiredRoles: ["owner", "member"],
   },
 );

--- a/apps/web/app/(ee)/api/bounties/[bountyId]/submissions/[submissionId]/reject/route.ts
+++ b/apps/web/app/(ee)/api/bounties/[bountyId]/submissions/[submissionId]/reject/route.ts
@@ -40,7 +40,7 @@ export const POST = withWorkspace(
     return NextResponse.json(rejectedSubmission);
   },
   {
-    requiredPlan: ["advanced", "enterprise"],
+    requiredPlan: ["business", "advanced", "enterprise"],
     requiredRoles: ["owner", "member"],
   },
 );

--- a/apps/web/app/(ee)/api/bounties/[bountyId]/submissions/route.ts
+++ b/apps/web/app/(ee)/api/bounties/[bountyId]/submissions/route.ts
@@ -80,9 +80,6 @@ export const GET = withWorkspace(
   {
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/(ee)/api/bounties/[bountyId]/sync-social-metrics/route.ts
+++ b/apps/web/app/(ee)/api/bounties/[bountyId]/sync-social-metrics/route.ts
@@ -195,9 +195,6 @@ export const POST = withWorkspace(
   {
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/(ee)/api/bounties/count/submissions/route.ts
+++ b/apps/web/app/(ee)/api/bounties/count/submissions/route.ts
@@ -56,9 +56,6 @@ export const GET = withWorkspace(
   {
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/(ee)/api/bounties/route.ts
+++ b/apps/web/app/(ee)/api/bounties/route.ts
@@ -142,9 +142,6 @@ export const GET = withWorkspace(
   {
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],
@@ -334,9 +331,6 @@ export const POST = withWorkspace(
   {
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/(ee)/api/commissions/route.ts
+++ b/apps/web/app/(ee)/api/commissions/route.ts
@@ -102,9 +102,6 @@ export const POST = withWorkspace(
   {
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/(ee)/api/customers/[id]/route.ts
+++ b/apps/web/app/(ee)/api/customers/[id]/route.ts
@@ -41,9 +41,6 @@ export const GET = withWorkspace(
   {
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],
@@ -152,9 +149,6 @@ export const PATCH = withWorkspace(
   {
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],
@@ -189,9 +183,6 @@ export const DELETE = withWorkspace(
   {
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/(ee)/api/customers/export/route.ts
+++ b/apps/web/app/(ee)/api/customers/export/route.ts
@@ -69,9 +69,6 @@ export const GET = withWorkspace(
   {
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/(ee)/api/customers/route.ts
+++ b/apps/web/app/(ee)/api/customers/route.ts
@@ -51,9 +51,6 @@ export const GET = withWorkspace(
   {
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],
@@ -137,9 +134,6 @@ export const POST = withWorkspace(
   {
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/(ee)/api/discount-codes/[discountCodeId]/route.ts
+++ b/apps/web/app/(ee)/api/discount-codes/[discountCodeId]/route.ts
@@ -75,9 +75,6 @@ export const DELETE = withWorkspace(
   {
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/(ee)/api/discount-codes/route.ts
+++ b/apps/web/app/(ee)/api/discount-codes/route.ts
@@ -39,9 +39,6 @@ export const GET = withWorkspace(
   {
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],
@@ -156,9 +153,6 @@ export const POST = withWorkspace(
   {
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/(ee)/api/events/export/route.ts
+++ b/apps/web/app/(ee)/api/events/export/route.ts
@@ -177,9 +177,6 @@ export const GET = withWorkspace(
   {
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/(ee)/api/events/route.ts
+++ b/apps/web/app/(ee)/api/events/route.ts
@@ -81,9 +81,6 @@ export const GET = withWorkspace(
   {
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/(ee)/api/fraud/groups/count/route.ts
+++ b/apps/web/app/(ee)/api/fraud/groups/count/route.ts
@@ -84,9 +84,6 @@ export const GET = withWorkspace(
   {
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/(ee)/api/groups/[groupIdOrSlug]/default-links/[defaultLinkId]/route.ts
+++ b/apps/web/app/(ee)/api/groups/[groupIdOrSlug]/default-links/[defaultLinkId]/route.ts
@@ -150,9 +150,6 @@ export const PATCH = withWorkspace(
     requiredPermissions: ["groups.write"],
     requiredPlan: [
       "business",
-      "business extra",
-      "business max",
-      "business plus",
       "advanced",
       "enterprise",
     ],
@@ -228,9 +225,6 @@ export const DELETE = withWorkspace(
     requiredPermissions: ["groups.write"],
     requiredPlan: [
       "business",
-      "business extra",
-      "business max",
-      "business plus",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/(ee)/api/groups/[groupIdOrSlug]/default-links/route.ts
+++ b/apps/web/app/(ee)/api/groups/[groupIdOrSlug]/default-links/route.ts
@@ -44,9 +44,6 @@ export const GET = withWorkspace(
     requiredPermissions: ["groups.read"],
     requiredPlan: [
       "business",
-      "business extra",
-      "business max",
-      "business plus",
       "advanced",
       "enterprise",
     ],
@@ -147,9 +144,6 @@ export const POST = withWorkspace(
     requiredPermissions: ["groups.write"],
     requiredPlan: [
       "business",
-      "business extra",
-      "business max",
-      "business plus",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/(ee)/api/groups/[groupIdOrSlug]/default/route.ts
+++ b/apps/web/app/(ee)/api/groups/[groupIdOrSlug]/default/route.ts
@@ -109,9 +109,6 @@ export const POST = withWorkspace(
     requiredPermissions: ["groups.write"],
     requiredPlan: [
       "business",
-      "business extra",
-      "business max",
-      "business plus",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/(ee)/api/groups/[groupIdOrSlug]/partners/route.ts
+++ b/apps/web/app/(ee)/api/groups/[groupIdOrSlug]/partners/route.ts
@@ -53,9 +53,6 @@ export const POST = withWorkspace(
     requiredPermissions: ["groups.write"],
     requiredPlan: [
       "business",
-      "business extra",
-      "business max",
-      "business plus",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/(ee)/api/groups/[groupIdOrSlug]/route.ts
+++ b/apps/web/app/(ee)/api/groups/[groupIdOrSlug]/route.ts
@@ -37,9 +37,6 @@ export const GET = withWorkspace(
     requiredPermissions: ["groups.read"],
     requiredPlan: [
       "business",
-      "business extra",
-      "business max",
-      "business plus",
       "advanced",
       "enterprise",
     ],
@@ -260,9 +257,6 @@ export const PATCH = withWorkspace(
     requiredPermissions: ["groups.write"],
     requiredPlan: [
       "business",
-      "business extra",
-      "business max",
-      "business plus",
       "advanced",
       "enterprise",
     ],
@@ -420,9 +414,6 @@ export const DELETE = withWorkspace(
     requiredPermissions: ["groups.write"],
     requiredPlan: [
       "business",
-      "business extra",
-      "business max",
-      "business plus",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/(ee)/api/groups/count/route.ts
+++ b/apps/web/app/(ee)/api/groups/count/route.ts
@@ -36,9 +36,6 @@ export const GET = withWorkspace(
     requiredPermissions: ["groups.read"],
     requiredPlan: [
       "business",
-      "business extra",
-      "business max",
-      "business plus",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/(ee)/api/groups/route.ts
+++ b/apps/web/app/(ee)/api/groups/route.ts
@@ -37,9 +37,6 @@ export const GET = withWorkspace(
     requiredPermissions: ["groups.read"],
     requiredPlan: [
       "business",
-      "business extra",
-      "business max",
-      "business plus",
       "advanced",
       "enterprise",
     ],
@@ -184,9 +181,6 @@ export const POST = withWorkspace(
     requiredPermissions: ["groups.write"],
     requiredPlan: [
       "business",
-      "business extra",
-      "business max",
-      "business plus",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/(ee)/api/partners/[partnerId]/comments/count/route.ts
+++ b/apps/web/app/(ee)/api/partners/[partnerId]/comments/count/route.ts
@@ -21,9 +21,6 @@ export const GET = withWorkspace(
   {
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/(ee)/api/partners/[partnerId]/comments/route.ts
+++ b/apps/web/app/(ee)/api/partners/[partnerId]/comments/route.ts
@@ -29,9 +29,6 @@ export const GET = withWorkspace(
   {
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/(ee)/api/partners/[partnerId]/referral/route.ts
+++ b/apps/web/app/(ee)/api/partners/[partnerId]/referral/route.ts
@@ -84,9 +84,6 @@ export const GET = withWorkspace(
   {
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/(ee)/api/partners/[partnerId]/route.ts
+++ b/apps/web/app/(ee)/api/partners/[partnerId]/route.ts
@@ -28,9 +28,6 @@ export const GET = withWorkspace(
   {
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/(ee)/api/partners/analytics/route.ts
+++ b/apps/web/app/(ee)/api/partners/analytics/route.ts
@@ -207,6 +207,6 @@ export const GET = withWorkspace(
     return NextResponse.json(topLinksWithEarnings);
   },
   {
-    requiredPlan: ["advanced", "enterprise"],
+    requiredPlan: ["business", "advanced", "enterprise"],
   },
 );

--- a/apps/web/app/(ee)/api/partners/applications/approve/route.ts
+++ b/apps/web/app/(ee)/api/partners/applications/approve/route.ts
@@ -26,7 +26,7 @@ export const POST = withWorkspace(
     });
   },
   {
-    requiredPlan: ["advanced", "enterprise"],
+    requiredPlan: ["business", "advanced", "enterprise"],
     requiredRoles: ["owner", "member"],
   },
 );

--- a/apps/web/app/(ee)/api/partners/applications/export/route.ts
+++ b/apps/web/app/(ee)/api/partners/applications/export/route.ts
@@ -90,9 +90,6 @@ export const GET = withWorkspace(
   {
     requiredPlan: [
       "business",
-      "business extra",
-      "business max",
-      "business plus",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/(ee)/api/partners/applications/reject/route.ts
+++ b/apps/web/app/(ee)/api/partners/applications/reject/route.ts
@@ -32,7 +32,7 @@ export const POST = withWorkspace(
     });
   },
   {
-    requiredPlan: ["advanced", "enterprise"],
+    requiredPlan: ["business", "advanced", "enterprise"],
     requiredRoles: ["owner", "member"],
   },
 );

--- a/apps/web/app/(ee)/api/partners/applications/route.ts
+++ b/apps/web/app/(ee)/api/partners/applications/route.ts
@@ -79,9 +79,6 @@ export const GET = withWorkspace(
   {
     requiredPlan: [
       "business",
-      "business extra",
-      "business max",
-      "business plus",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/(ee)/api/partners/ban/route.ts
+++ b/apps/web/app/(ee)/api/partners/ban/route.ts
@@ -54,7 +54,7 @@ export const POST = withWorkspace(
     });
   },
   {
-    requiredPlan: ["advanced", "enterprise"],
+    requiredPlan: ["business", "advanced", "enterprise"],
     requiredRoles: ["owner", "member"],
   },
 );

--- a/apps/web/app/(ee)/api/partners/count/route.ts
+++ b/apps/web/app/(ee)/api/partners/count/route.ts
@@ -45,9 +45,6 @@ export const GET = withWorkspace(
   {
     requiredPlan: [
       "business",
-      "business extra",
-      "business max",
-      "business plus",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/(ee)/api/partners/deactivate/route.ts
+++ b/apps/web/app/(ee)/api/partners/deactivate/route.ts
@@ -58,7 +58,7 @@ export const POST = withWorkspace(
     });
   },
   {
-    requiredPlan: ["advanced", "enterprise"],
+    requiredPlan: ["business", "advanced", "enterprise"],
     requiredRoles: ["owner", "member"],
   },
 );

--- a/apps/web/app/(ee)/api/partners/export/route.ts
+++ b/apps/web/app/(ee)/api/partners/export/route.ts
@@ -60,9 +60,6 @@ export const GET = withWorkspace(
   {
     requiredPlan: [
       "business",
-      "business extra",
-      "business max",
-      "business plus",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/(ee)/api/partners/links/route.ts
+++ b/apps/web/app/(ee)/api/partners/links/route.ts
@@ -61,7 +61,7 @@ export const GET = withWorkspace(
     return NextResponse.json(z.array(ProgramPartnerLinkSchema).parse(links));
   },
   {
-    requiredPlan: ["advanced", "enterprise"],
+    requiredPlan: ["business", "advanced", "enterprise"],
     requiredRoles: ["owner", "member"],
   },
 );
@@ -167,7 +167,7 @@ export const POST = withWorkspace(
     return NextResponse.json(partnerLink, { status: 201 });
   },
   {
-    requiredPlan: ["advanced", "enterprise"],
+    requiredPlan: ["business", "advanced", "enterprise"],
     requiredRoles: ["owner", "member"],
   },
 );

--- a/apps/web/app/(ee)/api/partners/links/upsert/route.ts
+++ b/apps/web/app/(ee)/api/partners/links/upsert/route.ts
@@ -242,6 +242,6 @@ export const PUT = withWorkspace(
   },
   {
     requiredPermissions: ["links.write"],
-    requiredPlan: ["advanced", "enterprise"],
+    requiredPlan: ["business", "advanced", "enterprise"],
   },
 );

--- a/apps/web/app/(ee)/api/partners/route.ts
+++ b/apps/web/app/(ee)/api/partners/route.ts
@@ -162,7 +162,7 @@ export const POST = withWorkspace(
     });
   },
   {
-    requiredPlan: ["advanced", "enterprise"],
+    requiredPlan: ["business", "advanced", "enterprise"],
     requiredRoles: ["owner", "member"],
   },
 );

--- a/apps/web/app/(ee)/api/partners/route.ts
+++ b/apps/web/app/(ee)/api/partners/route.ts
@@ -124,9 +124,6 @@ export const GET = withWorkspace(
   {
     requiredPlan: [
       "business",
-      "business extra",
-      "business max",
-      "business plus",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/(ee)/api/partners/tags/count/route.ts
+++ b/apps/web/app/(ee)/api/partners/tags/count/route.ts
@@ -27,9 +27,6 @@ export const GET = withWorkspace(
   {
     requiredPlan: [
       "business",
-      "business extra",
-      "business max",
-      "business plus",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/(ee)/api/partners/tags/route.ts
+++ b/apps/web/app/(ee)/api/partners/tags/route.ts
@@ -48,9 +48,6 @@ export const GET = withWorkspace(
   {
     requiredPlan: [
       "business",
-      "business extra",
-      "business max",
-      "business plus",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/(ee)/api/programs/[programId]/submitted-leads/count/route.ts
+++ b/apps/web/app/(ee)/api/programs/[programId]/submitted-leads/count/route.ts
@@ -91,9 +91,6 @@ export const GET = withWorkspace(
   {
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/(ee)/api/programs/[programId]/submitted-leads/route.ts
+++ b/apps/web/app/(ee)/api/programs/[programId]/submitted-leads/route.ts
@@ -69,9 +69,6 @@ export const GET = withWorkspace(
   {
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/(ee)/api/shopify/integration/callback/route.ts
+++ b/apps/web/app/(ee)/api/shopify/integration/callback/route.ts
@@ -87,9 +87,6 @@ export const PATCH = withWorkspace(
     requiredRoles: ["owner", "member"],
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/(ee)/api/stripe/integration/route.ts
+++ b/apps/web/app/(ee)/api/stripe/integration/route.ts
@@ -109,9 +109,6 @@ export const PATCH = withWorkspace(
   {
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/(ee)/api/track/lead/client/route.ts
+++ b/apps/web/app/(ee)/api/track/lead/client/route.ts
@@ -57,9 +57,6 @@ export const POST = withPublishableKey(
   {
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/(ee)/api/track/lead/route.ts
+++ b/apps/web/app/(ee)/api/track/lead/route.ts
@@ -61,9 +61,6 @@ export const POST = withWorkspace(
   {
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/(ee)/api/track/sale/client/route.ts
+++ b/apps/web/app/(ee)/api/track/sale/client/route.ts
@@ -70,9 +70,6 @@ export const POST = withPublishableKey(
   {
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/(ee)/api/track/sale/route.ts
+++ b/apps/web/app/(ee)/api/track/sale/route.ts
@@ -65,9 +65,6 @@ export const POST = withWorkspace(
   {
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/api/folders/[folderId]/route.ts
+++ b/apps/web/app/api/folders/[folderId]/route.ts
@@ -28,9 +28,6 @@ export const GET = withWorkspace(
     requiredPlan: [
       "pro",
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],
@@ -98,9 +95,6 @@ export const PATCH = withWorkspace(
     requiredPlan: [
       "pro",
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],
@@ -199,9 +193,6 @@ export const DELETE = withWorkspace(
     requiredPlan: [
       "pro",
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/api/folders/[folderId]/users/route.ts
+++ b/apps/web/app/api/folders/[folderId]/users/route.ts
@@ -79,9 +79,6 @@ export const GET = withWorkspace(
     requiredPermissions: ["folders.read"],
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/api/folders/access-requests/route.ts
+++ b/apps/web/app/api/folders/access-requests/route.ts
@@ -22,9 +22,6 @@ export const GET = withWorkspace(
     requiredPermissions: ["folders.read"],
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/api/folders/permissions/route.ts
+++ b/apps/web/app/api/folders/permissions/route.ts
@@ -51,9 +51,6 @@ export const GET = withWorkspace(
     requiredPermissions: ["folders.read"],
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/api/folders/route.ts
+++ b/apps/web/app/api/folders/route.ts
@@ -130,9 +130,6 @@ export const POST = withWorkspace(
     requiredPlan: [
       "pro",
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/api/webhooks/[webhookId]/events/route.ts
+++ b/apps/web/app/api/webhooks/[webhookId]/events/route.ts
@@ -31,9 +31,6 @@ export const GET = withWorkspace(
     requiredPermissions: ["webhooks.read"],
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/api/webhooks/[webhookId]/folders/route.ts
+++ b/apps/web/app/api/webhooks/[webhookId]/folders/route.ts
@@ -34,9 +34,6 @@ export const GET = withWorkspace(
     requiredPermissions: ["webhooks.read"],
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/api/webhooks/[webhookId]/links/route.ts
+++ b/apps/web/app/api/webhooks/[webhookId]/links/route.ts
@@ -30,9 +30,6 @@ export const GET = withWorkspace(
     requiredPermissions: ["webhooks.read"],
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/api/webhooks/[webhookId]/route.ts
+++ b/apps/web/app/api/webhooks/[webhookId]/route.ts
@@ -30,9 +30,6 @@ export const GET = withWorkspace(
     requiredPermissions: ["webhooks.read"],
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],
@@ -189,9 +186,6 @@ export const PATCH = withWorkspace(
     requiredPermissions: ["webhooks.write"],
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],
@@ -226,9 +220,6 @@ export const DELETE = withWorkspace(
     requiredPermissions: ["webhooks.write"],
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/api/webhooks/route.ts
+++ b/apps/web/app/api/webhooks/route.ts
@@ -29,9 +29,6 @@ export const GET = withWorkspace(
     requiredPermissions: ["webhooks.read"],
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],
@@ -109,9 +106,6 @@ export const POST = withWorkspace(
     requiredPermissions: ["webhooks.write"],
     requiredPlan: [
       "business",
-      "business plus",
-      "business extra",
-      "business max",
       "advanced",
       "enterprise",
     ],

--- a/apps/web/app/api/workspaces/[idOrSlug]/support/slack-invite/route.ts
+++ b/apps/web/app/api/workspaces/[idOrSlug]/support/slack-invite/route.ts
@@ -104,7 +104,7 @@ export const POST = withWorkspace(
     return NextResponse.json({ inviteIds });
   },
   {
-    requiredPlan: ["advanced", "enterprise"],
+    requiredPlan: ["enterprise"],
     requiredPermissions: ["workspaces.write"],
   },
 );

--- a/apps/web/lib/auth/publishable-key.ts
+++ b/apps/web/lib/auth/publishable-key.ts
@@ -30,9 +30,6 @@ export const withPublishableKey = (
       "free",
       "pro",
       "business",
-      "business plus",
-      "business max",
-      "business extra",
       "advanced",
       "enterprise",
     ],
@@ -100,7 +97,15 @@ export const withPublishableKey = (
             });
           }
 
-          if (!requiredPlan.includes(workspace.plan)) {
+          const normalizedWorkspacePlan = [
+            "business plus",
+            "business max",
+            "business extra",
+          ].includes(workspace.plan)
+            ? "business"
+            : workspace.plan;
+
+          if (!requiredPlan.includes(normalizedWorkspacePlan)) {
             throw new DubApiError({
               code: "forbidden",
               message: "Unauthorized: Need higher plan.",

--- a/apps/web/lib/auth/workspace.ts
+++ b/apps/web/lib/auth/workspace.ts
@@ -59,16 +59,7 @@ interface WithWorkspaceHandler {
 export const withWorkspace = (
   handler: WithWorkspaceHandler,
   {
-    requiredPlan = [
-      "free",
-      "pro",
-      "business",
-      "business plus",
-      "business max",
-      "business extra",
-      "advanced",
-      "enterprise",
-    ], // if the action needs a specific plan
+    requiredPlan = ["free", "pro", "business", "advanced", "enterprise"], // if the action needs a specific plan
     requiredPermissions = [],
     requiredRoles = [],
     featureFlag, // if the action needs a specific feature flag
@@ -453,8 +444,16 @@ export const withWorkspace = (
           }
         }
 
+        const normalizedWorkspacePlan = [
+          "business plus",
+          "business max",
+          "business extra",
+        ].includes(workspace.plan)
+          ? "business"
+          : workspace.plan;
+
         // plan checks
-        if (!requiredPlan.includes(workspace.plan)) {
+        if (!requiredPlan.includes(normalizedWorkspacePlan)) {
           throw new DubApiError({
             code: "forbidden",
             message: "Unauthorized: Need higher plan.",
@@ -463,7 +462,7 @@ export const withWorkspace = (
 
         // analytics API checks
         if (
-          workspace.plan === "free" &&
+          normalizedWorkspacePlan === "free" &&
           apiKey &&
           url.pathname.includes("/analytics")
         ) {

--- a/packages/utils/src/constants/pricing/pricing-plan-compare-features.tsx
+++ b/packages/utils/src/constants/pricing/pricing-plan-compare-features.tsx
@@ -366,15 +366,6 @@ export const PRICING_PLAN_COMPARE_FEATURES: {
           advanced: true,
           enterprise: true,
         },
-        text: "Partners API",
-        href: "https://dub.co/docs/api-reference/endpoint/create-a-partner",
-      },
-      {
-        check: {
-          default: false,
-          advanced: true,
-          enterprise: true,
-        },
         text: "Messaging center",
         href: "https://dub.co/help/article/messaging-partners",
       },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Access & Plans**
  * Standardized workspace eligibility across bounties, partners, customers, groups, folders, webhooks, tracking, and integrations.
  * Higher Business tiers are now treated like the core Business plan for endpoint access (not as separate entitlement levels).
  * Expanded Business-plan access to additional partner and bounty actions.
  * Slack support invitations are now limited to Enterprise plans only.
* **Plan Comparison**
  * Removed the “Partners API” entry from the pricing plan feature comparison.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->