### PR TITLE
Account for "multi-track" group move rules

### DIFF
--- a/apps/web/lib/api/groups/find-groups-with-matching-rules.ts
+++ b/apps/web/lib/api/groups/find-groups-with-matching-rules.ts
@@ -48,8 +48,22 @@ const doRuleSetsOverlap = (
     rules2ByAttribute.set(rule.attribute, rule);
   }
 
-  // Get all attributes that appear in BOTH rule sets (intersection).
-  // Skip partnerGroup — conflict detection is metric-interval only for now.
+  const partnerGroup1 = rules1ByAttribute.get("partnerGroup");
+  const partnerGroup2 = rules2ByAttribute.get("partnerGroup");
+
+  if (partnerGroup1 && partnerGroup2) {
+    const partnerGroupOverlap = doPartnerGroupConditionsOverlap(
+      partnerGroup1,
+      partnerGroup2,
+    );
+
+    // Disjoint eq/in partner-group filters cannot both match the same partner.
+    if (partnerGroupOverlap === false) {
+      return false;
+    }
+  }
+
+  // Get all metric attributes that appear in BOTH rule sets (intersection).
   const sharedAttributes = Array.from(rules1ByAttribute.keys()).filter(
     (attr) => attr !== "partnerGroup" && rules2ByAttribute.has(attr),
   );
@@ -77,6 +91,51 @@ const doRuleSetsOverlap = (
   }
 
   return true;
+};
+
+const partnerGroupConditionToIdSet = (
+  condition: WorkflowCondition,
+): Set<string> | null => {
+  if (condition.attribute !== "partnerGroup") {
+    return null;
+  }
+
+  switch (condition.operator) {
+    case "eq":
+      if (typeof condition.value === "string") {
+        return new Set([condition.value]);
+      }
+      return null;
+
+    case "in":
+      if (Array.isArray(condition.value)) {
+        return new Set(condition.value);
+      }
+      return null;
+
+    default:
+      return null;
+  }
+};
+
+const doPartnerGroupConditionsOverlap = (
+  condition1: WorkflowCondition,
+  condition2: WorkflowCondition,
+): boolean | null => {
+  const ids1 = partnerGroupConditionToIdSet(condition1);
+  const ids2 = partnerGroupConditionToIdSet(condition2);
+
+  if (!ids1 || !ids2) {
+    return null;
+  }
+
+  for (const id of ids1) {
+    if (ids2.has(id)) {
+      return true;
+    }
+  }
+
+  return false;
 };
 
 const conditionToInterval = (

--- a/apps/web/lib/api/groups/get-group-move-rules.ts
+++ b/apps/web/lib/api/groups/get-group-move-rules.ts
@@ -3,7 +3,7 @@ import { groupRulesSchema } from "@/lib/zod/schemas/groups";
 
 export const getGroupMoveRules = async (programId: string) => {
   const groups = await prisma.partnerGroup.findMany({
-    where: { programId },
+    where: { programId, workflow: { isNot: null } },
     select: {
       id: true,
       name: true,

--- a/apps/web/tests/workflows/find-groups-with-matching-rules.test.ts
+++ b/apps/web/tests/workflows/find-groups-with-matching-rules.test.ts
@@ -1,0 +1,148 @@
+import { findGroupsWithMatchingRules } from "@/lib/api/groups/find-groups-with-matching-rules";
+import type { GroupMoveRules } from "@/lib/api/workflows/move-group/types";
+import { describe, expect, it } from "vitest";
+
+const groupA = { id: "grp_a", name: "Group A", moveRules: [] as GroupMoveRules };
+const groupB = { id: "grp_b", name: "Group B", moveRules: [] as GroupMoveRules };
+const groupC = { id: "grp_c", name: "Group C", moveRules: [] as GroupMoveRules };
+
+describe("findGroupsWithMatchingRules", () => {
+  it("returns no conflict when partnerGroup eq/in filters are disjoint", () => {
+    groupB.moveRules = [
+      {
+        attribute: "totalLeads",
+        operator: "gte",
+        value: 10,
+      },
+      {
+        attribute: "partnerGroup",
+        operator: "eq",
+        value: "grp_source_a",
+      },
+    ];
+
+    const currentRules: GroupMoveRules = [
+      {
+        attribute: "totalLeads",
+        operator: "gte",
+        value: 10,
+      },
+      {
+        attribute: "partnerGroup",
+        operator: "eq",
+        value: "grp_source_b",
+      },
+    ];
+
+    expect(
+      findGroupsWithMatchingRules({
+        groups: [groupA, groupB, groupC],
+        currentRules,
+        currentGroupId: groupA.id,
+      }),
+    ).toEqual([]);
+  });
+
+  it("detects conflict when partnerGroup eq/in filters overlap", () => {
+    groupB.moveRules = [
+      {
+        attribute: "totalLeads",
+        operator: "gte",
+        value: 10,
+      },
+      {
+        attribute: "partnerGroup",
+        operator: "in",
+        value: ["grp_source_a", "grp_source_b"],
+      },
+    ];
+
+    const currentRules: GroupMoveRules = [
+      {
+        attribute: "totalLeads",
+        operator: "gte",
+        value: 10,
+      },
+      {
+        attribute: "partnerGroup",
+        operator: "eq",
+        value: "grp_source_b",
+      },
+    ];
+
+    expect(
+      findGroupsWithMatchingRules({
+        groups: [groupA, groupB, groupC],
+        currentRules,
+        currentGroupId: groupA.id,
+      }),
+    ).toEqual([{ id: groupB.id, name: groupB.name }]);
+  });
+
+  it("still detects metric conflicts when only one rule has partnerGroup", () => {
+    groupB.moveRules = [
+      {
+        attribute: "totalLeads",
+        operator: "gte",
+        value: 10,
+      },
+      {
+        attribute: "partnerGroup",
+        operator: "eq",
+        value: "grp_source_a",
+      },
+    ];
+
+    const currentRules: GroupMoveRules = [
+      {
+        attribute: "totalLeads",
+        operator: "gte",
+        value: 10,
+      },
+    ];
+
+    expect(
+      findGroupsWithMatchingRules({
+        groups: [groupA, groupB, groupC],
+        currentRules,
+        currentGroupId: groupA.id,
+      }),
+    ).toEqual([{ id: groupB.id, name: groupB.name }]);
+  });
+
+  it("falls back to metric overlap when partnerGroup uses ne/notIn", () => {
+    groupB.moveRules = [
+      {
+        attribute: "totalLeads",
+        operator: "gte",
+        value: 10,
+      },
+      {
+        attribute: "partnerGroup",
+        operator: "ne",
+        value: "grp_source_a",
+      },
+    ];
+
+    const currentRules: GroupMoveRules = [
+      {
+        attribute: "totalLeads",
+        operator: "gte",
+        value: 10,
+      },
+      {
+        attribute: "partnerGroup",
+        operator: "eq",
+        value: "grp_source_a",
+      },
+    ];
+
+    expect(
+      findGroupsWithMatchingRules({
+        groups: [groupA, groupB, groupC],
+        currentRules,
+        currentGroupId: groupA.id,
+      }),
+    ).toEqual([{ id: groupB.id, name: groupB.name }]);
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved group conflict detection by explicitly analyzing `partnerGroup` filters for determinable disjointness or overlap.
  - Kept existing behavior when `partnerGroup` filters can’t be confidently compared, falling back to metric-based conflict evaluation.
  - Refined group move rules to return only groups with a configured workflow.

- **Tests**
  - Added Vitest coverage for matching and conflict scenarios involving `partnerGroup` `eq`/`in` and mixed/unsupported partner-group conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->