### PR TITLE
Add status and method counts to API logs filters

### DIFF
--- a/apps/web/lib/api-logs/get-api-logs-count.ts
+++ b/apps/web/lib/api-logs/get-api-logs-count.ts
@@ -3,7 +3,7 @@ import * as z from "zod/v4";
 import {
   apiLogCountAggregateRowSchemaTB,
   apiLogCountFilterSchemaTB,
-  apiLogsCountResponseSchema,
+  apiLogCountRowSchemas,
   getApiLogsCountQuerySchema,
 } from "./schemas";
 
@@ -33,10 +33,10 @@ export async function getApiLogsCount(params: GetApiLogsCountParams) {
   const baseParams = {
     workspaceId,
     ...(groupBy && { groupBy }),
-    // if we're grouping by routePattern, omit routePattern filter (so all routes are returned)
+    // if we're grouping by a dimension, omit that filter so all values are returned
     ...(routePattern && groupBy !== "routePattern" && { routePattern }),
-    ...(method && { method }),
-    ...(statusCode && { statusCode }),
+    ...(method && groupBy !== "method" && { method }),
+    ...(statusCode && groupBy !== "statusCode" && { statusCode }),
     ...(tokenId && { tokenId }),
     ...(requestId && { requestId }),
     ...(requestType && { requestType }),
@@ -52,12 +52,14 @@ export async function getApiLogsCount(params: GetApiLogsCountParams) {
 
   const result = await pipe(baseParams);
 
-  if (groupBy === "routePattern") {
-    return apiLogsCountResponseSchema.parse(result.data);
+  if (groupBy) {
+    return z.array(apiLogCountRowSchemas[groupBy]).parse(result.data);
   }
 
   const aggregate = apiLogCountAggregateRowSchemaTB.safeParse(result.data[0]);
   const count = aggregate.success ? aggregate.data.count : 0;
 
-  return apiLogsCountResponseSchema.parse([{ routePattern: "all", count }]);
+  return z
+    .array(apiLogCountRowSchemas.routePattern)
+    .parse([{ routePattern: "all", count }]);
 }

--- a/apps/web/lib/api-logs/schemas.ts
+++ b/apps/web/lib/api-logs/schemas.ts
@@ -38,13 +38,19 @@ export const apiLogFilterSchemaTB = z.object({
   offset: z.number().optional(),
 });
 
+export const apiLogCountGroupBySchema = z.enum([
+  "routePattern",
+  "statusCode",
+  "method",
+]);
+
 export const apiLogCountFilterSchemaTB = apiLogFilterSchemaTB
   .omit({
     limit: true,
     offset: true,
   })
   .extend({
-    groupBy: z.enum(["routePattern"]).optional(),
+    groupBy: apiLogCountGroupBySchema.optional(),
   });
 
 // Raw Tinybird shape for the non-grouped count node
@@ -52,14 +58,23 @@ export const apiLogCountAggregateRowSchemaTB = z.object({
   count: z.number(),
 });
 
-// Single row for GET /api/logs/count (aggregate uses routePattern `"all"`)
-// TODO: extend this to support other groupBy values
-export const apiLogCountRowSchema = z.object({
-  routePattern: z.string(),
-  count: z.number(),
-});
+// Aggregate / routePattern grouping (aggregate uses routePattern `"all"`)
+export const apiLogCountRowSchemas = {
+  routePattern: z.object({
+    routePattern: z.string(),
+    count: z.number(),
+  }),
 
-export const apiLogsCountResponseSchema = z.array(apiLogCountRowSchema);
+  statusCode: z.object({
+    statusCode: z.number(),
+    count: z.number(),
+  }),
+
+  method: z.object({
+    method: z.string(),
+    count: z.number(),
+  }),
+} as const;
 
 export const apiLogByIdFilterSchemaTB = z.object({
   workspaceId: z.string(),
@@ -99,5 +114,5 @@ export const getApiLogsQuerySchema = z
 export const getApiLogsCountQuerySchema = getApiLogsQuerySchema
   .omit({ page: true, pageSize: true })
   .extend({
-    groupBy: z.enum(["routePattern"]).optional(),
+    groupBy: apiLogCountGroupBySchema.optional(),
   });

--- a/apps/web/lib/swr/use-api-logs-count.ts
+++ b/apps/web/lib/swr/use-api-logs-count.ts
@@ -1,14 +1,39 @@
-import type { ApiLogsCountRow } from "@/lib/types";
+import { apiLogCountRowSchemas } from "@/lib/api-logs/schemas";
+import type { ApiLogsCountGroupBy, ApiLogsCountRow } from "@/lib/types";
 import { useRouterStuff } from "@dub/ui";
 import { fetcher } from "@dub/utils";
 import useSWR from "swr";
+import * as z from "zod/v4";
 import useWorkspace from "./use-workspace";
+
+type ApiLogsCountDataMap = {
+  [K in ApiLogsCountGroupBy]: z.infer<(typeof apiLogCountRowSchemas)[K]>[];
+};
+
+// Overloads so `data` is typed from `groupBy` (implementation is the last signature)
+export function useApiLogsCount(options?: {
+  groupBy?: undefined;
+  enabled?: boolean;
+}): {
+  data: ApiLogsCountRow[] | undefined;
+  error: any;
+  isLoading: boolean;
+};
+
+export function useApiLogsCount<T extends ApiLogsCountGroupBy>(options: {
+  groupBy: T;
+  enabled?: boolean;
+}): {
+  data: ApiLogsCountDataMap[T] | undefined;
+  error: any;
+  isLoading: boolean;
+};
 
 export function useApiLogsCount({
   groupBy,
   enabled = true,
 }: {
-  groupBy?: "routePattern";
+  groupBy?: ApiLogsCountGroupBy;
   enabled?: boolean;
 } = {}) {
   const { id: workspaceId } = useWorkspace();
@@ -34,7 +59,7 @@ export function useApiLogsCount({
     },
   );
 
-  const { data, error } = useSWR<ApiLogsCountRow[]>(
+  const { data, error } = useSWR(
     workspaceId && enabled ? `/api/logs/count${queryString}` : null,
     fetcher,
     {

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -34,7 +34,8 @@ import {
 import * as z from "zod/v4";
 import { RESOURCE_COLORS } from "../ui/colors";
 import {
-  apiLogCountRowSchema,
+  apiLogCountGroupBySchema,
+  apiLogCountRowSchemas,
   apiLogEnrichedSchema,
   apiLogSchemaTB,
   requestTypeSchema,
@@ -867,9 +868,19 @@ export type CommissionActivitySnapshot = Pick<
 
 export type EnrichedApiLog = z.infer<typeof apiLogEnrichedSchema>;
 
-export type ApiLogsCountRow = z.infer<typeof apiLogCountRowSchema>;
+export type ApiLogsCountRow = z.infer<
+  typeof apiLogCountRowSchemas.routePattern
+>;
 
 export type ApiLogsCountByRoutePattern = ApiLogsCountRow;
+
+export type ApiLogsCountByStatusCode = z.infer<
+  typeof apiLogCountRowSchemas.statusCode
+>;
+
+export type ApiLogsCountByMethod = z.infer<typeof apiLogCountRowSchemas.method>;
+
+export type ApiLogsCountGroupBy = z.infer<typeof apiLogCountGroupBySchema>;
 
 export type RequestType = z.infer<typeof requestTypeSchema>;
 

--- a/apps/web/ui/logs/use-log-filters.ts
+++ b/apps/web/ui/logs/use-log-filters.ts
@@ -53,26 +53,49 @@ export function useLogFilters() {
         : false,
   });
 
+  const { data: statusCounts } = useApiLogsCount({
+    groupBy: "statusCode",
+    enabled:
+      selectedFilter === "statusCode" || searchParamsObj.statusCode
+        ? true
+        : false,
+  });
+
+  const { data: methodCounts } = useApiLogsCount({
+    groupBy: "method",
+    enabled:
+      selectedFilter === "method" || searchParamsObj.method ? true : false,
+  });
+
   const filters = useMemo(
     () => [
       {
         key: "statusCode",
         icon: CircleCheck,
         label: "Status",
-        options: HTTP_STATUS_CODES.map(({ value, label }) => {
-          const icon = createElement(CircleCheck, {
-            className: cn(
-              "h-4 w-4",
-              value >= 200 && value < 300 ? "text-green-600" : "text-red-600",
-            ),
-          });
+        options: statusCounts
+          ? HTTP_STATUS_CODES.map(({ value, label }) => {
+              const icon = createElement(CircleCheck, {
+                className: cn(
+                  "h-4 w-4",
+                  value >= 200 && value < 300
+                    ? "text-green-600"
+                    : "text-red-600",
+                ),
+              });
 
-          return {
-            value,
-            label,
-            icon,
-          };
-        }),
+              const count = statusCounts.find(
+                (row) => row.statusCode === value,
+              )?.count;
+
+              return {
+                value,
+                label,
+                icon,
+                right: nFormatter(count || 0, { full: true }),
+              };
+            })
+          : undefined,
       },
       {
         key: "routePattern",
@@ -88,10 +111,17 @@ export function useLogFilters() {
         key: "method",
         icon: ArrowsOppositeDirectionX,
         label: "Method",
-        options: HTTP_MUTATION_METHODS.map((m) => ({
-          value: m,
-          label: m,
-        })),
+        options: methodCounts
+          ? HTTP_MUTATION_METHODS.map((m) => {
+              const count = methodCounts.find((row) => row.method === m)?.count;
+
+              return {
+                value: m,
+                label: m,
+                right: nFormatter(count || 0, { full: true }),
+              };
+            })
+          : undefined,
       },
       {
         key: "tokenId",
@@ -112,7 +142,7 @@ export function useLogFilters() {
         })),
       },
     ],
-    [tokens, routePatterns],
+    [tokens, routePatterns, statusCounts, methodCounts],
   );
 
   const onSelect = useCallback(

--- a/packages/tinybird/pipes/get_api_logs_count.pipe
+++ b/packages/tinybird/pipes/get_api_logs_count.pipe
@@ -41,11 +41,57 @@ SQL >
     ORDER BY count DESC
     LIMIT 100
 
+NODE count_by_status_code
+SQL >
+    %
+    SELECT
+        status_code as statusCode,
+        count() as count
+    FROM dub_api_logs
+    WHERE
+        workspace_id = {{ String(workspaceId) }}
+        {% if defined(start) and defined(end) %}
+            AND timestamp >= {{ DateTime(start, '2024-06-01 00:00:00') }}
+            AND timestamp < {{ DateTime(end, '2024-06-07 00:00:00') }}
+        {% end %}
+        {% if defined(routePattern) %} AND route_pattern = {{ String(routePattern) }} {% end %}
+        {% if defined(method) %} AND method = {{ String(method) }} {% end %}
+        {% if defined(statusCode) %} AND status_code = {{ UInt16(statusCode) }} {% end %}
+        {% if defined(tokenId) %} AND token_id = {{ String(tokenId) }} {% end %}
+        {% if defined(requestId) %} AND id = {{ String(requestId) }} {% end %}
+        {% if defined(requestType) %} AND request_type = {{ String(requestType) }} {% end %}
+    GROUP BY status_code
+    ORDER BY count DESC
+
+NODE count_by_method
+SQL >
+    %
+    SELECT
+        method,
+        count() as count
+    FROM dub_api_logs
+    WHERE
+        workspace_id = {{ String(workspaceId) }}
+        {% if defined(start) and defined(end) %}
+            AND timestamp >= {{ DateTime(start, '2024-06-01 00:00:00') }}
+            AND timestamp < {{ DateTime(end, '2024-06-07 00:00:00') }}
+        {% end %}
+        {% if defined(routePattern) %} AND route_pattern = {{ String(routePattern) }} {% end %}
+        {% if defined(method) %} AND method = {{ String(method) }} {% end %}
+        {% if defined(statusCode) %} AND status_code = {{ UInt16(statusCode) }} {% end %}
+        {% if defined(tokenId) %} AND token_id = {{ String(tokenId) }} {% end %}
+        {% if defined(requestId) %} AND id = {{ String(requestId) }} {% end %}
+        {% if defined(requestType) %} AND request_type = {{ String(requestType) }} {% end %}
+    GROUP BY method
+    ORDER BY count DESC
+
 NODE endpoint
 SQL >
     %
     SELECT *
     FROM
         {% if defined(groupBy) and groupBy == 'routePattern' %} count_by_route_pattern
+        {% elif defined(groupBy) and groupBy == 'statusCode' %} count_by_status_code
+        {% elif defined(groupBy) and groupBy == 'method' %} count_by_method
         {% else %} count
         {% end %}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API log counts can now be grouped by route, status code, or HTTP method.
  * Status code and method filter dropdowns now show matching log counts.
  * Aggregate counts are still available when no grouping is selected.
* **Bug Fixes**
  * Fixed API log count querying and response handling to correctly omit/parse filters for the selected grouping mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->