### PR TITLE
Fix URI malformed errors when decoding link keys

### DIFF
--- a/apps/web/lib/planetscale/check-if-key-exists.ts
+++ b/apps/web/lib/planetscale/check-if-key-exists.ts
@@ -1,4 +1,4 @@
-import { punyEncode } from "@dub/utils";
+import { punyEncode, safeDecodeURIComponent } from "@dub/utils";
 import {
   encodeKey,
   isCaseSensitiveDomain,
@@ -18,7 +18,7 @@ export const checkIfKeyExists = async ({
       encodeKey(key)
     : // for non-case sensitive domains, we need to make sure that the key is always URI-decoded + punycode-encoded
       // (cause that's how we store it in MySQL)
-      punyEncode(decodeURIComponent(key));
+      punyEncode(safeDecodeURIComponent(key));
 
   const { rows } =
     (await conn.execute(

--- a/apps/web/lib/planetscale/get-link-via-edge.ts
+++ b/apps/web/lib/planetscale/get-link-via-edge.ts
@@ -1,4 +1,4 @@
-import { punyEncode } from "@dub/utils";
+import { punyEncode, safeDecodeURIComponent } from "@dub/utils";
 import {
   decodeKeyIfCaseSensitive,
   encodeKey,
@@ -20,7 +20,7 @@ const getLinkViaEdgeHelper = async ({
       encodeKey(key)
     : // for non-case sensitive domains, we need to make sure that the key is always URI-decoded + punycode-encoded
       // (cause that's how we store it in MySQL)
-      punyEncode(decodeURIComponent(key));
+      punyEncode(safeDecodeURIComponent(key));
 
   const { rows } =
     (await conn.execute(`SELECT * FROM Link WHERE domain = ? AND \`key\` = ?`, [

--- a/apps/web/lib/planetscale/get-link-with-partner.ts
+++ b/apps/web/lib/planetscale/get-link-with-partner.ts
@@ -1,4 +1,4 @@
-import { punyEncode } from "@dub/utils";
+import { punyEncode, safeDecodeURIComponent } from "@dub/utils";
 import {
   decodeKeyIfCaseSensitive,
   encodeKey,
@@ -30,7 +30,7 @@ export const getLinkWithPartner = async ({
 }): Promise<QueryResult | null> => {
   const keyToQuery = isCaseSensitiveDomain(domain)
     ? encodeKey(key)
-    : punyEncode(decodeURIComponent(key));
+    : punyEncode(safeDecodeURIComponent(key));
 
   console.time("getLinkWithPartner");
 

--- a/apps/web/tests/misc/safe-decode-uri-component.test.ts
+++ b/apps/web/tests/misc/safe-decode-uri-component.test.ts
@@ -1,0 +1,19 @@
+import { safeDecodeURIComponent } from "@dub/utils";
+import { describe, expect, it } from "vitest";
+
+describe("safeDecodeURIComponent", () => {
+  it("decodes valid percent-encoding", () => {
+    expect(safeDecodeURIComponent("hello%20world")).toBe("hello world");
+  });
+
+  it("returns the original string for malformed sequences", () => {
+    expect(safeDecodeURIComponent("100%off")).toBe("100%off");
+    expect(safeDecodeURIComponent("a%")).toBe("a%");
+    expect(safeDecodeURIComponent("a%2")).toBe("a%2");
+  });
+
+  it("leaves plain and already-decoded keys unchanged", () => {
+    expect(safeDecodeURIComponent("github")).toBe("github");
+    expect(safeDecodeURIComponent("안녕")).toBe("안녕");
+  });
+});

--- a/packages/utils/src/functions/urls.ts
+++ b/packages/utils/src/functions/urls.ts
@@ -7,6 +7,14 @@ export const isValidUrl = (url: string) => {
   }
 };
 
+export function safeDecodeURIComponent(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
 const SAFE_LINK_SCHEMES = new Set(["http:", "https:", "mailto:"]);
 
 export function isSafeLinkHref(


### PR DESCRIPTION
Before: malformed % in a key → uncaught URIError → 500

After: same key → decode skipped → lookup as-is → usually not_found (or whatever the existing miss path is)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed URL-encoded domains and keys without causing lookup errors.
  * Link lookups now remain functional when percent-encoded values are invalid or incomplete.

* **New Features**
  * Added safer URL decoding that preserves the original value when decoding fails.

* **Tests**
  * Added coverage for valid, malformed, plain-text, and non-ASCII URL values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->