### PR TITLE
Clear pending identity sync state when modal is dismissed

### DIFF
--- a/apps/web/app/(ee)/partners.dub.co/(dashboard)/profile/profile-details-form.tsx
+++ b/apps/web/app/(ee)/partners.dub.co/(dashboard)/profile/profile-details-form.tsx
@@ -322,6 +322,9 @@ function BasicInfoForm({
       onCancel: async () => {
         await submitProfile(false);
       },
+      onDismiss: () => {
+        pendingSubmitRef.current = null;
+      },
     });
 
   return (

--- a/apps/web/app/app.dub.co/(dashboard)/account/settings/page-client.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/account/settings/page-client.tsx
@@ -140,6 +140,9 @@ export function SettingsPageClient() {
       onCancel: async () => {
         await finishPendingPatch(false);
       },
+      onDismiss: () => {
+        pendingPatchRef.current = null;
+      },
     });
 
   const requestSubmit = ({

--- a/apps/web/ui/modals/identity-sync-confirm-modal.tsx
+++ b/apps/web/ui/modals/identity-sync-confirm-modal.tsx
@@ -121,6 +121,7 @@ type IdentitySyncConfirmModalProps = {
   next: IdentitySyncSnapshot;
   onConfirm: () => Promise<void> | void;
   onCancel?: () => Promise<void> | void;
+  onDismiss?: () => void;
 };
 
 function IdentitySyncConfirmModal({
@@ -133,6 +134,7 @@ function IdentitySyncConfirmModal({
   next,
   onConfirm,
   onCancel,
+  onDismiss,
 }: {
   showModal: boolean;
   setShowModal: Dispatch<SetStateAction<boolean>>;
@@ -167,7 +169,7 @@ function IdentitySyncConfirmModal({
     <Modal
       showModal={showModal}
       setShowModal={setShowModal}
-      onClose={handleCancel}
+      onClose={onDismiss}
       preventDefaultClose={isLoading}
       className="max-w-md"
     >


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dismissing identity-sync confirmation dialogs now properly clears pending profile or account changes.
  * Prevents previously queued updates from being unintentionally submitted after a dialog is closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->