### PR TITLE
Partner/Customer country multi-select fix

### DIFF
--- a/apps/web/ui/partners/rewards/rewards-logic.tsx
+++ b/apps/web/ui/partners/rewards/rewards-logic.tsx
@@ -707,13 +707,14 @@ function ConditionLogic({
                             "rounded-r-none",
                         )}
                       >
-                        {/* Country selection (single value only) */}
-                        {condition.attribute === "country" && !isArrayValue ? (
+                        {/* Country selection */}
+                        {condition.attribute === "country" ? (
                           // Country selector
                           <InlineBadgePopoverMenu
                             search
                             selectedValue={
-                              condition.value as string | undefined
+                              (condition.value as string[] | undefined) ??
+                              (isArrayValue ? [] : undefined)
                             }
                             items={Object.entries(COUNTRIES).map(
                               ([key, name]) => ({
@@ -730,16 +731,30 @@ function ConditionLogic({
                             onSelect={(value) => {
                               setValue(conditionKey, {
                                 ...condition,
-                                value,
+                                value: isArrayValue
+                                  ? Array.isArray(condition.value)
+                                    ? (condition.value as string[]).includes(
+                                        value,
+                                      )
+                                      ? (condition.value.filter(
+                                          (v) => v !== value,
+                                        ) as string[])
+                                      : ([
+                                          ...condition.value,
+                                          value,
+                                        ] as string[])
+                                    : [value]
+                                  : value,
                               });
                             }}
                           />
-                        ) : attribute?.options && !isArrayValue ? (
+                        ) : attribute?.options ? (
                           // Select option selector
                           <InlineBadgePopoverMenu
                             search={attribute.options.length > 4}
                             selectedValue={
-                              condition.value as string | undefined
+                              (condition.value as string[] | undefined) ??
+                              (isArrayValue ? [] : undefined)
                             }
                             items={attribute.options.map(({ id, label }) => ({
                               text: label,
@@ -748,7 +763,20 @@ function ConditionLogic({
                             onSelect={(value) => {
                               setValue(conditionKey, {
                                 ...condition,
-                                value,
+                                value: isArrayValue
+                                  ? Array.isArray(condition.value)
+                                    ? (condition.value as string[]).includes(
+                                        value,
+                                      )
+                                      ? (condition.value.filter(
+                                          (v) => v !== value,
+                                        ) as string[])
+                                      : ([
+                                          ...condition.value,
+                                          value,
+                                        ] as string[])
+                                    : [value]
+                                  : value,
                               });
                             }}
                           />

--- a/apps/web/ui/partners/rewards/rewards-logic.tsx
+++ b/apps/web/ui/partners/rewards/rewards-logic.tsx
@@ -296,6 +296,23 @@ const formatValue = (
   return truncate(value!.toString(), 20);
 };
 
+function getConditionMenuSelectedValue(
+  value: string | number | string[] | number[] | undefined,
+  isArrayValue: boolean,
+): string | string[] | undefined {
+  if (isArrayValue) {
+    if (Array.isArray(value)) {
+      return value as string[];
+    }
+    if (value != null && value !== "") {
+      return [String(value)];
+    }
+    return [];
+  }
+
+  return value as string | undefined;
+}
+
 function MetadataConditionOperatorMenu({
   selectedValue,
   onSelect,
@@ -712,10 +729,10 @@ function ConditionLogic({
                           // Country selector
                           <InlineBadgePopoverMenu
                             search
-                            selectedValue={
-                              (condition.value as string[] | undefined) ??
-                              (isArrayValue ? [] : undefined)
-                            }
+                            selectedValue={getConditionMenuSelectedValue(
+                              condition.value,
+                              isArrayValue,
+                            )}
                             items={Object.entries(COUNTRIES).map(
                               ([key, name]) => ({
                                 text: name,
@@ -752,10 +769,10 @@ function ConditionLogic({
                           // Select option selector
                           <InlineBadgePopoverMenu
                             search={attribute.options.length > 4}
-                            selectedValue={
-                              (condition.value as string[] | undefined) ??
-                              (isArrayValue ? [] : undefined)
-                            }
+                            selectedValue={getConditionMenuSelectedValue(
+                              condition.value,
+                              isArrayValue,
+                            )}
                             items={attribute.options.map(({ id, label }) => ({
                               text: label,
                               value: id,


### PR DESCRIPTION
The multi-selects and values weren't showing for "is one of" and "is not one of" conditions in the partner and customer country conditions.

## After
<img width="526" height="419" alt="CleanShot 2026-07-20 at 16 36 13@2x" src="https://github.com/user-attachments/assets/c5790135-201e-461f-a436-dc9ef390fa8c" />

## Before
<img width="524" height="306" alt="CleanShot 2026-07-20 at 16 35 59@2x" src="https://github.com/user-attachments/assets/31297662-7f48-436d-bcd7-93da8f4b3938" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reward condition selectors for country and option-based attributes.
  * Added consistent behavior for both single-select and multi-select operators.
  * Multi-select values now toggle correctly, preserving existing selections instead of overwriting them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->