### PR TITLE
Allow retrying failed payments in-app

### DIFF
--- a/apps/web/app/api/workspaces/[idOrSlug]/billing/invoices/route.ts
+++ b/apps/web/app/api/workspaces/[idOrSlug]/billing/invoices/route.ts
@@ -12,7 +12,7 @@ const querySchema = z.object({
     .enum(["subscription", "partnerPayout", "domainRenewal"])
     .optional()
     .default("subscription"),
-  status: z.enum(["open"]).optional(), // only for Stripe subscription invoices for now
+  stripeStatus: z.enum(["open"]).optional(), // only for Stripe subscription invoices
 });
 
 // TODO: move to GET /invoices
@@ -22,11 +22,13 @@ export const GET = withWorkspace(
       return NextResponse.json([]);
     }
 
-    const { type, status } = querySchema.parse(searchParams);
+    const { type, stripeStatus } = querySchema.parse(searchParams);
 
     const invoices =
       type === "subscription"
-        ? await getSubscriptionInvoices(workspace.stripeId, { status })
+        ? await getSubscriptionInvoices(workspace.stripeId, {
+            status: stripeStatus,
+          })
         : await getOtherInvoices({
             workspaceId: workspace.id,
             type,
@@ -46,6 +48,7 @@ const getSubscriptionInvoices = async (
   try {
     const invoices = await stripe.invoices.list({
       customer: stripeId,
+      limit: 100,
       ...(status && { status }),
     });
 

--- a/apps/web/app/api/workspaces/[idOrSlug]/billing/invoices/route.ts
+++ b/apps/web/app/api/workspaces/[idOrSlug]/billing/invoices/route.ts
@@ -4,6 +4,7 @@ import { stripe } from "@/lib/stripe";
 import { InvoiceSchema } from "@/lib/zod/schemas/invoices";
 import { APP_DOMAIN } from "@dub/utils";
 import { NextResponse } from "next/server";
+import Stripe from "stripe";
 import * as z from "zod/v4";
 
 const querySchema = z.object({
@@ -11,6 +12,7 @@ const querySchema = z.object({
     .enum(["subscription", "partnerPayout", "domainRenewal"])
     .optional()
     .default("subscription"),
+  status: z.enum(["open"]).optional(), // only for Stripe subscription invoices for now
 });
 
 // TODO: move to GET /invoices
@@ -20,12 +22,12 @@ export const GET = withWorkspace(
       return NextResponse.json([]);
     }
 
-    const { type } = querySchema.parse(searchParams);
+    const { type, status } = querySchema.parse(searchParams);
 
     const invoices =
       type === "subscription"
-        ? await subscriptionInvoices(workspace.stripeId)
-        : await otherInvoices({
+        ? await getSubscriptionInvoices(workspace.stripeId, { status })
+        : await getOtherInvoices({
             workspaceId: workspace.id,
             type,
           });
@@ -37,29 +39,33 @@ export const GET = withWorkspace(
   },
 );
 
-const subscriptionInvoices = async (stripeId: string) => {
+const getSubscriptionInvoices = async (
+  stripeId: string,
+  { status }: { status?: "open" } = {},
+) => {
   try {
     const invoices = await stripe.invoices.list({
       customer: stripeId,
-      limit: 100,
+      ...(status && { status }),
     });
 
-    return invoices.data.map((invoice) => {
-      return {
-        id: invoice.id,
-        total: invoice.amount_paid,
-        createdAt: new Date(invoice.created * 1000),
-        description: "Dub subscription",
-        pdfUrl: invoice.invoice_pdf,
-      };
-    });
+    return invoices.data.map((invoice) => mapSubscriptionInvoice(invoice));
   } catch (error) {
     console.log(error);
     return [];
   }
 };
 
-const otherInvoices = async ({
+const mapSubscriptionInvoice = (invoice: Stripe.Invoice) => ({
+  id: invoice.id,
+  total: invoice.total ?? invoice.amount_due,
+  stripeStatus: invoice.status,
+  createdAt: new Date(invoice.created * 1000),
+  description: "Dub subscription",
+  pdfUrl: invoice.invoice_pdf,
+});
+
+const getOtherInvoices = async ({
   workspaceId,
   type,
 }: {

--- a/apps/web/app/api/workspaces/[idOrSlug]/billing/retry-payment/route.ts
+++ b/apps/web/app/api/workspaces/[idOrSlug]/billing/retry-payment/route.ts
@@ -10,121 +10,15 @@ const retryPaymentSchema = z.object({
   invoiceId: z.string().startsWith("in_"),
 });
 
-async function getOpenInvoice(stripeId: string) {
-  const { data } = await stripe.invoices.list({
-    customer: stripeId,
-    status: "open",
-    limit: 1,
-  });
-
-  return data[0] ?? null;
-}
-
-function getInvoiceCustomerId(invoice: Stripe.Invoice): string | null {
-  if (typeof invoice.customer === "string") {
-    return invoice.customer;
-  }
-  return invoice.customer?.id ?? null;
-}
-
-function getInvoiceSubscriptionId(invoice: Stripe.Invoice): string | null {
-  const subscription = invoice.parent?.subscription_details?.subscription;
-  if (!subscription) {
-    return null;
-  }
-  return typeof subscription === "string" ? subscription : subscription.id;
-}
-
-async function hasDefaultPaymentMethod({
-  stripeId,
-  invoice,
-}: {
-  stripeId: string;
-  invoice: Stripe.Invoice;
-}) {
-  if (invoice.default_payment_method) {
-    return true;
-  }
-
-  const subscriptionId = getInvoiceSubscriptionId(invoice);
-  if (subscriptionId) {
-    const subscription = await stripe.subscriptions.retrieve(subscriptionId);
-    if (subscription.default_payment_method || subscription.default_source) {
-      return true;
-    }
-  }
-
-  const customer = await stripe.customers.retrieve(stripeId);
-  if (customer.deleted) {
-    return false;
-  }
-
-  return Boolean(
-    customer.invoice_settings?.default_payment_method ||
-      customer.default_source,
-  );
-}
-
-function assertStripeCustomer(stripeId: string | null) {
-  if (!stripeId) {
-    throw new DubApiError({
-      code: "bad_request",
-      message: "No Stripe customer ID",
-    });
-  }
-}
-
-function handleStripeError(error: unknown): never {
-  if (error instanceof DubApiError || error instanceof z.ZodError) {
-    throw error;
-  }
-
-  throw new DubApiError({
-    code: "bad_request",
-    message:
-      error instanceof Stripe.errors.StripeError
-        ? error.message
-        : "Failed to retry payment. Please update your payment method and try again.",
-  });
-}
-
-// GET /api/workspaces/[idOrSlug]/billing/retry-payment — preview open invoice amount due
-export const GET = withWorkspace(
-  async ({ workspace }) => {
-    assertStripeCustomer(workspace.stripeId);
-
-    try {
-      const invoice = await getOpenInvoice(workspace.stripeId!);
-
-      if (!invoice?.id) {
-        throw new DubApiError({
-          code: "not_found",
-          message: "No open invoice found to retry.",
-        });
-      }
-
-      return NextResponse.json({
-        invoiceId: invoice.id,
-        amountDue: invoice.amount_due,
-        currency: invoice.currency,
-        hasDefaultPaymentMethod: await hasDefaultPaymentMethod({
-          stripeId: workspace.stripeId!,
-          invoice,
-        }),
-      });
-    } catch (error) {
-      handleStripeError(error);
-    }
-  },
-  {
-    requiredPermissions: ["billing.write"],
-  },
-);
-
 // POST /api/workspaces/[idOrSlug]/billing/retry-payment — pay a specific open invoice
 export const POST = withWorkspace(
   async ({ workspace, req }) => {
-    assertStripeCustomer(workspace.stripeId);
+    if (!workspace.stripeId) {
+      throw new DubApiError({
+        code: "not_found",
+        message: "No Stripe customer ID",
+      });
+    }
 
     try {
       const { invoiceId } = retryPaymentSchema.parse(
@@ -133,10 +27,10 @@ export const POST = withWorkspace(
 
       const invoice = await stripe.invoices.retrieve(invoiceId);
 
-      if (getInvoiceCustomerId(invoice) !== workspace.stripeId) {
+      if (!invoice || invoice.customer !== workspace.stripeId) {
         throw new DubApiError({
           code: "not_found",
-          message: "No open invoice found to retry.",
+          message: "Invoice not found",
         });
       }
 
@@ -144,19 +38,6 @@ export const POST = withWorkspace(
         throw new DubApiError({
           code: "bad_request",
           message: "Invoice is not open and cannot be retried.",
-        });
-      }
-
-      if (
-        !(await hasDefaultPaymentMethod({
-          stripeId: workspace.stripeId!,
-          invoice,
-        }))
-      ) {
-        throw new DubApiError({
-          code: "bad_request",
-          message:
-            "No default payment method found. Please add a payment method and try again.",
         });
       }
 
@@ -178,7 +59,17 @@ export const POST = withWorkspace(
         status: paidInvoice.status,
       });
     } catch (error) {
-      handleStripeError(error);
+      if (error instanceof DubApiError || error instanceof z.ZodError) {
+        throw error;
+      }
+
+      throw new DubApiError({
+        code: "bad_request",
+        message:
+          error instanceof Stripe.errors.StripeError
+            ? error.message
+            : "Failed to retry payment. Please update your payment method and try again.",
+      });
     }
   },
   {

--- a/apps/web/app/api/workspaces/[idOrSlug]/billing/retry-payment/route.ts
+++ b/apps/web/app/api/workspaces/[idOrSlug]/billing/retry-payment/route.ts
@@ -1,0 +1,136 @@
+import { DubApiError } from "@/lib/api/errors";
+import { withWorkspace } from "@/lib/auth";
+import { stripe } from "@/lib/stripe";
+import { NextResponse } from "next/server";
+import Stripe from "stripe";
+
+async function getOpenInvoice(stripeId: string) {
+  const { data } = await stripe.invoices.list({
+    customer: stripeId,
+    status: "open",
+    limit: 1,
+  });
+
+  return data[0] ?? null;
+}
+
+async function hasDefaultPaymentMethod({
+  stripeId,
+  invoice,
+}: {
+  stripeId: string;
+  invoice: Stripe.Invoice;
+}) {
+  if (invoice.default_payment_method) {
+    return true;
+  }
+
+  const customer = await stripe.customers.retrieve(stripeId);
+  if (customer.deleted) {
+    return false;
+  }
+
+  return Boolean(customer.invoice_settings?.default_payment_method);
+}
+
+function assertStripeCustomer(stripeId: string | null) {
+  if (!stripeId) {
+    throw new DubApiError({
+      code: "bad_request",
+      message: "No Stripe customer ID",
+    });
+  }
+}
+
+function handleStripeError(error: unknown): never {
+  if (error instanceof DubApiError) {
+    throw error;
+  }
+
+  throw new DubApiError({
+    code: "bad_request",
+    message:
+      error instanceof Stripe.errors.StripeError
+        ? error.message
+        : "Failed to retry payment. Please update your payment method and try again.",
+  });
+}
+
+// GET /api/workspaces/[idOrSlug]/billing/retry-payment — preview open invoice amount due
+export const GET = withWorkspace(
+  async ({ workspace }) => {
+    assertStripeCustomer(workspace.stripeId);
+
+    try {
+      const invoice = await getOpenInvoice(workspace.stripeId!);
+
+      if (!invoice?.id) {
+        throw new DubApiError({
+          code: "not_found",
+          message: "No open invoice found to retry.",
+        });
+      }
+
+      return NextResponse.json({
+        invoiceId: invoice.id,
+        amountDue: invoice.amount_due,
+        currency: invoice.currency,
+        hasDefaultPaymentMethod: await hasDefaultPaymentMethod({
+          stripeId: workspace.stripeId!,
+          invoice,
+        }),
+      });
+    } catch (error) {
+      handleStripeError(error);
+    }
+  },
+  {
+    requiredPermissions: ["billing.write"],
+  },
+);
+
+// POST /api/workspaces/[idOrSlug]/billing/retry-payment — pay the latest open invoice
+export const POST = withWorkspace(
+  async ({ workspace }) => {
+    assertStripeCustomer(workspace.stripeId);
+
+    try {
+      const invoice = await getOpenInvoice(workspace.stripeId!);
+
+      if (!invoice?.id) {
+        throw new DubApiError({
+          code: "not_found",
+          message: "No open invoice found to retry.",
+        });
+      }
+
+      if (
+        !(await hasDefaultPaymentMethod({
+          stripeId: workspace.stripeId!,
+          invoice,
+        }))
+      ) {
+        throw new DubApiError({
+          code: "bad_request",
+          message:
+            "No default payment method found. Please add a payment method and try again.",
+        });
+      }
+
+      const paidInvoice = await stripe.invoices.pay(invoice.id);
+
+      return NextResponse.json({
+        invoiceId: paidInvoice.id,
+        amountDue: paidInvoice.amount_due,
+        amountPaid: paidInvoice.amount_paid,
+        currency: paidInvoice.currency,
+        status: paidInvoice.status,
+      });
+    } catch (error) {
+      handleStripeError(error);
+    }
+  },
+  {
+    requiredPermissions: ["billing.write"],
+  },
+);

--- a/apps/web/app/api/workspaces/[idOrSlug]/billing/retry-payment/route.ts
+++ b/apps/web/app/api/workspaces/[idOrSlug]/billing/retry-payment/route.ts
@@ -1,8 +1,14 @@
 import { DubApiError } from "@/lib/api/errors";
+import { parseRequestBody } from "@/lib/api/utils";
 import { withWorkspace } from "@/lib/auth";
 import { stripe } from "@/lib/stripe";
 import { NextResponse } from "next/server";
 import Stripe from "stripe";
+import * as z from "zod/v4";
+
+const retryPaymentSchema = z.object({
+  invoiceId: z.string().startsWith("in_"),
+});
 
 async function getOpenInvoice(stripeId: string) {
   const { data } = await stripe.invoices.list({
@@ -12,6 +18,21 @@ async function getOpenInvoice(stripeId: string) {
   });
 
   return data[0] ?? null;
+}
+
+function getInvoiceCustomerId(invoice: Stripe.Invoice): string | null {
+  if (typeof invoice.customer === "string") {
+    return invoice.customer;
+  }
+  return invoice.customer?.id ?? null;
+}
+
+function getInvoiceSubscriptionId(invoice: Stripe.Invoice): string | null {
+  const subscription = invoice.parent?.subscription_details?.subscription;
+  if (!subscription) {
+    return null;
+  }
+  return typeof subscription === "string" ? subscription : subscription.id;
 }
 
 async function hasDefaultPaymentMethod({
@@ -25,12 +46,23 @@ async function hasDefaultPaymentMethod({
     return true;
   }
 
+  const subscriptionId = getInvoiceSubscriptionId(invoice);
+  if (subscriptionId) {
+    const subscription = await stripe.subscriptions.retrieve(subscriptionId);
+    if (subscription.default_payment_method || subscription.default_source) {
+      return true;
+    }
+  }
+
   const customer = await stripe.customers.retrieve(stripeId);
   if (customer.deleted) {
     return false;
   }
 
-  return Boolean(customer.invoice_settings?.default_payment_method);
+  return Boolean(
+    customer.invoice_settings?.default_payment_method ||
+      customer.default_source,
+  );
 }
 
 function assertStripeCustomer(stripeId: string | null) {
@@ -43,7 +75,7 @@ function assertStripeCustomer(stripeId: string | null) {
 }
 
 function handleStripeError(error: unknown): never {
-  if (error instanceof DubApiError) {
+  if (error instanceof DubApiError || error instanceof z.ZodError) {
     throw error;
   }
 
@@ -89,18 +121,29 @@ export const GET = withWorkspace(
   },
 );
 
-// POST /api/workspaces/[idOrSlug]/billing/retry-payment — pay the latest open invoice
+// POST /api/workspaces/[idOrSlug]/billing/retry-payment — pay a specific open invoice
 export const POST = withWorkspace(
-  async ({ workspace }) => {
+  async ({ workspace, req }) => {
     assertStripeCustomer(workspace.stripeId);
 
     try {
-      const invoice = await getOpenInvoice(workspace.stripeId!);
+      const { invoiceId } = retryPaymentSchema.parse(
+        await parseRequestBody(req),
+      );
 
-      if (!invoice?.id) {
+      const invoice = await stripe.invoices.retrieve(invoiceId);
+
+      if (getInvoiceCustomerId(invoice) !== workspace.stripeId) {
         throw new DubApiError({
           code: "not_found",
           message: "No open invoice found to retry.",
+        });
+      }
+
+      if (invoice.status !== "open") {
+        throw new DubApiError({
+          code: "bad_request",
+          message: "Invoice is not open and cannot be retried.",
         });
       }
 
@@ -117,7 +160,15 @@ export const POST = withWorkspace(
         });
       }
 
-      const paidInvoice = await stripe.invoices.pay(invoice.id);
+      const paidInvoice = await stripe.invoices.pay(invoiceId);
+
+      if (paidInvoice.status !== "paid") {
+        throw new DubApiError({
+          code: "bad_request",
+          message:
+            "Payment could not be completed. Please update your payment method and try again.",
+        });
+      }
 
       return NextResponse.json({
         invoiceId: paidInvoice.id,

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/billing/invoices/page.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/billing/invoices/page.tsx
@@ -16,6 +16,7 @@ import {
   useRouterStuff,
 } from "@dub/ui";
 import { cn, currencyFormatter, fetcher } from "@dub/utils";
+import { StripeInvoiceStatusBadges } from "app/app.dub.co/(dashboard)/[slug]/(ee)/settings/billing/invoices/stripe-invoice-status-badges";
 import { AlertCircle } from "lucide-react";
 import Link from "next/link";
 import { useMemo } from "react";
@@ -85,6 +86,7 @@ export default function WorkspaceInvoices() {
                     key={invoice.id}
                     invoice={invoice}
                     displayPaymentMethod={displayPaymentMethod}
+                    isSubscription={selectedInvoiceType.id === "subscription"}
                   />
                 ))
               ) : (
@@ -123,12 +125,50 @@ export default function WorkspaceInvoices() {
 const InvoiceCard = ({
   invoice,
   displayPaymentMethod = false,
+  isSubscription = false,
 }: {
   invoice: InvoiceProps;
   displayPaymentMethod: boolean;
+  isSubscription?: boolean;
 }) => {
   const invoicePaymentMethod =
     INVOICE_PAYMENT_METHODS[invoice.paymentMethod ?? "ach"];
+
+  const formattedTotal = currencyFormatter(invoice.total);
+
+  const statusBadge = isSubscription
+    ? invoice.stripeStatus && (
+        <StatusBadge
+          variant={StripeInvoiceStatusBadges[invoice.stripeStatus].variant}
+          className="rounded-md py-0.5"
+        >
+          {StripeInvoiceStatusBadges[invoice.stripeStatus].label}
+        </StatusBadge>
+      )
+    : invoice.status &&
+      (() => {
+        const badge = PayoutStatusBadges[invoice.status];
+        return (
+          <StatusBadge
+            icon={invoice.status === "failed" ? AlertCircle : null}
+            variant={badge.variant}
+            className="rounded-md py-0.5"
+            {...(invoice.status === "failed" && invoice.failedReason
+              ? { tooltip: invoice.failedReason }
+              : {})}
+          >
+            {badge.label}
+          </StatusBadge>
+        );
+      })();
+
+  const pdfUrl =
+    invoice.pdfUrl &&
+    (isSubscription
+      ? invoice.stripeStatus !== "void"
+      : invoice.status !== "failed")
+      ? invoice.pdfUrl
+      : null;
 
   return (
     <div className="px-3 py-4 xl:px-12">
@@ -146,9 +186,9 @@ const InvoiceCard = ({
             </div>
           </div>
           <div className="flex items-center">
-            {invoice.pdfUrl && invoice.status !== "failed" ? (
+            {pdfUrl ? (
               <a
-                href={invoice.pdfUrl}
+                href={pdfUrl}
                 target="_blank"
                 className={cn(
                   buttonVariants({ variant: "secondary" }),
@@ -167,25 +207,8 @@ const InvoiceCard = ({
           <div className="text-left text-sm">
             <div className="font-medium">Total</div>
             <div className="flex items-center gap-1.5 text-neutral-500">
-              <span className="text-sm font-medium">
-                {currencyFormatter(invoice.total)}
-              </span>
-              {invoice.status &&
-                (() => {
-                  const badge = PayoutStatusBadges[invoice.status];
-                  return (
-                    <StatusBadge
-                      icon={invoice.status === "failed" ? AlertCircle : null}
-                      variant={badge.variant}
-                      className="rounded-md py-0.5"
-                      {...(invoice.status === "failed" && invoice.failedReason
-                        ? { tooltip: invoice.failedReason }
-                        : {})}
-                    >
-                      {badge.label}
-                    </StatusBadge>
-                  );
-                })()}
+              <span className="text-sm font-medium">{formattedTotal}</span>
+              {statusBadge}
             </div>
           </div>
 
@@ -229,25 +252,8 @@ const InvoiceCard = ({
         <div className="text-left text-sm sm:col-span-1">
           <div className="font-medium">Total</div>
           <div className="flex items-center gap-1.5 text-neutral-500">
-            <span className="text-sm font-medium">
-              {currencyFormatter(invoice.total)}
-            </span>
-            {invoice.status &&
-              (() => {
-                const badge = PayoutStatusBadges[invoice.status];
-                return (
-                  <StatusBadge
-                    icon={invoice.status === "failed" ? AlertCircle : null}
-                    variant={badge.variant}
-                    className="rounded-md py-0.5"
-                    {...(invoice.status === "failed" && invoice.failedReason
-                      ? { tooltip: invoice.failedReason }
-                      : {})}
-                  >
-                    {badge.label}
-                  </StatusBadge>
-                );
-              })()}
+            <span className="text-sm font-medium">{formattedTotal}</span>
+            {statusBadge}
           </div>
         </div>
 
@@ -274,9 +280,9 @@ const InvoiceCard = ({
         )}
 
         <div className="flex items-center justify-end sm:col-span-1 sm:justify-end">
-          {invoice.pdfUrl && invoice.status !== "failed" ? (
+          {pdfUrl ? (
             <a
-              href={invoice.pdfUrl}
+              href={pdfUrl}
               target="_blank"
               className={cn(
                 buttonVariants({ variant: "secondary" }),

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/billing/invoices/stripe-invoice-status-badges.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/billing/invoices/stripe-invoice-status-badges.tsx
@@ -1,0 +1,34 @@
+import { StripeInvoiceStatusSchema } from "@/lib/zod/schemas/invoices";
+import { StatusBadgeVariant } from "@dub/ui";
+import * as z from "zod/v4";
+
+type StripeInvoiceStatus = z.infer<typeof StripeInvoiceStatusSchema>;
+
+export const StripeInvoiceStatusBadges: Record<
+  StripeInvoiceStatus,
+  {
+    label: string;
+    variant: StatusBadgeVariant["variant"];
+  }
+> = {
+  draft: {
+    label: "Upcoming",
+    variant: "new",
+  },
+  open: {
+    label: "Open",
+    variant: "error",
+  },
+  paid: {
+    label: "Paid",
+    variant: "success",
+  },
+  uncollectible: {
+    label: "Uncollectible",
+    variant: "neutral",
+  },
+  void: {
+    label: "Void",
+    variant: "neutral",
+  },
+};

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/billing/payment-methods.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/billing/payment-methods.tsx
@@ -60,7 +60,10 @@ export default function PaymentMethods() {
   }
 
   return (
-    <div className="mb-8 rounded-xl border border-neutral-200 bg-white">
+    <div
+      id="payment-methods"
+      className="mb-8 scroll-mt-16 rounded-xl border border-neutral-200 bg-white"
+    >
       <div className="flex flex-col items-start justify-between gap-y-4 p-6 md:flex-row md:items-center md:p-8">
         <div>
           <h2 className="text-xl font-medium">Payment methods</h2>

--- a/apps/web/lib/zod/schemas/invoices.ts
+++ b/apps/web/lib/zod/schemas/invoices.ts
@@ -1,10 +1,19 @@
 import { InvoiceStatus, PaymentMethod } from "@prisma/client";
 import * as z from "zod/v4";
 
+export const StripeInvoiceStatusSchema = z.enum([
+  "draft",
+  "open",
+  "paid",
+  "uncollectible",
+  "void",
+]);
+
 export const InvoiceSchema = z.object({
   id: z.string(),
   total: z.number(),
   status: z.enum(InvoiceStatus).optional(),
+  stripeStatus: StripeInvoiceStatusSchema.optional(),
   paymentMethod: z.enum(PaymentMethod).nullable().optional(),
   createdAt: z.date(),
   description: z.string().default("Dub payout"),

--- a/apps/web/lib/zod/schemas/invoices.ts
+++ b/apps/web/lib/zod/schemas/invoices.ts
@@ -13,7 +13,7 @@ export const InvoiceSchema = z.object({
   id: z.string(),
   total: z.number(),
   status: z.enum(InvoiceStatus).optional(),
-  stripeStatus: StripeInvoiceStatusSchema.optional(),
+  stripeStatus: StripeInvoiceStatusSchema.nullish(), // only for Stripe subscription invoices
   paymentMethod: z.enum(PaymentMethod).nullable().optional(),
   createdAt: z.date(),
   description: z.string().default("Dub payout"),

--- a/apps/web/ui/layout/sidebar/sidebar-usage.tsx
+++ b/apps/web/ui/layout/sidebar/sidebar-usage.tsx
@@ -2,8 +2,8 @@
 
 import { clientAccessCheck } from "@/lib/client-access-check";
 import useWorkspace from "@/lib/swr/use-workspace";
+import { useRetryPaymentModal } from "@/ui/modals/retry-payment-modal";
 import { useStartPaidPlanModal } from "@/ui/modals/start-paid-plan-modal";
-import ManageSubscriptionButton from "@/ui/workspaces/manage-subscription-button";
 import {
   AnimatedSizeContainer,
   Button,
@@ -63,6 +63,8 @@ function UsageInner() {
 
   const { StartPaidPlanModal, setShowStartPaidPlanModal } =
     useStartPaidPlanModal();
+  const { RetryPaymentModal, setShowRetryPaymentModal } =
+    useRetryPaymentModal();
 
   const trialDaysLeft = useMemo(() => {
     if (!trialEndsAt || !isWorkspaceBillingTrialActive(trialEndsAt)) {
@@ -117,6 +119,7 @@ function UsageInner() {
   return loading || usage !== undefined ? (
     <>
       {isTrial ? <StartPaidPlanModal /> : null}
+      {paymentFailedAt ? <RetryPaymentModal /> : null}
       <AnimatedSizeContainer height>
         <div className="border-t border-neutral-300/80 p-3">
           {isTrial ? (
@@ -226,10 +229,11 @@ function UsageInner() {
           </div>
 
           {paymentFailedAt ? (
-            <ManageSubscriptionButton
-              text="Update Payment Method"
+            <Button
+              text="Retry payment"
               variant="primary"
               className="mt-4 w-full"
+              onClick={() => setShowRetryPaymentModal(true)}
               onMouseEnter={() => {
                 setHovered(true);
               }}

--- a/apps/web/ui/layout/sidebar/sidebar-usage.tsx
+++ b/apps/web/ui/layout/sidebar/sidebar-usage.tsx
@@ -229,18 +229,25 @@ function UsageInner() {
           </div>
 
           {paymentFailedAt ? (
-            <Button
-              text="Retry payment"
-              variant="primary"
-              className="mt-4 w-full"
-              onClick={() => setShowRetryPaymentModal(true)}
-              onMouseEnter={() => {
-                setHovered(true);
-              }}
-              onMouseLeave={() => {
-                setHovered(false);
-              }}
-            />
+            <DynamicTooltipWrapper
+              tooltipProps={
+                permissionsError ? { content: permissionsError } : undefined
+              }
+            >
+              <Button
+                text="Retry payment"
+                variant="primary"
+                className="mt-4 w-full"
+                disabled={Boolean(permissionsError)}
+                onClick={() => setShowRetryPaymentModal(true)}
+                onMouseEnter={() => {
+                  setHovered(true);
+                }}
+                onMouseLeave={() => {
+                  setHovered(false);
+                }}
+              />
+            </DynamicTooltipWrapper>
           ) : isTrial ? (
             <DynamicTooltipWrapper
               tooltipProps={

--- a/apps/web/ui/layout/upgrade-banner.tsx
+++ b/apps/web/ui/layout/upgrade-banner.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import useWorkspace from "@/lib/swr/use-workspace";
+import { useRetryPaymentModal } from "@/ui/modals/retry-payment-modal";
 import { useTrialLimitActivateModal } from "@/ui/modals/trial-limit-activate-modal";
 import { Button, Crown, TriangleWarning, useMediaQuery } from "@dub/ui";
 import {
@@ -10,7 +11,6 @@ import {
 } from "@dub/utils";
 import { motion } from "motion/react";
 import Link from "next/link";
-import ManageSubscriptionButton from "../workspaces/manage-subscription-button";
 
 export function useUpgradeBannerVisibility() {
   const {
@@ -38,9 +38,11 @@ export function UpgradeBanner() {
     useWorkspace();
   const { openTrialLimitModal, TrialLimitActivateModal } =
     useTrialLimitActivateModal();
+  const { setShowRetryPaymentModal, RetryPaymentModal } =
+    useRetryPaymentModal();
   const trialActive = isWorkspaceBillingTrialActive(trialEndsAt);
 
-  const { isVisible, needsUpgrade, paymentFailed, subscriptionCanceled } =
+  const { isVisible, needsUpgrade, subscriptionCanceled } =
     useUpgradeBannerVisibility();
 
   const overageLimitResource = getTrialLimitResourceForOverageBanner({
@@ -58,6 +60,7 @@ export function UpgradeBanner() {
   return (
     <>
       <TrialLimitActivateModal />
+      <RetryPaymentModal />
       <motion.div
         initial={{ transform: "translateY(-100%)" }}
         animate={{ transform: "translateY(0)" }}
@@ -94,7 +97,16 @@ export function UpgradeBanner() {
           ) : subscriptionCanceled ? (
             "Your subscription has been canceled. To reactivate, please upgrade to a paid plan."
           ) : (
-            "Your last payment failed. Please update your payment method to avoid service disruption."
+            <>
+              Your last payment failed. Please{" "}
+              <Link
+                href={`/${slug}/settings/billing#payment-methods`}
+                className="underline"
+              >
+                update your payment method
+              </Link>{" "}
+              to avoid service disruption.
+            </>
           )}
         </p>
         {needsUpgrade || subscriptionCanceled ? (
@@ -124,9 +136,10 @@ export function UpgradeBanner() {
             </Link>
           )
         ) : (
-          <ManageSubscriptionButton
-            text={isMobile ? "Update" : "Update Payment Method"}
+          <Button
+            text={isMobile ? "Retry" : "Retry payment"}
             variant="secondary"
+            onClick={() => setShowRetryPaymentModal(true)}
             className={customButtonClassname}
           />
         )}

--- a/apps/web/ui/layout/upgrade-banner.tsx
+++ b/apps/web/ui/layout/upgrade-banner.tsx
@@ -1,9 +1,16 @@
 "use client";
 
+import { clientAccessCheck } from "@/lib/client-access-check";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { useRetryPaymentModal } from "@/ui/modals/retry-payment-modal";
 import { useTrialLimitActivateModal } from "@/ui/modals/trial-limit-activate-modal";
-import { Button, Crown, TriangleWarning, useMediaQuery } from "@dub/ui";
+import {
+  Button,
+  Crown,
+  DynamicTooltipWrapper,
+  TriangleWarning,
+  useMediaQuery,
+} from "@dub/ui";
 import {
   cn,
   getTrialLimitResourceForOverageBanner,
@@ -34,8 +41,14 @@ export function useUpgradeBannerVisibility() {
 }
 
 export function UpgradeBanner() {
-  const { slug, exceededEvents, exceededLinks, exceededPayouts, trialEndsAt } =
-    useWorkspace();
+  const {
+    slug,
+    exceededEvents,
+    exceededLinks,
+    exceededPayouts,
+    trialEndsAt,
+    role,
+  } = useWorkspace();
   const { openTrialLimitModal, TrialLimitActivateModal } =
     useTrialLimitActivateModal();
   const { setShowRetryPaymentModal, RetryPaymentModal } =
@@ -44,6 +57,11 @@ export function UpgradeBanner() {
 
   const { isVisible, needsUpgrade, subscriptionCanceled } =
     useUpgradeBannerVisibility();
+
+  const permissionsError = clientAccessCheck({
+    action: "billing.write",
+    role,
+  }).error;
 
   const overageLimitResource = getTrialLimitResourceForOverageBanner({
     exceededEvents: Boolean(exceededEvents),
@@ -136,12 +154,19 @@ export function UpgradeBanner() {
             </Link>
           )
         ) : (
-          <Button
-            text={isMobile ? "Retry" : "Retry payment"}
-            variant="secondary"
-            onClick={() => setShowRetryPaymentModal(true)}
-            className={customButtonClassname}
-          />
+          <DynamicTooltipWrapper
+            tooltipProps={
+              permissionsError ? { content: permissionsError } : undefined
+            }
+          >
+            <Button
+              text={isMobile ? "Retry" : "Retry payment"}
+              variant="secondary"
+              disabled={Boolean(permissionsError)}
+              onClick={() => setShowRetryPaymentModal(true)}
+              className={customButtonClassname}
+            />
+          </DynamicTooltipWrapper>
         )}
       </motion.div>
     </>

--- a/apps/web/ui/modals/retry-payment-modal.tsx
+++ b/apps/web/ui/modals/retry-payment-modal.tsx
@@ -10,6 +10,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { toast } from "sonner";
@@ -30,6 +31,7 @@ function RetryPaymentModal({
 }) {
   const { id: workspaceId, slug, mutate } = useWorkspace();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const submittingRef = useRef(false);
   const [isLoadingInvoice, setIsLoadingInvoice] = useState(false);
   const [invoice, setInvoice] = useState<OpenInvoice | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -81,18 +83,25 @@ function RetryPaymentModal({
 
   const handleConfirm = async () => {
     if (
-      isSubmitting ||
+      submittingRef.current ||
       !workspaceId ||
       !invoice ||
       !invoice.hasDefaultPaymentMethod
     ) {
       return;
     }
+    submittingRef.current = true;
     setIsSubmitting(true);
     try {
       const res = await fetch(
         `/api/workspaces/${workspaceId}/billing/retry-payment`,
-        { method: "POST" },
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ invoiceId: invoice.invoiceId }),
+        },
       );
       if (res.ok) {
         toast.success("Payment succeeded.");
@@ -117,6 +126,7 @@ function RetryPaymentModal({
         "Failed to retry payment. Please update your payment method and try again.",
       );
     } finally {
+      submittingRef.current = false;
       setIsSubmitting(false);
     }
   };

--- a/apps/web/ui/modals/retry-payment-modal.tsx
+++ b/apps/web/ui/modals/retry-payment-modal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import useWorkspace from "@/lib/swr/use-workspace";
+import { InvoiceProps } from "@/lib/types";
 import { Button, LoadingSpinner, Modal } from "@dub/ui";
 import { currencyFormatter } from "@dub/utils";
 import Link from "next/link";
@@ -15,13 +16,6 @@ import {
 } from "react";
 import { toast } from "sonner";
 
-type OpenInvoice = {
-  invoiceId: string;
-  amountDue: number;
-  currency: string;
-  hasDefaultPaymentMethod: boolean;
-};
-
 function RetryPaymentModal({
   showModal,
   setShowModal,
@@ -33,7 +27,7 @@ function RetryPaymentModal({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const submittingRef = useRef(false);
   const [isLoadingInvoice, setIsLoadingInvoice] = useState(false);
-  const [invoice, setInvoice] = useState<OpenInvoice | null>(null);
+  const [invoice, setInvoice] = useState<InvoiceProps | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -44,7 +38,9 @@ function RetryPaymentModal({
     setInvoice(null);
     setLoadError(null);
 
-    fetch(`/api/workspaces/${workspaceId}/billing/retry-payment`)
+    fetch(
+      `/api/workspaces/${workspaceId}/billing/invoices?type=subscription&status=open`,
+    )
       .then(async (res) => {
         const body = await res.json().catch(() => null);
         if (!res.ok) {
@@ -52,13 +48,9 @@ function RetryPaymentModal({
             body?.error?.message ?? "Failed to load open invoice.",
           );
         }
+        const openInvoice = Array.isArray(body) ? body[0] : null;
         if (!cancelled) {
-          setInvoice({
-            invoiceId: body.invoiceId,
-            amountDue: body.amountDue,
-            currency: body.currency,
-            hasDefaultPaymentMethod: Boolean(body.hasDefaultPaymentMethod),
-          });
+          setInvoice(openInvoice ?? null);
         }
       })
       .catch((error) => {
@@ -82,12 +74,7 @@ function RetryPaymentModal({
   }, [showModal, workspaceId]);
 
   const handleConfirm = async () => {
-    if (
-      submittingRef.current ||
-      !workspaceId ||
-      !invoice ||
-      !invoice.hasDefaultPaymentMethod
-    ) {
+    if (submittingRef.current || !workspaceId || !invoice) {
       return;
     }
     submittingRef.current = true;
@@ -100,7 +87,7 @@ function RetryPaymentModal({
           headers: {
             "Content-Type": "application/json",
           },
-          body: JSON.stringify({ invoiceId: invoice.invoiceId }),
+          body: JSON.stringify({ invoiceId: invoice.id }),
         },
       );
       if (res.ok) {
@@ -130,8 +117,6 @@ function RetryPaymentModal({
       setIsSubmitting(false);
     }
   };
-
-  const missingPaymentMethod = invoice && !invoice.hasDefaultPaymentMethod;
 
   return (
     <Modal
@@ -170,28 +155,12 @@ function RetryPaymentModal({
             <div className="rounded-lg border border-neutral-200 bg-white p-4">
               <p className="text-sm text-neutral-500">Amount due</p>
               <p className="mt-1 text-base font-semibold tabular-nums text-neutral-900">
-                {currencyFormatter(invoice.amountDue, {
-                  currency: invoice.currency.toUpperCase(),
-                })}
+                {currencyFormatter(invoice.total)}
               </p>
             </div>
-            {missingPaymentMethod ? (
-              <p className="text-sm text-neutral-600">
-                No default payment method found. Please{" "}
-                <Link
-                  href={`/${slug}/settings/billing#payment-methods`}
-                  className="font-medium text-neutral-900 underline underline-offset-2"
-                  onClick={() => setShowModal(false)}
-                >
-                  add a payment method
-                </Link>{" "}
-                to retry this payment.
-              </p>
-            ) : (
-              <p className="text-sm text-neutral-600">
-                We&apos;ll charge your default payment method for this amount.
-              </p>
-            )}
+            <p className="text-sm text-neutral-600">
+              We&apos;ll charge your default payment method for this amount.
+            </p>
           </>
         )}
       </div>
@@ -209,17 +178,7 @@ function RetryPaymentModal({
           className="h-8 rounded-lg px-3 text-sm"
           text="Retry payment"
           loading={isSubmitting}
-          disabled={
-            isSubmitting ||
-            isLoadingInvoice ||
-            !invoice ||
-            !invoice.hasDefaultPaymentMethod
-          }
-          disabledTooltip={
-            missingPaymentMethod
-              ? "Add a payment method to retry this payment."
-              : undefined
-          }
+          disabled={isSubmitting || isLoadingInvoice || !invoice}
           onClick={handleConfirm}
         />
       </div>

--- a/apps/web/ui/modals/retry-payment-modal.tsx
+++ b/apps/web/ui/modals/retry-payment-modal.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import useWorkspace from "@/lib/swr/use-workspace";
+import { Button, LoadingSpinner, Modal } from "@dub/ui";
+import { currencyFormatter } from "@dub/utils";
+import Link from "next/link";
+import {
+  Dispatch,
+  SetStateAction,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { toast } from "sonner";
+
+type OpenInvoice = {
+  invoiceId: string;
+  amountDue: number;
+  currency: string;
+  hasDefaultPaymentMethod: boolean;
+};
+
+function RetryPaymentModal({
+  showModal,
+  setShowModal,
+}: {
+  showModal: boolean;
+  setShowModal: Dispatch<SetStateAction<boolean>>;
+}) {
+  const { id: workspaceId, slug, mutate } = useWorkspace();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isLoadingInvoice, setIsLoadingInvoice] = useState(false);
+  const [invoice, setInvoice] = useState<OpenInvoice | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!showModal || !workspaceId) return;
+
+    let cancelled = false;
+    setIsLoadingInvoice(true);
+    setInvoice(null);
+    setLoadError(null);
+
+    fetch(`/api/workspaces/${workspaceId}/billing/retry-payment`)
+      .then(async (res) => {
+        const body = await res.json().catch(() => null);
+        if (!res.ok) {
+          throw new Error(
+            body?.error?.message ?? "Failed to load open invoice.",
+          );
+        }
+        if (!cancelled) {
+          setInvoice({
+            invoiceId: body.invoiceId,
+            amountDue: body.amountDue,
+            currency: body.currency,
+            hasDefaultPaymentMethod: Boolean(body.hasDefaultPaymentMethod),
+          });
+        }
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          setLoadError(
+            error instanceof Error
+              ? error.message
+              : "Failed to load open invoice.",
+          );
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsLoadingInvoice(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [showModal, workspaceId]);
+
+  const handleConfirm = async () => {
+    if (
+      isSubmitting ||
+      !workspaceId ||
+      !invoice ||
+      !invoice.hasDefaultPaymentMethod
+    ) {
+      return;
+    }
+    setIsSubmitting(true);
+    try {
+      const res = await fetch(
+        `/api/workspaces/${workspaceId}/billing/retry-payment`,
+        { method: "POST" },
+      );
+      if (res.ok) {
+        toast.success("Payment succeeded.");
+        // Hide the banner immediately; charge.succeeded / subscription webhooks clear paymentFailedAt in DB
+        await mutate(
+          (current) =>
+            current ? { ...current, paymentFailedAt: null } : current,
+          { revalidate: false },
+        );
+        setShowModal(false);
+        return;
+      }
+
+      const body = await res.json().catch(() => null);
+      toast.error(
+        body?.error?.message ??
+          "Failed to retry payment. Please update your payment method and try again.",
+      );
+    } catch (error) {
+      console.error(error);
+      toast.error(
+        "Failed to retry payment. Please update your payment method and try again.",
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const missingPaymentMethod = invoice && !invoice.hasDefaultPaymentMethod;
+
+  return (
+    <Modal
+      showModal={showModal}
+      setShowModal={setShowModal}
+      className="max-w-md"
+    >
+      <div className="sm:py-4.5 border-b border-neutral-200 px-4 py-3 sm:px-6">
+        <h3 className="text-lg font-medium text-neutral-900">Retry payment</h3>
+      </div>
+
+      <div className="flex flex-col gap-4 bg-neutral-50 p-4 sm:p-6">
+        {isLoadingInvoice ? (
+          <div className="flex items-center justify-center py-6">
+            <LoadingSpinner className="size-5" />
+          </div>
+        ) : loadError || !invoice ? (
+          <div className="space-y-2 text-sm text-neutral-600">
+            <p>{loadError ?? "No open invoice found to retry."}</p>
+            {slug && (
+              <p>
+                You can{" "}
+                <Link
+                  href={`/${slug}/settings/billing#payment-methods`}
+                  className="font-medium text-neutral-900 underline underline-offset-2"
+                  onClick={() => setShowModal(false)}
+                >
+                  update your payment method
+                </Link>{" "}
+                instead.
+              </p>
+            )}
+          </div>
+        ) : (
+          <>
+            <div className="rounded-lg border border-neutral-200 bg-white p-4">
+              <p className="text-sm text-neutral-500">Amount due</p>
+              <p className="mt-1 text-base font-semibold tabular-nums text-neutral-900">
+                {currencyFormatter(invoice.amountDue, {
+                  currency: invoice.currency.toUpperCase(),
+                })}
+              </p>
+            </div>
+            {missingPaymentMethod ? (
+              <p className="text-sm text-neutral-600">
+                No default payment method found. Please{" "}
+                <Link
+                  href={`/${slug}/settings/billing#payment-methods`}
+                  className="font-medium text-neutral-900 underline underline-offset-2"
+                  onClick={() => setShowModal(false)}
+                >
+                  add a payment method
+                </Link>{" "}
+                to retry this payment.
+              </p>
+            ) : (
+              <p className="text-sm text-neutral-600">
+                We&apos;ll charge your default payment method for this amount.
+              </p>
+            )}
+          </>
+        )}
+      </div>
+
+      <div className="flex items-center justify-between gap-2 border-t border-neutral-200 px-4 py-5 sm:px-6">
+        <Button
+          variant="secondary"
+          className="h-8 rounded-lg px-3 text-sm"
+          text="Cancel"
+          onClick={() => setShowModal(false)}
+          disabled={isSubmitting}
+        />
+        <Button
+          variant="primary"
+          className="h-8 rounded-lg px-3 text-sm"
+          text="Retry payment"
+          loading={isSubmitting}
+          disabled={
+            isSubmitting ||
+            isLoadingInvoice ||
+            !invoice ||
+            !invoice.hasDefaultPaymentMethod
+          }
+          disabledTooltip={
+            missingPaymentMethod
+              ? "Add a payment method to retry this payment."
+              : undefined
+          }
+          onClick={handleConfirm}
+        />
+      </div>
+    </Modal>
+  );
+}
+
+export function useRetryPaymentModal() {
+  const [showModal, setShowModal] = useState(false);
+
+  const RetryPaymentModalCallback = useCallback(() => {
+    return (
+      <RetryPaymentModal showModal={showModal} setShowModal={setShowModal} />
+    );
+  }, [showModal]);
+
+  return useMemo(
+    () => ({
+      setShowRetryPaymentModal: setShowModal,
+      RetryPaymentModal: RetryPaymentModalCallback,
+    }),
+    [setShowModal, RetryPaymentModalCallback],
+  );
+}

--- a/apps/web/ui/modals/retry-payment-modal.tsx
+++ b/apps/web/ui/modals/retry-payment-modal.tsx
@@ -39,7 +39,7 @@ function RetryPaymentModal({
     setLoadError(null);
 
     fetch(
-      `/api/workspaces/${workspaceId}/billing/invoices?type=subscription&status=open`,
+      `/api/workspaces/${workspaceId}/billing/invoices?type=subscription&stripeStatus=open`,
     )
       .then(async (res) => {
         const body = await res.json().catch(() => null);
@@ -48,9 +48,9 @@ function RetryPaymentModal({
             body?.error?.message ?? "Failed to load open invoice.",
           );
         }
-        const openInvoice = Array.isArray(body) ? body[0] : null;
+        const firstOpenInvoice = Array.isArray(body) ? body[0] : null;
         if (!cancelled) {
-          setInvoice(openInvoice ?? null);
+          setInvoice(firstOpenInvoice ?? null);
         }
       })
       .catch((error) => {
@@ -92,7 +92,7 @@ function RetryPaymentModal({
       );
       if (res.ok) {
         toast.success("Payment succeeded.");
-        // Hide the banner immediately; charge.succeeded / subscription webhooks clear paymentFailedAt in DB
+        // optimistically hide the banner; charge.succeeded / subscription webhooks clear paymentFailedAt in DB
         await mutate(
           (current) =>
             current ? { ...current, paymentFailedAt: null } : current,

--- a/packages/ui/src/status-badge.tsx
+++ b/packages/ui/src/status-badge.tsx
@@ -33,6 +33,8 @@ const statusBadgeVariants = cva(
   },
 );
 
+export type StatusBadgeVariant = VariantProps<typeof statusBadgeVariants>;
+
 const defaultIcons = {
   neutral: CircleInfo,
   new: CircleHalfDottedCheck,
@@ -44,12 +46,12 @@ const defaultIcons = {
 
 interface BadgeProps
   extends React.HTMLAttributes<HTMLSpanElement>,
-    VariantProps<typeof statusBadgeVariants> {
+    StatusBadgeVariant {
   icon?: Icon | null;
   tooltip?: string | React.ReactNode;
 }
 
-function StatusBadge({
+export function StatusBadge({
   className,
   variant,
   size,
@@ -79,5 +81,3 @@ function StatusBadge({
     </DynamicTooltipWrapper>
   );
 }
-
-export { StatusBadge, statusBadgeVariants };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Retry payment” flow for failed payments, including an open subscription invoice preview and a confirm/retry action in a modal.
  * Enhanced the invoices page to support subscription invoice statuses, with improved totals and consistent “View invoice” links.
  * Added retry-payment entry points on upgrade/banner and usage surfaces, plus an anchor to the payment methods section.
* **Bug Fixes**
  * Retry now validates invoice ownership and the expected invoice state before charging, and returns normalized errors.
  * Invoice listing now computes totals more reliably and supports filtering by Stripe invoice status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->