### PR TITLE
Move unban partner side effects to a background job.

### DIFF
--- a/apps/web/lib/actions/partners/unban-partner.ts
+++ b/apps/web/lib/actions/partners/unban-partner.ts
@@ -78,11 +78,16 @@ export const unbanPartnerAction = authActionClient
       }),
     ]);
 
-    await unbanPartnerJob.dispatch({
-      workspaceId: workspace.id,
-      programId,
-      partnerId,
-    });
+    await unbanPartnerJob.dispatch(
+      {
+        workspaceId: workspace.id,
+        programId,
+        partnerId,
+      },
+      {
+        label: partnerId,
+      },
+    );
 
     waitUntil(
       trackActivityLog({

--- a/apps/web/lib/actions/partners/unban-partner.ts
+++ b/apps/web/lib/actions/partners/unban-partner.ts
@@ -1,16 +1,11 @@
 "use server";
 
 import { trackActivityLog } from "@/lib/api/activity-log/track-activity-log";
-import { trackCommissionStatusUpdate } from "@/lib/api/commissions/track-commission-update-activity-log";
 import { getGroupOrThrow } from "@/lib/api/groups/get-group-or-throw";
-import { linkCache } from "@/lib/api/links/cache";
-import { includeProgramEnrollment } from "@/lib/api/links/include-program-enrollment";
-import { includeTags } from "@/lib/api/links/include-tags";
 import { getDefaultProgramIdOrThrow } from "@/lib/api/programs/get-default-program-id-or-throw";
+import { unbanPartnerJob } from "@/lib/jobs/handlers/unban-partner-job";
 import { prisma } from "@/lib/prisma";
-import { recordLink } from "@/lib/tinybird";
 import { banPartnerSchema } from "@/lib/zod/schemas/partners";
-import { FraudRuleType } from "@prisma/client";
 import { waitUntil } from "@vercel/functions";
 import { authActionClient } from "../safe-action";
 import { throwIfNoPermission } from "../throw-if-no-permission";
@@ -58,20 +53,6 @@ export const unbanPartnerAction = authActionClient
         programEnrollment.groupId || programEnrollment.program.defaultGroupId,
     });
 
-    // Fetch canceled commissions before the transaction for activity logging
-    const canceledCommissions = await prisma.commission.findMany({
-      where: {
-        ...where,
-        status: "canceled",
-      },
-      select: {
-        id: true,
-        amount: true,
-        earnings: true,
-        status: true,
-      },
-    });
-
     await prisma.$transaction([
       prisma.link.updateMany({
         where,
@@ -95,115 +76,28 @@ export const unbanPartnerAction = authActionClient
           discountId: partnerGroup.discountId,
         },
       }),
-
-      prisma.commission.updateMany({
-        where: {
-          ...where,
-          status: "canceled",
-        },
-        data: {
-          status: "pending",
-        },
-      }),
-
-      prisma.payout.updateMany({
-        where: {
-          ...where,
-          status: "canceled",
-        },
-        data: {
-          status: "pending",
-        },
-      }),
-
-      prisma.bountySubmission.updateMany({
-        where: {
-          ...where,
-          status: "rejected",
-        },
-        data: {
-          status: "submitted",
-        },
-      }),
     ]);
 
