### PR TITLE
`skipRevalidateTag` to silence `revalidateTag` errors

### DIFF
--- a/apps/web/lib/api/links/cache.ts
+++ b/apps/web/lib/api/links/cache.ts
@@ -47,13 +47,18 @@ class LinkCache {
     return await pipeline.exec();
   }
 
-  async set(link: ExpandedLink) {
+  async set(
+    link: ExpandedLink,
+    { skipRevalidateTag = false }: { skipRevalidateTag?: boolean } = {},
+  ) {
     const redisLink = formatRedisLink(link);
     const cacheKey = this._createKey({ domain: link.domain, key: link.key });
 
     // Update LRU cache immediately to prevent stale reads
     linkLRUCache.set(cacheKey, redisLink);
-    revalidateTag(`static:${link.domain.toLowerCase()}:${link.key}`);
+    if (!skipRevalidateTag) {
+      revalidateTag(`static:${link.domain.toLowerCase()}:${link.key}`);
+    }
 
     await Promise.all([
       redisGlobal.set(cacheKey, redisLink, {

--- a/apps/web/lib/middleware/link.ts
+++ b/apps/web/lib/middleware/link.ts
@@ -113,7 +113,7 @@ export async function LinkMiddleware(req: NextRequest, ev: NextFetchEvent) {
     ev.waitUntil(
       (async () => {
         if (!isPartnerLink) {
-          await linkCache.set(linkData as any);
+          await linkCache.set(linkData as any, { skipRevalidateTag: true });
           return;
         }
 
@@ -123,11 +123,14 @@ export async function LinkMiddleware(req: NextRequest, ev: NextFetchEvent) {
         });
 
         // we'll use this data on /track/click
-        await linkCache.set({
-          ...(linkData as any),
-          ...(partner && { partner }),
-          ...(discount && { discount }),
-        });
+        await linkCache.set(
+          {
+            ...(linkData as any),
+            ...(partner && { partner }),
+            ...(discount && { discount }),
+          },
+          { skipRevalidateTag: true },
+        );
       })(),
     );
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved link caching to optionally skip unnecessary cache revalidation, reducing redundant refreshes.
- **Reliability**
  - Enhanced cached link responses for both partner and non-partner links.
  - Partner payloads now include optional fields only when present, improving correctness and consistency of cached data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->