### PR TITLE
Use getOrCreateCustomer in Stripe checkout webhook

### DIFF
--- a/apps/web/app/(ee)/api/stripe/integration/webhook/checkout-session-completed.ts
+++ b/apps/web/app/(ee)/api/stripe/integration/webhook/checkout-session-completed.ts
@@ -103,6 +103,17 @@ export async function checkoutSessionCompleted({
                   },
                 ]
               : []),
+
+            // include create unique keys so concurrent P2002 fallbacks can find
+            // the customer that won the insert (externalId / stripeCustomerId)
+            ...(payload.externalId
+              ? [
+                  {
+                    projectId: workspace.id,
+                    externalId: payload.externalId,
+                  },
+                ]
+              : []),
           ],
         },
         create: {

--- a/apps/web/app/(ee)/api/stripe/integration/webhook/checkout-session-completed.ts
+++ b/apps/web/app/(ee)/api/stripe/integration/webhook/checkout-session-completed.ts
@@ -114,6 +114,14 @@ export async function checkoutSessionCompleted({
                   },
                 ]
               : []),
+
+            ...(stripeCustomerId
+              ? [
+                  {
+                    stripeCustomerId,
+                  },
+                ]
+              : []),
           ],
         },
         create: {

--- a/apps/web/app/(ee)/api/stripe/integration/webhook/checkout-session-completed.ts
+++ b/apps/web/app/(ee)/api/stripe/integration/webhook/checkout-session-completed.ts
@@ -188,14 +188,13 @@ export async function checkoutSessionCompleted({
         if (promotionCodeId) {
           const promoCodeResponse = await attributeViaPromotionCodeId({
             promotionCodeId,
-            stripeAccountId,
             workspace,
             mode,
-            stripeCustomerId,
             customerDetails: {
               name: charge.customer_details?.name,
               email: charge.customer_details?.email,
               address: charge.customer_details?.address,
+              stripeCustomerId,
             },
           });
           if (promoCodeResponse) {
@@ -260,14 +259,13 @@ export async function checkoutSessionCompleted({
         } else if (promotionCodeId) {
           const promoCodeResponse = await attributeViaPromotionCodeId({
             promotionCodeId,
-            stripeAccountId,
             workspace,
             mode,
-            stripeCustomerId,
             customerDetails: {
               name: charge.customer_details?.name,
               email: charge.customer_details?.email,
               address: charge.customer_details?.address,
+              stripeCustomerId,
             },
           });
           if (promoCodeResponse) {

--- a/apps/web/app/(ee)/api/stripe/integration/webhook/checkout-session-completed.ts
+++ b/apps/web/app/(ee)/api/stripe/integration/webhook/checkout-session-completed.ts
@@ -1,6 +1,7 @@
 import { convertCurrency } from "@/lib/analytics/convert-currency";
 import { isFirstConversion } from "@/lib/analytics/is-first-conversion";
 import { createId } from "@/lib/api/create-id";
+import { getOrCreateCustomer } from "@/lib/api/customers/get-or-create-customer";
 import { includeTags } from "@/lib/api/links/include-tags";
 import { syncPartnerLinksStats } from "@/lib/api/partners/sync-partner-links-stats";
 import { executeWorkflows } from "@/lib/api/workflows/execute-workflows";
@@ -49,7 +50,6 @@ export async function checkoutSessionCompleted({
     | undefined;
 
   let customer: Customer | null = null;
-  let existingCustomer: Customer | null = null;
   let clickEvent: ClickEventTB | null = null;
   let leadEvent: LeadEventTB | undefined;
   let linkId: string | undefined;
@@ -71,25 +71,6 @@ export async function checkoutSessionCompleted({
       };
     }
 
-    existingCustomer = await prisma.customer.findFirst({
-      where: {
-        projectId: workspace.id,
-        // check for existing customer with the same externalId (via clickId or email)
-        OR: [
-          {
-            externalId: clickEvent.click_id,
-          },
-          ...(stripeCustomerEmail
-            ? [
-                {
-                  externalId: stripeCustomerEmail,
-                },
-              ]
-            : []),
-        ],
-      },
-    });
-
     const payload = {
       name: stripeCustomerName,
       email: stripeCustomerEmail,
@@ -104,19 +85,40 @@ export async function checkoutSessionCompleted({
       clickedAt: new Date(clickEvent.timestamp + "Z"),
     };
 
-    if (existingCustomer) {
-      customer = await prisma.customer.update({
+    const { customer: existingOrNewCustomer, created } =
+      await getOrCreateCustomer({
+        findMode: "first",
         where: {
-          id: existingCustomer.id,
+          OR: [
+            {
+              projectId: workspace.id,
+              externalId: clickEvent.click_id,
+            },
+
+            ...(stripeCustomerEmail
+              ? [
+                  {
+                    projectId: workspace.id,
+                    externalId: stripeCustomerEmail,
+                  },
+                ]
+              : []),
+          ],
         },
-        data: payload,
-      });
-    } else {
-      customer = await prisma.customer.create({
-        data: {
+        create: {
           id: createId({ prefix: "cus_" }),
           ...payload,
         },
+      });
+
+    if (created) {
+      customer = existingOrNewCustomer;
+    } else {
+      customer = await prisma.customer.update({
+        where: {
+          id: existingOrNewCustomer.id,
+        },
+        data: payload,
       });
     }
 
@@ -131,7 +133,8 @@ export async function checkoutSessionCompleted({
       metadata: "",
     };
 
-    if (!existingCustomer) {
+    // if the customer was created, we record the lead event and increment the link leads
+    if (created) {
       await recordLead(leadEvent);
       waitUntil(incrementLinkLeads(clickEvent.link_id));
     }
@@ -199,7 +202,7 @@ export async function checkoutSessionCompleted({
       }
     } else {
       // find customer by stripeCustomerId or email
-      existingCustomer = await prisma.customer.findFirst({
+      const existingCustomer = await prisma.customer.findFirst({
         where: {
           OR: [
             {

--- a/apps/web/app/(ee)/api/stripe/integration/webhook/invoice-paid.ts
+++ b/apps/web/app/(ee)/api/stripe/integration/webhook/invoice-paid.ts
@@ -102,14 +102,13 @@ export async function invoicePaid({
     if (promotionCodeId) {
       const promoCodeResponse = await attributeViaPromotionCodeId({
         promotionCodeId,
-        stripeAccountId,
         workspace,
         mode,
-        stripeCustomerId,
         customerDetails: {
           name: invoice.customer_name,
           email: invoice.customer_email,
           address: invoice.customer_address,
+          stripeCustomerId,
         },
       });
 

--- a/apps/web/app/(ee)/api/stripe/integration/webhook/utils/attribute-via-promotion-code-id.ts
+++ b/apps/web/app/(ee)/api/stripe/integration/webhook/utils/attribute-via-promotion-code-id.ts
@@ -138,8 +138,7 @@ export async function attributeViaPromotionCodeId({
 
   // Concurrent webhook already created this customer — continue sale without re-recording lead
   if (!created) {
-    const cachedLead = await redis.get<LeadEventTB>(`leadCache:${customer.id}`);
-    let existingLead = cachedLead;
+    let existingLead = await redis.get<LeadEventTB>(`leadCache:${customer.id}`);
 
     if (!existingLead) {
       existingLead = await getLeadEvent({

--- a/apps/web/app/(ee)/api/stripe/integration/webhook/utils/attribute-via-promotion-code-id.ts
+++ b/apps/web/app/(ee)/api/stripe/integration/webhook/utils/attribute-via-promotion-code-id.ts
@@ -160,7 +160,7 @@ export async function attributeViaPromotionCodeId({
       clickEvent,
       leadEvent: {
         ...existingLead,
-        workspace_id: customer.projectId,
+        workspace_id: workspace.id,
       },
     };
   }
@@ -170,7 +170,7 @@ export async function attributeViaPromotionCodeId({
 
   const leadEvent = {
     ...rest,
-    workspace_id: customer.projectId,
+    workspace_id: workspace.id,
     event_id: nanoid(16),
     event_name: "Attributed via discount code",
     customer_id: customer.id,

--- a/apps/web/app/(ee)/api/stripe/integration/webhook/utils/attribute-via-promotion-code-id.ts
+++ b/apps/web/app/(ee)/api/stripe/integration/webhook/utils/attribute-via-promotion-code-id.ts
@@ -240,6 +240,7 @@ export async function attributeViaPromotionCodeId({
           workspace,
           data: transformLeadEventData({
             ...leadEvent,
+            timestamp,
             link: linkUpdated,
             customer,
             partner: result?.webhookPartner,
@@ -254,6 +255,7 @@ export async function attributeViaPromotionCodeId({
                 event: "lead.created",
                 data: {
                   ...leadEvent,
+                  timestamp,
                   link: linkUpdated,
                   customer,
                 },

--- a/apps/web/app/(ee)/api/stripe/integration/webhook/utils/attribute-via-promotion-code-id.ts
+++ b/apps/web/app/(ee)/api/stripe/integration/webhook/utils/attribute-via-promotion-code-id.ts
@@ -40,8 +40,19 @@ export async function attributeViaPromotionCodeId({
   mode: StripeMode;
   customerDetails: PromoCodeCustomerDetails;
 }) {
+  console.log(
+    `Attributing via promotion code ID ${promotionCodeId} for customer ${customerDetails.stripeCustomerId} in workspace ${workspace.id}`,
+  );
+
   const stripeAccountId = workspace.stripeConnectId!;
   const stripeCustomerId = customerDetails.stripeCustomerId;
+
+  if (!workspace.defaultProgramId) {
+    console.log(
+      `Workspace with stripeConnectId ${stripeAccountId} has no default program, skipping...`,
+    );
+    return null;
+  }
 
   // Find the promotion code for the promotion code id
   const promotionCode = await getPromotionCode({
@@ -57,12 +68,7 @@ export async function attributeViaPromotionCodeId({
     return null;
   }
 
-  if (!workspace.defaultProgramId) {
-    console.log(
-      `Workspace with stripeConnectId ${stripeAccountId} has no default program, skipping...`,
-    );
-    return null;
-  }
+  console.log(`Promotion code found: ${promotionCode.code}`);
 
   const discountCode = await prisma.discountCode.findUnique({
     where: {
@@ -133,6 +139,8 @@ export async function attributeViaPromotionCodeId({
       country: customerAddress?.country,
       projectId: workspace.id,
       projectConnectId: workspace.stripeConnectId,
+      programId: link.programId,
+      partnerId: link.partnerId,
     },
   });
 

--- a/apps/web/app/(ee)/api/stripe/integration/webhook/utils/attribute-via-promotion-code-id.ts
+++ b/apps/web/app/(ee)/api/stripe/integration/webhook/utils/attribute-via-promotion-code-id.ts
@@ -1,13 +1,14 @@
 import { createId } from "@/lib/api/create-id";
+import { getOrCreateCustomer } from "@/lib/api/customers/get-or-create-customer";
 import { syncPartnerLinksStats } from "@/lib/api/partners/sync-partner-links-stats";
 import { executeWorkflows } from "@/lib/api/workflows/execute-workflows";
 import { generateRandomName } from "@/lib/names";
 import { queuePartnerCommissionCreation } from "@/lib/partners/queue-partner-commission-creation";
 import { sendPartnerPostback } from "@/lib/postback/send-partner-postback";
 import { prisma } from "@/lib/prisma";
-import { recordLead } from "@/lib/tinybird";
+import { getLeadEvent, recordLead } from "@/lib/tinybird";
 import { recordFakeClick } from "@/lib/tinybird/record-fake-click";
-import { StripeMode } from "@/lib/types";
+import { LeadEventTB, StripeMode } from "@/lib/types";
 import { redis } from "@/lib/upstash";
 import { sendWorkspaceWebhook } from "@/lib/webhook/publish";
 import { transformLeadEventData } from "@/lib/webhook/transform";
@@ -22,26 +23,26 @@ export type PromoCodeCustomerDetails = {
   name?: string | null;
   email?: string | null;
   address?: Pick<Stripe.Address, "country" | "state"> | null;
+  stripeCustomerId: string;
 };
 
 export async function attributeViaPromotionCodeId({
   promotionCodeId,
-  stripeAccountId,
   workspace,
   mode,
-  stripeCustomerId,
   customerDetails,
 }: {
   promotionCodeId: string; // must be Stripe's promotion code ID `promo_xxx`, not the actual promo code
-  stripeAccountId: string;
   workspace: Pick<
     Project,
     "id" | "defaultProgramId" | "stripeConnectId" | "webhookEnabled"
   >;
   mode: StripeMode;
-  stripeCustomerId: string;
   customerDetails: PromoCodeCustomerDetails;
 }) {
+  const stripeAccountId = workspace.stripeConnectId!;
+  const stripeCustomerId = customerDetails.stripeCustomerId;
+
   // Find the promotion code for the promotion code id
   const promotionCode = await getPromotionCode({
     promotionCodeId,
@@ -106,33 +107,62 @@ export async function attributeViaPromotionCodeId({
     },
   });
 
-  let customer: Awaited<ReturnType<typeof prisma.customer.create>>;
-  try {
-    customer = await prisma.customer.create({
-      data: {
-        id: createId({ prefix: "cus_" }),
-        name:
-          customerDetails.name || customerDetails.email || generateRandomName(),
-        email: customerDetails.email,
-        externalId: clickEvent.click_id,
-        stripeCustomerId,
-        linkId: clickEvent.link_id,
-        clickId: clickEvent.click_id,
-        clickedAt: new Date(clickEvent.timestamp + "Z"),
-        country: customerAddress?.country,
-        projectId: workspace.id,
-        projectConnectId: workspace.stripeConnectId,
-      },
-    });
-  } catch (error) {
-    // a concurrent webhook may have created the customer first (unique stripeCustomerId)
-    if (error.code === "P2002") {
+  const { customer, created } = await getOrCreateCustomer({
+    findMode: "first",
+    where: {
+      OR: [
+        {
+          stripeCustomerId,
+        },
+        {
+          projectId: workspace.id,
+          externalId: clickEvent.click_id,
+        },
+      ],
+    },
+    create: {
+      id: createId({ prefix: "cus_" }),
+      name:
+        customerDetails.name || customerDetails.email || generateRandomName(),
+      email: customerDetails.email,
+      externalId: clickEvent.click_id,
+      stripeCustomerId,
+      linkId: clickEvent.link_id,
+      clickId: clickEvent.click_id,
+      clickedAt: new Date(clickEvent.timestamp + "Z"),
+      country: customerAddress?.country,
+      projectId: workspace.id,
+      projectConnectId: workspace.stripeConnectId,
+    },
+  });
+
+  // Concurrent webhook already created this customer — continue sale without re-recording lead
+  if (!created) {
+    const cachedLead = await redis.get<LeadEventTB>(`leadCache:${customer.id}`);
+    let existingLead = cachedLead;
+
+    if (!existingLead) {
+      existingLead = await getLeadEvent({
+        customerId: customer.id,
+      });
+    }
+
+    if (!existingLead) {
       console.log(
-        `Customer with stripeCustomerId ${stripeCustomerId} was created concurrently, skipping promo code attribution...`,
+        `Customer with stripeCustomerId ${stripeCustomerId} already exists but no lead event found, skipping promo code attribution...`,
       );
       return null;
     }
-    throw error;
+
+    return {
+      linkId,
+      customer,
+      clickEvent,
+      leadEvent: {
+        ...existingLead,
+        workspace_id: customer.projectId,
+      },
+    };
   }
 
   // Prepare the payload for the lead event
@@ -140,7 +170,7 @@ export async function attributeViaPromotionCodeId({
 
   const leadEvent = {
     ...rest,
-    workspace_id: clickEvent.workspace_id || customer.projectId,
+    workspace_id: customer.projectId,
     event_id: nanoid(16),
     event_name: "Attributed via discount code",
     customer_id: customer.id,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Stripe checkout completion customer matching for qualifying reference IDs, using more reliable, project-scoped idempotent customer handling to reduce mismatches.
  * Standardized promotion-code attribution to consistently carry the correct Stripe customer identifier across checkout completions and paid invoices.
  * Reduced duplicate lead attribution by reusing previously stored lead events when a customer already exists, and ensured lead/webhook records include the correct workspace scope and explicit timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->