### PR TITLE
`PartnerGroupHistorySheet` → `PartnerEnrollmentHistorySheet`

### DIFF
--- a/apps/web/ui/activity-logs/action-renderers/partner-status-changed-renderer.tsx
+++ b/apps/web/ui/activity-logs/action-renderers/partner-status-changed-renderer.tsx
@@ -1,0 +1,38 @@
+import { ActivityLog } from "@/lib/types";
+import { PartnerStatusBadges } from "@/ui/partners/partner-status-badges";
+import { ProgramEnrollmentStatus } from "@prisma/client";
+import { ReactNode } from "react";
+import { PartnerStatusPill, UserChip } from "../activity-entry-chips";
+
+interface StatusChangeSet {
+  old: ProgramEnrollmentStatus | null;
+  new: ProgramEnrollmentStatus | null;
+}
+
+function Label({ children }: { children: ReactNode }) {
+  return (
+    <span className="text-sm font-medium text-neutral-800">{children}</span>
+  );
+}
+
+export function PartnerStatusChangedRenderer({ log }: { log: ActivityLog }) {
+  const statusChange = log.changeSet?.status as StatusChangeSet | undefined;
+  const status = statusChange?.new ?? null;
+
+  if (!status || !(status in PartnerStatusBadges)) {
+    return <span>Status changed</span>;
+  }
+
+  return (
+    <>
+      <Label>Status updated to</Label>
+      <PartnerStatusPill status={status} />
+      {log.user ? (
+        <>
+          <Label>by</Label>
+          <UserChip user={log.user} />
+        </>
+      ) : null}
+    </>
+  );
+}

--- a/apps/web/ui/activity-logs/activity-entry-chips.tsx
+++ b/apps/web/ui/activity-logs/activity-entry-chips.tsx
@@ -1,6 +1,8 @@
 import { ActivityLog, GroupProps, ProgramProps } from "@/lib/types";
 import { getResourceColorData, RAINBOW_CONIC_GRADIENT } from "@/ui/colors";
+import { PartnerStatusBadges } from "@/ui/partners/partner-status-badges";
 import { SubmittedLeadStatusBadges } from "@/ui/submitted-leads/submitted-lead-status-badges";
+import { ProgramEnrollmentStatus } from "@prisma/client";
 import { Bolt, Tooltip } from "@dub/ui";
 import { cn, OG_AVATAR_URL } from "@dub/utils";
 import { SubmittedLeadStatus } from "@prisma/client";
