### PR TITLE
Return 404 when OG program group is missing

### DIFF
--- a/apps/web/app/api/og/program/route.tsx
+++ b/apps/web/app/api/og/program/route.tsx
@@ -15,6 +15,7 @@ const DARK_CELLS = [
   [53, 1],
 ];
 
+// GET /api/og/program?slug=program&groupSlug=group
 export async function GET(req: NextRequest) {
   const slug = req.nextUrl.searchParams.get("slug");
   const groupSlug = req.nextUrl.searchParams.get("groupSlug");
@@ -47,12 +48,18 @@ export async function GET(req: NextRequest) {
   ]);
 
   if (!program) {
-    return new Response(`Program not found`, {
+    return new Response("Program not found", {
       status: 404,
     });
   }
 
   const group = program.groups[0];
+
+  if (!group) {
+    return new Response("Group not found", {
+      status: 404,
+    });
+  }
 
   const logo = group.wordmark || group.logo;
   const brandColor = group.brandColor || "#000000";


### PR DESCRIPTION
Fix the error

```
2026-07-29 05:32:22.660 [error] TypeError: Cannot read properties of undefined (reading 'wordmark')
    at C (.next/server/app/api/og/program/route.js:1:4267)
    at async k (.next/server/app/api/og/program/route.js:1:10438)
    at async g (.next/server/app/api/og/program/route.js:1:11441)
    at async J (.next/server/app/api/og/program/route.js:1:12563)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved program image generation error handling.
  * Returns a clear “Group not found” response when a program has no associated group.
  * Standardized the “Program not found” response for missing programs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->