### PR TITLE
Fix delete link discount code cleanup

### DIFF
--- a/apps/web/lib/api/links/delete-link.ts
+++ b/apps/web/lib/api/links/delete-link.ts
@@ -1,9 +1,9 @@
+import { enqueueDeleteDiscountCode } from "@/lib/discounts/delete-discount-code";
 import { prisma } from "@/lib/prisma";
 import { storage } from "@/lib/storage";
 import { recordLink } from "@/lib/tinybird";
 import { R2_URL } from "@dub/utils";
 import { waitUntil } from "@vercel/functions";
-import { deleteDiscountCodes } from "../../discounts/delete-discount-code";
 import { linkCache } from "./cache";
 import { includeProgramEnrollment } from "./include-program-enrollment";
 import { includeTags } from "./include-tags";
@@ -29,17 +29,23 @@ export async function deleteLink(linkId: string) {
     },
   });
 
-  // DiscountCode.linkId is a required relation (onDelete: Restrict),
-  // so the discount code must be deleted before the link
-  if (link.discountCode) {
-    await deleteDiscountCodes([link.discountCode]);
-  }
+  await prisma.$transaction([
+    ...(link.discountCode
+      ? [
+          prisma.discountCode.delete({
+            where: {
+              id: link.discountCode.id,
+            },
+          }),
+        ]
+      : []),
 
-  await prisma.link.delete({
-    where: {
-      id: linkId,
-    },
-  });
+    prisma.link.delete({
+      where: {
+        id: linkId,
+      },
+    }),
+  ]);
 
   waitUntil(
     Promise.allSettled([
@@ -65,6 +71,9 @@ export async function deleteLink(linkId: string) {
             },
           },
         }),
+
+      link.discountCode?.discount &&
+        enqueueDeleteDiscountCode([link.discountCode]),
     ]),
   );
 

--- a/apps/web/lib/api/links/delete-link.ts
+++ b/apps/web/lib/api/links/delete-link.ts
@@ -73,8 +73,7 @@ export async function deleteLink(linkId: string) {
           },
         }),
 
-      link.discountCode?.discount &&
-        enqueueDeleteDiscountCode([link.discountCode]),
+      link.discountCode && enqueueDeleteDiscountCode([link.discountCode]),
     ]),
   );
 

--- a/apps/web/lib/api/links/delete-link.ts
+++ b/apps/web/lib/api/links/delete-link.ts
@@ -29,6 +29,7 @@ export async function deleteLink(linkId: string) {
     },
   });
 
+  // Delete the discount code and link in a transaction
   await prisma.$transaction([
     ...(link.discountCode
       ? [

--- a/apps/web/lib/api/links/delete-link.ts
+++ b/apps/web/lib/api/links/delete-link.ts
@@ -10,7 +10,7 @@ import { includeTags } from "./include-tags";
 import { transformLink } from "./utils";
 
 export async function deleteLink(linkId: string) {
-  const link = await prisma.link.delete({
+  const link = await prisma.link.findUniqueOrThrow({
     where: {
       id: linkId,
     },
@@ -26,6 +26,18 @@ export async function deleteLink(linkId: string) {
           },
         },
       },
+    },
+  });
+
+  // DiscountCode.linkId is a required relation (onDelete: Restrict),
+  // so the discount code must be deleted before the link
+  if (link.discountCode) {
+    await deleteDiscountCodes([link.discountCode]);
+  }
+
+  await prisma.link.delete({
+    where: {
+      id: linkId,
     },
   });
 
@@ -53,8 +65,6 @@ export async function deleteLink(linkId: string) {
             },
           },
         }),
-
-      link.discountCode && deleteDiscountCodes([link.discountCode]),
     ]),
   );
 

--- a/apps/web/lib/discounts/delete-discount-code.ts
+++ b/apps/web/lib/discounts/delete-discount-code.ts
@@ -91,14 +91,14 @@ export async function enqueueDeleteDiscountCode(
 
   for (const chunkOfCodes of chunks) {
     await enqueueBatchJobs(
-      chunkOfCodes.map(({ code, programId, discount }) => ({
+      chunkOfCodes.map((discountCode) => ({
         url: `${APP_DOMAIN_WITH_NGROK}/api/cron/discount-codes/disable`,
         method: "POST",
         queueName: "delete-discount-code",
         body: {
-          code,
-          programId,
-          provider: discount.provider,
+          code: discountCode.code,
+          programId: discountCode.programId,
+          provider: discountCode.discount.provider,
         },
       })),
     );

--- a/apps/web/lib/discounts/delete-discount-code.ts
+++ b/apps/web/lib/discounts/delete-discount-code.ts
@@ -10,6 +10,13 @@ type DeleteDiscountCodesParams = Pick<
   discount: Pick<Discount, "provider"> | null;
 };
 
+type EnqueueDeleteDiscountCodeParams = Pick<
+  DiscountCode,
+  "code" | "programId"
+> & {
+  discount: Pick<Discount, "provider"> | null;
+};
+
 // Triggered in the following cases:
 // 1. When a discount is deleted
 // 2. When a link is deleted that has a discount code associated with it
@@ -61,19 +68,22 @@ export async function deleteDiscountCodes(
     );
   }
 
-  // Only enqueue external-provider cleanup for codes whose provider is known.
-  // Orphaned codes (discount relation is null) still get deleted locally above
-  // but we can't tell which external provider to clean up, so we skip them.
+  await enqueueDeleteDiscountCode(discountCodes);
+}
+
+// Only enqueue external-provider cleanup for codes whose provider is known.
+// Orphaned codes (discount relation is null) still get deleted locally above
+// but we can't tell which external provider to clean up, so we skip them.
+export async function enqueueDeleteDiscountCode(
+  discountCodes: EnqueueDeleteDiscountCodeParams[],
+) {
   const codesWithProvider = discountCodes.filter(
     (dc): dc is typeof dc & { discount: Pick<Discount, "provider"> } =>
       dc.discount != null,
   );
 
-  const orphanedCount = discountCodes.length - codesWithProvider.length;
-  if (orphanedCount > 0) {
-    console.warn(
-      `[deleteDiscountCodes] Skipping external provider cleanup for ${orphanedCount} orphaned discount code(s) with no discount relation.`,
-    );
+  if (codesWithProvider.length === 0) {
+    return;
   }
 
   // Queue the job to remove the discount codes from provider
@@ -81,14 +91,14 @@ export async function deleteDiscountCodes(
 
   for (const chunkOfCodes of chunks) {
     await enqueueBatchJobs(
-      chunkOfCodes.map((discountCode) => ({
+      chunkOfCodes.map(({ code, programId, discount }) => ({
         url: `${APP_DOMAIN_WITH_NGROK}/api/cron/discount-codes/disable`,
         method: "POST",
         queueName: "delete-discount-code",
         body: {
-          code: discountCode.code,
-          programId: discountCode.programId,
-          provider: discountCode.discount.provider,
+          code,
+          programId,
+          provider: discount.provider,
         },
       })),
     );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Link deletion now removes any associated discount code(s in a coordinated, single operation for more consistent cleanup.
  - Associated external provider cleanup is still handled via background queuing after deletion.
  - Discount-provider cleanup now ignores entries without a linked provider silently, without the previous warning—while continuing to exclude orphaned entries from external cleanup.
  - Post-deletion side effects (such as image/cache updates and analytics/count updates) continue to run as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->