### PR TITLE
Handle concurrent tag create conflicts via P2002

### DIFF
--- a/apps/web/app/api/tags/route.ts
+++ b/apps/web/app/api/tags/route.ts
@@ -116,33 +116,30 @@ export const POST = withWorkspace(
 
     const { tag, color, name } = createTagBodySchema.parse(await req.json());
 
-    const existingTag = await prisma.tag.findFirst({
-      where: {
-        projectId: workspace.id,
-        name: name || tag,
-      },
-    });
-
-    if (existingTag) {
-      throw new DubApiError({
-        code: "conflict",
-        message: "A tag with that name already exists.",
+    try {
+      const createdTag = await prisma.tag.create({
+        data: {
+          id: createId({ prefix: "tag_" }),
+          name: tag || name!,
+          color: color || randomBadgeColor(),
+          projectId: workspace.id,
+        },
       });
+
+      return NextResponse.json(LinkTagSchema.parse(createdTag), {
+        headers,
+        status: 201,
+      });
+    } catch (error) {
+      if (error.code === "P2002") {
+        throw new DubApiError({
+          code: "conflict",
+          message: "A tag with that name already exists.",
+        });
+      }
+
+      throw error;
     }
-
-    const response = await prisma.tag.create({
-      data: {
-        id: createId({ prefix: "tag_" }),
-        name: tag || name!,
-        color: color || randomBadgeColor(),
-        projectId: workspace.id,
-      },
-    });
-
-    return NextResponse.json(LinkTagSchema.parse(response), {
-      headers,
-      status: 201,
-    });
   },
   {
     requiredPermissions: ["tags.write"],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tag creation to reliably handle duplicate tag names.
  * Users now receive a clear conflict error when attempting to create a tag with an existing name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->