@@ -132,6 +134,25 @@ export function SubmittedLeadStatusPill({
   if (!badge) return null;
 
   return <ActivityChip className={badge.className}>{badge.label}</ActivityChip>;
+}
+
+export function PartnerStatusPill({
+  status,
+}: {
+  status: ProgramEnrollmentStatus;
+}) {
+  const badge = PartnerStatusBadges[status];
+
+  if (!badge) return null;
+
+  const Icon = badge.icon;
+
+  return (
+    <ActivityChip className={badge.className}>
+      <Icon className="size-3.5" />
+      {badge.label}
+    </ActivityChip>
+  );
 }
 
 export function ActivityLogUserAvatar({ user }: { user: ActivityLog["user"] }) {

--- a/apps/web/ui/activity-logs/activity-feed.tsx
+++ b/apps/web/ui/activity-logs/activity-feed.tsx
@@ -1,5 +1,5 @@
 import { ActivityLog, ActivityLogResourceType } from "@/lib/types";
-import { PartnerGroupActivityItem } from "@/ui/activity-logs/partner-group-activity-item";
+import { PartnerEnrollmentActivityItem } from "@/ui/activity-logs/partner-enrollment-activity-item";
 import { RewardActivityItem } from "@/ui/activity-logs/reward-activity-item";
 import { SubmittedLeadActivityItem } from "@/ui/activity-logs/submitted-lead-activity-item";
 import { ComponentType } from "react";
@@ -8,7 +8,7 @@ const ACTIVITY_ITEM_MAP: Record<
   Exclude<ActivityLogResourceType, "commission">,
   ComponentType<{ log: ActivityLog; isLast?: boolean }>
 > = {
-  partner: PartnerGroupActivityItem,
+  partner: PartnerEnrollmentActivityItem,
   submittedLead: SubmittedLeadActivityItem,
   clickReward: RewardActivityItem,
   leadReward: RewardActivityItem,

--- a/apps/web/ui/activity-logs/activity-log-registry.tsx
+++ b/apps/web/ui/activity-logs/activity-log-registry.tsx
@@ -1,5 +1,6 @@
 import { ActivityLog, ActivityLogAction } from "@/lib/types";
 import {
+  CircleDotted,
   CircleInfo,
   FileSend,
   MoneyBill2,
@@ -10,9 +11,21 @@ import {
 import { CircleMinus, CirclePlusIcon } from "lucide-react";
 import { ComponentType, ReactNode } from "react";
 import { PartnerGroupChangedRenderer } from "./action-renderers/partner-group-changed-renderer";
+import { PartnerStatusChangedRenderer } from "./action-renderers/partner-status-changed-renderer";
 import { RewardActivityRenderer } from "./action-renderers/reward-activity-renderer";
 import { SubmittedLeadCreatedRenderer } from "./action-renderers/submitted-lead-created-renderer";
 import { SubmittedLeadStatusChangedRenderer } from "./action-renderers/submitted-lead-status-changed-renderer";
+
+const PARTNER_STATUS_ACTIONS = [
+  "partner_application.approved",
+  "partner_application.rejected",
+  "partner.banned",
+  "partner.unbanned",
+  "partner.deactivated",
+  "partner.reactivated",
+  "partner.archived",
+  "partner.unarchived",
+] as const satisfies readonly ActivityLogAction[];
 
 export type ActorType = "USER" | "SYSTEM";
 
@@ -26,6 +39,9 @@ const ACTIVITY_LOG_ICONS: Partial<
   Record<ActivityLogAction, ComponentType<{ className?: string }>>
 > = {
   "partner.groupChanged": UserArrowRight,
+  ...Object.fromEntries(
+    PARTNER_STATUS_ACTIONS.map((action) => [action, CircleDotted]),
+  ),
 
   "submittedLead.created": FileSend,
   "submittedLead.qualified": UserClock,
@@ -51,6 +67,10 @@ const ACTIVITY_LOG_REGISTRY: Array<{
     action: "partner.groupChanged",
     renderer: PartnerGroupChangedRenderer,
   },
+  ...PARTNER_STATUS_ACTIONS.map((action) => ({
+    action,
+    renderer: PartnerStatusChangedRenderer,
+  })),
   {
     action: "submittedLead.created",
     renderer: SubmittedLeadCreatedRenderer,

--- a/apps/web/ui/activity-logs/partner-enrollment-activity-item.tsx
+++ b/apps/web/ui/activity-logs/partner-enrollment-activity-item.tsx
@@ -6,15 +6,15 @@ import {
   getActivityLogRenderer,
 } from "./activity-log-registry";
 
-interface PartnerGroupActivityItemProps {
+interface PartnerEnrollmentActivityItemProps {
   log: ActivityLog;
   isLast?: boolean;
 }
 
-export function PartnerGroupActivityItem({
+export function PartnerEnrollmentActivityItem({
   log,
   isLast = false,
-}: PartnerGroupActivityItemProps) {
+}: PartnerEnrollmentActivityItemProps) {
   const icon = getActivityLogIcon(log);
   const Renderer = getActivityLogRenderer(log.action);
 
@@ -32,7 +32,7 @@ export function PartnerGroupActivityItem({
       )}
 
       <div
-        className="flex size-6 shrink-0 items-center justify-center text-neutral-500"
+        className="mt-0.5 flex size-6 shrink-0 items-center justify-center bg-white text-neutral-500"
         aria-hidden="true"
       >
         {icon}
@@ -47,7 +47,7 @@ export function PartnerGroupActivityItem({
           side="left"
           rows={["local", "utc", "unix"]}
         >
-          <time className="text-xs text-neutral-500">
+          <time className="w-fit shrink-0 cursor-help text-xs text-neutral-500">
             {formatDate(log.createdAt, {
               month: "short",
               year: "numeric",

--- a/apps/web/ui/activity-logs/partner-enrollment-activity-section.tsx
+++ b/apps/web/ui/activity-logs/partner-enrollment-activity-section.tsx
@@ -6,7 +6,7 @@ import {
   ActivityFeedSkeleton,
 } from "@/ui/activity-logs/activity-feed";
 
-export function PartnerGroupActivitySection({
+export function PartnerEnrollmentActivitySection({
   partnerId,
 }: {
   partnerId: string;
@@ -15,7 +15,6 @@ export function PartnerGroupActivitySection({
     query: {
       resourceType: "partner",
       resourceId: partnerId,
-      action: "partner.groupChanged",
     },
     enabled: !!partnerId,
   });
@@ -37,7 +36,7 @@ export function PartnerGroupActivitySection({
   if (!activityLogs || activityLogs.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center py-8 text-center">
-        <p className="text-sm text-neutral-500">No group history yet</p>
+        <p className="text-sm text-neutral-500">No history yet</p>
       </div>
     );
   }

--- a/apps/web/ui/activity-logs/partner-enrollment-history-sheet.tsx
+++ b/apps/web/ui/activity-logs/partner-enrollment-history-sheet.tsx
@@ -2,25 +2,25 @@
 
 import { useActivityLogs } from "@/lib/swr/use-activity-logs";
 import { EnrolledPartnerExtendedProps } from "@/lib/types";
-import { PartnerGroupActivitySection } from "@/ui/activity-logs/partner-group-activity-section";
+import { PartnerEnrollmentActivitySection } from "@/ui/activity-logs/partner-enrollment-activity-section";
 import { X } from "@/ui/shared/icons";
 import { Button, Sheet } from "@dub/ui";
 import { Dispatch, SetStateAction, useState } from "react";
 
-interface PartnerGroupHistorySheetProps {
+interface PartnerEnrollmentHistorySheetProps {
   partner: Pick<EnrolledPartnerExtendedProps, "id">;
   isOpen: boolean;
   setIsOpen: Dispatch<SetStateAction<boolean>>;
 }
 
-function PartnerGroupHistorySheetContent({
+function PartnerEnrollmentHistorySheetContent({
   partner,
-}: Omit<PartnerGroupHistorySheetProps, "isOpen">) {
+}: Omit<PartnerEnrollmentHistorySheetProps, "isOpen">) {
   return (
     <div className="flex size-full flex-col">
       <div className="flex h-16 shrink-0 items-center justify-between border-b border-neutral-200 px-6 py-4">
         <Sheet.Title className="text-lg font-semibold">
-          Partner group history
+          Partner history
         </Sheet.Title>
         <Sheet.Close asChild>
           <Button
@@ -32,24 +32,24 @@ function PartnerGroupHistorySheetContent({
       </div>
 
       <div className="scrollbar-hide flex min-h-0 flex-1 flex-col overflow-y-auto p-4 sm:p-6">
-        <PartnerGroupActivitySection partnerId={partner.id} />
+        <PartnerEnrollmentActivitySection partnerId={partner.id} />
       </div>
     </div>
   );
 }
 
-export function PartnerGroupHistorySheet({
+export function PartnerEnrollmentHistorySheet({
   isOpen,
   ...rest
-}: PartnerGroupHistorySheetProps) {
+}: PartnerEnrollmentHistorySheetProps) {
   return (
     <Sheet open={isOpen} onOpenChange={rest.setIsOpen}>
-      <PartnerGroupHistorySheetContent {...rest} />
+      <PartnerEnrollmentHistorySheetContent {...rest} />
     </Sheet>
   );
 }
 
-export function usePartnerGroupHistorySheet({
+export function usePartnerEnrollmentHistorySheet({
   partner,
 }: {
   partner: Pick<EnrolledPartnerExtendedProps, "id"> | null;
@@ -61,7 +61,6 @@ export function usePartnerGroupHistorySheet({
       ? {
           resourceType: "partner",
           resourceId: partner.id,
-          action: "partner.groupChanged",
         }
       : undefined,
     enabled: !!partner?.id,
@@ -69,8 +68,8 @@ export function usePartnerGroupHistorySheet({
 
   return {
     hasActivityLogs: (activityLogs?.length ?? 0) > 0,
-    partnerGroupHistorySheet: partner ? (
-      <PartnerGroupHistorySheet
+    partnerEnrollmentHistorySheet: partner ? (
+      <PartnerEnrollmentHistorySheet
         partner={partner}
         isOpen={isOpen}
         setIsOpen={setIsOpen}

--- a/apps/web/ui/partners/activity-event.tsx
+++ b/apps/web/ui/partners/activity-event.tsx
@@ -44,7 +44,7 @@ export function ActivityEvent({
               side="right"
               rows={["local", "utc", "unix"]}
             >
-              <span className="shrink-0 text-xs text-neutral-400 sm:ml-auto">
+              <span className="w-fit shrink-0 cursor-help text-xs text-neutral-400 sm:ml-auto">
                 {formatDateTime(timestamp)}
               </span>
             </TimestampTooltip>

--- a/apps/web/ui/partners/partner-info-cards.tsx
+++ b/apps/web/ui/partners/partner-info-cards.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/lib/types";
 import { DEFAULT_PARTNER_GROUP } from "@/lib/zod/schemas/groups";
 import { INACTIVE_ENROLLMENT_STATUSES } from "@/lib/zod/schemas/partners";
-import { usePartnerGroupHistorySheet } from "@/ui/activity-logs/partner-group-history-sheet";
+import { usePartnerEnrollmentHistorySheet } from "@/ui/activity-logs/partner-enrollment-history-sheet";
 import {
   Button,
   CalendarIcon,
@@ -107,10 +107,10 @@ export function PartnerInfoCards({
   const isAdmin = type === "admin";
 
   const {
-    partnerGroupHistorySheet,
-    setIsOpen: setGroupHistoryOpen,
+    partnerEnrollmentHistorySheet,
+    setIsOpen: setPartnerEnrollmentHistoryOpen,
     hasActivityLogs,
-  } = usePartnerGroupHistorySheet({ partner: partner || null });
+  } = usePartnerEnrollmentHistorySheet({ partner: partner || null });
 
   const { group } = useGroup(
     {
@@ -163,21 +163,17 @@ export function PartnerInfoCards({
         ) : (
           <Users className="size-3.5" />
         ),
-        text: isPendingApplication ? (
-          <span className="inline-flex flex-wrap items-center gap-1">
-            <TimestampTooltip
-              timestamp={partner.createdAt}
-              rows={["local", "utc", "unix"]}
-              side="left"
-              delayDuration={250}
-            >
-              <span>Applied {formatDate(partner.createdAt)}</span>
-            </TimestampTooltip>
-          </span>
-        ) : (
-          `${isPendingApplication ? "Applied" : "Partner since"} ${formatDate(partner.createdAt)}`
+        text: `${isPendingApplication ? "Applied" : "Partner since"} ${formatDate(partner.createdAt)}`,
+        timestamp: partner.createdAt,
+        wrapper: ({ children }) => (
+          <button
+            type="button"
+            onClick={() => setPartnerEnrollmentHistoryOpen(true)}
+            className="underline decoration-dotted underline-offset-2"
+          >
+            {children}
+          </button>
         ),
-        timestamp: isPendingApplication ? undefined : partner.createdAt,
       },
       {
         id: "payoutMethod" as const,
@@ -391,13 +387,13 @@ export function PartnerInfoCards({
                     variant="outline"
                     text="View history"
                     className="h-7 w-fit rounded-lg px-1.5 text-xs font-medium text-neutral-400"
-                    onClick={() => setGroupHistoryOpen(true)}
+                    onClick={() => setPartnerEnrollmentHistoryOpen(true)}
                   />
                 )}
               </div>
             )}
 
-            {partnerGroupHistorySheet}
+            {partnerEnrollmentHistorySheet}
             {partner ? (
               <PartnerInfoGroup
                 partner={partner}

--- a/apps/web/ui/partners/partner-info-cards.tsx
+++ b/apps/web/ui/partners/partner-info-cards.tsx
@@ -165,15 +165,19 @@ export function PartnerInfoCards({
         ),
         text: `${isPendingApplication ? "Applied" : "Partner since"} ${formatDate(partner.createdAt)}`,
         timestamp: partner.createdAt,
-        wrapper: ({ children }) => (
-          <button
-            type="button"
-            onClick={() => setPartnerEnrollmentHistoryOpen(true)}
-            className="underline decoration-dotted underline-offset-2"
-          >
-            {children}
-          </button>
-        ),
+        ...(isPendingApplication
+          ? {}
+          : {
+              wrapper: ({ children }) => (
+                <button
+                  type="button"
+                  onClick={() => setPartnerEnrollmentHistoryOpen(true)}
+                  className="underline decoration-dotted underline-offset-2"
+                >
+                  {children}
+                </button>
+              ),
+            }),
       },
       {
         id: "payoutMethod" as const,


### PR DESCRIPTION
<img width="1132" height="1274" alt="CleanShot 2026-07-29 at 15 05 20@2x" src="https://github.com/user-attachments/assets/b561d24d-2e7e-4677-a1cd-f50dbb10328b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added partner enrollment history views with activity entries for partner “status changed” events.
  - Status changes now show the updated enrollment status (with badges when available) and, when present, the user who made the change.

- **Improvements**
  - Switched the activity feed and history sheet to partner enrollment history (including updated empty-state text).
  - Enhanced timestamp tooltip sizing/help cursor behavior and made “Partner since/Applied” interactions open enrollment history for all partners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->