### PR TITLE
Sanitize invalid analytics timezone

### DIFF
--- a/apps/web/app/(ee)/api/partners/applications/analytics/route.ts
+++ b/apps/web/app/(ee)/api/partners/applications/analytics/route.ts
@@ -1,4 +1,5 @@
 import { getStartEndDates } from "@/lib/analytics/utils/get-start-end-dates";
+import { sanitizeTimezone } from "@/lib/analytics/utils/sanitize-timezone";
 import { getDefaultProgramIdOrThrow } from "@/lib/api/programs/get-default-program-id-or-throw";
 import {
   applicationEventAnalyticsQuerySchema,
@@ -53,7 +54,7 @@ export const GET = withWorkspace(async ({ workspace, searchParams }) => {
   } = parsedFilters;
 
   // Align with CONVERT_TZ in raw SQL and analyticsQuerySchema default (UTC when omitted).
-  const timezone = timezoneParam ?? "UTC";
+  const timezone = sanitizeTimezone(timezoneParam);
 
   const { startDate, endDate } = getStartEndDates({
     interval,

--- a/apps/web/app/(ee)/api/partners/applications/analytics/route.ts
+++ b/apps/web/app/(ee)/api/partners/applications/analytics/route.ts
@@ -1,5 +1,4 @@
 import { getStartEndDates } from "@/lib/analytics/utils/get-start-end-dates";
-import { sanitizeTimezone } from "@/lib/analytics/utils/sanitize-timezone";
 import { getDefaultProgramIdOrThrow } from "@/lib/api/programs/get-default-program-id-or-throw";
 import {
   applicationEventAnalyticsQuerySchema,
@@ -54,7 +53,7 @@ export const GET = withWorkspace(async ({ workspace, searchParams }) => {
   } = parsedFilters;
 
   // Align with CONVERT_TZ in raw SQL and analyticsQuerySchema default (UTC when omitted).
-  const timezone = sanitizeTimezone(timezoneParam);
+  const timezone = timezoneParam ?? "UTC";
 
   const { startDate, endDate } = getStartEndDates({
     interval,

--- a/apps/web/lib/analytics/utils/get-start-end-dates.ts
+++ b/apps/web/lib/analytics/utils/get-start-end-dates.ts
@@ -1,6 +1,7 @@
 import { tz, TZDate } from "@date-fns/tz";
 import { differenceInDays, endOfDay, startOfDay } from "date-fns";
 import { getIntervalData } from "./get-interval-data";
+import { sanitizeTimezone } from "./sanitize-timezone";
 
 export const getStartEndDates = ({
   interval,
@@ -15,6 +16,8 @@ export const getStartEndDates = ({
   dataAvailableFrom?: Date;
   timezone?: string;
 }) => {
+  timezone = sanitizeTimezone(timezone);
+
   let startDate: TZDate;
   let endDate: TZDate;
   let granularity: "minute" | "hour" | "day" | "month" = "day";
@@ -26,7 +29,7 @@ export const getStartEndDates = ({
     endDate = endOfDay(new TZDate(new Date(end ?? Date.now()), timezone));
 
     const daysDifference = differenceInDays(endDate, startDate, {
-      in: timezone ? tz(timezone) : undefined,
+      in: tz(timezone),
     });
 
     if (daysDifference <= 2) {

--- a/apps/web/lib/analytics/utils/sanitize-timezone.ts
+++ b/apps/web/lib/analytics/utils/sanitize-timezone.ts
@@ -1,0 +1,10 @@
+export function sanitizeTimezone(timezone?: string): string {
+  if (!timezone) return "UTC";
+
+  try {
+    Intl.DateTimeFormat(undefined, { timeZone: timezone });
+    return timezone;
+  } catch {
+    return "UTC";
+  }
+}

--- a/apps/web/lib/zod/schemas/analytics.ts
+++ b/apps/web/lib/zod/schemas/analytics.ts
@@ -168,6 +168,7 @@ export const analyticsQuerySchema = z.object({
   timezone: z
     .string()
     .optional()
+    .overwrite((v) => (v === undefined ? undefined : sanitizeTimezone(v)))
     .describe(
       "The IANA time zone code for aligning timeseries granularity (e.g. America/New_York). Defaults to UTC.",
     )
@@ -400,10 +401,6 @@ export function parseAnalyticsQuery(searchParams: Record<string, string>) {
     data.tagId = data.tagIds;
   }
 
-  if (data.timezone !== undefined) {
-    data.timezone = sanitizeTimezone(data.timezone);
-  }
-
   return data;
 }
 export function parseEventsQuery(searchParams: Record<string, string>) {
@@ -411,10 +408,6 @@ export function parseEventsQuery(searchParams: Record<string, string>) {
 
   if (data.tagIds && !data.tagId) {
     data.tagId = data.tagIds;
-  }
-
-  if (data.timezone !== undefined) {
-    data.timezone = sanitizeTimezone(data.timezone);
   }
 
   return data;

--- a/apps/web/lib/zod/schemas/analytics.ts
+++ b/apps/web/lib/zod/schemas/analytics.ts
@@ -5,6 +5,7 @@ import {
   OLD_TO_NEW_ANALYTICS_ENDPOINTS,
   VALID_ANALYTICS_ENDPOINTS,
 } from "@/lib/analytics/constants";
+import { sanitizeTimezone } from "@/lib/analytics/utils/sanitize-timezone";
 import {
   DEFAULT_PAGINATION_LIMIT,
   DUB_FOUNDING_DATE,
@@ -167,6 +168,7 @@ export const analyticsQuerySchema = z.object({
   timezone: z
     .string()
     .optional()
+    .transform(sanitizeTimezone)
     .describe(
       "The IANA time zone code for aligning timeseries granularity (e.g. America/New_York). Defaults to UTC.",
     )

--- a/apps/web/lib/zod/schemas/analytics.ts
+++ b/apps/web/lib/zod/schemas/analytics.ts
@@ -168,7 +168,6 @@ export const analyticsQuerySchema = z.object({
   timezone: z
     .string()
     .optional()
-    .transform(sanitizeTimezone)
     .describe(
       "The IANA time zone code for aligning timeseries granularity (e.g. America/New_York). Defaults to UTC.",
     )
@@ -401,6 +400,10 @@ export function parseAnalyticsQuery(searchParams: Record<string, string>) {
     data.tagId = data.tagIds;
   }
 
+  if (data.timezone !== undefined) {
+    data.timezone = sanitizeTimezone(data.timezone);
+  }
+
   return data;
 }
 export function parseEventsQuery(searchParams: Record<string, string>) {
@@ -408,6 +411,10 @@ export function parseEventsQuery(searchParams: Record<string, string>) {
 
   if (data.tagIds && !data.tagId) {
     data.tagId = data.tagIds;
+  }
+
+  if (data.timezone !== undefined) {
+    data.timezone = sanitizeTimezone(data.timezone);
   }
 
   return data;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved analytics date calculations by validating and normalizing timezone settings.
  * Invalid or missing timezones now safely fall back to UTC.
  * Ensured analytics queries consistently use a valid timezone for reliable results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->