### PR TITLE
Always show Permanently delete with a disabled tooltip when not allowed.

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/[partnerId]/layout.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/[partnerId]/layout.tsx
@@ -2,7 +2,7 @@
 
 import { deleteProgramInviteAction } from "@/lib/actions/partners/delete-program-invite";
 import { resendProgramInviteAction } from "@/lib/actions/partners/resend-program-invite";
-import { canDeletePartner } from "@/lib/partners/utils";
+import { getDeletePartnerDisabledTooltip } from "@/lib/partners/utils";
 import { mutatePrefix } from "@/lib/swr/mutate";
 import usePartner from "@/lib/swr/use-partner";
 import useWorkspace from "@/lib/swr/use-workspace";
@@ -249,7 +249,7 @@ function PageControls({ partner }: { partner: EnrolledPartnerProps }) {
       partner,
     });
 
-  const canDelete = canDeletePartner(partner);
+  const deletePartnerDisabledTooltip = getDeletePartnerDisabledTooltip(partner);
 
   return (
     <>
@@ -451,18 +451,17 @@ function PageControls({ partner }: { partner: EnrolledPartnerProps }) {
                     </MenuItem>
                   )}
 
-                  {canDelete && (
-                    <MenuItem
-                      icon={Trash}
-                      variant="danger"
-                      onClick={() => {
-                        setShowDeletePartnerModal(true);
-                        setIsOpen(false);
-                      }}
-                    >
-                      Permanently delete
-                    </MenuItem>
-                  )}
+                  <MenuItem
+                    icon={Trash}
+                    variant="danger"
+                    onClick={() => {
+                      setShowDeletePartnerModal(true);
+                      setIsOpen(false);
+                    }}
+                    disabledTooltip={deletePartnerDisabledTooltip}
+                  >
+                    Permanently delete
+                  </MenuItem>
                 </div>
               </>
             )}

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/partners-table.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/partners-table.tsx
@@ -2,7 +2,7 @@
 
 import { deleteProgramInviteAction } from "@/lib/actions/partners/delete-program-invite";
 import { resendProgramInviteAction } from "@/lib/actions/partners/resend-program-invite";
-import { canDeletePartner } from "@/lib/partners/utils";
+import { getDeletePartnerDisabledTooltip } from "@/lib/partners/utils";
 import { mutatePrefix } from "@/lib/swr/mutate";
 import useGroups from "@/lib/swr/use-groups";
 import usePartnersCount from "@/lib/swr/use-partners-count";
@@ -731,7 +731,9 @@ function RowMenuButton({
       partner: row.original,
     });
 
-  const canDelete = canDeletePartner(row.original);
+  const deletePartnerDisabledTooltip = getDeletePartnerDisabledTooltip(
+    row.original,
+  );
 
   const { executeAsync: resendInvite, isPending: isResendingInvite } =
     useAction(resendProgramInviteAction, {
@@ -913,17 +915,16 @@ function RowMenuButton({
                       />
                     )}
 
-                    {canDelete && (
-                      <MenuItem
-                        icon={Trash}
-                        label="Permanently delete"
-                        variant="danger"
-                        onSelect={() => {
-                          setShowDeletePartnerModal(true);
-                          setIsOpen(false);
-                        }}
-                      />
-                    )}
+                    <MenuItem
+                      icon={Trash}
+                      label="Permanently delete"
+                      variant="danger"
+                      onSelect={() => {
+                        setShowDeletePartnerModal(true);
+                        setIsOpen(false);
+                      }}
+                      disabledTooltip={deletePartnerDisabledTooltip}
+                    />
                   </Command.Group>
                 </>
               )}
@@ -1101,25 +1102,29 @@ function MenuItem({
     },
   };
 
-  const { text, icon } = variantStyles[variant];
+  const { text, icon } = disabledTooltip
+    ? { text: "text-content-disabled", icon: "text-content-disabled" }
+    : variantStyles[variant];
 
   return (
     <DynamicTooltipWrapper
       tooltipProps={disabledTooltip ? { content: disabledTooltip } : undefined}
     >
-      <Command.Item
-        className={cn(
-          "flex cursor-pointer select-none items-center gap-2 whitespace-nowrap rounded-md p-2 text-sm",
-          disabledTooltip
-            ? "cursor-not-allowed opacity-75"
-            : "data-[selected=true]:bg-neutral-100",
-          text,
-        )}
-        onSelect={disabledTooltip ? undefined : onSelect}
-      >
-        <IconComp className={cn("size-4 shrink-0", icon)} />
-        {label}
-      </Command.Item>
+      <div>
+        <Command.Item
+          className={cn(
+            "flex cursor-pointer select-none items-center gap-2 whitespace-nowrap rounded-md p-2 text-sm",
+            disabledTooltip
+              ? "cursor-not-allowed opacity-50"
+              : "data-[selected=true]:bg-neutral-100",
+            text,
+          )}
+          onSelect={disabledTooltip ? undefined : onSelect}
+        >
+          <IconComp className={cn("size-4 shrink-0", icon)} />
+          {label}
+        </Command.Item>
+      </div>
     </DynamicTooltipWrapper>
   );
 }

--- a/apps/web/lib/partners/utils.ts
+++ b/apps/web/lib/partners/utils.ts
@@ -1,29 +1,39 @@
 import { DELETABLE_ENROLLMENT_STATUSES } from "@/lib/zod/schemas/partners";
 import { EnrolledPartnerExtendedProps } from "../types";
 
-export function canDeletePartner({
-  status,
-  totalClicks,
-  totalLeads,
-  totalSales,
-  totalCommissions,
-}: Pick<
+type DeletePartnerEligibility = Pick<
   EnrolledPartnerExtendedProps,
   "status" | "totalClicks" | "totalLeads" | "totalSales"
 > & {
   totalCommissions: number | bigint;
-}): boolean {
-  if (!DELETABLE_ENROLLMENT_STATUSES.includes(status)) {
-    return false;
+};
+
+function hasPartnerActivity({
+  totalClicks,
+  totalLeads,
+  totalSales,
+  totalCommissions,
+}: DeletePartnerEligibility) {
+  return (
+    totalClicks > 0 || totalLeads > 0 || totalSales > 0 || totalCommissions > 0
+  );
+}
+
+export function canDeletePartner(partner: DeletePartnerEligibility) {
+  return (
+    DELETABLE_ENROLLMENT_STATUSES.includes(partner.status) &&
+    !hasPartnerActivity(partner)
+  );
+}
+
+export function getDeletePartnerDisabledTooltip(
+  partner: DeletePartnerEligibility,
+) {
+  if (hasPartnerActivity(partner)) {
+    return "Partners with clicks, leads, sales, or commissions cannot be permanently deleted.";
   }
 
-  // Deletable partners must have no activity
-  const hasActivity =
-    totalClicks > 0 || totalLeads > 0 || totalSales > 0 || totalCommissions > 0;
-
-  if (hasActivity) {
-    return false;
+  if (!DELETABLE_ENROLLMENT_STATUSES.includes(partner.status)) {
+    return "Partner must be banned or deactivated before they can be permanently deleted.";
   }
-
-  return true;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - The “Permanently delete” option is now consistently visible in partner menus.
  - When deletion isn’t available, the option is clearly disabled and includes an explanatory tooltip.
  - Updated disabled-menu styling improves visual clarity and consistency.
  - Partner deletion eligibility is now evaluated consistently across dashboard views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->