### PR TITLE
Show placeholder when identity sync preview has no name

### DIFF
--- a/apps/web/ui/modals/identity-sync-confirm-modal.tsx
+++ b/apps/web/ui/modals/identity-sync-confirm-modal.tsx
@@ -50,21 +50,23 @@ function IdentitySyncPreviewRow({
         />
       )}
       <div>
-        {showName && snapshot.name && (
+        {showName && (
           <div
             className={
-              isNameContextOnly
-                ? "text-[14px] font-semibold leading-4 text-neutral-900 opacity-50"
-                : "text-[14px] font-semibold leading-4 text-neutral-900"
+              snapshot.name
+                ? isNameContextOnly
+                  ? "text-[14px] font-semibold leading-4 text-neutral-900 opacity-50"
+                  : "text-[14px] font-semibold leading-4 text-neutral-900"
+                : "text-[14px] font-medium leading-4 text-neutral-500"
             }
           >
-            {snapshot.name}
+            {snapshot.name || "No name set"}
           </div>
         )}
         {showEmail && snapshot.email && (
           <div
             className={
-              showName && snapshot.name
+              showName
                 ? "mt-1 text-sm font-medium leading-5 text-neutral-500"
                 : "text-sm font-medium leading-5 text-neutral-900"
             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Identity synchronization previews now clearly indicate when no name is set.
  * Improved styling and layout for entries with missing names, ensuring associated email details remain consistently displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->