### PR TITLE
Add partner group source condition to group move rules.

### DIFF
--- a/apps/web/app/(ee)/api/groups/[groupIdOrSlug]/route.ts
+++ b/apps/web/app/(ee)/api/groups/[groupIdOrSlug]/route.ts
@@ -2,6 +2,7 @@ import { recordAuditLog } from "@/lib/api/audit-logs/record-audit-log";
 import { DubApiError } from "@/lib/api/errors";
 import { getGroupOrThrow } from "@/lib/api/groups/get-group-or-throw";
 import { movePartnersToGroup } from "@/lib/api/groups/move-partners-to-group";
+import { removeGroupIdFromMoveRules } from "@/lib/api/groups/remove-group-id-from-move-rules";
 import { upsertGroupMoveRules } from "@/lib/api/groups/upsert-group-move-rules";
 import { getDefaultProgramIdOrThrow } from "@/lib/api/programs/get-default-program-id-or-throw";
 import { parseRequestBody } from "@/lib/api/utils";
@@ -386,20 +387,27 @@ export const DELETE = withWorkspace(
 
     if (deletedGroup) {
       waitUntil(
-        recordAuditLog({
-          workspaceId: workspace.id,
-          programId,
-          action: "group.deleted",
-          description: `Group ${group.name} (${group.id}) deleted`,
-          actor: session.user,
-          targets: [
-            {
-              type: "group",
-              id: group.id,
-              metadata: group,
-            },
-          ],
-        }),
+        Promise.allSettled([
+          recordAuditLog({
+            workspaceId: workspace.id,
+            programId,
+            action: "group.deleted",
+            description: `Group ${group.name} (${group.id}) deleted`,
+            actor: session.user,
+            targets: [
+              {
+                type: "group",
+                id: group.id,
+                metadata: group,
+              },
+            ],
+          }),
+
+          removeGroupIdFromMoveRules({
+            programId,
+            groupId: group.id,
+          }),
+        ]),
       );
     }
 

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/campaigns/[campaignId]/duplicate-logic-warning.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/campaigns/[campaignId]/duplicate-logic-warning.tsx
@@ -1,6 +1,6 @@
+import { sendCampaignConditionSchema } from "@/lib/api/workflows/send-campaign/schema";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { CampaignList } from "@/lib/types";
-import { sendCampaignConditionSchema } from "@/lib/api/workflows/send-campaign/schema";
 import { ChevronUp, Copy, LoadingSpinner } from "@dub/ui";
 import { cn, fetcher } from "@dub/utils";
 import Link from "next/link";

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/groups/[groupSlug]/settings/group-additional-settings.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/groups/[groupSlug]/settings/group-additional-settings.tsx
@@ -8,6 +8,7 @@ import useGroup from "@/lib/swr/use-group";
 import { useGroupMoveRules } from "@/lib/swr/use-group-move-rules";
 import { GroupProps } from "@/lib/types";
 import { updateGroupSchema } from "@/lib/zod/schemas/groups";
+import { workflowConditionsSchema } from "@/lib/zod/schemas/workflows";
 import { GroupSettingsRow } from "@/ui/partners/groups/group-settings-row";
 import { Button, Checkbox, Modal, Switch } from "@dub/ui";
 import { pluralize } from "@dub/utils";
@@ -117,8 +118,15 @@ function GroupAdditionalSettingsForm({
   const onSubmit = async (data: FormData) => {
     if (!group) return;
     if (data.moveRules && data.moveRules.length > 0) {
-      // TODO
-      // Add a client-only validation for the move rules
+      const parsed = workflowConditionsSchema.safeParse(data.moveRules);
+
+      if (!parsed.success) {
+        toast.error(
+          parsed.error.issues[0]?.message ??
+            "Please complete the group move rule.",
+        );
+        return;
+      }
 
       if (groups) {
         const groupsWithMatchingRules = findGroupsWithMatchingRules({

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/groups/[groupSlug]/settings/group-move-rules.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/groups/[groupSlug]/settings/group-move-rules.tsx
@@ -130,7 +130,7 @@ export function GroupMoveRules() {
                 attribute === rule.attribute ||
                 !usedMetricAttributes.includes(attribute),
             );
-            const isLastMetric = metricIndex === metricRuleIndexes.length - 1;
+            const isFirstMetric = metricIndex === 0;
 
             return (
               <Fragment key={ruleFields[index]?.id ?? index}>
@@ -147,7 +147,7 @@ export function GroupMoveRules() {
                   }}
                   onRemove={() => handleRemoveRule(index)}
                   nestedCondition={
-                    isLastMetric
+                    isFirstMetric
                       ? hasPartnerGroupCondition
                         ? {
                             rule: moveRules[partnerGroupRuleIndex]!,

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/groups/[groupSlug]/settings/group-move-rules.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/groups/[groupSlug]/settings/group-move-rules.tsx
@@ -130,6 +130,7 @@ export function GroupMoveRules() {
                 attribute === rule.attribute ||
                 !usedMetricAttributes.includes(attribute),
             );
+            const isLastMetric = metricIndex === metricRuleIndexes.length - 1;
 
             return (
               <Fragment key={ruleFields[index]?.id ?? index}>
@@ -145,46 +146,38 @@ export function GroupMoveRules() {
                     });
                   }}
                   onRemove={() => handleRemoveRule(index)}
+                  nestedCondition={
+                    isLastMetric
+                      ? hasPartnerGroupCondition
+                        ? {
+                            rule: moveRules[partnerGroupRuleIndex]!,
+                            onUpdate: (updatedRule) => {
+                              updateRule(partnerGroupRuleIndex, {
+                                ...moveRules[partnerGroupRuleIndex],
+                                ...updatedRule,
+                              });
+                            },
+                            onRemove: () => removeRule(partnerGroupRuleIndex),
+                          }
+                        : canAddPartnerGroupCondition
+                          ? {
+                              onAdd: () => {
+                                appendRule({
+                                  attribute: "partnerGroup",
+                                  operator: "eq",
+                                  value: undefined,
+                                } as unknown as WorkflowCondition);
+                              },
+                            }
+                          : undefined
+                      : undefined
+                  }
                 />
 
                 <div className="ml-6 h-4 w-px bg-neutral-200" />
               </Fragment>
             );
           })}
-
-          {hasPartnerGroupCondition && (
-            <>
-              <PartnerGroupCondition
-                rule={moveRules[partnerGroupRuleIndex]!}
-                onUpdate={(updatedRule) => {
-                  updateRule(partnerGroupRuleIndex, {
-                    ...moveRules[partnerGroupRuleIndex],
-                    ...updatedRule,
-                  });
-                }}
-                onRemove={() => removeRule(partnerGroupRuleIndex)}
-              />
-              <div className="ml-6 h-4 w-px bg-neutral-200" />
-            </>
-          )}
-
-          {canAddPartnerGroupCondition && (
-            <>
-              <Button
-                text="Add condition"
-                variant="secondary"
-                className="h-8 w-fit rounded-lg px-3"
-                onClick={() => {
-                  appendRule({
-                    attribute: "partnerGroup",
-                    operator: "eq",
-                    value: undefined,
-                  } as unknown as WorkflowCondition);
-                }}
-              />
-              <div className="ml-6 h-4 w-px bg-neutral-200" />
-            </>
-          )}
 
           <GroupMoveTarget />
         </div>
@@ -218,6 +211,7 @@ function MetricGroupRule({
   rule,
   onUpdate,
   onRemove,
+  nestedCondition,
   index,
   metricIndex,
   availableAttributes,
@@ -225,6 +219,13 @@ function MetricGroupRule({
   rule: WorkflowCondition;
   onUpdate: (updates: Partial<WorkflowCondition>) => void;
   onRemove: () => void;
+  nestedCondition?:
+    | { onAdd: () => void }
+    | {
+        rule: WorkflowCondition;
+        onUpdate: (updates: Partial<WorkflowCondition>) => void;
+        onRemove: () => void;
+      };
   index: number;
   metricIndex: number;
   availableAttributes: MetricAttributeKey[];
@@ -271,9 +272,9 @@ function MetricGroupRule({
   };
 
   return (
-    <div className="flex flex-col rounded-lg border border-neutral-200 bg-white">
+    <div className="flex flex-col overflow-hidden rounded-xl border border-neutral-200 bg-white shadow-[0_2px_4px_0_rgba(0,0,0,0.03)]">
       <div className="flex items-center justify-between p-2.5 pr-3">
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2.5">
           <div className="flex size-7 shrink-0 items-center justify-center rounded-md bg-neutral-100">
             {isFirst ? (
               <Users className="size-4 text-neutral-600" />
@@ -367,6 +368,28 @@ function MetricGroupRule({
           <X className="size-4" />
         </button>
       </div>
+
+      {nestedCondition && (
+        <div className="rounded-xl border border-neutral-200 bg-neutral-100 px-2.5 pb-2.5">
+          <div className="pt-2.5">
+            {"onAdd" in nestedCondition ? (
+              <Button
+                text="Add condition"
+                variant="secondary"
+                className="h-8 w-full justify-center gap-2 rounded-lg border-neutral-200 bg-white px-3 hover:bg-neutral-50"
+                icon={<ArrowTurnRight2 className="size-4" />}
+                onClick={nestedCondition.onAdd}
+              />
+            ) : (
+              <PartnerGroupCondition
+                rule={nestedCondition.rule}
+                onUpdate={nestedCondition.onUpdate}
+                onRemove={nestedCondition.onRemove}
+              />
+            )}
+          </div>
+        </div>
+      )}
     </div>
   );
 }
@@ -412,11 +435,26 @@ function PartnerGroupCondition({
 
   const groupBadgeText = (() => {
     if (selectedGroups.length === 0) {
-      return isMulti ? "Select groups" : "Select group";
+      return isMulti ? "select groups" : "select group";
     }
 
     if (isMulti && selectedGroups.length > 1) {
-      return `${selectedGroups.length} Partner ${pluralize("Group", selectedGroups.length)}`;
+      return (
+        <span className="inline-flex items-center gap-2">
+          <span className="flex items-center">
+            {selectedGroups.slice(0, 2).map((group, index) => (
+              <span
+                key={group.id}
+                className={index > 0 ? "-ml-1.5" : undefined}
+              >
+                <GroupColorCircle group={group} />
+              </span>
+            ))}
+          </span>
+          {selectedGroups.length} Partner{" "}
+          {pluralize("Group", selectedGroups.length)}
+        </span>
+      );
     }
 
     return (
@@ -467,60 +505,55 @@ function PartnerGroupCondition({
   };
 
   return (
-    <div className="flex flex-col rounded-lg border border-neutral-200 bg-white">
-      <div className="flex items-center justify-between p-2.5 pr-3">
-        <div className="flex items-center gap-2">
-          <div className="flex size-7 shrink-0 items-center justify-center rounded-md bg-neutral-100">
-            <ArrowTurnRight2 className="size-4 text-neutral-600" />
-          </div>
-          <span className="text-sm font-medium text-neutral-800">
-            And if
-            <span className="mx-1 inline-block rounded bg-blue-50 px-1.5 text-sm font-semibold text-blue-700">
-              partner group
-            </span>
-            <InlineBadgePopover
-              text={
-                GROUP_MOVE_OPERATORS[
-                  selectedOperator as keyof typeof GROUP_MOVE_OPERATORS
-                ]?.label ?? "condition"
-              }
-              buttonClassName="mx-1"
-            >
-              <InlineBadgePopoverMenu
-                selectedValue={selectedOperator}
-                onSelect={handleOperatorSelect}
-                items={PARTNER_GROUP_OPERATORS.map((operator) => ({
-                  value: operator,
-                  text: GROUP_MOVE_OPERATORS[operator].label,
-                }))}
-              />
-            </InlineBadgePopover>
-            <InlineBadgePopover
-              text={groupBadgeText}
-              invalid={selectedGroupIds.length === 0}
-              buttonClassName="mx-1"
-            >
-              <InlineBadgePopoverMenu
-                search
-                selectedValue={isMulti ? selectedGroupIds : selectedGroupIds[0]}
-                onSelect={handleGroupSelect}
-                items={availableGroups.map((group) => ({
-                  value: group.id,
-                  text: group.name,
-                  icon: <GroupColorCircle group={group} />,
-                }))}
-              />
-            </InlineBadgePopover>
-          </span>
+    <div className="flex items-center justify-between rounded-[10px] border border-neutral-200 bg-white p-2.5 pr-3 shadow-[0_2px_2px_0_rgba(0,0,0,0.03)]">
+      <div className="flex items-center gap-2.5">
+        <div className="flex size-7 shrink-0 items-center justify-center rounded-md bg-neutral-100">
+          <ArrowTurnRight2 className="size-4 text-neutral-600" />
         </div>
-        <button
-          type="button"
-          onClick={onRemove}
-          className="rounded p-1 text-neutral-400 hover:bg-neutral-100 hover:text-neutral-600"
-        >
-          <X className="size-4" />
-        </button>
+        <span className="text-sm font-medium text-neutral-800">
+          And if partner group
+          <InlineBadgePopover
+            text={
+              GROUP_MOVE_OPERATORS[
+                selectedOperator as keyof typeof GROUP_MOVE_OPERATORS
+              ]?.label ?? "condition"
+            }
+            buttonClassName="mx-1"
+          >
+            <InlineBadgePopoverMenu
+              selectedValue={selectedOperator}
+              onSelect={handleOperatorSelect}
+              items={PARTNER_GROUP_OPERATORS.map((operator) => ({
+                value: operator,
+                text: GROUP_MOVE_OPERATORS[operator].label,
+              }))}
+            />
+          </InlineBadgePopover>
+          <InlineBadgePopover
+            text={groupBadgeText}
+            invalid={selectedGroupIds.length === 0}
+            buttonClassName="mx-1"
+          >
+            <InlineBadgePopoverMenu
+              search
+              selectedValue={isMulti ? selectedGroupIds : selectedGroupIds[0]}
+              onSelect={handleGroupSelect}
+              items={availableGroups.map((group) => ({
+                value: group.id,
+                text: group.name,
+                icon: <GroupColorCircle group={group} />,
+              }))}
+            />
+          </InlineBadgePopover>
+        </span>
       </div>
+      <button
+        type="button"
+        onClick={onRemove}
+        className="rounded p-1 text-neutral-400 hover:bg-neutral-100 hover:text-neutral-600"
+      >
+        <X className="size-4" />
+      </button>
     </div>
   );
 }

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/groups/[groupSlug]/settings/group-move-rules.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/groups/[groupSlug]/settings/group-move-rules.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import {
-  GROUP_MOVE_ATTRIBUTE_KEYS,
   GROUP_MOVE_ATTRIBUTES,
+  GROUP_MOVE_METRIC_ATTRIBUTE_KEYS,
+  GROUP_MOVE_OPERATORS,
 } from "@/lib/api/workflows/move-group/schema";
 import type {
   GroupMoveAttribute,
@@ -12,6 +13,7 @@ import type {
 import { WorkflowCondition } from "@/lib/api/workflows/types";
 import { getPlanCapabilities } from "@/lib/plan-capabilities";
 import useGroup from "@/lib/swr/use-group";
+import useGroups from "@/lib/swr/use-groups";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { useAdvancedUpsellModal } from "@/ui/partners/advanced-upsell-modal";
 import { GroupColorCircle } from "@/ui/partners/groups/group-color-circle";
@@ -21,19 +23,30 @@ import {
   InlineBadgePopoverMenu,
 } from "@/ui/shared/inline-badge-popover";
 import { ArrowTurnRight2, Button, UserArrowRight, Users } from "@dub/ui";
-import { currencyFormatter, nFormatter } from "@dub/utils";
+import { currencyFormatter, nFormatter, pluralize } from "@dub/utils";
 import { X } from "lucide-react";
 import { Fragment, useMemo } from "react";
 import { Controller, useFieldArray, useFormContext } from "react-hook-form";
 
 // Draft form value shapes (partial ranges allowed while editing)
 type RangeValue = { min: number; max?: number };
-type ValueType = number | RangeValue | undefined;
+type ValueType = number | RangeValue | string | string[] | undefined;
+
+type MetricAttributeKey = (typeof GROUP_MOVE_METRIC_ATTRIBUTE_KEYS)[number];
 
 const RANGE_SELECTOR_OPTIONS = [
   { text: "and no limit", value: "noLimit" },
   { text: "and less than", value: "lessThan" },
 ];
+
+const PARTNER_GROUP_OPERATORS = ["eq", "ne", "in", "notIn"] as const;
+
+const isMultiGroupOperator = (
+  operator: WorkflowCondition["operator"],
+): boolean => operator === "in" || operator === "notIn";
+
+const isPartnerGroupRule = (rule: WorkflowCondition | undefined) =>
+  rule?.attribute === "partnerGroup";
 
 export function GroupMoveRules() {
   const { plan } = useWorkspace();
@@ -49,24 +62,59 @@ export function GroupMoveRules() {
     append: appendRule,
     remove: removeRule,
     update: updateRule,
+    replace: replaceRules,
   } = useFieldArray({
     control,
     name: "moveRules",
     shouldUnregister: false,
   });
 
-  const usedAttributes = useMemo(
+  const metricRuleIndexes = useMemo(
     () =>
       moveRules
-        ?.map((r) => r.attribute)
-        .filter((a): a is NonNullable<typeof a> => a != null),
+        .map((rule, index) => ({ rule, index }))
+        .filter(({ rule }) => !isPartnerGroupRule(rule)),
     [moveRules],
   );
 
-  const disableAddRuleButton =
-    ruleFields.length >= GROUP_MOVE_ATTRIBUTE_KEYS.length;
+  const partnerGroupRuleIndex = useMemo(
+    () => moveRules.findIndex((rule) => isPartnerGroupRule(rule)),
+    [moveRules],
+  );
+
+  const hasPartnerGroupCondition = partnerGroupRuleIndex !== -1;
+
+  const usedMetricAttributes = useMemo(
+    () =>
+      metricRuleIndexes
+        .map(({ rule }) => rule.attribute)
+        .filter((a): a is NonNullable<typeof a> => a != null),
+    [metricRuleIndexes],
+  );
+
+  const canAddMetricRule =
+    usedMetricAttributes.length < GROUP_MOVE_METRIC_ATTRIBUTE_KEYS.length;
+
+  // Source group is only an additional condition after at least one metric rule
+  const canAddPartnerGroupCondition =
+    metricRuleIndexes.length > 0 && !hasPartnerGroupCondition;
 
   const { canUseGroupMoveRule } = getPlanCapabilities(plan);
+
+  const handleRemoveRule = (index: number) => {
+    const removingLastMetric =
+      !isPartnerGroupRule(moveRules[index]) &&
+      metricRuleIndexes.length === 1 &&
+      hasPartnerGroupCondition;
+
+    if (removingLastMetric) {
+      // Partner group can only exist as a second condition
+      replaceRules([]);
+      return;
+    }
+
+    removeRule(index);
+  };
 
   return (
     <>
@@ -76,24 +124,19 @@ export function GroupMoveRules() {
         <NoGroupRule />
       ) : (
         <div className="relative flex flex-col">
-          {ruleFields.map((field, index) => {
-            const rule = moveRules?.[index];
-            if (!rule) {
-              return null;
-            }
-
-            // Filter out attributes already used by other rules
-            const availableAttributes = GROUP_MOVE_ATTRIBUTE_KEYS.filter(
+          {metricRuleIndexes.map(({ rule, index }, metricIndex) => {
+            const availableAttributes = GROUP_MOVE_METRIC_ATTRIBUTE_KEYS.filter(
               (attribute) =>
                 attribute === rule.attribute ||
-                !usedAttributes?.includes(attribute),
+                !usedMetricAttributes.includes(attribute),
             );
 
             return (
-              <Fragment key={field.id}>
-                <GroupRule
+              <Fragment key={ruleFields[index]?.id ?? index}>
+                <MetricGroupRule
                   index={index}
                   rule={rule}
+                  metricIndex={metricIndex}
                   availableAttributes={availableAttributes}
                   onUpdate={(updatedRule) => {
                     updateRule(index, {
@@ -101,15 +144,47 @@ export function GroupMoveRules() {
                       ...updatedRule,
                     });
                   }}
-                  onRemove={() => {
-                    removeRule(index);
-                  }}
+                  onRemove={() => handleRemoveRule(index)}
                 />
 
                 <div className="ml-6 h-4 w-px bg-neutral-200" />
               </Fragment>
             );
           })}
+
+          {hasPartnerGroupCondition && (
+            <>
+              <PartnerGroupCondition
+                rule={moveRules[partnerGroupRuleIndex]!}
+                onUpdate={(updatedRule) => {
+                  updateRule(partnerGroupRuleIndex, {
+                    ...moveRules[partnerGroupRuleIndex],
+                    ...updatedRule,
+                  });
+                }}
+                onRemove={() => removeRule(partnerGroupRuleIndex)}
+              />
+              <div className="ml-6 h-4 w-px bg-neutral-200" />
+            </>
+          )}
+
+          {canAddPartnerGroupCondition && (
+            <>
+              <Button
+                text="Add condition"
+                variant="secondary"
+                className="h-8 w-fit rounded-lg px-3"
+                onClick={() => {
+                  appendRule({
+                    attribute: "partnerGroup",
+                    operator: "eq",
+                    value: undefined,
+                  } as unknown as WorkflowCondition);
+                }}
+              />
+              <div className="ml-6 h-4 w-px bg-neutral-200" />
+            </>
+          )}
 
           <GroupMoveTarget />
         </div>
@@ -127,9 +202,9 @@ export function GroupMoveRules() {
               value: undefined,
             } as unknown as WorkflowCondition);
           }}
-          disabled={disableAddRuleButton}
+          disabled={!canAddMetricRule && ruleFields.length > 0}
           disabledTooltip={
-            disableAddRuleButton
+            !canAddMetricRule && ruleFields.length > 0
               ? "All rules are in use. Delete existing rules."
               : undefined
           }
@@ -139,22 +214,24 @@ export function GroupMoveRules() {
   );
 }
 
-function GroupRule({
+function MetricGroupRule({
   rule,
   onUpdate,
   onRemove,
   index,
+  metricIndex,
   availableAttributes,
 }: {
   rule: WorkflowCondition;
   onUpdate: (updates: Partial<WorkflowCondition>) => void;
   onRemove: () => void;
   index: number;
-  availableAttributes: GroupMoveAttributeKey[];
+  metricIndex: number;
+  availableAttributes: MetricAttributeKey[];
 }) {
-  const isFirst = index === 0;
+  const isFirst = metricIndex === 0;
   const attributeConfig = rule.attribute
-    ? GROUP_MOVE_ATTRIBUTES[rule.attribute]
+    ? GROUP_MOVE_ATTRIBUTES[rule.attribute as GroupMoveAttributeKey]
     : undefined;
   const attributeType = attributeConfig?.inputType || "number";
 
@@ -219,7 +296,6 @@ function GroupRule({
                 }))}
                 selectedValue={rule.attribute}
                 onSelect={(value) => {
-                  // Reset to default gte operator when attribute changes
                   onUpdate({
                     ...rule,
                     attribute: value,
@@ -229,7 +305,6 @@ function GroupRule({
                 }}
               />
             </InlineBadgePopover>
-            {/* Select the attribute value */}
             {rule.attribute && (
               <>
                 is at least
@@ -282,6 +357,160 @@ function GroupRule({
                 )}
               </>
             )}
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={onRemove}
+          className="rounded p-1 text-neutral-400 hover:bg-neutral-100 hover:text-neutral-600"
+        >
+          <X className="size-4" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function PartnerGroupCondition({
+  rule,
+  onUpdate,
+  onRemove,
+}: {
+  rule: WorkflowCondition;
+  onUpdate: (updates: Partial<WorkflowCondition>) => void;
+  onRemove: () => void;
+}) {
+  const { group: currentGroup } = useGroup();
+  const { groups } = useGroups();
+
+  const availableGroups = useMemo(
+    () => groups?.filter((g) => g.id !== currentGroup?.id) ?? [],
+    [groups, currentGroup?.id],
+  );
+
+  const isMulti = isMultiGroupOperator(rule.operator);
+  const selectedOperator = PARTNER_GROUP_OPERATORS.includes(
+    rule.operator as (typeof PARTNER_GROUP_OPERATORS)[number],
+  )
+    ? rule.operator
+    : "eq";
+
+  const selectedGroupIds = useMemo(() => {
+    if (typeof rule.value === "string") {
+      return [rule.value];
+    }
+    if (Array.isArray(rule.value)) {
+      return rule.value;
+    }
+    return [];
+  }, [rule.value]);
+
+  const selectedGroups = useMemo(
+    () => (groups ?? []).filter((group) => selectedGroupIds.includes(group.id)),
+    [groups, selectedGroupIds],
+  );
+
+  const groupBadgeText = (() => {
+    if (selectedGroups.length === 0) {
+      return isMulti ? "Select groups" : "Select group";
+    }
+
+    if (isMulti && selectedGroups.length > 1) {
+      return `${selectedGroups.length} Partner ${pluralize("Group", selectedGroups.length)}`;
+    }
+
+    return (
+      <span className="inline-flex items-center gap-1.5">
+        <GroupColorCircle group={selectedGroups[0]} />
+        {selectedGroups[0].name}
+      </span>
+    );
+  })();
+
+  const handleOperatorSelect = (
+    operator: (typeof PARTNER_GROUP_OPERATORS)[number],
+  ) => {
+    const nextIsMulti = isMultiGroupOperator(operator);
+    const wasMulti = isMultiGroupOperator(rule.operator);
+
+    let nextValue: string | string[] | undefined;
+
+    if (nextIsMulti === wasMulti) {
+      nextValue = rule.value as string | string[] | undefined;
+    } else if (nextIsMulti) {
+      nextValue =
+        typeof rule.value === "string" && rule.value ? [rule.value] : [];
+    } else {
+      nextValue =
+        Array.isArray(rule.value) && rule.value.length > 0
+          ? rule.value[0]
+          : undefined;
+    }
+
+    onUpdate({
+      operator,
+      value: nextValue as any,
+    });
+  };
+
+  const handleGroupSelect = (groupId: string) => {
+    if (isMulti) {
+      const current = Array.isArray(rule.value) ? rule.value : [];
+      const next = current.includes(groupId)
+        ? current.filter((id) => id !== groupId)
+        : [...current, groupId];
+      onUpdate({ value: next as any });
+      return;
+    }
+
+    onUpdate({ value: groupId });
+  };
+
+  return (
+    <div className="flex flex-col rounded-lg border border-neutral-200 bg-white">
+      <div className="flex items-center justify-between p-2.5 pr-3">
+        <div className="flex items-center gap-2">
+          <div className="flex size-7 shrink-0 items-center justify-center rounded-md bg-neutral-100">
+            <ArrowTurnRight2 className="size-4 text-neutral-600" />
+          </div>
+          <span className="text-sm font-medium text-neutral-800">
+            And if
+            <span className="mx-1 inline-block rounded bg-blue-50 px-1.5 text-sm font-semibold text-blue-700">
+              partner group
+            </span>
+            <InlineBadgePopover
+              text={
+                GROUP_MOVE_OPERATORS[
+                  selectedOperator as keyof typeof GROUP_MOVE_OPERATORS
+                ]?.label ?? "condition"
+              }
+              buttonClassName="mx-1"
+            >
+              <InlineBadgePopoverMenu
+                selectedValue={selectedOperator}
+                onSelect={handleOperatorSelect}
+                items={PARTNER_GROUP_OPERATORS.map((operator) => ({
+                  value: operator,
+                  text: GROUP_MOVE_OPERATORS[operator].label,
+                }))}
+              />
+            </InlineBadgePopover>
+            <InlineBadgePopover
+              text={groupBadgeText}
+              invalid={selectedGroupIds.length === 0}
+              buttonClassName="mx-1"
+            >
+              <InlineBadgePopoverMenu
+                search
+                selectedValue={isMulti ? selectedGroupIds : selectedGroupIds[0]}
+                onSelect={handleGroupSelect}
+                items={availableGroups.map((group) => ({
+                  value: group.id,
+                  text: group.name,
+                  icon: <GroupColorCircle group={group} />,
+                }))}
+              />
+            </InlineBadgePopover>
           </span>
         </div>
         <button
@@ -416,7 +645,7 @@ function ValueInput({
 
         return (
           <InlineBadgePopoverAmountInput
-            type={attributeType}
+            type={attributeType === "currency" ? "currency" : "number"}
             value={displayValue}
             onChange={handleChange}
             onBlur={field.onBlur}
@@ -497,7 +726,7 @@ const getMinValue = (value: ValueType): number | null => {
     return value;
   }
 
-  if (typeof value === "object" && value !== null && value.min != null) {
+  if (isRangeValue(value) && value.min != null) {
     return value.min;
   }
 
@@ -505,7 +734,7 @@ const getMinValue = (value: ValueType): number | null => {
 };
 
 const getMaxValue = (value: ValueType): number | null => {
-  if (typeof value === "object" && value !== null && value.max != null) {
+  if (isRangeValue(value) && value.max != null) {
     return value.max;
   }
 
@@ -516,6 +745,7 @@ const isRangeValue = (value: ValueType): value is RangeValue => {
   return (
     typeof value === "object" &&
     value !== null &&
+    !Array.isArray(value) &&
     ("min" in value || "max" in value)
   );
 };

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/groups/[groupSlug]/settings/group-move-rules.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/groups/[groupSlug]/settings/group-move-rules.tsx
@@ -29,7 +29,7 @@ import { Fragment, useMemo } from "react";
 import { Controller, useFieldArray, useFormContext } from "react-hook-form";
 
 // Draft form value shapes (partial ranges allowed while editing)
-type RangeValue = { min: number; max?: number };
+type RangeValue = { min?: number; max?: number };
 type ValueType = number | RangeValue | string | string[] | undefined;
 
 type MetricAttributeKey = (typeof GROUP_MOVE_METRIC_ATTRIBUTE_KEYS)[number];
@@ -47,6 +47,26 @@ const isMultiGroupOperator = (
 
 const isPartnerGroupRule = (rule: WorkflowCondition | undefined) =>
   rule?.attribute === "partnerGroup";
+
+const isMetricRuleComplete = (rule: WorkflowCondition | undefined): boolean => {
+  if (!rule?.attribute || isPartnerGroupRule(rule)) {
+    return false;
+  }
+
+  const min = getMinValue(rule.value as ValueType);
+  if (min == null || min === 0) {
+    return false;
+  }
+
+  if (rule.operator === "between") {
+    const max = getMaxValue(rule.value as ValueType);
+    if (max == null || max === 0) {
+      return false;
+    }
+  }
+
+  return true;
+};
 
 export function GroupMoveRules() {
   const { plan } = useWorkspace();
@@ -95,9 +115,11 @@ export function GroupMoveRules() {
   const canAddMetricRule =
     usedMetricAttributes.length < GROUP_MOVE_METRIC_ATTRIBUTE_KEYS.length;
 
-  // Source group is only an additional condition after at least one metric rule
+  // Source group is only an additional condition after a complete metric rule
   const canAddPartnerGroupCondition =
-    metricRuleIndexes.length > 0 && !hasPartnerGroupCondition;
+    metricRuleIndexes.length > 0 &&
+    !hasPartnerGroupCondition &&
+    isMetricRuleComplete(metricRuleIndexes[0].rule);
 
   const { canUseGroupMoveRule } = getPlanCapabilities(plan);
 
@@ -370,7 +392,7 @@ function MetricGroupRule({
       </div>
 
       {nestedCondition && (
-        <div className="rounded-xl border border-neutral-200 bg-neutral-100 px-2.5 pb-2.5">
+        <div className="-mx-px rounded-xl border-x border-t border-neutral-200 bg-neutral-100 px-2.5 pb-2.5">
           <div className="pt-2.5">
             {"onAdd" in nestedCondition ? (
               <Button

--- a/apps/web/lib/api/groups/find-groups-with-matching-rules.ts
+++ b/apps/web/lib/api/groups/find-groups-with-matching-rules.ts
@@ -48,9 +48,10 @@ const doRuleSetsOverlap = (
     rules2ByAttribute.set(rule.attribute, rule);
   }
 
-  // Get all attributes that appear in BOTH rule sets (intersection)
-  const sharedAttributes = Array.from(rules1ByAttribute.keys()).filter((attr) =>
-    rules2ByAttribute.has(attr),
+  // Get all attributes that appear in BOTH rule sets (intersection).
+  // Skip partnerGroup — conflict detection is metric-interval only for now.
+  const sharedAttributes = Array.from(rules1ByAttribute.keys()).filter(
+    (attr) => attr !== "partnerGroup" && rules2ByAttribute.has(attr),
   );
 
   // If there are no shared attributes, the rule sets cannot conflict
@@ -92,7 +93,13 @@ const conditionToInterval = (
       return null;
 
     case "between":
-      if (typeof condition.value === "object" && condition.value !== null) {
+      if (
+        typeof condition.value === "object" &&
+        condition.value !== null &&
+        !Array.isArray(condition.value) &&
+        "min" in condition.value &&
+        "max" in condition.value
+      ) {
         return {
           min: condition.value.min,
           max: condition.value.max,

--- a/apps/web/lib/api/groups/find-groups-with-matching-rules.ts
+++ b/apps/web/lib/api/groups/find-groups-with-matching-rules.ts
@@ -96,14 +96,15 @@ const conditionToInterval = (
       if (
         typeof condition.value === "object" &&
         condition.value !== null &&
-        !Array.isArray(condition.value) &&
-        "min" in condition.value &&
-        "max" in condition.value
+        !Array.isArray(condition.value)
       ) {
-        return {
-          min: condition.value.min,
-          max: condition.value.max,
-        };
+        const { min, max } = condition.value;
+
+        if (typeof min !== "number" || typeof max !== "number") {
+          return null;
+        }
+
+        return { min, max };
       }
       return null;
 

--- a/apps/web/lib/api/groups/remove-group-id-from-move-rules.ts
+++ b/apps/web/lib/api/groups/remove-group-id-from-move-rules.ts
@@ -1,0 +1,97 @@
+import type { WorkflowCondition } from "@/lib/api/workflows/types";
+import { prisma } from "@/lib/prisma";
+import { workflowConditionsSchema } from "@/lib/zod/schemas/workflows";
+
+// Scrubs a deleted group ID from other groups' move-rule workflows in the program.
+export async function removeGroupIdFromMoveRules({
+  programId,
+  groupId,
+}: {
+  programId: string;
+  groupId: string;
+}): Promise<void> {
+  const groups = await prisma.partnerGroup.findMany({
+    where: {
+      programId,
+      id: { not: groupId },
+      workflowId: { not: null },
+    },
+    select: {
+      workflowId: true,
+      workflow: {
+        select: {
+          id: true,
+          triggerConditions: true,
+        },
+      },
+    },
+  });
+
+  for (const group of groups) {
+    if (!group.workflowId || !group.workflow) {
+      continue;
+    }
+
+    const parsed = workflowConditionsSchema.safeParse(
+      group.workflow.triggerConditions,
+    );
+
+    if (!parsed.success) {
+      continue;
+    }
+
+    const nextConditions = scrubGroupIdFromConditions({
+      conditions: parsed.data,
+      groupId,
+    });
+
+    if (JSON.stringify(nextConditions) === JSON.stringify(parsed.data)) {
+      continue;
+    }
+
+    await prisma.workflow.update({
+      where: {
+        id: group.workflowId,
+      },
+      data: {
+        triggerConditions: nextConditions,
+      },
+    });
+  }
+}
+
+function scrubGroupIdFromConditions({
+  conditions,
+  groupId,
+}: {
+  conditions: WorkflowCondition[];
+  groupId: string;
+}): WorkflowCondition[] {
+  return conditions.flatMap((condition) => {
+    if (condition.attribute !== "partnerGroup") {
+      return [condition];
+    }
+
+    const { value } = condition;
+
+    if (typeof value === "string") {
+      return value === groupId ? [] : [condition];
+    }
+
+    if (Array.isArray(value)) {
+      const nextValue = value.filter((id) => id !== groupId);
+
+      if (nextValue.length === 0) {
+        return [];
+      }
+
+      if (nextValue.length === value.length) {
+        return [condition];
+      }
+
+      return [{ ...condition, value: nextValue }];
+    }
+
+    return [condition];
+  });
+}

--- a/apps/web/lib/api/groups/upsert-group-move-rules.ts
+++ b/apps/web/lib/api/groups/upsert-group-move-rules.ts
@@ -53,6 +53,10 @@ export async function upsertGroupMoveRules({
   await validateWorkflowConditions({
     conditions: moveRules,
     workflowType: "moveGroup",
+    context: {
+      programId: group.programId,
+      groupId: group.id,
+    },
   });
 
   const groupsWithMatchingRules = findGroupsWithMatchingRules({

--- a/apps/web/lib/api/workflows/attribute-definitions.ts
+++ b/apps/web/lib/api/workflows/attribute-definitions.ts
@@ -42,6 +42,12 @@ export const WORKFLOW_ATTRIBUTES = {
     inputType: "none",
     operators: ["gte"],
   },
+  partnerGroup: {
+    name: "partnerGroup",
+    label: "group",
+    inputType: "group",
+    operators: ["eq", "ne", "in", "notIn"],
+  },
 } as const;
 
 export const WORKFLOW_ATTRIBUTE_KEYS = Object.keys(

--- a/apps/web/lib/api/workflows/attribute-validators.ts
+++ b/apps/web/lib/api/workflows/attribute-validators.ts
@@ -1,0 +1,57 @@
+import { throwIfInvalidGroupIds } from "@/lib/api/groups/throw-if-invalid-group-ids";
+import { DubApiError } from "../errors";
+
+export type WorkflowAttributeValidatorContext = {
+  programId: string;
+  groupId?: string;
+};
+
+type WorkflowAttributeValidator = ({
+  value,
+  context,
+}: {
+  value: unknown;
+  operator: string;
+  context: WorkflowAttributeValidatorContext;
+}) => Promise<void>;
+
+export const WORKFLOW_ATTRIBUTE_VALIDATORS: Partial<
+  Record<string, WorkflowAttributeValidator>
+> = {
+  partnerGroup: async ({ value, context }) => {
+    const groupIds = normalizeStringArray(value);
+
+    if (groupIds.length === 0) {
+      throw new DubApiError({
+        code: "bad_request",
+        message: "Please select at least one group.",
+      });
+    }
+
+    if (context.groupId && groupIds.includes(context.groupId)) {
+      throw new DubApiError({
+        code: "bad_request",
+        message: "Cannot select the current group as a source group.",
+      });
+    }
+
+    await throwIfInvalidGroupIds({
+      programId: context.programId,
+      groupIds,
+    });
+  },
+};
+
+const normalizeStringArray = (value: unknown): string[] => {
+  if (typeof value === "string") {
+    return value ? [value] : [];
+  }
+
+  if (Array.isArray(value)) {
+    return value.filter(
+      (id): id is string => typeof id === "string" && id.length > 0,
+    );
+  }
+
+  return [];
+};

--- a/apps/web/lib/api/workflows/evaluate-workflow-conditions.ts
+++ b/apps/web/lib/api/workflows/evaluate-workflow-conditions.ts
@@ -7,7 +7,7 @@ export function evaluateWorkflowConditions({
   attributes,
 }: {
   conditions: WorkflowCondition[];
-  attributes: Partial<Record<WorkflowAttributeKey, number | null>>;
+  attributes: Partial<Record<WorkflowAttributeKey, number | string | null>>;
 }): boolean {
   if (conditions.length === 0) return false;
 

--- a/apps/web/lib/api/workflows/evaluate-workflow-conditions.ts
+++ b/apps/web/lib/api/workflows/evaluate-workflow-conditions.ts
@@ -26,6 +26,11 @@ export function evaluateWorkflowConditions({
       return false;
     }
 
+    if (condition.value == null) {
+      console.error(`Value is required for ${condition.attribute}.`);
+      return false;
+    }
+
     if (!operator.evaluate(attributeValue, condition.value)) {
       return false;
     }

--- a/apps/web/lib/api/workflows/move-group/execute.ts
+++ b/apps/web/lib/api/workflows/move-group/execute.ts
@@ -63,11 +63,14 @@ export const executeMoveGroupWorkflow = async ({
     return;
   }
 
-  const attributes: Partial<Record<WorkflowAttributeKey, number | null>> = {
+  const attributes: Partial<
+    Record<WorkflowAttributeKey, number | string | null>
+  > = {
     totalLeads: metrics?.aggregated?.leads ?? 0,
     totalConversions: metrics?.aggregated?.conversions ?? 0,
     totalSaleAmount: metrics?.aggregated?.saleAmount ?? 0,
     totalCommissions: metrics?.aggregated?.commissions ?? 0,
+    partnerGroup: programEnrollment.groupId,
   };
 
   const shouldExecute = evaluateWorkflowConditions({

--- a/apps/web/lib/api/workflows/move-group/schema.ts
+++ b/apps/web/lib/api/workflows/move-group/schema.ts
@@ -1,3 +1,4 @@
+import { WORKFLOW_OPERATORS } from "@/lib/api/workflows/operator-definitions";
 import { WORKFLOW_ATTRIBUTES } from "../attribute-definitions";
 
 export const GROUP_MOVE_ATTRIBUTES = {
@@ -17,8 +18,28 @@ export const GROUP_MOVE_ATTRIBUTES = {
     ...WORKFLOW_ATTRIBUTES.totalCommissions,
     operators: ["gte", "between"] as const,
   },
+  partnerGroup: WORKFLOW_ATTRIBUTES.partnerGroup,
 };
 
 export const GROUP_MOVE_ATTRIBUTE_KEYS = Object.keys(
   GROUP_MOVE_ATTRIBUTES,
 ) as readonly (keyof typeof GROUP_MOVE_ATTRIBUTES)[];
+
+export const GROUP_MOVE_METRIC_ATTRIBUTE_KEYS =
+  GROUP_MOVE_ATTRIBUTE_KEYS.filter(
+    (
+      key,
+    ): key is Exclude<
+      (typeof GROUP_MOVE_ATTRIBUTE_KEYS)[number],
+      "partnerGroup"
+    > => key !== "partnerGroup",
+  );
+
+export const GROUP_MOVE_OPERATORS = {
+  gte: WORKFLOW_OPERATORS.gte,
+  between: WORKFLOW_OPERATORS.between,
+  eq: WORKFLOW_OPERATORS.eq,
+  ne: WORKFLOW_OPERATORS.ne,
+  in: WORKFLOW_OPERATORS.in,
+  notIn: WORKFLOW_OPERATORS.notIn,
+};

--- a/apps/web/lib/api/workflows/operator-definitions.ts
+++ b/apps/web/lib/api/workflows/operator-definitions.ts
@@ -1,10 +1,17 @@
-type ConditionValue = number | { min: number; max?: number };
+export type ConditionValue =
+  | number
+  | { min: number; max?: number }
+  | string
+  | string[];
 
 type WorkflowOperator = {
   name: string;
   label: string;
   validate: (value: ConditionValue) => void;
-  evaluate: (attributeValue: number, conditionValue: ConditionValue) => boolean;
+  evaluate: (
+    attributeValue: number | string,
+    conditionValue: ConditionValue,
+  ) => boolean;
 };
 
 export const WORKFLOW_OPERATORS = {
@@ -17,8 +24,11 @@ export const WORKFLOW_OPERATORS = {
         throw new Error("Please enter a value greater than or equal to 0.");
       }
     },
-    evaluate(attributeValue: number, conditionValue: ConditionValue) {
-      if (typeof conditionValue !== "number") {
+    evaluate(attributeValue: number | string, conditionValue: ConditionValue) {
+      if (
+        typeof attributeValue !== "number" ||
+        typeof conditionValue !== "number"
+      ) {
         return false;
       }
 
@@ -31,7 +41,7 @@ export const WORKFLOW_OPERATORS = {
     name: "between",
     label: "between",
     validate(value: ConditionValue) {
-      if (typeof value !== "object" || value === null) {
+      if (typeof value !== "object" || value === null || Array.isArray(value)) {
         throw new Error("Please enter a valid value.");
       }
 
@@ -50,8 +60,13 @@ export const WORKFLOW_OPERATORS = {
         throw new Error("Maximum value must be greater than minimum value.");
       }
     },
-    evaluate(attributeValue: number, conditionValue: ConditionValue) {
-      if (typeof conditionValue !== "object" || conditionValue === null) {
+    evaluate(attributeValue: number | string, conditionValue: ConditionValue) {
+      if (
+        typeof attributeValue !== "number" ||
+        typeof conditionValue !== "object" ||
+        conditionValue === null ||
+        Array.isArray(conditionValue)
+      ) {
         return false;
       }
 
@@ -62,6 +77,98 @@ export const WORKFLOW_OPERATORS = {
       }
 
       return attributeValue >= min && attributeValue <= max;
+    },
+  },
+
+  // Equality (string)
+  eq: {
+    name: "eq",
+    label: "is",
+    validate(value: ConditionValue) {
+      if (typeof value !== "string" || value.length === 0) {
+        throw new Error("Please select a valid value.");
+      }
+    },
+    evaluate(attributeValue: number | string, conditionValue: ConditionValue) {
+      if (
+        typeof attributeValue !== "string" ||
+        typeof conditionValue !== "string"
+      ) {
+        return false;
+      }
+
+      return attributeValue === conditionValue;
+    },
+  },
+
+  // Not equal (string)
+  ne: {
+    name: "ne",
+    label: "is not",
+    validate(value: ConditionValue) {
+      if (typeof value !== "string" || value.length === 0) {
+        throw new Error("Please select a valid value.");
+      }
+    },
+    evaluate(attributeValue: number | string, conditionValue: ConditionValue) {
+      if (
+        typeof attributeValue !== "string" ||
+        typeof conditionValue !== "string"
+      ) {
+        return false;
+      }
+
+      return attributeValue !== conditionValue;
+    },
+  },
+
+  // In list (string[])
+  in: {
+    name: "in",
+    label: "is any of",
+    validate(value: ConditionValue) {
+      if (
+        !Array.isArray(value) ||
+        value.length === 0 ||
+        value.some((v) => typeof v !== "string" || v.length === 0)
+      ) {
+        throw new Error("Please select at least one valid value.");
+      }
+    },
+    evaluate(attributeValue: number | string, conditionValue: ConditionValue) {
+      if (
+        typeof attributeValue !== "string" ||
+        !Array.isArray(conditionValue)
+      ) {
+        return false;
+      }
+
+      return conditionValue.includes(attributeValue);
+    },
+  },
+
+  // Not in list (string[])
+  notIn: {
+    name: "notIn",
+    label: "is not any of",
+    validate(value: ConditionValue) {
+      if (
+        !Array.isArray(value) ||
+        value.length === 0 ||
+        value.some((v) => typeof v !== "string" || v.length === 0)
+      ) {
+        throw new Error("Please select at least one valid value.");
+      }
+    },
+    evaluate(attributeValue: number | string, conditionValue: ConditionValue) {
+      if (
+        typeof attributeValue !== "string" ||
+        !Array.isArray(conditionValue)
+      ) {
+        return false;
+      }
+
+      return !conditionValue.includes(attributeValue);
     },
   },
 } satisfies Record<string, WorkflowOperator>;

--- a/apps/web/lib/api/workflows/operator-definitions.ts
+++ b/apps/web/lib/api/workflows/operator-definitions.ts
@@ -125,7 +125,7 @@ export const WORKFLOW_OPERATORS = {
   // In list (string[])
   in: {
     name: "in",
-    label: "is any of",
+    label: "is one of",
     validate(value: ConditionValue) {
       if (
         !Array.isArray(value) ||
@@ -150,7 +150,7 @@ export const WORKFLOW_OPERATORS = {
   // Not in list (string[])
   notIn: {
     name: "notIn",
-    label: "is not any of",
+    label: "is not one of",
     validate(value: ConditionValue) {
       if (
         !Array.isArray(value) ||

--- a/apps/web/lib/api/workflows/operator-definitions.ts
+++ b/apps/web/lib/api/workflows/operator-definitions.ts
@@ -1,6 +1,6 @@
 export type ConditionValue =
   | number
-  | { min: number; max?: number }
+  | { min?: number; max?: number }
   | string
   | string[];
 

--- a/apps/web/lib/api/workflows/validate-workflow-conditions.ts
+++ b/apps/web/lib/api/workflows/validate-workflow-conditions.ts
@@ -4,6 +4,10 @@ import { WORKFLOW_OPERATORS } from "@/lib/api/workflows/operator-definitions";
 import { SEND_CAMPAIGN_ATTRIBUTES } from "@/lib/api/workflows/send-campaign/schema";
 import type { WorkflowType } from "@/lib/api/workflows/types";
 import { DubApiError } from "../errors";
+import {
+  WORKFLOW_ATTRIBUTE_VALIDATORS,
+  type WorkflowAttributeValidatorContext,
+} from "./attribute-validators";
 
 // Map of workflow type to its attributes
 const WORKFLOW_TYPE_ATTRIBUTES = {
@@ -24,12 +28,34 @@ type WorkflowConditionInput = {
 export async function validateWorkflowConditions({
   conditions,
   workflowType,
+  context,
 }: {
   conditions?: WorkflowConditionInput[] | null;
   workflowType: WorkflowType;
+  context?: WorkflowAttributeValidatorContext;
 }): Promise<void> {
   if (!conditions || conditions.length === 0) {
     return;
+  }
+
+  // Move group workflow requires at least one metric condition and one partner group condition
+  if (workflowType === "moveGroup") {
+    const hasPartnerGroup = conditions.some(
+      (condition) => condition.attribute === "partnerGroup",
+    );
+
+    const hasMetricCondition = conditions.some(
+      (condition) =>
+        condition.attribute && condition.attribute !== "partnerGroup",
+    );
+
+    if (hasPartnerGroup && !hasMetricCondition) {
+      throw new DubApiError({
+        code: "bad_request",
+        message:
+          "Partner group can only be used as an additional condition alongside a metric rule.",
+      });
+    }
   }
 
   const attributes = WORKFLOW_TYPE_ATTRIBUTES[workflowType];
@@ -94,6 +120,31 @@ export async function validateWorkflowConditions({
         code: "bad_request",
         message: `Condition ${conditionIndex + 1}: ${error instanceof Error ? error.message : "Invalid value."}`,
       });
+    }
+
+    const attributeValidator =
+      WORKFLOW_ATTRIBUTE_VALIDATORS[condition.attribute];
+
+    if (attributeValidator && context) {
+      try {
+        await attributeValidator({
+          value: condition.value,
+          operator: condition.operator,
+          context,
+        });
+      } catch (error) {
+        if (error instanceof DubApiError) {
+          throw new DubApiError({
+            code: error.code,
+            message: `Condition ${conditionIndex + 1}: ${error.message}`,
+          });
+        }
+
+        throw new DubApiError({
+          code: "bad_request",
+          message: `Condition ${conditionIndex + 1}: ${error instanceof Error ? error.message : "Invalid value."}`,
+        });
+      }
     }
   }
 }

--- a/apps/web/lib/api/workflows/validate-workflow-conditions.ts
+++ b/apps/web/lib/api/workflows/validate-workflow-conditions.ts
@@ -22,7 +22,7 @@ const WORKFLOW_TYPE_ATTRIBUTES = {
 type WorkflowConditionInput = {
   attribute: string;
   operator: string;
-  value: unknown;
+  value?: unknown;
 };
 
 export async function validateWorkflowConditions({

--- a/apps/web/lib/bounty/api/generate-performance-bounty-name.ts
+++ b/apps/web/lib/bounty/api/generate-performance-bounty-name.ts
@@ -16,7 +16,13 @@ export const generatePerformanceBountyName = ({
       condition.attribute as keyof typeof PERFORMANCE_BOUNTY_SCOPE_ATTRIBUTES
     ];
   const value =
-    typeof condition.value === "number" ? condition.value : condition.value.min;
+    typeof condition.value === "number"
+      ? condition.value
+      : typeof condition.value === "object" &&
+          condition.value !== null &&
+          !Array.isArray(condition.value)
+        ? condition.value.min
+        : 0;
   const valueFormatted = isCurrency
     ? `${currencyFormatter(value, { trailingZeroDisplay: "stripIfInteger" })} in`
     : `${nFormatter(value, { full: true })}`;

--- a/apps/web/lib/bounty/api/generate-performance-bounty-name.ts
+++ b/apps/web/lib/bounty/api/generate-performance-bounty-name.ts
@@ -20,7 +20,8 @@ export const generatePerformanceBountyName = ({
       ? condition.value
       : typeof condition.value === "object" &&
           condition.value !== null &&
-          !Array.isArray(condition.value)
+          !Array.isArray(condition.value) &&
+          typeof condition.value.min === "number"
         ? condition.value.min
         : 0;
   const valueFormatted = isCurrency

--- a/apps/web/lib/zod/schemas/workflows.ts
+++ b/apps/web/lib/zod/schemas/workflows.ts
@@ -16,6 +16,7 @@ export const WORKFLOW_ATTRIBUTE_TRIGGER: Record<
   totalCommissions: WorkflowTrigger.partnerMetricsUpdated,
   partnerEnrolledDays: WorkflowTrigger.partnerEnrolled,
   partnerJoined: WorkflowTrigger.partnerEnrolled,
+  partnerGroup: WorkflowTrigger.partnerMetricsUpdated,
 } as const;
 
 export const SCHEDULED_WORKFLOW_TRIGGERS: WorkflowTrigger[] = [
@@ -42,6 +43,8 @@ export const workflowConditionSchema = z.object({
       min: z.number(),
       max: z.number(),
     }),
+    z.string(),
+    z.array(z.string()).min(1),
   ]),
 });
 

--- a/apps/web/lib/zod/schemas/workflows.ts
+++ b/apps/web/lib/zod/schemas/workflows.ts
@@ -2,7 +2,10 @@ import {
   WORKFLOW_ATTRIBUTE_KEYS,
   WorkflowAttributeKey,
 } from "@/lib/api/workflows/attribute-definitions";
-import { WORKFLOW_OPERATOR_KEYS } from "@/lib/api/workflows/operator-definitions";
+import {
+  WORKFLOW_OPERATOR_KEYS,
+  WORKFLOW_OPERATORS,
+} from "@/lib/api/workflows/operator-definitions";
 import { WorkflowTrigger } from "@prisma/client";
 import * as z from "zod/v4";
 
@@ -34,19 +37,54 @@ export enum WORKFLOW_ACTION_TYPES {
 }
 
 // Individual condition
-export const workflowConditionSchema = z.object({
-  attribute: z.enum(WORKFLOW_ATTRIBUTE_KEYS),
-  operator: z.enum(WORKFLOW_OPERATOR_KEYS).default("gte"),
-  value: z.union([
-    z.number(),
-    z.object({
-      min: z.number(),
-      max: z.number(),
+export const workflowConditionSchema = z
+  .object({
+    attribute: z.enum(WORKFLOW_ATTRIBUTE_KEYS, {
+      error: "Please select an activity for this rule.",
     }),
-    z.string(),
-    z.array(z.string()).min(1),
-  ]),
-});
+    operator: z.enum(WORKFLOW_OPERATOR_KEYS).default("gte"),
+    value: z
+      .union([
+        z.number(),
+        z.object({
+          min: z.number().optional(),
+          max: z.number().optional(),
+        }),
+        z.string(),
+        z.array(z.string()),
+      ])
+      .optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.value == null) {
+      ctx.addIssue({
+        code: "custom",
+        message:
+          data.attribute === "partnerGroup"
+            ? "Please select a partner group."
+            : "Please enter a threshold value for this rule.",
+        path: ["value"],
+      });
+      return;
+    }
+
+    const operatorDefinition =
+      WORKFLOW_OPERATORS[data.operator as keyof typeof WORKFLOW_OPERATORS];
+
+    if (!operatorDefinition) {
+      return;
+    }
+
+    try {
+      operatorDefinition.validate(data.value as any);
+    } catch (error) {
+      ctx.addIssue({
+        code: "custom",
+        message: error instanceof Error ? error.message : "Invalid value.",
+        path: ["value"],
+      });
+    }
+  });
 
 // Array of conditions
 export const workflowConditionsSchema = z.array(workflowConditionSchema);

--- a/apps/web/tests/workflows/comparison-operators.test.ts
+++ b/apps/web/tests/workflows/comparison-operators.test.ts
@@ -74,6 +74,10 @@ describe("WORKFLOW_OPERATORS.between.validate", () => {
     expect(() => validate(5)).toThrow("Please enter a valid value.");
   });
 
+  it("rejects arrays", () => {
+    expect(() => validate(["grp_1"])).toThrow("Please enter a valid value.");
+  });
+
   it("rejects non-positive or missing min", () => {
     expect(() => validate({ min: 0, max: 5 })).toThrow(
       "Please enter a minimum value greater than 0.",
@@ -98,6 +102,83 @@ describe("WORKFLOW_OPERATORS.between.validate", () => {
     );
     expect(() => validate({ min: 5, max: 4 })).toThrow(
       "Maximum value must be greater than minimum value.",
+    );
+  });
+});
+
+describe("WORKFLOW_OPERATORS.eq", () => {
+  const { evaluate, validate } = WORKFLOW_OPERATORS.eq;
+
+  it("evaluates string equality", () => {
+    expect(evaluate("grp_1", "grp_1")).toBe(true);
+    expect(evaluate("grp_1", "grp_2")).toBe(false);
+  });
+
+  it("returns false for non-string inputs", () => {
+    expect(evaluate(1, "grp_1")).toBe(false);
+    expect(evaluate("grp_1", 1)).toBe(false);
+  });
+
+  it("validates non-empty strings", () => {
+    expect(() => validate("grp_1")).not.toThrow();
+    expect(() => validate("")).toThrow("Please select a valid value.");
+    expect(() => validate(["grp_1"])).toThrow("Please select a valid value.");
+  });
+});
+
+describe("WORKFLOW_OPERATORS.ne", () => {
+  const { evaluate, validate } = WORKFLOW_OPERATORS.ne;
+
+  it("evaluates string inequality", () => {
+    expect(evaluate("grp_1", "grp_2")).toBe(true);
+    expect(evaluate("grp_1", "grp_1")).toBe(false);
+  });
+
+  it("validates non-empty strings", () => {
+    expect(() => validate("grp_1")).not.toThrow();
+    expect(() => validate("")).toThrow("Please select a valid value.");
+  });
+});
+
+describe("WORKFLOW_OPERATORS.in", () => {
+  const { evaluate, validate } = WORKFLOW_OPERATORS.in;
+
+  it("evaluates membership in a list", () => {
+    expect(evaluate("grp_1", ["grp_1", "grp_2"])).toBe(true);
+    expect(evaluate("grp_3", ["grp_1", "grp_2"])).toBe(false);
+  });
+
+  it("returns false for invalid shapes", () => {
+    expect(evaluate("grp_1", "grp_1")).toBe(false);
+    expect(evaluate(1, ["grp_1"])).toBe(false);
+  });
+
+  it("validates non-empty string arrays", () => {
+    expect(() => validate(["grp_1"])).not.toThrow();
+    expect(() => validate([])).toThrow(
+      "Please select at least one valid value.",
+    );
+    expect(() => validate("grp_1")).toThrow(
+      "Please select at least one valid value.",
+    );
+    expect(() => validate([""])).toThrow(
+      "Please select at least one valid value.",
+    );
+  });
+});
+
+describe("WORKFLOW_OPERATORS.notIn", () => {
+  const { evaluate, validate } = WORKFLOW_OPERATORS.notIn;
+
+  it("evaluates exclusion from a list", () => {
+    expect(evaluate("grp_3", ["grp_1", "grp_2"])).toBe(true);
+    expect(evaluate("grp_1", ["grp_1", "grp_2"])).toBe(false);
+  });
+
+  it("validates non-empty string arrays", () => {
+    expect(() => validate(["grp_1", "grp_2"])).not.toThrow();
+    expect(() => validate([])).toThrow(
+      "Please select at least one valid value.",
     );
   });
 });

--- a/apps/web/tests/workflows/move-group-workflow.test.ts
+++ b/apps/web/tests/workflows/move-group-workflow.test.ts
@@ -492,6 +492,234 @@ describe.sequential("Workflow - MoveGroup", async () => {
     expect(workflowConditions[1].value).toStrictEqual({ min: 1, max: 2 });
   });
 
+  test("Metric + partnerGroup move rules create workflow with both conditions", async () => {
+    const slug = "e2e-partner-group-config";
+    await cleanupOrphanedGroup(http, slug, allGroupsForCleanup);
+
+    const { data: existingGroups } = await http.get<PartnerGroup[]>({
+      path: "/groups",
+    });
+
+    expect(existingGroups.length).toBeGreaterThan(0);
+    const sourceGroup = existingGroups[0];
+
+    const { status: groupStatus, data: group } = await http.post<PartnerGroup>({
+      path: "/groups",
+      body: {
+        name: "E2E Group - Partner Group Config",
+        slug,
+        color: randomValue(RESOURCE_COLORS),
+      },
+    });
+
+    expect(groupStatus).toEqual(201);
+
+    onTestFinished(async () => {
+      await http.delete({ path: `/groups/${group.id}` });
+    });
+
+    const { status: patchStatus } = await http.patch({
+      path: `/groups/${group.id}`,
+      body: {
+        moveRules: [
+          {
+            attribute: "totalLeads",
+            operator: "between",
+            value: { min: 2, max: 3 },
+          },
+          {
+            attribute: "partnerGroup",
+            operator: "eq",
+            value: sourceGroup.id,
+          },
+        ],
+      },
+    });
+
+    expect(patchStatus).toEqual(200);
+
+    const { data: workflow } = await http.get<any>({
+      path: "/e2e/workflows",
+      query: { groupId: group.id },
+    });
+
+    expect(workflow).not.toBeNull();
+
+    const workflowConditions = workflow.triggerConditions as any[];
+    expect(workflowConditions).toHaveLength(2);
+    expect(workflowConditions[0].attribute).toBe("totalLeads");
+    expect(workflowConditions[0].operator).toBe("between");
+    expect(workflowConditions[0].value).toStrictEqual({ min: 2, max: 3 });
+    expect(workflowConditions[1].attribute).toBe("partnerGroup");
+    expect(workflowConditions[1].operator).toBe("eq");
+    expect(workflowConditions[1].value).toBe(sourceGroup.id);
+  });
+
+  test(
+    "Workflow executes when partnerGroup matches source group",
+    { timeout: 90000 },
+    async () => {
+      const slug = "e2e-partner-group-match";
+      await cleanupOrphanedGroup(http, slug, allGroupsForCleanup);
+
+      const { data: existingGroups } = await http.get<PartnerGroup[]>({
+        path: "/groups",
+      });
+
+      expect(existingGroups.length).toBeGreaterThan(0);
+      const sourceGroup = existingGroups[0];
+
+      const { status: targetStatus, data: targetGroup } =
+        await http.post<PartnerGroup>({
+          path: "/groups",
+          body: {
+            name: "E2E Target Group - Partner Group Match",
+            slug,
+            color: randomValue(RESOURCE_COLORS),
+          },
+        });
+
+      expect(targetStatus).toEqual(201);
+
+      onTestFinished(async () => {
+        await http.delete({ path: `/groups/${targetGroup.id}` });
+      });
+
+      const { status: patchStatus } = await http.patch({
+        path: `/groups/${targetGroup.id}`,
+        body: {
+          moveRules: [
+            {
+              attribute: "totalLeads",
+              operator: "between",
+              value: { min: 1, max: 2 },
+            },
+            {
+              attribute: "partnerGroup",
+              operator: "eq",
+              value: sourceGroup.id,
+            },
+          ],
+        },
+      });
+
+      expect(patchStatus).toEqual(200);
+
+      const { status: partnerStatus, data: partner } =
+        await http.post<EnrolledPartnerProps>({
+          path: "/partners",
+          body: {
+            name: "E2E Test Partner - Partner Group Match",
+            email: randomPartnerEmail(),
+            groupId: sourceGroup.id,
+          },
+        });
+
+      expect(partnerStatus).toEqual(201);
+      expect(partner.links).not.toBeNull();
+      expect(partner.groupId).toBe(sourceGroup.id);
+
+      const partnerLink = partner.links![0];
+
+      await trackE2ELead(http, partnerLink);
+
+      await verifyPartnerGroupMove({
+        http,
+        partnerId: partner.id,
+        expectedGroupId: targetGroup.id,
+      });
+    },
+  );
+
+  test("Workflow doesn't execute when partnerGroup does not match source group", async () => {
+    const slug = "e2e-partner-group-mismatch";
+    const sourceSlug = "e2e-partner-group-mismatch-src";
+    await cleanupOrphanedGroup(http, slug, allGroupsForCleanup);
+    await cleanupOrphanedGroup(http, sourceSlug, allGroupsForCleanup);
+
+    const { data: existingGroups } = await http.get<PartnerGroup[]>({
+      path: "/groups",
+    });
+
+    expect(existingGroups.length).toBeGreaterThan(0);
+    const allowedSourceGroup = existingGroups[0];
+
+    const { status: nonMatchingSourceStatus, data: nonMatchingSourceGroup } =
+      await http.post<PartnerGroup>({
+        path: "/groups",
+        body: {
+          name: "E2E Source Group - Partner Group Mismatch",
+          slug: sourceSlug,
+          color: randomValue(RESOURCE_COLORS),
+        },
+      });
+
+    expect(nonMatchingSourceStatus).toEqual(201);
+
+    const { status: targetStatus, data: targetGroup } =
+      await http.post<PartnerGroup>({
+        path: "/groups",
+        body: {
+          name: "E2E Target Group - Partner Group Mismatch",
+          slug,
+          color: randomValue(RESOURCE_COLORS),
+        },
+      });
+
+    expect(targetStatus).toEqual(201);
+
+    onTestFinished(async () => {
+      await http.delete({ path: `/groups/${targetGroup.id}` });
+      await http.delete({ path: `/groups/${nonMatchingSourceGroup.id}` });
+    });
+
+    const { status: patchStatus } = await http.patch({
+      path: `/groups/${targetGroup.id}`,
+      body: {
+        moveRules: [
+          {
+            attribute: "totalLeads",
+            operator: "between",
+            value: { min: 1, max: 2 },
+          },
+          {
+            attribute: "partnerGroup",
+            operator: "eq",
+            value: allowedSourceGroup.id,
+          },
+        ],
+      },
+    });
+
+    expect(patchStatus).toEqual(200);
+
+    const { status: partnerStatus, data: partner } =
+      await http.post<EnrolledPartnerProps>({
+        path: "/partners",
+        body: {
+          name: "E2E Test Partner - Partner Group Mismatch",
+          email: randomPartnerEmail(),
+          groupId: nonMatchingSourceGroup.id,
+        },
+      });
+
+    expect(partnerStatus).toEqual(201);
+    expect(partner.links).not.toBeNull();
+    expect(partner.groupId).toBe(nonMatchingSourceGroup.id);
+
+    const partnerLink = partner.links![0];
+
+    await trackE2ELead(http, partnerLink);
+
+    await new Promise((resolve) => setTimeout(resolve, 10000));
+
+    const { data: partnerAfter } = await http.get<EnrolledPartnerProps>({
+      path: `/partners/${partner.id}`,
+    });
+
+    expect(partnerAfter.groupId).toBe(nonMatchingSourceGroup.id);
+  });
+
   test("Workflow skips partner with groupMoveDisabledAt set", async () => {
     const slug = "e2e-target-skip-partner-move";
 

--- a/apps/web/ui/shared/inline-badge-popover.tsx
+++ b/apps/web/ui/shared/inline-badge-popover.tsx
@@ -121,6 +121,7 @@ export function InlineBadgePopoverMenu<T extends any>({
   const { setIsOpen, isOpen } = useContext(InlineBadgePopoverContext);
 
   const isMultiSelect = Array.isArray(selectedValue);
+  const [searchQuery, setSearchQuery] = useState("");
 
   const commandRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -129,6 +130,10 @@ export function InlineBadgePopoverMenu<T extends any>({
   useEffect(() => {
     if (!search) commandRef.current?.focus();
   }, []);
+
+  useEffect(() => {
+    if (!isOpen) setSearchQuery("");
+  }, [isOpen]);
 
   const sortedItems = useMemo(
     () =>
@@ -164,6 +169,8 @@ export function InlineBadgePopoverMenu<T extends any>({
       {search && (
         <div className="-mx-1 -mt-1 mb-1 flex items-center overflow-hidden rounded-t-lg border-b border-neutral-200">
           <Command.Input
+            value={searchQuery}
+            onValueChange={setSearchQuery}
             placeholder="Search"
             className="border-0 bg-transparent py-2 pl-4 pr-2 outline-none placeholder:text-neutral-400 focus:ring-0 sm:text-sm"
           />
@@ -179,6 +186,18 @@ export function InlineBadgePopoverMenu<T extends any>({
             ref={scrollRef}
             onScroll={updateScrollProgress}
           >
+            {search && (
+              <Command.Empty className="flex flex-col items-center justify-center px-4 py-[30px] text-center text-sm font-medium text-neutral-500">
+                {searchQuery.trim() ? (
+                  <>
+                    <p className="leading-5">No results for</p>
+                    <p className="leading-5">&ldquo;{searchQuery}&rdquo;</p>
+                  </>
+                ) : (
+                  <p className="leading-5">No results</p>
+                )}
+              </Command.Empty>
+            )}
             {displayedItems.map(
               ({
                 icon,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Group move rules now support partner targeting via `partnerGroup` (equals, not equals, in, not in) with multi-select, alongside metric-based criteria and an optional nested partner condition.
* **Bug Fixes**
  * Group deletion now removes the group from partner-group conditions in related workflows.
  * Improved rule validation/execution: stricter `between` handling, more reliable overlap detection, null-safe condition evaluation, and added move-group structural validation.
  * Added client-side validation when saving group move rules.
* **Tests**
  * Expanded unit/operator tests and added end-to-end coverage for partner-group rule execution and non-execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->