### PR TITLE
Return proper status codes from cron signature verification failures.

### DIFF
--- a/apps/web/app/api/jobs/process/[jobName]/route.ts
+++ b/apps/web/app/api/jobs/process/[jobName]/route.ts
@@ -1,3 +1,4 @@
+import { handleAndReturnErrorResponse } from "@/lib/api/errors";
 import { logger, withAxiomBodyLog } from "@/lib/axiom/server";
 import { verifyQstashSignature } from "@/lib/cron/verify-qstash";
 import { jobEnvelopeSchema } from "@/lib/jobs";
@@ -16,7 +17,11 @@ export const POST = withAxiomBodyLog(
     const clonedReq = req.clone();
     const rawBody = await clonedReq.text();
 
-    await verifyQstashSignature({ req, rawBody });
+    try {
+      await verifyQstashSignature({ req, rawBody });
+    } catch (error) {
+      return handleAndReturnErrorResponse(error);
+    }
 
     let parsedBody: unknown = null;
 

--- a/apps/web/lib/api/error-codes.ts
+++ b/apps/web/lib/api/error-codes.ts
@@ -20,3 +20,5 @@ export const ErrorCode = z.enum(
     ...(keyof typeof ErrorCodes)[],
   ],
 );
+
+export type HttpStatusCode = (typeof ErrorCodes)[keyof typeof ErrorCodes];

--- a/apps/web/lib/cron/verify-qstash.ts
+++ b/apps/web/lib/cron/verify-qstash.ts
@@ -1,4 +1,4 @@
-import { Receiver } from "@upstash/qstash";
+import { Receiver, SignatureError } from "@upstash/qstash";
 import { DubApiError } from "../api/errors";
 
 // we're using Upstash's Receiver to verify the request signature
@@ -25,12 +25,25 @@ export const verifyQstashSignature = async ({
     });
   }
 
