### PR TITLE
Use 30d Tinybird link count in usage summary email

### DIFF
--- a/apps/web/app/(ee)/api/cron/usage/utils.ts
+++ b/apps/web/app/(ee)/api/cron/usage/utils.ts
@@ -5,6 +5,7 @@ import {
   sendWorkspaceLimitAlert,
 } from "@/lib/cron/send-limit-alert";
 import { prisma } from "@/lib/prisma";
+import { getWorkspaceUsage } from "@/lib/tinybird/get-workspace-usage";
 import { WorkspaceProps } from "@/lib/types";
 import { sendBatchEmail } from "@dub/email";
 import ClicksSummary from "@dub/email/templates/clicks-summary";
@@ -171,6 +172,14 @@ export const updateUsage = async () => {
           0,
         );
 
+        const createdLinks = await getWorkspaceUsage({
+          workspaceId: workspace.id,
+          resource: "links",
+          interval: "30d",
+        }).then((data) =>
+          data.reduce((acc, curr) => acc + (curr.value ?? 0), 0),
+        );
+
         const emails = workspace.users.map(
           (user) => user.user.email,
         ) as string[];
@@ -184,7 +193,7 @@ export const updateUsage = async () => {
               workspaceName: workspace.name,
               workspaceSlug: workspace.slug,
               totalClicks,
-              createdLinks: workspace.linksUsage,
+              createdLinks,
               topLinks: topFiveLinks,
             }),
             variant: "notifications",

--- a/apps/web/app/(ee)/api/cron/usage/utils.ts
+++ b/apps/web/app/(ee)/api/cron/usage/utils.ts
@@ -250,10 +250,10 @@ export const updateUsage = async () => {
           type: plan === "free" ? "cron" : "alerts",
           mention: plan !== "free",
         });
