### PR TITLE
Showing the logo on the mobile nav

### DIFF
--- a/packages/ui/src/nav/nav-mobile.tsx
+++ b/packages/ui/src/nav/nav-mobile.tsx
@@ -15,6 +15,7 @@ import {
   DubLinksIcon,
   DubPartnersIcon,
 } from "../icons";
+import { NavWordmark } from "../nav-wordmark";
 import { navItems, type NavItem, type NavTheme } from "./nav";
 
 const specialIcons: Record<string, ReactNode> = {
@@ -105,6 +106,21 @@ export function NavMobile({
           <Menu className="h-5 w-5 text-neutral-600 dark:text-white/70" />
         )}
       </button>
+      {/* The nav below covers the logo in the main nav, so we render it again here */}
+      {open && (
+        <Link
+          href={createHref("/home", domain, {
+            utm_source: "Custom Domain",
+            utm_medium: "Navbar",
+            utm_campaign: domain,
+            utm_content: "Logo",
+          })}
+          onClick={() => setOpen(false)}
+          className="fixed left-3 top-0 z-30 flex h-14 items-center pr-2"
+        >
+          <NavWordmark />
+        </Link>
+      )}
       <nav
         className={cn(
           "fixed inset-0 z-20 hidden max-h-screen w-full overflow-y-auto bg-white px-5 py-16 lg:hidden dark:bg-black dark:text-white/70",


### PR DESCRIPTION
At some point it was removed from the mobile nav, so this adds it back.

## Update

<img width="417" height="569" alt="CleanShot 2026-07-27 at 16 29 08@2x" src="https://github.com/user-attachments/assets/a399dc21-829d-46d7-a7ac-68c3b5b71b98" />

## Current

<img width="445" height="573" alt="CleanShot 2026-07-27 at 16 30 27@2x" src="https://github.com/user-attachments/assets/2feae711-e485-4b07-911a-0a678c22cef9" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a branded wordmark link to the top-left of the mobile navigation menu.
  * The link directs users to the home page and closes the menu when selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->