+    await unbanPartnerJob.dispatch({
+      workspaceId: workspace.id,
+      programId,
+      partnerId,
+    });
+
     waitUntil(
-      (async () => {
-        const links = await prisma.link.findMany({
-          where,
-          include: {
-            ...includeTags,
-            ...includeProgramEnrollment,
+      trackActivityLog({
+        workspaceId: workspace.id,
+        programId,
+        resourceType: "partner",
+        resourceId: partnerId,
+        userId: user.id,
+        action: "partner.unbanned",
+        changeSet: {
+          status: {
+            old: "banned",
+            new: "approved",
           },
-        });
-
-        await Promise.allSettled([
-          // Expire links from cache
-          linkCache.expireMany(links),
-
-          // Update Tinybird links metadata
-          recordLink(links),
-
-          // Track commission activity logs for the unban
-          trackCommissionStatusUpdate({
-            workspaceId: workspace.id,
-            programId,
-            commissions: canceledCommissions,
-            newStatus: "pending",
-          }),
-
-          trackActivityLog({
-            workspaceId: workspace.id,
-            programId,
-            resourceType: "partner",
-            resourceId: partnerId,
-            userId: user.id,
-            action: "partner.unbanned",
-            changeSet: {
-              status: {
-                old: "banned",
-                new: "approved",
-              },
-            },
-          }),
-        ]);
-
-        await prisma.$transaction([
-          // Since we're unbanning the partner, we need to
-          // clean up any pending cross-program ban alerts that originated from this program.
-          prisma.fraudEvent.deleteMany({
-            where: {
-              partnerId,
-              sourceProgramId: programId,
-              fraudEventGroup: {
-                type: FraudRuleType.partnerCrossProgramBan,
-              },
-            },
-          }),
-
-          // Delete the fraud group if it has no more fraud events
-          prisma.fraudEventGroup.deleteMany({
-            where: {
-              partnerId,
-              type: FraudRuleType.partnerCrossProgramBan,
-              fraudEvents: {
-                none: {},
-              },
-            },
-          }),
-
-          // Delete any pending fraud alerts for this partner in this program
-          prisma.fraudAlert.deleteMany({
-            where: {
-              partnerId,
-              programId,
-              status: "pending",
-            },
-          }),
-        ]);
-
-        // TODO
-        // Send email to partner about being unbanned
-      })(),
+        },
+      }),
     );
   });

--- a/apps/web/lib/jobs/handlers/unban-partner-job.ts
+++ b/apps/web/lib/jobs/handlers/unban-partner-job.ts
@@ -1,0 +1,204 @@
+import { linkCache } from "@/lib/api/links/cache";
+import { includeProgramEnrollment } from "@/lib/api/links/include-program-enrollment";
+import { includeTags } from "@/lib/api/links/include-tags";
+import { recordLink } from "@/lib/tinybird";
+import {
+  BountySubmissionStatus,
+  CommissionStatus,
+  FraudAlertStatus,
+  FraudRuleType,
+  PayoutStatus,
+  ProgramEnrollmentStatus,
+} from "@prisma/client";
+import * as z from "zod/v4";
+import { trackCommissionStatusUpdate } from "../../api/commissions/track-commission-update-activity-log";
+import { CRON_BATCH_SIZE } from "../../cron";
+import { prisma } from "../../prisma";
+import { defineJob } from "../index";
+
+const inputSchema = z.object({
+  workspaceId: z.string(),
+  programId: z.string(),
+  partnerId: z.string(),
+});
+
+export const unbanPartnerJob = defineJob({
+  name: "unban-partner-job",
+  schema: inputSchema,
+  async handle(input) {
+    const { partnerId, programId, workspaceId } = input;
+
+    const where = {
+      partnerId,
+      programId,
+    };
+
+    const programEnrollment = await prisma.programEnrollment.findUnique({
+      where: {
+        partnerId_programId: where,
+      },
+      select: {
+        status: true,
+      },
+    });
+
+    if (!programEnrollment) {
+      console.error(
+        `[unbanPartnerJob] Program enrollment not found for partner ${partnerId} and program ${programId}. Skipping...`,
+      );
+      return;
+    }
+
+    if (programEnrollment.status !== ProgramEnrollmentStatus.approved) {
+      console.error(
+        `[unbanPartnerJob] Partner ${partnerId} is not approved in program ${programId} (status: ${programEnrollment.status}). Skipping...`,
+      );
+      return;
+    }
+
+    await restoreCanceledCommissions({
+      workspaceId,
+      programId,
+      partnerId,
+    });
+
+    const [payouts, bountySubmissions] = await Promise.all([
+      prisma.payout.updateMany({
+        where: {
+          ...where,
+          status: PayoutStatus.canceled,
+        },
+        data: {
+          status: PayoutStatus.pending,
+        },
+      }),
+
+      prisma.bountySubmission.updateMany({
+        where: {
+          ...where,
+          status: BountySubmissionStatus.rejected,
+        },
+        data: {
+          status: BountySubmissionStatus.submitted,
+        },
+      }),
+    ]);
+
+    console.info(
+      `Marked ${payouts.count} payouts and ${bountySubmissions.count} bounty submissions as submitted for partner ${partnerId} in program ${programId}.`,
+    );
+
+    const links = await prisma.link.findMany({
+      where: where,
+      include: {
+        ...includeTags,
+        ...includeProgramEnrollment,
+      },
+    });
+
+    if (links.length > 0) {
+      await Promise.allSettled([
+        linkCache.expireMany(links),
+        recordLink(links),
+      ]);
+    }
+
+    // Clean up any pending cross-program ban alerts that originated from this program.
+    await prisma.$transaction([
+      prisma.fraudEvent.deleteMany({
+        where: {
+          partnerId,
+          sourceProgramId: programId,
+          fraudEventGroup: {
+            type: FraudRuleType.partnerCrossProgramBan,
+          },
+        },
+      }),
+
+      // Delete the fraud group if it has no more fraud events
+      prisma.fraudEventGroup.deleteMany({
+        where: {
+          partnerId,
+          type: FraudRuleType.partnerCrossProgramBan,
+          fraudEvents: {
+            none: {},
+          },
+        },
+      }),
+
+      // Delete any pending fraud alerts for this partner in this program
+      prisma.fraudAlert.deleteMany({
+        where: {
+          partnerId,
+          programId,
+          status: FraudAlertStatus.pending,
+        },
+      }),
+    ]);
+  },
+});
+
+// Restore canceled commissions for a partner in a program
+async function restoreCanceledCommissions({
+  workspaceId,
+  programId,
+  partnerId,
+}: {
+  workspaceId: string;
+  programId: string;
+  partnerId: string;
+}) {
+  let restoredCommissions = 0;
+
+  while (true) {
+    const commissions = await prisma.commission.findMany({
+      where: {
+        partnerId,
+        programId,
+        status: CommissionStatus.canceled,
+      },
+      select: {
+        id: true,
+        amount: true,
+        earnings: true,
+        status: true,
+      },
+      orderBy: {
+        id: "asc",
+      },
+      take: CRON_BATCH_SIZE,
+    });
+
+    if (commissions.length === 0) {
+      break;
+    }
+
+    const { count } = await prisma.commission.updateMany({
+      where: {
+        id: {
+          in: commissions.map(({ id }) => id),
+        },
+        status: CommissionStatus.canceled,
+      },
+      data: {
+        status: CommissionStatus.pending,
+      },
+    });
+
+    await trackCommissionStatusUpdate({
+      workspaceId,
+      programId,
+      commissions,
+      newStatus: CommissionStatus.pending,
+    });
+
+    restoredCommissions += count;
+  }
+
+  console.info(
+    `[unbanPartnerJob] Restored ${restoredCommissions} commissions for partner ${partnerId} in program ${programId}.`,
+  );
+}
+
+// TODO
+// Send email to partner about being unbanned

