### PR TITLE
Increase tag name max length from 50 to 190 characters.

### DIFF
--- a/apps/web/lib/zod/schemas/tags.ts
+++ b/apps/web/lib/zod/schemas/tags.ts
@@ -48,23 +48,22 @@ export const tagColorSchema = z
   })
   .describe("The color of the tag");
 
+const tagName = z
+  .string()
+  .trim()
+  .min(1)
+  .max(190)
+  .describe("The name of the tag to create.");
+
 export const createTagBodySchema = z
   .object({
-    name: z
-      .string()
-      .trim()
-      .min(1)
-      .max(50)
-      .describe("The name of the tag to create."),
+    name: tagName,
     color: tagColorSchema.describe(
       `The color of the tag. If not provided, a random color will be used from the list: ${RESOURCE_COLORS.join(", ")}.`,
     ),
-    tag: z
-      .string()
-      .trim()
-      .min(1)
-      .describe("The name of the tag to create.")
-      .meta({ deprecated: true }),
+    tag: tagName.meta({
+      deprecated: true,
+    }),
   })
   .partial()
   .superRefine((data, ctx) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the maximum allowed tag name length from 50 to 190 characters.
  * Applied consistent validation to both current and deprecated tag name fields, including trimming and minimum-length checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->