### PR TITLE
Skip connect-payout reminders for unsupported countries

### DIFF
--- a/apps/web/app/(ee)/api/cron/payouts/reminders/partners/route.ts
+++ b/apps/web/app/(ee)/api/cron/payouts/reminders/partners/route.ts
@@ -1,4 +1,5 @@
 import { MIN_PAYOUT_AMOUNT_FOR_REMINDERS } from "@/lib/constants/misc";
+import { PAYOUT_SUPPORTED_COUNTRIES } from "@/lib/constants/payouts-supported-countries";
 import { qstash } from "@/lib/cron";
 import { withCron } from "@/lib/cron/with-cron";
 import { queueBatchEmail } from "@/lib/email/queue-batch-email";
@@ -34,6 +35,9 @@ export const GET = withCron(async () => {
       },
       partner: {
         payoutsEnabledAt: null,
+        country: {
+          in: PAYOUT_SUPPORTED_COUNTRIES.map((c) => c.code),
+        },
         OR: [
           { connectPayoutsLastRemindedAt: null },
           {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Partner payout reminders are now limited to countries where payouts are supported, preventing notifications from being sent for ineligible locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->