--- a/apps/web/lib/jobs/handlers/unban-partner-job.ts
+++ b/apps/web/lib/jobs/handlers/unban-partner-job.ts
@@ -1,6 +1,7 @@
 import { linkCache } from "@/lib/api/links/cache";
 import { includeProgramEnrollment } from "@/lib/api/links/include-program-enrollment";
 import { includeTags } from "@/lib/api/links/include-tags";
+import { syncTotalCommissions } from "@/lib/api/partners/sync-total-commissions";
 import { recordLink } from "@/lib/tinybird";
 import {
   BountySubmissionStatus,
@@ -60,6 +61,11 @@ export const unbanPartnerJob = defineJob({
       workspaceId,
       programId,
       partnerId,
+    });
+
+    await syncTotalCommissions({
+      partnerId,
+      programId,
     });
 
     const [payouts, bountySubmissions] = await Promise.all([

--- a/apps/web/lib/jobs/registry.ts
+++ b/apps/web/lib/jobs/registry.ts
@@ -10,6 +10,9 @@ const jobLoaders = {
     import("./handlers/partner-tag-deleted-job").then(
       (m) => m.partnerTagDeletedJob,
     ),
+
+  "unban-partner-job": () =>
+    import("./handlers/unban-partner-job").then((m) => m.unbanPartnerJob),
 } as const satisfies Record<string, () => Promise<JobDefinition>>;
 
 const jobCache = new Map<string, JobDefinition>();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Partner unbanning now completes additional recovery steps in the background.
  * Restores previously canceled commissions, along with updated commission activity/status tracking.
  * Re-enables partner links and refreshes related link cache data.
* **Improvements**
  * Unbanning now performs faster core approval, then asynchronously restores payouts and bounty submissions from canceled/rejected back to active states.
  * Clears associated pending fraud restrictions tied to the partner and program.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->