### PR TITLE
Allow messaging invited partners after they reply

### DIFF
--- a/apps/web/lib/messages/message-partner.ts
+++ b/apps/web/lib/messages/message-partner.ts
@@ -52,49 +52,66 @@ export const messagePartnerAction = authActionClient
     }
 
     // Make sure partner is either approved or trusted in the partner network, enrolled in the program, or already has a message with the program
-    const { _count, programs, ...partner } =
-      await prisma.partner.findFirstOrThrow({
-        where: {
-          id: partnerId,
-          ...partnerReachableByProgramWhereInput(programId),
-        },
-        include: {
-          _count: {
-            select: {
-              messages: {
-                where: {
-                  programId,
-                },
+    const {
+      _count,
+      programs,
+      messages: partnerReplies,
+      ...partner
+    } = await prisma.partner.findFirstOrThrow({
+      where: {
+        id: partnerId,
+        ...partnerReachableByProgramWhereInput(programId),
+      },
+      include: {
+        _count: {
+          select: {
+            messages: {
+              where: {
+                programId,
+                senderPartnerId: null,
               },
             },
           },
-          programs: {
-            where: {
-              programId,
-            },
-            select: {
-              status: true,
-            },
+        },
+        // Any partner reply unlocks further program messages
+        messages: {
+          where: {
+            programId,
+            senderPartnerId: { not: null },
+          },
+          take: 1,
+          select: { id: true },
+        },
+        programs: {
+          where: {
+            programId,
+          },
+          select: {
+            status: true,
           },
         },
-      });
+      },
+    });
 
-    // if the partner is not enrolled / is in invited status, cap at one message
     const enrollment = programs[0];
+    const programMessageCount = _count.messages;
+    const partnerHasReplied = partnerReplies.length > 0;
+
+    // Cap unsolicited outreach while invited / not enrolled; unlock once partner replies
     if (
       (!enrollment || enrollment.status === "invited") &&
-      _count.messages >= 1
+      !partnerHasReplied &&
+      programMessageCount >= 1
     ) {
       throw new DubApiError({
         code: "forbidden",
-        message:
-          "You can only send one initial message to a partner you've invited.",
+        message: "You can only send one message until the partner replies.",
       });
     }
 
-    // if partner is not enrolled in the program and it's the first message
+    // if partner is not enrolled in the program and it's the first program message
     // it means the program is reaching out via the partner network
-    if (!enrollment && _count.messages === 0) {
+    if (!enrollment && programMessageCount === 0) {
       const networkInvitesUsage = await getNetworkInvitesUsage(workspace);
 
       if (networkInvitesUsage >= workspace.networkInvitesLimit) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved partner messaging limits by distinguishing program-sent messages from partner replies.
  * Partners who respond can now receive eligible follow-up outreach without being blocked by the unsolicited messaging cap.
  * Continued to enforce outreach limits for partners who have not replied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->