### PR TITLE
Fix folder delete confirmation for names with special characters

### DIFF
--- a/apps/web/ui/modals/delete-folder-modal.tsx
+++ b/apps/web/ui/modals/delete-folder-modal.tsx
@@ -72,7 +72,7 @@ const DeleteFolderModal = ({
                 <p className="block text-sm text-neutral-500">
                   To verify, type{" "}
                   <span className="font-medium text-neutral-700">
-                    {folder.name}
+                    confirm delete folder
                   </span>{" "}
                   below
                 </p>
@@ -88,7 +88,7 @@ const DeleteFolderModal = ({
                       className="block w-full rounded-md border-0 text-neutral-900 placeholder-neutral-400 focus:outline-none focus:ring-0 sm:text-sm"
                       aria-invalid="true"
                       autoFocus={!isMobile}
-                      pattern={folder.name}
+                      pattern="confirm delete folder"
                     />
                   </div>
                 </div>


### PR DESCRIPTION
Require typing "confirm delete folder" instead of the folder name so HTML pattern validation no longer fails on names like "Forms (Internal)".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated folder deletion confirmation to require the phrase “confirm delete folder,” providing a consistent and clear verification step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->