### PR TITLE
Tighten group move rules with a dedicated Zod schema

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/groups/[groupSlug]/settings/group-additional-settings.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/groups/[groupSlug]/settings/group-additional-settings.tsx
@@ -119,7 +119,10 @@ function GroupAdditionalSettingsForm({
     if (!group) return;
     if (data.moveRules && data.moveRules.length > 0) {
       try {
-        validateGroupMoveRules(data.moveRules);
+        validateGroupMoveRules({
+          rules: data.moveRules,
+          destinationGroupId: group.id,
+        });
       } catch (error) {
         toast.error(error.message);
         return;

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/groups/[groupSlug]/settings/group-move-rules.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/groups/[groupSlug]/settings/group-move-rules.tsx
@@ -3,9 +3,16 @@
 import { getPlanCapabilities } from "@/lib/plan-capabilities";
 import useGroup from "@/lib/swr/use-group";
 import useWorkspace from "@/lib/swr/use-workspace";
-import { WorkflowCondition } from "@/lib/types";
-import { GroupColorCircle } from "@/ui/partners/groups/group-color-circle";
+import {
+  GROUP_MOVE_ATTRIBUTE_CONFIG,
+  GROUP_MOVE_ATTRIBUTES,
+  type GroupMoveAttribute,
+  type GroupMoveAttributeConfig,
+  type GroupMoveCondition,
+  type GroupMoveRules as GroupMoveRulesForm,
+} from "@/lib/zod/schemas/group-move-workflows";
 import { useAdvancedUpsellModal } from "@/ui/partners/advanced-upsell-modal";
+import { GroupColorCircle } from "@/ui/partners/groups/group-color-circle";
 import {
   InlineBadgePopover,
   InlineBadgePopoverAmountInput,
@@ -17,21 +24,9 @@ import { X } from "lucide-react";
 import { Fragment, useMemo } from "react";
 import { Controller, useFieldArray, useFormContext } from "react-hook-form";
 
-const ATTRIBUTES = [
-  { key: "totalLeads", text: "total leads", type: "number" },
-  { key: "totalConversions", text: "total conversions", type: "number" },
-  { key: "totalSaleAmount", text: "total revenue", type: "currency" },
-  { key: "totalCommissions", text: "total commissions", type: "currency" },
-] as const;
-
-type Attribute = (typeof ATTRIBUTES)[number];
-type AttributeType = (typeof ATTRIBUTES)[number]["type"];
+// Draft form value shapes (partial ranges allowed while editing)
 type RangeValue = { min: number; max?: number };
 type ValueType = number | RangeValue | undefined;
-
-const ATTRIBUTE_BY_KEY = Object.fromEntries(
-  ATTRIBUTES.map(({ key, text, type }) => [key, { text, type }]),
-);
 
 const RANGE_SELECTOR_OPTIONS = [
   { text: "and no limit", value: "noLimit" },
@@ -42,7 +37,7 @@ export function GroupMoveRules() {
   const { plan } = useWorkspace();
 
   const { control, watch } = useFormContext<{
-    moveRules?: WorkflowCondition[];
+    moveRules?: GroupMoveRulesForm;
   }>();
 
   const moveRules = watch("moveRules") ?? [];
@@ -66,7 +61,8 @@ export function GroupMoveRules() {
     [moveRules],
   );
 
-  const disableAddRuleButton = ruleFields.length >= ATTRIBUTES.length;
+  const disableAddRuleButton =
+    ruleFields.length >= GROUP_MOVE_ATTRIBUTES.length;
 
   const { canUseGroupMoveRule } = getPlanCapabilities(plan);
 
@@ -85,9 +81,10 @@ export function GroupMoveRules() {
             }
 
             // Filter out attributes already used by other rules
-            const availableAttributes = ATTRIBUTES.filter(
-              (a) =>
-                a.key === rule.attribute || !usedAttributes?.includes(a.key),
+            const availableAttributes = GROUP_MOVE_ATTRIBUTES.filter(
+              (attribute) =>
+                attribute === rule.attribute ||
+                !usedAttributes?.includes(attribute),
             );
 
             return (
@@ -126,7 +123,7 @@ export function GroupMoveRules() {
               attribute: undefined,
               operator: "gte",
               value: undefined,
-            } as unknown as WorkflowCondition);
+            } as unknown as GroupMoveCondition);
           }}
           disabled={disableAddRuleButton}
           disabledTooltip={
@@ -147,14 +144,17 @@ function GroupRule({
   index,
   availableAttributes,
 }: {
-  rule: WorkflowCondition;
-  onUpdate: (updates: Partial<WorkflowCondition>) => void;
+  rule: GroupMoveCondition;
+  onUpdate: (updates: Partial<GroupMoveCondition>) => void;
   onRemove: () => void;
   index: number;
-  availableAttributes: Attribute[];
+  availableAttributes: GroupMoveAttribute[];
 }) {
   const isFirst = index === 0;
-  const attributeType = ATTRIBUTE_BY_KEY[rule.attribute]?.type || "number";
+  const attributeConfig = rule.attribute
+    ? GROUP_MOVE_ATTRIBUTE_CONFIG[rule.attribute]
+    : undefined;
+  const attributeType = attributeConfig?.inputType || "number";
 
   // Determine if "and less than" is selected based on operator
   // If operator is "between", it means "and less than" was selected (even if max is not set yet)
@@ -206,14 +206,14 @@ function GroupRule({
             {isFirst ? "If partner" : "And if partner"}
             {/* Select the attribute */}
             <InlineBadgePopover
-              text={ATTRIBUTE_BY_KEY[rule.attribute]?.text || "activity"}
+              text={attributeConfig?.label || "activity"}
               invalid={!rule.attribute}
               buttonClassName="mx-1"
             >
               <InlineBadgePopoverMenu
-                items={availableAttributes.map((a) => ({
-                  value: a.key,
-                  text: a.text,
+                items={availableAttributes.map((attribute) => ({
+                  value: attribute,
+                  text: GROUP_MOVE_ATTRIBUTE_CONFIG[attribute].label,
                 }))}
                 selectedValue={rule.attribute}
                 onSelect={(value) => {
@@ -365,13 +365,13 @@ function ValueInput({
   onUpdate,
 }: {
   index: number;
-  rule: WorkflowCondition;
-  attributeType: AttributeType;
+  rule: GroupMoveCondition;
+  attributeType: GroupMoveAttributeConfig["inputType"];
   part: "min" | "max";
-  onUpdate: (updates: Partial<WorkflowCondition>) => void;
+  onUpdate: (updates: Partial<GroupMoveCondition>) => void;
 }) {
   const { control } = useFormContext<{
-    moveRules?: WorkflowCondition[];
+    moveRules?: GroupMoveRulesForm;
   }>();
 
   const isCurrency = attributeType === "currency";
@@ -451,7 +451,7 @@ const handleClearValue = (
 const handleUpdateMinValue = (
   currentFieldValue: ValueType,
   convertedValue: number,
-  operator: WorkflowCondition["operator"],
+  operator: GroupMoveCondition["operator"],
 ): ValueType => {
   if (operator === "between" && isRangeValue(currentFieldValue)) {
     const rangeValue = currentFieldValue as RangeValue;
@@ -463,8 +463,8 @@ const handleUpdateMinValue = (
 const handleUpdateMaxValue = (
   currentFieldValue: ValueType,
   convertedValue: number,
-  onUpdate: (updates: Partial<WorkflowCondition>) => void,
-  ruleOperator: WorkflowCondition["operator"],
+  onUpdate: (updates: Partial<GroupMoveCondition>) => void,
+  ruleOperator: GroupMoveCondition["operator"],
 ): ValueType => {
   if (isRangeValue(currentFieldValue)) {
     const rangeValue = currentFieldValue as RangeValue;
@@ -537,7 +537,7 @@ const convertFromDisplayValue = (
 // Format the value based on the attribute type
 const formatValue = (
   value: ValueType,
-  type: AttributeType | undefined,
+  type: GroupMoveAttributeConfig["inputType"] | undefined,
   part: "min" | "max" = "min",
 ) => {
   const numValue = part === "min" ? getMinValue(value) : getMaxValue(value);

--- a/apps/web/lib/api/groups/find-groups-with-matching-rules.ts
+++ b/apps/web/lib/api/groups/find-groups-with-matching-rules.ts
@@ -1,4 +1,7 @@
-import { WorkflowCondition } from "@/lib/types";
+import type {
+  GroupMoveCondition,
+  GroupMoveRules,
+} from "@/lib/zod/schemas/group-move-workflows";
 import { groupRulesSchema } from "@/lib/zod/schemas/groups";
 import * as z from "zod/v4";
 
@@ -8,7 +11,7 @@ export const findGroupsWithMatchingRules = ({
   currentGroupId,
 }: {
   groups: z.infer<typeof groupRulesSchema>;
-  currentRules: WorkflowCondition[] | null | undefined;
+  currentRules: GroupMoveRules | null | undefined;
   currentGroupId: string;
 }): Array<{ id: string; name: string }> => {
   if (
@@ -34,15 +37,15 @@ export const findGroupsWithMatchingRules = ({
 // Two rule sets conflict if there exists ANY set of attribute values that would satisfy both simultaneously.
 // This ensures that for any given set of attribute values, at most one group rule set will match.
 const doRuleSetsOverlap = (
-  rules1: WorkflowCondition[],
-  rules2: WorkflowCondition[],
+  rules1: GroupMoveRules,
+  rules2: GroupMoveRules,
 ): boolean => {
-  const rules1ByAttribute = new Map<string, WorkflowCondition>();
+  const rules1ByAttribute = new Map<string, GroupMoveCondition>();
   for (const rule of rules1) {
     rules1ByAttribute.set(rule.attribute, rule);
   }
 
-  const rules2ByAttribute = new Map<string, WorkflowCondition>();
+  const rules2ByAttribute = new Map<string, GroupMoveCondition>();
   for (const rule of rules2) {
     rules2ByAttribute.set(rule.attribute, rule);
   }
@@ -78,7 +81,7 @@ const doRuleSetsOverlap = (
 };
 
 const conditionToInterval = (
-  condition: WorkflowCondition,
+  condition: GroupMoveCondition,
 ): { min: number; max: number } | null => {
   switch (condition.operator) {
     case "gte":
@@ -105,8 +108,8 @@ const conditionToInterval = (
 };
 
 const doConditionsOverlap = (
-  condition1: WorkflowCondition,
-  condition2: WorkflowCondition,
+  condition1: GroupMoveCondition,
+  condition2: GroupMoveCondition,
 ): boolean => {
   // Conditions must be for the same attribute to overlap
   if (condition1.attribute !== condition2.attribute) {

--- a/apps/web/lib/api/groups/upsert-group-move-rules.ts
+++ b/apps/web/lib/api/groups/upsert-group-move-rules.ts
@@ -9,6 +9,7 @@ import { createId } from "../create-id";
 import { DubApiError } from "../errors";
 import { findGroupsWithMatchingRules } from "./find-groups-with-matching-rules";
 import { getGroupMoveRules } from "./get-group-move-rules";
+import { validateGroupMoveRules } from "./validate-group-move-rules";
 
 export async function upsertGroupMoveRules({
   workspace,
@@ -46,6 +47,19 @@ export async function upsertGroupMoveRules({
     return {
       workflowId: undefined,
     };
+  }
+
+  try {
+    validateGroupMoveRules({
+      rules: moveRules,
+      destinationGroupId: group.id,
+    });
+  } catch (error) {
+    throw new DubApiError({
+      code: "bad_request",
+      message:
+        error instanceof Error ? error.message : "Invalid group move rules.",
+    });
   }
 
   const groupsWithMatchingRules = findGroupsWithMatchingRules({

--- a/apps/web/lib/api/groups/upsert-group-move-rules.ts
+++ b/apps/web/lib/api/groups/upsert-group-move-rules.ts
@@ -1,6 +1,7 @@
 import { getPlanCapabilities } from "@/lib/plan-capabilities";
 import { prisma } from "@/lib/prisma";
-import { WorkflowAction, WorkflowCondition, WorkspaceProps } from "@/lib/types";
+import { WorkflowAction, WorkspaceProps } from "@/lib/types";
+import type { GroupMoveRules } from "@/lib/zod/schemas/group-move-workflows";
 import { WORKFLOW_ACTION_TYPES } from "@/lib/zod/schemas/workflows";
 import { pluralize } from "@dub/utils";
 import { PartnerGroup, WorkflowTrigger } from "@prisma/client";
@@ -16,7 +17,7 @@ export async function upsertGroupMoveRules({
 }: {
   workspace: Pick<WorkspaceProps, "plan" | "defaultProgramId">;
   group: PartnerGroup;
-  moveRules?: WorkflowCondition[];
+  moveRules?: GroupMoveRules;
 }): Promise<{ workflowId: string | null | undefined }> {
   const { canUseGroupMoveRule } = getPlanCapabilities(workspace.plan);
 

--- a/apps/web/lib/api/groups/validate-group-move-rules.ts
+++ b/apps/web/lib/api/groups/validate-group-move-rules.ts
@@ -1,11 +1,30 @@
 import {
   GROUP_MOVE_ATTRIBUTE_CONFIG,
-  GROUP_MOVE_ATTRIBUTE_VALIDATORS,
   GROUP_MOVE_OPERATOR_LABELS,
   GROUP_MOVE_OPERATOR_VALIDATORS,
+  GroupMoveAttribute,
   type GroupMoveCondition,
   type GroupMoveRules,
 } from "@/lib/zod/schemas/group-move-workflows";
+
+type GroupMoveAttributeValidator = (params: {
+  rule: GroupMoveCondition;
+  ruleIndex: number;
+  destinationGroupId: string;
+}) => void;
+
+// Add business rules for each attribute
+// NOTE: Keeping this empty for now, next PR will use this
+const GROUP_MOVE_ATTRIBUTE_VALIDATORS: Record<
+  GroupMoveAttribute,
+  GroupMoveAttributeValidator
+> = {
+  // Operator validators already cover performance value shape/constraints.
+  totalLeads: () => {},
+  totalConversions: () => {},
+  totalSaleAmount: () => {},
+  totalCommissions: () => {},
+};
 
 export const validateGroupMoveRules = ({
   rules,
@@ -65,7 +84,10 @@ const validateRule = ({
     ];
 
   if (validateOperator) {
-    validateOperator(rule, ruleIndex);
+    validateOperator({
+      rule,
+      ruleIndex,
+    });
   }
 
   // Validate attribute-specific constraints (business rules)

--- a/apps/web/lib/api/groups/validate-group-move-rules.ts
+++ b/apps/web/lib/api/groups/validate-group-move-rules.ts
@@ -1,6 +1,7 @@
 import {
   GROUP_MOVE_ATTRIBUTE_CONFIG,
   GROUP_MOVE_ATTRIBUTE_VALIDATORS,
+  GROUP_MOVE_OPERATOR_LABELS,
   GROUP_MOVE_OPERATOR_VALIDATORS,
   type GroupMoveCondition,
   type GroupMoveRules,
@@ -44,9 +45,11 @@ const validateRule = ({
   const allowedOperators = GROUP_MOVE_ATTRIBUTE_CONFIG[rule.attribute]
     .operators as readonly string[];
 
+  const operatorLabel = GROUP_MOVE_OPERATOR_LABELS[rule.operator];
+
   if (!allowedOperators.includes(rule.operator)) {
     throw new Error(
-      `Rule ${ruleIndex + 1}: Operator "${rule.operator}" is not valid for this condition.`,
+      `Operator "${operatorLabel}" is not valid for the activity "${rule.attribute}".`,
     );
   }
 

--- a/apps/web/lib/api/groups/validate-group-move-rules.ts
+++ b/apps/web/lib/api/groups/validate-group-move-rules.ts
@@ -1,6 +1,6 @@
-import { WorkflowCondition } from "@/lib/types";
+import type { GroupMoveRules } from "@/lib/zod/schemas/group-move-workflows";
 
-export const validateGroupMoveRules = (rules?: WorkflowCondition[]) => {
+export const validateGroupMoveRules = (rules?: GroupMoveRules) => {
   if (!rules || rules.length === 0) {
     return;
   }

--- a/apps/web/lib/api/groups/validate-group-move-rules.ts
+++ b/apps/web/lib/api/groups/validate-group-move-rules.ts
@@ -1,61 +1,74 @@
-import type { GroupMoveRules } from "@/lib/zod/schemas/group-move-workflows";
+import {
+  GROUP_MOVE_ATTRIBUTE_CONFIG,
+  GROUP_MOVE_ATTRIBUTE_VALIDATORS,
+  GROUP_MOVE_OPERATOR_VALIDATORS,
+  type GroupMoveCondition,
+  type GroupMoveRules,
+} from "@/lib/zod/schemas/group-move-workflows";
 
-export const validateGroupMoveRules = (rules?: GroupMoveRules) => {
+export const validateGroupMoveRules = ({
+  rules,
+  destinationGroupId,
+}: {
+  rules?: GroupMoveRules;
+  destinationGroupId: string;
+}) => {
   if (!rules || rules.length === 0) {
     return;
   }
 
   for (let i = 0; i < rules.length; i++) {
-    const rule = rules[i];
-
-    // Check if attribute is selected
-    if (!rule.attribute) {
-      throw new Error(`Rule ${i + 1}: Please select an activity.`);
-    }
-
-    // Check if value is set
-    if (rule.value == null || rule.value === undefined) {
-      throw new Error(`Rule ${i + 1}: Please enter a value.`);
-    }
-
-    // For gte operator, value should be a number greater than 0
-    if (rule.operator === "gte") {
-      if (
-        typeof rule.value !== "number" ||
-        isNaN(rule.value) ||
-        rule.value <= 0
-      ) {
-        throw new Error(`Rule ${i + 1}: Please enter a value greater than 0.`);
-      }
-    }
-
-    // For between operator, check min and max
-    if (rule.operator === "between") {
-      if (typeof rule.value !== "object" || rule.value === null) {
-        throw new Error(`Rule ${i + 1}: Please enter a valid value.`);
-      }
-
-      const min = rule.value.min;
-      const max = rule.value.max;
-
-      if (min == null || min === undefined || isNaN(min) || min <= 0) {
-        throw new Error(
-          `Rule ${i + 1}: Please enter a minimum value greater than 0.`,
-        );
-      }
-
-      if (max == null || max === undefined || isNaN(max) || max <= 0) {
-        throw new Error(
-          `Rule ${i + 1}: Please enter a maximum value (limit) greater than 0.`,
-        );
-      }
-
-      // Ensure max is greater than min
-      if (max <= min) {
-        throw new Error(
-          `Rule ${i + 1}: Maximum value must be greater than minimum value.`,
-        );
-      }
-    }
+    validateRule({
+      rule: rules[i],
+      ruleIndex: i,
+      destinationGroupId,
+    });
   }
+};
+
+// Validates a single group move rule
+const validateRule = ({
+  rule,
+  ruleIndex,
+  destinationGroupId,
+}: {
+  rule: GroupMoveCondition;
+  ruleIndex: number;
+  destinationGroupId: string;
+}) => {
+  if (!rule.attribute) {
+    throw new Error(`Rule ${ruleIndex + 1}: Please select an activity.`);
+  }
+
+  // Check if operator is valid for the attribute
+  const allowedOperators = GROUP_MOVE_ATTRIBUTE_CONFIG[rule.attribute]
+    .operators as readonly string[];
+
+  if (!allowedOperators.includes(rule.operator)) {
+    throw new Error(
+      `Rule ${ruleIndex + 1}: Operator "${rule.operator}" is not valid for this condition.`,
+    );
+  }
+
+  // Check if value is set
+  if (rule.value == null || rule.value === undefined) {
+    throw new Error(`Rule ${ruleIndex + 1}: Please enter a value.`);
+  }
+
+  // Validate value shape/constraints for the selected operator
+  const validateOperator =
+    GROUP_MOVE_OPERATOR_VALIDATORS[
+      rule.operator as keyof typeof GROUP_MOVE_OPERATOR_VALIDATORS
+    ];
+
+  if (validateOperator) {
+    validateOperator(rule, ruleIndex);
+  }
+
+  // Validate attribute-specific constraints (business rules)
+  GROUP_MOVE_ATTRIBUTE_VALIDATORS[rule.attribute]({
+    rule,
+    ruleIndex,
+    destinationGroupId,
+  });
 };

--- a/apps/web/lib/api/groups/validate-group-move-rules.ts
+++ b/apps/web/lib/api/groups/validate-group-move-rules.ts
@@ -1,7 +1,7 @@
+import { COMPARISON_OPERATORS } from "@/lib/api/workflows/operators";
 import {
   GROUP_MOVE_ATTRIBUTE_CONFIG,
   GROUP_MOVE_OPERATOR_LABELS,
-  GROUP_MOVE_OPERATOR_VALIDATORS,
   GroupMoveAttribute,
   type GroupMoveCondition,
   type GroupMoveRules,
@@ -78,16 +78,16 @@ const validateRule = ({
   }
 
   // Validate value shape/constraints for the selected operator
-  const validateOperator =
-    GROUP_MOVE_OPERATOR_VALIDATORS[
-      rule.operator as keyof typeof GROUP_MOVE_OPERATOR_VALIDATORS
-    ];
+  const operator = COMPARISON_OPERATORS[rule.operator];
 
-  if (validateOperator) {
-    validateOperator({
-      rule,
-      ruleIndex,
-    });
+  if (operator) {
+    try {
+      operator.validate(rule.value);
+    } catch (error) {
+      throw new Error(
+        `Rule ${ruleIndex + 1}: ${error instanceof Error ? error.message : "Invalid value."}`,
+      );
+    }
   }
 
   // Validate attribute-specific constraints (business rules)

--- a/apps/web/lib/api/workflows/evaluate-workflow-conditions.ts
+++ b/apps/web/lib/api/workflows/evaluate-workflow-conditions.ts
@@ -1,5 +1,5 @@
 import { WorkflowCondition, WorkflowConditionAttribute } from "@/lib/types";
-import { OPERATOR_FUNCTIONS } from "@/lib/zod/schemas/workflows";
+import { COMPARISON_OPERATORS } from "./operators";
 
 export function evaluateWorkflowConditions({
   conditions,
@@ -11,9 +11,9 @@ export function evaluateWorkflowConditions({
   if (conditions.length === 0) return false;
 
   for (const condition of conditions) {
-    const operatorFn = OPERATOR_FUNCTIONS[condition.operator];
+    const operator = COMPARISON_OPERATORS[condition.operator];
 
-    if (!operatorFn) {
+    if (!operator) {
       console.error(`Operator ${condition.operator} is not supported.`);
       return false;
     }
@@ -25,7 +25,7 @@ export function evaluateWorkflowConditions({
       return false;
     }
 
-    if (!operatorFn(attributeValue, condition.value)) {
+    if (!operator.evaluate(attributeValue, condition.value)) {
       return false;
     }
   }

--- a/apps/web/lib/api/workflows/operators.ts
+++ b/apps/web/lib/api/workflows/operators.ts
@@ -1,0 +1,66 @@
+import { WorkflowComparisonOperator } from "@/lib/types";
+
+type ConditionValue = number | { min: number; max?: number };
+
+type ComparisonOperator = {
+  validate: (value: ConditionValue) => void;
+  evaluate: (attributeValue: number, conditionValue: ConditionValue) => boolean;
+};
+
+export const COMPARISON_OPERATORS: Record<
+  WorkflowComparisonOperator,
+  ComparisonOperator
+> = {
+  // Greater than or equal to
+  gte: {
+    validate(value) {
+      if (typeof value !== "number" || isNaN(value) || value <= 0) {
+        throw new Error("Please enter a value greater than 0.");
+      }
+    },
+    evaluate(attributeValue, conditionValue) {
+      if (typeof conditionValue !== "number") {
+        return false;
+      }
+
+      return attributeValue >= conditionValue;
+    },
+  },
+
+  // Between (inclusive)
+  between: {
+    validate(value) {
+      if (typeof value !== "object" || value === null) {
+        throw new Error("Please enter a valid value.");
+      }
+
+      const min = value.min;
+      const max = value.max;
+
+      if (min == null || min === undefined || isNaN(min) || min <= 0) {
+        throw new Error("Please enter a minimum value greater than 0.");
+      }
+
+      if (max == null || max === undefined || isNaN(max) || max <= 0) {
+        throw new Error("Please enter a maximum value (limit) greater than 0.");
+      }
+
+      if (max <= min) {
+        throw new Error("Maximum value must be greater than minimum value.");
+      }
+    },
+    evaluate(attributeValue, conditionValue) {
+      if (typeof conditionValue !== "object" || conditionValue === null) {
+        return false;
+      }
+
+      const { min, max } = conditionValue;
+
+      if (min == null || max == null) {
+        return false;
+      }
+
+      return attributeValue >= min && attributeValue <= max;
+    },
+  },
+};

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -739,11 +739,6 @@ export type WorkflowComparisonOperator =
 
 export type WorkflowAction = z.infer<typeof workflowActionSchema>;
 
-export type OperatorFn = (
-  aV: number,
-  cV: number | { min: number; max?: number },
-) => boolean;
-
 export type BountySubmissionsQueryFilters = z.infer<
   typeof getBountySubmissionsQuerySchema
 >;

--- a/apps/web/lib/zod/schemas/group-move-workflows.ts
+++ b/apps/web/lib/zod/schemas/group-move-workflows.ts
@@ -54,6 +54,61 @@ export const groupMoveConditionSchema = z.object({
 
 export const groupMoveRulesSchema = z.array(groupMoveConditionSchema);
 
+export const GROUP_MOVE_OPERATOR_VALIDATORS = {
+  gte(rule: GroupMoveCondition, ruleIndex: number) {
+    if (
+      typeof rule.value !== "number" ||
+      isNaN(rule.value) ||
+      rule.value <= 0
+    ) {
+      throw new Error(
+        `Rule ${ruleIndex + 1}: Please enter a value greater than 0.`,
+      );
+    }
+  },
+
+  between(rule: GroupMoveCondition, ruleIndex: number) {
+    if (typeof rule.value !== "object" || rule.value === null) {
+      throw new Error(`Rule ${ruleIndex + 1}: Please enter a valid value.`);
+    }
+
+    const min = rule.value.min;
+    const max = rule.value.max;
+
+    if (min == null || min === undefined || isNaN(min) || min <= 0) {
+      throw new Error(
+        `Rule ${ruleIndex + 1}: Please enter a minimum value greater than 0.`,
+      );
+    }
+
+    if (max == null || max === undefined || isNaN(max) || max <= 0) {
+      throw new Error(
+        `Rule ${ruleIndex + 1}: Please enter a maximum value (limit) greater than 0.`,
+      );
+    }
+
+    // Ensure max is greater than min
+    if (max <= min) {
+      throw new Error(
+        `Rule ${ruleIndex + 1}: Maximum value must be greater than minimum value.`,
+      );
+    }
+  },
+} as const;
+
+// Add business rules for each attribute
+// Keeping this empty for now
+export const GROUP_MOVE_ATTRIBUTE_VALIDATORS: Record<
+  GroupMoveAttribute,
+  GroupMoveAttributeValidator
+> = {
+  // Operator validators already cover performance value shape/constraints.
+  totalLeads: () => {},
+  totalConversions: () => {},
+  totalSaleAmount: () => {},
+  totalCommissions: () => {},
+};
+
 export type GroupMoveCondition = z.infer<typeof groupMoveConditionSchema>;
 
 export type GroupMoveRules = z.infer<typeof groupMoveRulesSchema>;
@@ -67,3 +122,13 @@ export type GroupMoveAttributeConfig = {
   inputType: "number" | "currency";
   operators: readonly GroupMoveOperator[];
 };
+
+type GroupMoveAttributeValidatorArgs = {
+  rule: GroupMoveCondition;
+  ruleIndex: number;
+  destinationGroupId: string;
+};
+
+type GroupMoveAttributeValidator = (
+  params: GroupMoveAttributeValidatorArgs,
+) => void;

--- a/apps/web/lib/zod/schemas/group-move-workflows.ts
+++ b/apps/web/lib/zod/schemas/group-move-workflows.ts
@@ -54,48 +54,6 @@ export const groupMoveConditionSchema = z.object({
 
 export const groupMoveRulesSchema = z.array(groupMoveConditionSchema);
 
-export const GROUP_MOVE_OPERATOR_VALIDATORS = {
-  gte({ rule, ruleIndex }: GroupMoveAttributeValidatorArgs) {
-    if (
-      typeof rule.value !== "number" ||
-      isNaN(rule.value) ||
-      rule.value <= 0
-    ) {
-      throw new Error(
-        `Rule ${ruleIndex + 1}: Please enter a value greater than 0.`,
-      );
-    }
-  },
-
-  between({ rule, ruleIndex }: GroupMoveAttributeValidatorArgs) {
-    if (typeof rule.value !== "object" || rule.value === null) {
-      throw new Error(`Rule ${ruleIndex + 1}: Please enter a valid value.`);
-    }
-
-    const min = rule.value.min;
-    const max = rule.value.max;
-
-    if (min == null || min === undefined || isNaN(min) || min <= 0) {
-      throw new Error(
-        `Rule ${ruleIndex + 1}: Please enter a minimum value greater than 0.`,
-      );
-    }
-
-    if (max == null || max === undefined || isNaN(max) || max <= 0) {
-      throw new Error(
-        `Rule ${ruleIndex + 1}: Please enter a maximum value (limit) greater than 0.`,
-      );
-    }
-
-    // Ensure max is greater than min
-    if (max <= min) {
-      throw new Error(
-        `Rule ${ruleIndex + 1}: Maximum value must be greater than minimum value.`,
-      );
-    }
-  },
-} as const;
-
 export type GroupMoveCondition = z.infer<typeof groupMoveConditionSchema>;
 
 export type GroupMoveRules = z.infer<typeof groupMoveRulesSchema>;
@@ -108,9 +66,4 @@ export type GroupMoveAttributeConfig = {
   label: string;
   inputType: "number" | "currency";
   operators: readonly GroupMoveOperator[];
-};
-
-type GroupMoveAttributeValidatorArgs = {
-  rule: GroupMoveCondition;
-  ruleIndex: number;
 };

--- a/apps/web/lib/zod/schemas/group-move-workflows.ts
+++ b/apps/web/lib/zod/schemas/group-move-workflows.ts
@@ -55,7 +55,7 @@ export const groupMoveConditionSchema = z.object({
 export const groupMoveRulesSchema = z.array(groupMoveConditionSchema);
 
 export const GROUP_MOVE_OPERATOR_VALIDATORS = {
-  gte(rule: GroupMoveCondition, ruleIndex: number) {
+  gte({ rule, ruleIndex }: GroupMoveAttributeValidatorArgs) {
     if (
       typeof rule.value !== "number" ||
       isNaN(rule.value) ||
@@ -67,7 +67,7 @@ export const GROUP_MOVE_OPERATOR_VALIDATORS = {
     }
   },
 
-  between(rule: GroupMoveCondition, ruleIndex: number) {
+  between({ rule, ruleIndex }: GroupMoveAttributeValidatorArgs) {
     if (typeof rule.value !== "object" || rule.value === null) {
       throw new Error(`Rule ${ruleIndex + 1}: Please enter a valid value.`);
     }
@@ -96,19 +96,6 @@ export const GROUP_MOVE_OPERATOR_VALIDATORS = {
   },
 } as const;
 
-// Add business rules for each attribute
-// Keeping this empty for now
-export const GROUP_MOVE_ATTRIBUTE_VALIDATORS: Record<
-  GroupMoveAttribute,
-  GroupMoveAttributeValidator
-> = {
-  // Operator validators already cover performance value shape/constraints.
-  totalLeads: () => {},
-  totalConversions: () => {},
-  totalSaleAmount: () => {},
-  totalCommissions: () => {},
-};
-
 export type GroupMoveCondition = z.infer<typeof groupMoveConditionSchema>;
 
 export type GroupMoveRules = z.infer<typeof groupMoveRulesSchema>;
@@ -126,9 +113,4 @@ export type GroupMoveAttributeConfig = {
 type GroupMoveAttributeValidatorArgs = {
   rule: GroupMoveCondition;
   ruleIndex: number;
-  destinationGroupId: string;
 };
-
-type GroupMoveAttributeValidator = (
-  params: GroupMoveAttributeValidatorArgs,
-) => void;

--- a/apps/web/lib/zod/schemas/group-move-workflows.ts
+++ b/apps/web/lib/zod/schemas/group-move-workflows.ts
@@ -1,0 +1,69 @@
+import * as z from "zod/v4";
+
+export const GROUP_MOVE_ATTRIBUTES = [
+  "totalLeads",
+  "totalConversions",
+  "totalSaleAmount",
+  "totalCommissions",
+] as const;
+
+export const GROUP_MOVE_OPERATORS = ["gte", "between"] as const;
+
+export const GROUP_MOVE_ATTRIBUTE_CONFIG: Record<
+  GroupMoveAttribute,
+  GroupMoveAttributeConfig
+> = {
+  totalLeads: {
+    label: "total leads",
+    inputType: "number",
+    operators: ["gte", "between"],
+  },
+  totalConversions: {
+    label: "total conversions",
+    inputType: "number",
+    operators: ["gte", "between"],
+  },
+  totalSaleAmount: {
+    label: "total revenue",
+    inputType: "currency",
+    operators: ["gte", "between"],
+  },
+  totalCommissions: {
+    label: "total commissions",
+    inputType: "currency",
+    operators: ["gte", "between"],
+  },
+};
+
+export const GROUP_MOVE_OPERATOR_LABELS: Record<GroupMoveOperator, string> = {
+  gte: "more than",
+  between: "between",
+} as const;
+
+export const groupMoveConditionSchema = z.object({
+  attribute: z.enum(GROUP_MOVE_ATTRIBUTES),
+  operator: z.enum(GROUP_MOVE_OPERATORS).default("gte"),
+  value: z.union([
+    z.number(),
+    z.object({
+      min: z.number(),
+      max: z.number(),
+    }),
+  ]),
+});
+
+export const groupMoveRulesSchema = z.array(groupMoveConditionSchema);
+
+export type GroupMoveCondition = z.infer<typeof groupMoveConditionSchema>;
+
+export type GroupMoveRules = z.infer<typeof groupMoveRulesSchema>;
+
+export type GroupMoveAttribute = (typeof GROUP_MOVE_ATTRIBUTES)[number];
+
+type GroupMoveOperator = (typeof GROUP_MOVE_OPERATORS)[number];
+
+export type GroupMoveAttributeConfig = {
+  label: string;
+  inputType: "number" | "currency";
+  operators: readonly GroupMoveOperator[];
+};

--- a/apps/web/lib/zod/schemas/groups.ts
+++ b/apps/web/lib/zod/schemas/groups.ts
@@ -7,13 +7,13 @@ import slugify from "@sindresorhus/slugify";
 import * as z from "zod/v4";
 import { DiscountSchema } from "./discount";
 import { GroupBountySummarySchema } from "./group-bounties";
+import { groupMoveRulesSchema } from "./group-move-workflows";
 import { booleanQuerySchema, getPaginationQuerySchema } from "./misc";
 import { programApplicationFormSchema } from "./program-application-form";
 import { programLanderSchema } from "./program-lander";
 import { RewardSchema } from "./rewards";
 import { centsSchemaWithDefault, parseUrlSchema } from "./utils";
 import { UTMTemplateSchema } from "./utm";
-import { workflowConditionSchema } from "./workflows";
 
 export const DEFAULT_PARTNER_GROUP = {
   name: "Default Group",
@@ -73,7 +73,7 @@ export const GroupSchema = z.object({
   additionalLinks: z.array(additionalPartnerLinkSchema).nullable(),
   maxPartnerLinks: z.number(),
   linkStructure: z.enum(PartnerLinkStructure),
-  moveRules: z.array(workflowConditionSchema).nullish().default(null),
+  moveRules: groupMoveRulesSchema.nullish().default(null),
 });
 
 export const GroupWithFormDataSchema = GroupSchema.extend({
@@ -152,7 +152,7 @@ export const updateGroupSchema = createGroupSchema.partial().extend({
   autoApprovePartners: z.coerce.boolean().optional(),
   updateAutoApprovePartnersForAllGroups: z.coerce.boolean().optional(),
   updateHoldingPeriodDaysForAllGroups: z.coerce.boolean().optional(),
-  moveRules: z.array(workflowConditionSchema).optional(),
+  moveRules: groupMoveRulesSchema.optional(),
 });
 
 export const PartnerGroupDefaultLinkSchema = z.object({

--- a/apps/web/lib/zod/schemas/workflows.ts
+++ b/apps/web/lib/zod/schemas/workflows.ts
@@ -63,14 +63,6 @@ export const OPERATOR_FUNCTIONS: Record<
   },
 };
 
-export const WORKFLOW_COMPARISON_OPERATOR_LABELS: Record<
-  WorkflowComparisonOperator,
-  string
-> = {
-  gte: "more than",
-  between: "between",
-} as const;
-
 export enum WORKFLOW_ACTION_TYPES {
   AwardBounty = "awardBounty",
   SendCampaign = "sendCampaign",

--- a/apps/web/lib/zod/schemas/workflows.ts
+++ b/apps/web/lib/zod/schemas/workflows.ts
@@ -1,14 +1,6 @@
-import {
-  WorkflowComparisonOperator,
-  WorkflowConditionAttribute,
-} from "@/lib/types";
+import { WorkflowConditionAttribute } from "@/lib/types";
 import { WorkflowTrigger } from "@prisma/client";
 import * as z from "zod/v4";
-
-type OperatorFn = (
-  aV: number,
-  cV: number | { min: number; max?: number },
-) => boolean;
 
 export const WORKFLOW_ATTRIBUTES = [
   "totalLeads",
@@ -39,32 +31,6 @@ export const SCHEDULED_WORKFLOW_TRIGGERS: WorkflowTrigger[] = [
 
 export const WORKFLOW_SCHEDULES: Partial<Record<WorkflowTrigger, string>> = {
   partnerEnrolled: "0 */12 * * *", // every 12 hours
-};
-
-export const OPERATOR_FUNCTIONS: Record<
-  WorkflowComparisonOperator,
-  OperatorFn
-> = {
-  gte: (aV, cV) => {
-    if (typeof cV !== "number") {
-      return false;
-    }
-
-    return aV >= cV;
-  },
-  between: (aV, cV) => {
-    if (typeof cV !== "object" || cV === null) {
-      return false;
-    }
-
-    const { min, max } = cV;
-
-    if (min == null || max == null) {
-      return false;
-    }
-
-    return aV >= min && aV <= max;
-  },
 };
 
 export enum WORKFLOW_ACTION_TYPES {

--- a/apps/web/lib/zod/schemas/workflows.ts
+++ b/apps/web/lib/zod/schemas/workflows.ts
@@ -1,10 +1,14 @@
 import {
-  OperatorFn,
   WorkflowComparisonOperator,
   WorkflowConditionAttribute,
 } from "@/lib/types";
 import { WorkflowTrigger } from "@prisma/client";
 import * as z from "zod/v4";
+
+type OperatorFn = (
+  aV: number,
+  cV: number | { min: number; max?: number },
+) => boolean;
 
 export const WORKFLOW_ATTRIBUTES = [
   "totalLeads",

--- a/apps/web/tests/workflows/comparison-operators.test.ts
+++ b/apps/web/tests/workflows/comparison-operators.test.ts
@@ -1,0 +1,101 @@
+import { COMPARISON_OPERATORS } from "@/lib/api/workflows/operators";
+import { describe, expect, it } from "vitest";
+
+describe("COMPARISON_OPERATORS.gte.evaluate", () => {
+  const { evaluate } = COMPARISON_OPERATORS.gte;
+
+  it("returns true when attribute value is greater than or equal to condition", () => {
+    expect(evaluate(10, 10)).toBe(true);
+    expect(evaluate(11, 10)).toBe(true);
+  });
+
+  it("returns false when attribute value is less than condition", () => {
+    expect(evaluate(9, 10)).toBe(false);
+  });
+
+  it("returns false when condition value is not a number", () => {
+    expect(evaluate(10, { min: 1, max: 5 })).toBe(false);
+  });
+});
+
+describe("COMPARISON_OPERATORS.between.evaluate", () => {
+  const { evaluate } = COMPARISON_OPERATORS.between;
+
+  it("returns true when attribute value is within inclusive range", () => {
+    expect(evaluate(1, { min: 1, max: 5 })).toBe(true);
+    expect(evaluate(3, { min: 1, max: 5 })).toBe(true);
+    expect(evaluate(5, { min: 1, max: 5 })).toBe(true);
+  });
+
+  it("returns false when attribute value is outside range", () => {
+    expect(evaluate(0, { min: 1, max: 5 })).toBe(false);
+    expect(evaluate(6, { min: 1, max: 5 })).toBe(false);
+  });
+
+  it("returns false when condition value is missing or invalid", () => {
+    expect(evaluate(3, 3)).toBe(false);
+    expect(evaluate(3, { min: 1 })).toBe(false);
+    expect(evaluate(3, null as unknown as { min: number; max: number })).toBe(
+      false,
+    );
+  });
+});
+
+describe("COMPARISON_OPERATORS.gte.validate", () => {
+  const { validate } = COMPARISON_OPERATORS.gte;
+
+  it("accepts a positive number", () => {
+    expect(() => validate(1)).not.toThrow();
+    expect(() => validate(100)).not.toThrow();
+  });
+
+  it("rejects non-number, NaN, and non-positive values", () => {
+    expect(() => validate({ min: 1, max: 5 })).toThrow(
+      "Please enter a value greater than 0.",
+    );
+    expect(() => validate(NaN)).toThrow(
+      "Please enter a value greater than 0.",
+    );
+    expect(() => validate(0)).toThrow("Please enter a value greater than 0.");
+    expect(() => validate(-1)).toThrow("Please enter a value greater than 0.");
+  });
+});
+
+describe("COMPARISON_OPERATORS.between.validate", () => {
+  const { validate } = COMPARISON_OPERATORS.between;
+
+  it("accepts a valid min/max range", () => {
+    expect(() => validate({ min: 1, max: 5 })).not.toThrow();
+  });
+
+  it("rejects an invalid value shape", () => {
+    expect(() => validate(5)).toThrow("Please enter a valid value.");
+  });
+
+  it("rejects non-positive or missing min", () => {
+    expect(() => validate({ min: 0, max: 5 })).toThrow(
+      "Please enter a minimum value greater than 0.",
+    );
+    expect(() => validate({ min: NaN, max: 5 })).toThrow(
+      "Please enter a minimum value greater than 0.",
+    );
+  });
+
+  it("rejects non-positive or missing max", () => {
+    expect(() => validate({ min: 1, max: 0 })).toThrow(
+      "Please enter a maximum value (limit) greater than 0.",
+    );
+    expect(() => validate({ min: 1 })).toThrow(
+      "Please enter a maximum value (limit) greater than 0.",
+    );
+  });
+
+  it("rejects when max is less than or equal to min", () => {
+    expect(() => validate({ min: 5, max: 5 })).toThrow(
+      "Maximum value must be greater than minimum value.",
+    );
+    expect(() => validate({ min: 5, max: 4 })).toThrow(
+      "Maximum value must be greater than minimum value.",
+    );
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added schema-driven group move rules with a dedicated set of supported attributes and operators, including numeric “greater than or equal” and bounded “between” ranges.
* **Bug Fixes**
  * Improved group move rule validation and rule overlap/matching consistency; validation now considers the destination group for more accurate feedback.
* **Tests**
  * Added unit coverage for comparison-operator evaluation and validation, ensuring correct inclusive boundary handling and graceful failures for invalid inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->