-        const sentFirstUsageLimitEmail = sentEmails.some(
+        const firstUsageLimitEmail = sentEmails.find(
           (email) => email.type === "firstUsageLimitEmail",
         );
-        if (!sentFirstUsageLimitEmail) {
+        if (!firstUsageLimitEmail) {
           await sendWorkspaceLimitAlert({
             emails,
             workspace: workspace as unknown as WorkspaceProps,
@@ -267,11 +267,11 @@ export const updateUsage = async () => {
           if (!sentSecondUsageLimitEmail) {
             const daysSinceFirstEmail = Math.floor(
               (new Date().getTime() -
-                new Date(sentEmails[0].createdAt).getTime()) /
+                firstUsageLimitEmail.createdAt.getTime()) /
                 (1000 * 3600 * 24),
             );
             if (daysSinceFirstEmail >= 3) {
-              sendWorkspaceLimitAlert({
+              await sendWorkspaceLimitAlert({
                 emails,
                 workspace: workspace as unknown as WorkspaceProps,
                 type: "secondUsageLimitEmail",

--- a/apps/web/app/(ee)/api/cron/usage/utils.ts
+++ b/apps/web/app/(ee)/api/cron/usage/utils.ts
@@ -12,12 +12,14 @@ import ClicksSummary from "@dub/email/templates/clicks-summary";
 import {
   APP_DOMAIN_WITH_NGROK,
   capitalize,
+  chunk,
   getAdjustedBillingCycleStart,
   log,
 } from "@dub/utils";
 import { getMonth, getYear } from "date-fns";
 
 const limit = 100;
+const WORKSPACE_CHUNK_SIZE = 5;
 
 export const updateUsage = async () => {
   const workspaces = await prisma.project.findMany({
@@ -72,136 +74,143 @@ export const updateUsage = async () => {
 
   // Reset usage and alert emails for the billingReset workspaces
   // also send 30-day summary email
-  await Promise.allSettled(
-    billingReset.map(async (workspace) => {
-      const { usage, usageLimit, plan, planPeriod, billingCycleEndsAt } =
-        workspace;
+  for (const workspaceChunk of chunk(billingReset, WORKSPACE_CHUNK_SIZE)) {
+    await Promise.allSettled(
+      workspaceChunk.map(async (workspace) => {
+        const { usage, usageLimit, plan, planPeriod, billingCycleEndsAt } =
+          workspace;
 
-      // if yearly plan, we skip resetting usage if the billing cycle end date is not this year+month
-      let resetUsage = true;
-      if (
-        planPeriod === "yearly" &&
-        billingCycleEndsAt &&
-        !(
-          getYear(billingCycleEndsAt) === getYear(new Date()) &&
-          getMonth(billingCycleEndsAt) === getMonth(new Date())
-        )
-      ) {
-        resetUsage = false;
-      }
+        // if yearly plan, we skip resetting usage if the billing cycle end date is not this year+month
+        let resetUsage = true;
+        if (
+          planPeriod === "yearly" &&
+          billingCycleEndsAt &&
+          !(
+            getYear(billingCycleEndsAt) === getYear(new Date()) &&
+            getMonth(billingCycleEndsAt) === getMonth(new Date())
+          )
+        ) {
+          resetUsage = false;
+        }
 
-      if (resetUsage) {
-        /* 
-          We only reset events usage if it's not over usageLimit by:
-          - 4x for free plan (4K events)
-          - 2x for all other plans
-        */
-        const resetEventsUsage =
-          plan === "free" ? usage <= usageLimit * 4 : usage <= usageLimit * 2;
+        if (resetUsage) {
+          /* 
+            We only reset events usage if it's not over usageLimit by:
+            - 4x for free plan (4K events)
+            - 2x for all other plans
+          */
+          const resetEventsUsage =
+            plan === "free" ? usage <= usageLimit * 4 : usage <= usageLimit * 2;
 
-        await prisma.project.update({
-          where: {
-            id: workspace.id,
-          },
-          data: {
-            usage: resetEventsUsage ? 0 : undefined,
-            linksUsage: 0,
-            payoutsUsage: 0,
-            aiUsage: 0,
-            sentEmails: {
-              deleteMany: {
-                type: {
-                  in: [
-                    "firstUsageLimitEmail",
-                    "secondUsageLimitEmail",
-                    "firstLinksLimitEmail",
-                    "secondLinksLimitEmail",
-                  ],
+          await prisma.project.update({
+            where: {
+              id: workspace.id,
+            },
+            data: {
+              usage: resetEventsUsage ? 0 : undefined,
+              linksUsage: 0,
+              payoutsUsage: 0,
+              aiUsage: 0,
+              sentEmails: {
+                deleteMany: {
+                  type: {
+                    in: [
+                      "firstUsageLimitEmail",
+                      "secondUsageLimitEmail",
+                      "firstLinksLimitEmail",
+                      "secondLinksLimitEmail",
+                    ],
+                  },
                 },
               },
             },
-          },
-        });
-        console.log(`Reset usage for workspace "${workspace.slug}"`);
-      }
+          });
+          console.log(`Reset usage for workspace "${workspace.slug}"`);
+        }
 
-      /* Only send the 30-day summary email if:
-         - the workspace has at least 1 link click
-         - the workspace was created more than 30 days ago
-       */
-      if (
-        workspace.usage > 0 &&
-        workspace.createdAt.getTime() <
-          new Date().getTime() - 30 * 24 * 60 * 60 * 1000
-      ) {
-        const topLinks = await getAnalytics({
-          workspaceId: workspace.id,
-          event: "clicks",
-          groupBy: "top_links",
-          interval: "30d",
-          root: false,
-        });
+        /* Only send the 30-day summary email if:
+           - the workspace has at least 1 link click
+           - the workspace was created more than 30 days ago
+         */
+        if (
+          workspace.usage > 0 &&
+          workspace.createdAt.getTime() <
+            new Date().getTime() - 30 * 24 * 60 * 60 * 1000
+        ) {
+          const topLinks = await getAnalytics({
+            workspaceId: workspace.id,
+            event: "clicks",
+            groupBy: "top_links",
+            interval: "30d",
+            root: false,
+          });
 
-        const topLinkIds = topLinks.slice(0, 100).map(({ link }) => link);
+          const topLinkIds = topLinks.slice(0, 100).map(({ link }) => link);
 
-        const linksMetadata = await prisma.link.findMany({
-          where: {
-            projectId: workspace.id,
-            id: {
-              in: topLinkIds,
+          const linksMetadata = await prisma.link.findMany({
+            where: {
+              projectId: workspace.id,
+              id: {
+                in: topLinkIds,
+              },
             },
-          },
-          select: {
-            id: true,
-            shortLink: true,
-          },
-        });
+            select: {
+              id: true,
+              shortLink: true,
+            },
+          });
 
-        const topFiveLinks = topLinks
-          .filter((d: { link: string; clicks: number }) =>
-            linksMetadata.find((l) => l.id === d.link),
-          )
-          .slice(0, 5)
-          .map((d: { link: string; clicks: number }) => ({
-            link: linksMetadata.find((l) => l.id === d.link)!, // coerce here since we're already filtering out links that don't exist
-            clicks: d.clicks,
-          }));
+          const topFiveLinks = topLinks
+            .filter((d: { link: string; clicks: number }) =>
+              linksMetadata.find((l) => l.id === d.link),
+            )
+            .slice(0, 5)
+            .map((d: { link: string; clicks: number }) => ({
+              link: linksMetadata.find((l) => l.id === d.link)!, // coerce here since we're already filtering out links that don't exist
+              clicks: d.clicks,
+            }));
 
-        const totalClicks = topLinks.reduce(
-          (acc, curr) => acc + curr.clicks,
-          0,
-        );
+          const totalClicks = topLinks.reduce(
+            (acc, curr) => acc + curr.clicks,
+            0,
+          );
 
-        const createdLinks = await getWorkspaceUsage({
-          workspaceId: workspace.id,
-          resource: "links",
-          interval: "30d",
-        }).then((data) =>
-          data.reduce((acc, curr) => acc + (curr.value ?? 0), 0),
-        );
+          // Yearly plans keep linksUsage across months, so fetch a real 30d count.
+          // Monthly plans can use linksUsage (previous billing cycle, pre-reset).
+          const createdLinks =
+            planPeriod === "yearly"
+              ? await getWorkspaceUsage({
+                  workspaceId: workspace.id,
+                  resource: "links",
+                  interval: "30d",
+                }).then((data) =>
+                  data.reduce((acc, curr) => acc + (curr.value ?? 0), 0),
+                )
+              : workspace.linksUsage;
 
-        const emails = workspace.users.map(
-          (user) => user.user.email,
-        ) as string[];
+          const emails = workspace.users.map(
+            (user) => user.user.email,
+          ) as string[];
 
-        await sendBatchEmail(
-          emails.map((email) => ({
-            subject: `Your 30-day Dub summary for ${workspace.name}`,
-            to: email,
-            react: ClicksSummary({
-              email,
-              workspaceName: workspace.name,
-              workspaceSlug: workspace.slug,
-              totalClicks,
-              createdLinks,
-              topLinks: topFiveLinks,
-            }),
-            variant: "notifications",
-          })),
-        );
-      }
-    }),
-  );
+          await sendBatchEmail(
+            emails.map((email) => ({
+              subject: `Your 30-day Dub summary for ${workspace.name}`,
+              to: email,
+              react: ClicksSummary({
+                email,
+                workspaceName: workspace.name,
+                workspaceSlug: workspace.slug,
+                totalClicks,
+                createdLinks,
+                topLinks: topFiveLinks,
+              }),
+              variant: "notifications",
+            })),
+          );
+        }
+      }),
+    );
+  }
 
   // Update usageLastChecked for workspaces
   await prisma.project.updateMany({
@@ -225,53 +234,55 @@ export const updateUsage = async () => {
   );
 
   // Send email to notify overages
-  await Promise.allSettled(
-    exceedingUsage.map(async (workspace) => {
-      const { slug, plan, usage, usageLimit, users, sentEmails } = workspace;
-      const emails = users.map((user) => user.user.email) as string[];
-      const slackWebhookUrl = slackWebhookByWorkspace.get(workspace.id);
+  for (const workspaceChunk of chunk(exceedingUsage, WORKSPACE_CHUNK_SIZE)) {
+    await Promise.allSettled(
+      workspaceChunk.map(async (workspace) => {
+        const { slug, plan, usage, usageLimit, users, sentEmails } = workspace;
+        const emails = users.map((user) => user.user.email) as string[];
+        const slackWebhookUrl = slackWebhookByWorkspace.get(workspace.id);
 
-      await log({
-        message: `*${slug}* is over their *${capitalize(
-          plan,
-        )} Plan* usage limit. Usage: ${usage}, Limit: ${usageLimit}, Email: ${emails.join(
-          ", ",
-        )}`,
-        type: plan === "free" ? "cron" : "alerts",
-        mention: plan !== "free",
-      });
-      const sentFirstUsageLimitEmail = sentEmails.some(
-        (email) => email.type === "firstUsageLimitEmail",
-      );
-      if (!sentFirstUsageLimitEmail) {
-        await sendWorkspaceLimitAlert({
-          emails,
-          workspace: workspace as unknown as WorkspaceProps,
-          type: "firstUsageLimitEmail",
-          slackWebhookUrl,
+        await log({
+          message: `*${slug}* is over their *${capitalize(
+            plan,
+          )} Plan* usage limit. Usage: ${usage}, Limit: ${usageLimit}, Email: ${emails.join(
+            ", ",
+          )}`,
+          type: plan === "free" ? "cron" : "alerts",
+          mention: plan !== "free",
         });
-      } else {
-        const sentSecondUsageLimitEmail = sentEmails.some(
-          (email) => email.type === "secondUsageLimitEmail",
+        const sentFirstUsageLimitEmail = sentEmails.some(
+          (email) => email.type === "firstUsageLimitEmail",
         );
-        if (!sentSecondUsageLimitEmail) {
-          const daysSinceFirstEmail = Math.floor(
-            (new Date().getTime() -
-              new Date(sentEmails[0].createdAt).getTime()) /
-              (1000 * 3600 * 24),
+        if (!sentFirstUsageLimitEmail) {
+          await sendWorkspaceLimitAlert({
+            emails,
+            workspace: workspace as unknown as WorkspaceProps,
+            type: "firstUsageLimitEmail",
+            slackWebhookUrl,
+          });
+        } else {
+          const sentSecondUsageLimitEmail = sentEmails.some(
+            (email) => email.type === "secondUsageLimitEmail",
           );
-          if (daysSinceFirstEmail >= 3) {
-            sendWorkspaceLimitAlert({
-              emails,
-              workspace: workspace as unknown as WorkspaceProps,
-              type: "secondUsageLimitEmail",
-              slackWebhookUrl,
-            });
+          if (!sentSecondUsageLimitEmail) {
+            const daysSinceFirstEmail = Math.floor(
+              (new Date().getTime() -
+                new Date(sentEmails[0].createdAt).getTime()) /
+                (1000 * 3600 * 24),
+            );
+            if (daysSinceFirstEmail >= 3) {
+              sendWorkspaceLimitAlert({
+                emails,
+                workspace: workspace as unknown as WorkspaceProps,
+                type: "secondUsageLimitEmail",
+                slackWebhookUrl,
+              });
+            }
           }
         }
-      }
-    }),
-  );
+      }),
+    );
+  }
 
   await qstash.publishJSON({
     url: `${APP_DOMAIN_WITH_NGROK}/api/cron/usage`,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of the “created links” metric in 30-day workspace usage summary emails for yearly plans by summing 30-day link usage from usage data (null/undefined treated as 0).
  * Improved reliability of background usage processing by handling workspaces in smaller batches to avoid concurrency spikes.
  * Fixed overage second-limit alert behavior by basing “days since first email” on the recorded first email and ensuring the second alert is sent consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->