### PR TITLE
Fix partner group label shown in campaign email recipients

### DIFF
--- a/apps/web/app/(ee)/api/campaigns/[campaignId]/events/route.ts
+++ b/apps/web/app/(ee)/api/campaigns/[campaignId]/events/route.ts
@@ -19,6 +19,7 @@ export const GET = withWorkspace(
     const events = await getCampaignEvents({
       ...getCampaignsEventsQuerySchema.parse(searchParams),
       campaignId,
+      programId,
     });
 
     return NextResponse.json(events);

--- a/apps/web/lib/api/campaigns/get-campaign-events.ts
+++ b/apps/web/lib/api/campaigns/get-campaign-events.ts
@@ -8,10 +8,12 @@ import * as z from "zod/v4";
 interface GetCampaignEventsParams
   extends z.infer<typeof getCampaignsEventsQuerySchema> {
   campaignId: string;
+  programId: string;
 }
 
 export const getCampaignEvents = async ({
   campaignId,
+  programId,
   status,
   page = 1,
   pageSize,
@@ -37,6 +39,7 @@ export const getCampaignEvents = async ({
           name: true,
           image: true,
           programs: {
+            where: { programId },
             select: {
               partnerGroup: {
                 select: {
@@ -46,6 +49,7 @@ export const getCampaignEvents = async ({
                 },
               },
             },
+            take: 1,
           },
         },
       },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Campaign event results are now correctly scoped to the selected program.
  * Partner information shown with campaign events now reflects the requested program consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->