### PR TITLE
Payouts upgrade messaging

### DIFF
--- a/apps/web/app/(ee)/api/groups/route.ts
+++ b/apps/web/app/(ee)/api/groups/route.ts
@@ -93,6 +93,7 @@ export const POST = withWorkspace(
           code: "exceeded_limit",
           message: exceededLimitError({
             plan: workspace.plan,
+            planPeriod: workspace.planPeriod,
             limit: workspace.groupsLimit,
             type: "groups",
           }),

--- a/apps/web/app/api/analytics/dashboard/route.ts
+++ b/apps/web/app/api/analytics/dashboard/route.ts
@@ -4,7 +4,6 @@ import { DubApiError, handleAndReturnErrorResponse } from "@/lib/api/errors";
 import { assertValidDateRangeForPlan } from "@/lib/api/utils/assert-valid-date-range-for-plan";
 import { exceededLimitError } from "@/lib/exceeded-limit-error";
 import { prisma } from "@/lib/prisma";
-import { PlanProps } from "@/lib/types";
 import { redis } from "@/lib/upstash";
 import { parseAnalyticsQuery } from "@/lib/zod/schemas/analytics";
 import { DUB_DEMO_LINKS, DUB_WORKSPACE_ID, getSearchParams } from "@dub/utils";
@@ -140,7 +139,8 @@ export const GET = async (req: Request) => {
       throw new DubApiError({
         code: "forbidden",
         message: exceededLimitError({
-          plan: workspace.plan as PlanProps,
+          plan: workspace.plan,
+          planPeriod: workspace.planPeriod,
           limit: workspace.usageLimit,
           type: "clicks",
         }),

--- a/apps/web/app/api/domains/route.ts
+++ b/apps/web/app/api/domains/route.ts
@@ -177,6 +177,7 @@ export const POST = withWorkspace(
             code: "exceeded_limit",
             message: exceededLimitError({
               plan: workspace.plan,
+              planPeriod: workspace.planPeriod,
               limit: workspace.domainsLimit,
               type: "domains",
             }),

--- a/apps/web/app/api/folders/route.ts
+++ b/apps/web/app/api/folders/route.ts
@@ -68,6 +68,7 @@ export const POST = withWorkspace(
               code: "exceeded_limit",
               message: exceededLimitError({
                 plan: workspace.plan,
+                planPeriod: workspace.planPeriod,
                 limit: foldersLimit,
                 type: "folders",
               }),

--- a/apps/web/app/api/links/bulk/route.ts
+++ b/apps/web/app/api/links/bulk/route.ts
@@ -52,6 +52,7 @@ export const POST = withWorkspace(
         code: "exceeded_limit",
         message: exceededLimitError({
           plan: workspace.plan,
+          planPeriod: workspace.planPeriod,
           limit: workspace.linksLimit,
           type: "links",
         }),

--- a/apps/web/app/api/links/sync/route.ts
+++ b/apps/web/app/api/links/sync/route.ts
@@ -41,6 +41,7 @@ export const POST = withWorkspace(
       return new Response(
         exceededLimitError({
           plan: workspace.plan,
+          planPeriod: workspace.planPeriod,
           limit: workspace.linksLimit,
           type: "links",
         }),

--- a/apps/web/app/api/tags/route.ts
+++ b/apps/web/app/api/tags/route.ts
@@ -107,6 +107,7 @@ export const POST = withWorkspace(
         code: "exceeded_limit",
         message: exceededLimitError({
           plan: workspace.plan,
+          planPeriod: workspace.planPeriod,
           limit: workspace.tagsLimit,
           type: "tags",
         }),

--- a/apps/web/app/api/workspaces/[idOrSlug]/invites/accept/route.ts
+++ b/apps/web/app/api/workspaces/[idOrSlug]/invites/accept/route.ts
@@ -60,6 +60,7 @@ export const POST = withSession(async ({ session, params }) => {
         id: true,
         slug: true,
         plan: true,
+        planPeriod: true,
         usersLimit: true,
         _count: {
           select: {
@@ -93,6 +94,7 @@ export const POST = withSession(async ({ session, params }) => {
       code: "exceeded_limit",
       message: exceededLimitError({
         plan: workspace.plan as PlanProps,
+        planPeriod: workspace.planPeriod,
         limit: workspace.usersLimit,
         type: "users",
       }),
@@ -134,6 +136,7 @@ export const POST = withSession(async ({ session, params }) => {
         code: "exceeded_limit",
         message: exceededLimitError({
           plan: workspace.plan as PlanProps,
+          planPeriod: workspace.planPeriod,
           limit: workspace.usersLimit,
           type: "users",
         }),

--- a/apps/web/app/api/workspaces/[idOrSlug]/invites/route.ts
+++ b/apps/web/app/api/workspaces/[idOrSlug]/invites/route.ts
@@ -132,6 +132,7 @@ export const POST = withWorkspace(
         code: "exceeded_limit",
         message: exceededLimitError({
           plan: workspace.plan,
+          planPeriod: workspace.planPeriod,
           limit: workspace.usersLimit,
           type: "users",
         }),

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/members/page.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/members/page.tsx
@@ -53,7 +53,7 @@ export default function WorkspaceMembersPage() {
 
   const { setShowInviteCodeModal, InviteCodeModal } = useInviteCodeModal();
 
-  const { role, plan, usersLimit } = useWorkspace();
+  const { role, plan, planPeriod, usersLimit } = useWorkspace();
   const { data: session } = useSession();
   const { id: workspaceId } = useWorkspace();
   const { users: workspaceUsers } = useWorkspaceUsers();
@@ -105,8 +105,13 @@ export default function WorkspaceMembersPage() {
   }).error;
 
   const inviteUserLimitError =
-    isAtUserLimit && plan
-      ? exceededLimitError({ plan, limit: usersLimit, type: "users" })
+    isAtUserLimit && plan && planPeriod
+      ? exceededLimitError({
+          plan,
+          planPeriod,
+          limit: usersLimit,
+          type: "users",
+        })
       : undefined;
 
   const availableRolesForPlan = useMemo(() => {

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/members/page.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/members/page.tsx
@@ -105,7 +105,7 @@ export default function WorkspaceMembersPage() {
   }).error;
 
   const inviteUserLimitError =
-    isAtUserLimit && plan && planPeriod
+    isAtUserLimit && plan
       ? exceededLimitError({
           plan,
           planPeriod,

--- a/apps/web/lib/actions/partners/confirm-payouts.ts
+++ b/apps/web/lib/actions/partners/confirm-payouts.ts
@@ -90,6 +90,7 @@ export const confirmPayoutsAction = authActionClient
       throw new Error(
         exceededLimitError({
           plan: workspace.plan,
+          planPeriod: workspace.planPeriod,
           limit: workspace.payoutsLimit,
           type: "payouts",
         }),

--- a/apps/web/lib/ai/generate-partner-network-invite-email.ts
+++ b/apps/web/lib/ai/generate-partner-network-invite-email.ts
@@ -10,6 +10,7 @@ import { prisma } from "@/lib/prisma";
 import { PlanProps } from "@/lib/types";
 import { emailSchema } from "@/lib/zod/schemas/auth";
 import { anthropic } from "@ai-sdk/anthropic";
+import { PlanPeriod } from "@prisma/client";
 import { generateText, Output } from "ai";
 import * as z from "zod/v4";
 import { authActionClient } from "../actions/safe-action";
@@ -89,6 +90,7 @@ export const generatePartnerNetworkInviteEmailAction = authActionClient
       workspaceId: workspace.id,
       aiLimit: workspace.aiLimit,
       plan: workspace.plan,
+      planPeriod: workspace.planPeriod,
     });
 
     try {
@@ -229,10 +231,12 @@ async function reserveAIUsageCredit({
   workspaceId,
   aiLimit,
   plan,
+  planPeriod,
 }: {
   workspaceId: string;
   aiLimit: number;
   plan: PlanProps;
+  planPeriod: PlanPeriod | null;
 }) {
   const { count } = await prisma.project.updateMany({
     where: {
@@ -253,6 +257,7 @@ async function reserveAIUsageCredit({
       code: "forbidden",
       message: exceededLimitError({
         plan,
+        planPeriod,
         limit: aiLimit,
         type: "AI",
       }),

--- a/apps/web/lib/api/links/usage-checks.ts
+++ b/apps/web/lib/api/links/usage-checks.ts
@@ -9,6 +9,7 @@ export const throwIfClicksUsageExceeded = (workspace: WorkspaceWithUsers) => {
       code: "forbidden",
       message: exceededLimitError({
         plan: workspace.plan,
+        planPeriod: workspace.planPeriod,
         limit: workspace.usageLimit,
         type: "clicks",
       }),
@@ -26,6 +27,7 @@ export const throwIfLinksUsageExceeded = (workspace: WorkspaceWithUsers) => {
       code: "forbidden",
       message: exceededLimitError({
         plan: workspace.plan,
+        planPeriod: workspace.planPeriod,
         limit: workspace.linksLimit,
         type: "links",
       }),
@@ -39,6 +41,7 @@ export const throwIfAIUsageExceeded = (workspace: WorkspaceWithUsers) => {
       code: "forbidden",
       message: exceededLimitError({
         plan: workspace.plan,
+        planPeriod: workspace.planPeriod,
         limit: workspace.aiLimit,
         type: "AI",
       }),

--- a/apps/web/lib/exceeded-limit-error.ts
+++ b/apps/web/lib/exceeded-limit-error.ts
@@ -1,12 +1,15 @@
 import { capitalize, currencyFormatter } from "@dub/utils";
+import { PlanPeriod } from "@prisma/client";
 import { PlanProps } from "./types";
 
 export const exceededLimitError = ({
   plan,
+  planPeriod,
   limit,
   type,
 }: {
   plan: PlanProps;
+  planPeriod?: PlanPeriod | null;
   limit: number;
   type:
     | "clicks"
@@ -19,11 +22,22 @@ export const exceededLimitError = ({
     | "payouts"
     | "groups";
 }) => {
-  return `You've reached your ${
-    ["links", "AI", "payouts"].includes(type) ? "monthly" : ""
-  } limit of ${
+  const period = ["links", "AI", "payouts"].includes(type)
+    ? planPeriod === "yearly"
+      ? "yearly"
+      : "monthly"
+    : null;
+
+  const upgradeMessage =
+    type === "payouts"
+      ? planPeriod === "yearly"
+        ? "Upgrade for higher limits."
+        : "Go yearly for 12x usage upfront, or upgrade for higher limits."
+      : "Please upgrade for higher limits.";
+
+  return `You've reached your${period ? ` ${period}` : ""} limit of ${
     type === "payouts"
       ? currencyFormatter(limit)
       : `${limit} ${limit === 1 ? type.slice(0, -1) : type}`
-  } on the ${capitalize(plan)} plan. Please upgrade for higher limits.`;
+  } on the ${capitalize(plan)} plan. ${upgradeMessage}`;
 };

--- a/apps/web/lib/exceeded-limit-error.ts
+++ b/apps/web/lib/exceeded-limit-error.ts
@@ -4,38 +4,32 @@ import { PlanProps } from "./types";
 
 export const exceededLimitError = ({
   plan,
-  planPeriod,
+  planPeriod = "monthly",
   limit,
   type,
 }: {
   plan: PlanProps;
-  planPeriod?: PlanPeriod | null;
+  planPeriod: PlanPeriod | null;
   limit: number;
   type:
     | "clicks"
+    | "payouts"
     | "links"
-    | "AI"
     | "domains"
     | "tags"
-    | "users"
     | "folders"
-    | "payouts"
-    | "groups";
+    | "groups"
+    | "users"
+    | "AI";
 }) => {
-  const period = ["links", "AI", "payouts"].includes(type)
-    ? planPeriod === "yearly"
-      ? "yearly"
-      : "monthly"
-    : null;
+  const periodSpecificResources = ["clicks", "links", "payouts", "AI"];
 
   const upgradeMessage =
-    type === "payouts"
-      ? planPeriod === "yearly"
-        ? "Upgrade for higher limits."
-        : "Go yearly for 12x usage upfront, or upgrade for higher limits."
+    periodSpecificResources.includes(type) && planPeriod === "monthly"
+      ? "Go yearly for 12x usage upfront, or upgrade for higher limits."
       : "Please upgrade for higher limits.";
 
-  return `You've reached your${period ? ` ${period}` : ""} limit of ${
+  return `You've reached your${periodSpecificResources.includes(type) ? ` ${planPeriod}` : ""} limit of ${
     type === "payouts"
       ? currencyFormatter(limit)
       : `${limit} ${limit === 1 ? type.slice(0, -1) : type}`

--- a/apps/web/lib/exceeded-limit-error.ts
+++ b/apps/web/lib/exceeded-limit-error.ts
@@ -4,12 +4,12 @@ import { PlanProps } from "./types";
 
 export const exceededLimitError = ({
   plan,
-  planPeriod = "monthly",
+  planPeriod,
   limit,
   type,
 }: {
   plan: PlanProps;
-  planPeriod: PlanPeriod | null;
+  planPeriod?: PlanPeriod | null;
   limit: number;
   type:
     | "clicks"
@@ -24,12 +24,16 @@ export const exceededLimitError = ({
 }) => {
   const periodSpecificResources = ["clicks", "links", "payouts", "AI"];
 
+  // planPeriod is null for workspaces without a billing period (e.g. free plans),
+  // whose limits reset monthly
+  const period = planPeriod ?? "monthly";
+
   const upgradeMessage =
-    periodSpecificResources.includes(type) && planPeriod === "monthly"
+    periodSpecificResources.includes(type) && period === "monthly"
       ? "Go yearly for 12x usage upfront, or upgrade for higher limits."
       : "Please upgrade for higher limits.";
 
-  return `You've reached your${periodSpecificResources.includes(type) ? ` ${planPeriod}` : ""} limit of ${
+  return `You've reached your${periodSpecificResources.includes(type) ? ` ${period}` : ""} limit of ${
     type === "payouts"
       ? currencyFormatter(limit)
       : `${limit} ${limit === 1 ? type.slice(0, -1) : type}`

--- a/apps/web/ui/partners/confirm-payouts-sheet.tsx
+++ b/apps/web/ui/partners/confirm-payouts-sheet.tsx
@@ -918,7 +918,6 @@ function ConfirmPayoutsSheetContent() {
           }
           disabledTooltip={
             plan &&
-            planPeriod &&
             typeof payoutsUsage === "number" &&
             typeof payoutsLimit === "number" &&
             typeof amount === "number" &&

--- a/apps/web/ui/partners/confirm-payouts-sheet.tsx
+++ b/apps/web/ui/partners/confirm-payouts-sheet.tsx
@@ -9,6 +9,7 @@ import {
   INVOICE_MIN_PAYOUT_AMOUNT_CENTS,
   STRIPE_PAYMENT_METHOD_NORMALIZATION,
 } from "@/lib/constants/payouts";
+import { exceededLimitError } from "@/lib/exceeded-limit-error";
 import { calculatePayoutFeeWithWaiver } from "@/lib/partners/calculate-payout-fee-with-waiver";
 import {
   CUTOFF_PERIOD,
@@ -923,11 +924,12 @@ function ConfirmPayoutsSheetContent() {
             typeof amount === "number" &&
             payoutsUsage + amount > payoutsLimit ? (
               <TooltipContent
-                title={
-                  planPeriod === "yearly"
-                    ? `You've reached your yearly limit of ${currencyFormatter(payoutsLimit)} on the ${capitalize(plan)} plan. Upgrade for higher limits.`
-                    : `You've reached your monthly limit of ${currencyFormatter(payoutsLimit)} on the ${capitalize(plan)} plan. Go yearly for 12x usage upfront, or upgrade for higher limits.`
-                }
+                title={exceededLimitError({
+                  plan,
+                  planPeriod,
+                  limit: payoutsLimit,
+                  type: "payouts",
+                })}
                 cta="Upgrade"
                 href={`/${slug}/settings/billing/upgrade?planPeriod=yearly`}
               />

--- a/apps/web/ui/partners/confirm-payouts-sheet.tsx
+++ b/apps/web/ui/partners/confirm-payouts-sheet.tsx
@@ -9,7 +9,6 @@ import {
   INVOICE_MIN_PAYOUT_AMOUNT_CENTS,
   STRIPE_PAYMENT_METHOD_NORMALIZATION,
 } from "@/lib/constants/payouts";
-import { exceededLimitError } from "@/lib/exceeded-limit-error";
 import { calculatePayoutFeeWithWaiver } from "@/lib/partners/calculate-payout-fee-with-waiver";
 import {
   CUTOFF_PERIOD,
@@ -23,7 +22,7 @@ import useCommissionsCount from "@/lib/swr/use-commissions-count";
 import usePaymentMethods from "@/lib/swr/use-payment-methods";
 import useProgram from "@/lib/swr/use-program";
 import useWorkspace from "@/lib/swr/use-workspace";
-import { PayoutResponse, PlanProps } from "@/lib/types";
+import { PayoutResponse } from "@/lib/types";
 import { X } from "@/ui/shared/icons";
 import {
   Button,
@@ -84,6 +83,7 @@ function ConfirmPayoutsSheetContent() {
     id: workspaceId,
     slug,
     plan,
+    planPeriod,
     role,
     defaultProgramId,
     payoutsUsage,
@@ -916,18 +916,20 @@ function ConfirmPayoutsSheetContent() {
             amount === 0
           }
           disabledTooltip={
-            payoutsUsage &&
-            payoutsLimit &&
-            amount &&
+            plan &&
+            plan !== "enterprise" &&
+            typeof payoutsUsage === "number" &&
+            typeof payoutsLimit === "number" &&
+            typeof amount === "number" &&
             payoutsUsage + amount > payoutsLimit ? (
               <TooltipContent
-                title={exceededLimitError({
-                  plan: plan as PlanProps,
-                  limit: payoutsLimit,
-                  type: "payouts",
-                })}
+                title={
+                  planPeriod === "yearly"
+                    ? `You've reached your yearly limit of ${currencyFormatter(payoutsLimit)} on the ${capitalize(plan)} plan. Upgrade for higher limits.`
+                    : `You've reached your monthly limit of ${currencyFormatter(payoutsLimit)} on the ${capitalize(plan)} plan. Go yearly for 12x usage upfront, or upgrade for higher limits.`
+                }
                 cta="Upgrade"
-                href={`/${slug}/settings/billing/upgrade`}
+                href={`/${slug}/settings/billing/upgrade?planPeriod=yearly`}
               />
             ) : amount && amount < INVOICE_MIN_PAYOUT_AMOUNT_CENTS ? (
               "Your payout total is less than the minimum invoice amount of $10."

--- a/apps/web/ui/partners/confirm-payouts-sheet.tsx
+++ b/apps/web/ui/partners/confirm-payouts-sheet.tsx
@@ -918,7 +918,7 @@ function ConfirmPayoutsSheetContent() {
           }
           disabledTooltip={
             plan &&
-            plan !== "enterprise" &&
+            planPeriod &&
             typeof payoutsUsage === "number" &&
             typeof payoutsLimit === "number" &&
             typeof amount === "number" &&


### PR DESCRIPTION
- When the workspace is on monthly, and they hit their payout limit, change the messaging to educate about switching to yearly to unlock the full usage upfront.
- When clicking upgrade, the billing options show the yearly plans by default

https://github.com/user-attachments/assets/4cc6a05e-e7bf-4c9e-ac2e-b98a8bc1be67



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Usage-limit messages now include your billing period (plan period) for links, AI usage, payouts, domains, folders, tags, groups, and workspace members/invites.
  * Monthly-plan limit notices more accurately adjust upgrade guidance, including year-vs-month specific messaging where applicable.
  * Upgrade prompts and links now carry billing-period-aware parameters to keep the recommended option consistent across limit states.
  * Partner payout confirmations and workspace invitation limit checks now display billing-period-aware exceeded-limit details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->