### PR TITLE
Fix broken link, replace `isProgramPage with `useCurrentProduct`

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/customers/(index)/page.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/customers/(index)/page.tsx
@@ -6,9 +6,6 @@ import { CustomersTable } from "@/ui/customers/customers-table/customers-table";
 export default function ProgramCustomersPage() {
   const { defaultProgramId } = useWorkspace();
   return (
-    <CustomersTable
-      query={{ programId: defaultProgramId || undefined }}
-      isProgramPage
-    />
+    <CustomersTable query={{ programId: defaultProgramId || undefined }} />
   );
 }

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/customers/[customerId]/layout.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/customers/[customerId]/layout.tsx
@@ -84,12 +84,11 @@ export default function ProgramCustomerLayout({
               customerActivity={customerActivity}
               isCustomerActivityLoading={!customer || isCustomerActivityLoading}
               workspaceSlug={workspaceSlug}
-              isProgramPage
             />
           </div>
           <div className="@3xl/page:order-1">
             <div className="border-border-subtle overflow-hidden rounded-xl border bg-neutral-100">
-              <CustomerTabs customer={customer} isProgramPage />
+              <CustomerTabs customer={customer} />
               <div className="border-border-subtle -mx-px -mb-px rounded-xl border bg-white p-4">
                 {children}
               </div>

--- a/apps/web/lib/swr/use-customers-count.ts
+++ b/apps/web/lib/swr/use-customers-count.ts
@@ -1,4 +1,4 @@
-import { useRouterStuff } from "@dub/ui";
+import { useCurrentProduct, useRouterStuff } from "@dub/ui";
 import { fetcher } from "@dub/utils";
 import useSWR from "swr";
 import * as z from "zod/v4";
@@ -14,14 +14,23 @@ export default function useCustomersCount<T = number>({
   enabled?: boolean;
   includeParams?: string[];
 } = {}) {
-  const { id: workspaceId } = useWorkspace();
+  const { id: workspaceId, defaultProgramId } = useWorkspace();
   const { getQueryString } = useRouterStuff();
+  const { product } = useCurrentProduct();
 
   const { data, error, isLoading } = useSWR<T>(
     enabled &&
       workspaceId &&
+      product &&
       `/api/customers/count${getQueryString(
-        { workspaceId, ...query },
+        {
+          workspaceId,
+          ...(product === "program" &&
+            defaultProgramId && {
+              programId: defaultProgramId,
+            }),
+          ...query,
+        },
         {
           include: includeParams,
         },

--- a/apps/web/ui/analytics/events/events-table.tsx
+++ b/apps/web/ui/analytics/events/events-table.tsx
@@ -276,7 +276,7 @@ export default function EventsTable({
               href={
                 partnerPage
                   ? `/programs/${programSlug}/customers/${getValue().id}`
-                  : `/${slug}/links/customers/${getValue().id}`
+                  : `/${slug}/${product}/customers/${getValue().id}`
               }
               className="px-4 py-2.5"
             />

--- a/apps/web/ui/customers/customer-details-column.tsx
+++ b/apps/web/ui/customers/customer-details-column.tsx
@@ -9,6 +9,7 @@ import {
   Hyperlink,
   TimestampTooltip,
   Tooltip,
+  useCurrentProduct,
   UTM_PARAMETERS,
 } from "@dub/ui";
 import {
@@ -30,16 +31,16 @@ export function CustomerDetailsColumn({
   customer,
   customerActivity,
   isCustomerActivityLoading,
-  isProgramPage = false,
   workspaceSlug,
 }: {
   customer?: CustomerEnriched;
   customerActivity?: CustomerActivityResponse;
   isCustomerActivityLoading: boolean;
-  isProgramPage?: boolean;
   workspaceSlug?: string;
 }) {
   const { programSlug } = useParams<{ programSlug: string }>();
+  const { product } = useCurrentProduct();
+
   const { EditCustomerModal, openEditCustomerModal } = useEditCustomerModal();
 
   const basicFields = [
@@ -224,7 +225,7 @@ export function CustomerDetailsColumn({
                             href={
                               value === "Unknown"
                                 ? undefined
-                                : `/${workspaceSlug || `programs/${programSlug}`}/${isProgramPage ? "program/" : ""}analytics?${key}=${encodeURIComponent(value)}`
+                                : `/${workspaceSlug ? `${workspaceSlug}/${product}` : `programs/${programSlug}`}/analytics?${key}=${encodeURIComponent(value)}`
                             }
                             target="_blank"
                           >
@@ -286,7 +287,7 @@ export function CustomerDetailsColumn({
                         <ConditionalLink
                           href={
                             workspaceSlug
-                              ? `/${workspaceSlug}/${isProgramPage ? "program/" : ""}analytics?${key}=${encodeURIComponent(value)}`
+                              ? `/${workspaceSlug}/${product}/analytics?${key}=${encodeURIComponent(value)}`
                               : undefined
                           }
                           target="_blank"

--- a/apps/web/ui/customers/customer-tabs.tsx
+++ b/apps/web/ui/customers/customer-tabs.tsx
@@ -1,19 +1,18 @@
 import useWorkspace from "@/lib/swr/use-workspace";
 import { CustomerEnriched } from "@/lib/types";
-import { MoneyBills2, Receipt2 } from "@dub/ui";
+import { MoneyBills2, Receipt2, useCurrentProduct } from "@dub/ui";
 import { useParams } from "next/navigation";
 import { useMemo } from "react";
 import { PageNavTabs } from "../layout/page-nav-tabs";
 
 export function CustomerTabs({
   customer,
-  isProgramPage = false,
 }: {
   customer?: Pick<CustomerEnriched, "programId" | "partner">;
-  isProgramPage?: boolean;
 }) {
   const { customerId } = useParams<{ customerId: string }>();
   const { slug: workspaceSlug } = useWorkspace();
+  const { product } = useCurrentProduct();
 
   const tabs = useMemo(
     () => [
@@ -37,11 +36,7 @@ export function CustomerTabs({
 
   return (
     <PageNavTabs
-      basePath={
-        isProgramPage
-          ? `/${workspaceSlug}/program/customers/${customerId}`
-          : `/${workspaceSlug}/customers/${customerId}`
-      }
+      basePath={`/${workspaceSlug}/${product}/customers/${customerId}`}
       tabs={tabs}
     />
   );

--- a/apps/web/ui/customers/customers-table/customers-table.tsx
+++ b/apps/web/ui/customers/customers-table/customers-table.tsx
@@ -25,6 +25,7 @@ import {
   TimestampTooltip,
   useColumnVisibility,
   useCopyToClipboard,
+  useCurrentProduct,
   usePagination,
   useRouterStuff,
   useTable,
@@ -59,12 +60,11 @@ type ColumnMeta = {
 
 export function CustomersTable({
   query,
-  isProgramPage = false,
 }: {
   query?: Partial<z.infer<typeof getCustomersQuerySchema>>;
-  isProgramPage?: boolean;
 }) {
   const { id: workspaceId, slug: workspaceSlug, plan } = useWorkspace();
+  const { product } = useCurrentProduct();
   const { canManageCustomers } = getPlanCapabilities(plan);
 
   const router = useRouter();
@@ -104,7 +104,7 @@ export function CustomersTable({
     all: [
       "customer",
       "country",
-      ...(isProgramPage ? ["partner"] : []),
+      ...(product === "program" ? ["partner"] : ["link"]),
       "link",
       "saleAmount",
       "createdAt",
@@ -115,7 +115,7 @@ export function CustomersTable({
     defaultVisible: [
       "customer",
       "country",
-      ...(isProgramPage ? ["partner"] : ["link"]),
+      ...(product === "program" ? ["partner"] : ["link"]),
       "saleAmount",
       "createdAt",
       "firstSaleAt",
@@ -124,7 +124,7 @@ export function CustomersTable({
   };
 
   const { columnVisibility, setColumnVisibility } = useColumnVisibility(
-    isProgramPage
+    product === "program"
       ? "program-customers-table-columns"
       : "customers-table-columns",
     customersColumns,
@@ -328,13 +328,11 @@ export function CustomersTable({
           cell: ({ row }) => <RowMenuButton row={row} />,
         },
       ].filter((c) => c.id === "menu" || customersColumns.all.includes(c.id)),
-    [isProgramPage, workspaceSlug],
+    [product, workspaceSlug],
   );
 
   const getCustomerUrl = (row: Row<CustomerProps>) =>
-    isProgramPage
-      ? `/${workspaceSlug}/program/customers/${row.original.id}`
-      : `/${workspaceSlug}/links/customers/${row.original.id}`;
+    `/${workspaceSlug}/${product}/customers/${row.original.id}`;
 
   const { table, ...tableProps } = useTable({
     data: canManageCustomers ? customers || [] : EXAMPLE_CUSTOMER_DATA,
@@ -398,7 +396,6 @@ export function CustomersTable({
         sortBy={sortBy}
         sortOrder={sortOrder}
         enabled={canManageCustomers}
-        isProgramPage={isProgramPage}
       />
       {!canManageCustomers || customers?.length !== 0 ? (
         <Table
@@ -486,12 +483,10 @@ function CustomersFilters({
   sortBy,
   sortOrder,
   enabled,
-  isProgramPage,
 }: {
   sortBy: string;
   sortOrder: "asc" | "desc";
   enabled: boolean;
-  isProgramPage: boolean;
 }) {
   const {
     filters,
@@ -501,7 +496,7 @@ function CustomersFilters({
     onRemoveAll,
     setSearch,
     setSelectedFilter,
-  } = useCustomerFilters({ sortBy, sortOrder }, { enabled, isProgramPage });
+  } = useCustomerFilters({ sortBy, sortOrder }, { enabled });
 
   return (
     <div>

--- a/apps/web/ui/customers/customers-table/use-customer-filters.tsx
+++ b/apps/web/ui/customers/customers-table/use-customer-filters.tsx
@@ -17,13 +17,10 @@ import { useDebounce } from "use-debounce";
 
 export function useCustomerFilters(
   extraSearchParams: Record<string, string>,
-  {
-    enabled = true,
-    isProgramPage = false,
-  }: { enabled?: boolean; isProgramPage?: boolean } = {},
+  { enabled = true }: { enabled?: boolean } = {},
 ) {
   const { searchParamsObj, queryParams } = useRouterStuff();
-  const { id: workspaceId, slug, defaultProgramId } = useWorkspace();
+  const { id: workspaceId, slug } = useWorkspace();
 
   const [selectedFilter, setSelectedFilter] = useState<string | null>(null);
   const [search, setSearch] = useState("");
@@ -42,10 +39,6 @@ export function useCustomerFilters(
   >({
     query: {
       groupBy: "country",
-      ...(isProgramPage &&
-        defaultProgramId && {
-          programId: defaultProgramId,
-        }),
     },
     enabled,
   });
@@ -61,10 +54,6 @@ export function useCustomerFilters(
   >({
     query: {
       groupBy: "linkId",
-      ...(isProgramPage &&
-        defaultProgramId && {
-          programId: defaultProgramId,
-        }),
     },
     enabled,
   });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected customer counts and filtering in program views by using the current workspace and product context for queries.
  * Updated customer navigation across tables, tabs, and details to use consistent product-based routes.
  * Fixed analytics link destinations so “device/browser/os” and UTM tracking point to the appropriate customer pages.
  * Standardized customer table and filters behavior by removing the need for an explicit “program page” flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->