-  const isValid = await receiver.verify({
-    signature,
-    body: rawBody,
-    // Pass the region header for multi-region support
-    upstashRegion: req.headers.get("upstash-region") ?? undefined,
-  });
+  let isValid: boolean;
+
+  try {
+    isValid = await receiver.verify({
+      signature,
+      body: rawBody,
+      // Pass the region header for multi-region support
+      upstashRegion: req.headers.get("upstash-region") ?? undefined,
+    });
+  } catch (error) {
+    if (error instanceof SignatureError) {
+      throw new DubApiError({
+        code: "unauthorized",
+        message: "Invalid Upstash-Signature header.",
+      });
+    }
+
+    throw error;
+  }
 
   if (!isValid) {
     throw new DubApiError({

--- a/apps/web/lib/cron/verify-qstash.ts
+++ b/apps/web/lib/cron/verify-qstash.ts
@@ -1,4 +1,3 @@
-import { log } from "@dub/utils";
 import { Receiver } from "@upstash/qstash";
 import { DubApiError } from "../api/errors";
 
@@ -22,7 +21,7 @@ export const verifyQstashSignature = async ({
   if (!signature) {
     throw new DubApiError({
       code: "bad_request",
-      message: "Upstash-Signature header not found.",
+      message: "Upstash-Signature header is required.",
     });
   }
 
@@ -34,18 +33,9 @@ export const verifyQstashSignature = async ({
   });
 
   if (!isValid) {
-    const url = req.url;
-    const messageId = req.headers.get("Upstash-Message-Id");
-
-    log({
-      message: `Invalid QStash request signature: *${url}* - *${messageId}*`,
-      type: "errors",
-      mention: true,
-    });
-
     throw new DubApiError({
       code: "unauthorized",
-      message: "Invalid QStash request signature.",
+      message: "Invalid Upstash-Signature header.",
     });
   }
 };

--- a/apps/web/lib/cron/verify-vercel.ts
+++ b/apps/web/lib/cron/verify-vercel.ts
@@ -1,5 +1,7 @@
 import { DubApiError } from "../api/errors";
 
+const cronSecret = process.env.CRON_SECRET;
+
 export const verifyVercelSignature = async (req: Request) => {
   // skip verification in local development
   if (process.env.VERCEL !== "1") {
@@ -8,13 +10,24 @@ export const verifyVercelSignature = async (req: Request) => {
 
   const authHeader = req.headers.get("authorization");
 
-  if (
-    !process.env.CRON_SECRET ||
-    authHeader !== `Bearer ${process.env.CRON_SECRET}`
-  ) {
+  if (!authHeader) {
     throw new DubApiError({
       code: "unauthorized",
-      message: "Invalid Vercel cron request signature",
+      message: "Vercel Authorization header is required.",
+    });
+  }
+
+  if (!cronSecret) {
+    throw new DubApiError({
+      code: "internal_server_error",
+      message: "CRON_SECRET environment variable is not set.",
+    });
+  }
+
+  if (authHeader !== `Bearer ${cronSecret}`) {
+    throw new DubApiError({
+      code: "unauthorized",
+      message: "Invalid Vercel Authorization header.",
     });
   }
 };

--- a/apps/web/lib/cron/with-cron.ts
+++ b/apps/web/lib/cron/with-cron.ts
@@ -1,5 +1,6 @@
-import { APP_DOMAIN_WITH_NGROK, getSearchParams, log } from "@dub/utils";
+import { getSearchParams } from "@dub/utils";
 import { logAndRespond } from "app/(ee)/api/cron/utils";
+import { ErrorCodes, HttpStatusCode } from "../api/error-codes";
 import { logger, withAxiomBodyLog } from "../axiom/server";
 import { verifyQstashSignature } from "./verify-qstash";
 import { verifyVercelSignature } from "./verify-vercel";
@@ -30,7 +31,6 @@ export const withCron = (handler: WithCronHandler) => {
 
       const params = (await initialParams) || {};
       const searchParams = getSearchParams(req.url);
-      const url = new URL(req.url || "", APP_DOMAIN_WITH_NGROK);
 
       try {
         let rawBody: string | undefined;
@@ -63,12 +63,10 @@ export const withCron = (handler: WithCronHandler) => {
         logger.error(errorMessage, error);
         await logger.flush();
 
-        await log({
-          message: `Cron job "${url.pathname}" failed during execution. Error: ${errorMessage}`,
-          type: "errors",
-        });
+        const statusCode: HttpStatusCode =
+          ErrorCodes[error.code ?? "internal_server_error"];
 
-        return logAndRespond(errorMessage, { status: 500 });
+        return logAndRespond(errorMessage, { status: statusCode });
       }
     },
   );

--- a/apps/web/lib/cron/with-cron.ts
+++ b/apps/web/lib/cron/with-cron.ts
@@ -1,6 +1,7 @@
 import { getSearchParams } from "@dub/utils";
 import { logAndRespond } from "app/(ee)/api/cron/utils";
-import { ErrorCodes, HttpStatusCode } from "../api/error-codes";
+import { ErrorCodes } from "../api/error-codes";
+import { DubApiError } from "../api/errors";
 import { logger, withAxiomBodyLog } from "../axiom/server";
 import { verifyQstashSignature } from "./verify-qstash";
 import { verifyVercelSignature } from "./verify-vercel";
@@ -63,8 +64,10 @@ export const withCron = (handler: WithCronHandler) => {
         logger.error(errorMessage, error);
         await logger.flush();
 
-        const statusCode: HttpStatusCode =
-          ErrorCodes[error.code ?? "internal_server_error"];
+        const statusCode =
+          error instanceof DubApiError
+            ? ErrorCodes[error.code]
+            : ErrorCodes.internal_server_error;
 
         return logAndRespond(errorMessage, { status: statusCode });
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Background job signature verification failures now stop processing and return an immediate, consistent error response.
  * Scheduled/cron endpoints now return HTTP status codes that better match the underlying error instead of defaulting to 500.
  * Clearer outcomes for missing or invalid authentication headers, and for misconfigured cron secrets.
  * Improved consistency of error responses across scheduled job endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->