### PR TITLE
Make sure `performanceCount` doesn't exceed `condition.value`

### DIFF
--- a/apps/web/lib/bounty/api/upsert-draft-bounty-submissions.ts
+++ b/apps/web/lib/bounty/api/upsert-draft-bounty-submissions.ts
@@ -101,7 +101,7 @@ export function planDraftBountySubmissionUpserts({
         programId,
         partnerId: partner.id,
         bountyId,
-        performanceCount,
+        performanceCount: conditionMet ? condition.value : performanceCount,
         ...(conditionMet && {
           status: "submitted",
           completedAt: new Date(),
@@ -114,7 +114,7 @@ export function planDraftBountySubmissionUpserts({
     if (existing.performanceCount !== performanceCount || conditionMet) {
       toUpdate.push({
         id: existing.id,
-        performanceCount,
+        performanceCount: conditionMet ? condition.value : performanceCount,
         promoteToSubmitted: conditionMet,
       });
     }

--- a/apps/web/tests/bounties/upsert-draft-bounty-submissions.test.ts
+++ b/apps/web/tests/bounties/upsert-draft-bounty-submissions.test.ts
@@ -211,7 +211,7 @@ describe("planDraftBountySubmissionUpserts", () => {
 
     expect(toCreate).toHaveLength(1);
     expect(toCreate[0]).toMatchObject({
-      performanceCount: 15_000,
+      performanceCount: condition.value,
       status: "submitted",
       completedAt: expect.any(Date),
     });
@@ -248,7 +248,7 @@ describe("planDraftBountySubmissionUpserts", () => {
     expect(toUpdate).toEqual([
       {
         id: "bnty_sub_1",
-        performanceCount: 12_000,
+        performanceCount: condition.value,
         promoteToSubmitted: true,
       },
     ]);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected bounty submission performance counts when workflow conditions are met.
  * New and refreshed submissions now consistently use the configured condition value (when applicable) instead of the partner’s computed lifetime statistics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->