### PR TITLE
Block disposable domains when requesting an email change

### DIFF
--- a/apps/web/lib/actions/send-otp.ts
+++ b/apps/web/lib/actions/send-otp.ts
@@ -39,10 +39,10 @@ export const sendOtpAction = actionClient
     }
 
     const isGenericEmailWithPlus = email.includes("+") && isGenericEmail(email);
-    const domainBlocked = await isEmailDomainBlocked(email);
+    const emailDomainBlocked = await isEmailDomainBlocked(email);
 
     // if any of the flags match, run one final edge case check, before throwing an error
-    if (isGenericEmailWithPlus || domainBlocked) {
+    if (isGenericEmailWithPlus || emailDomainBlocked) {
       // edge case: the user already has a partner account on Dub with this email address,
       // or they have an existing application for a program, we can allow them to continue
       const [isPartnerAccount, hasExistingApplications] = await Promise.all([

--- a/apps/web/lib/actions/send-otp.ts
+++ b/apps/web/lib/actions/send-otp.ts
@@ -1,11 +1,11 @@
 "use server";
 
 import { getIP } from "@/lib/api/utils/get-ip";
+import { isEmailDomainBlocked } from "@/lib/email/is-email-domain-blocked";
 import { prisma } from "@/lib/prisma";
-import { ratelimit, redis } from "@/lib/upstash";
+import { ratelimit } from "@/lib/upstash";
 import { sendEmail } from "@dub/email";
 import VerifyEmail from "@dub/email/templates/verify-email";
-import { get } from "@vercel/edge-config";
 import { flattenValidationErrors } from "next-safe-action";
 import * as z from "zod/v4";
 import { generateOTP } from "../auth";
@@ -39,38 +39,10 @@ export const sendOtpAction = actionClient
     }
 
     const isGenericEmailWithPlus = email.includes("+") && isGenericEmail(email);
-
-    const emailDomain = (email.split("@")[1] ?? "").trim().toLowerCase();
-
-    const [isDisposable, emailDomainTerms] = await Promise.all([
-      redis.sismember("disposableEmailDomains", emailDomain),
-      process.env.EDGE_CONFIG ? get("emailDomainTerms") : [],
-    ]);
-
-    const escapedDomainTerms =
-      emailDomainTerms && Array.isArray(emailDomainTerms)
-        ? emailDomainTerms
-            .map((term: string) =>
-              String(term)
-                .trim()
-                .toLowerCase()
-                .replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
-            )
-            .filter((term) => term.length > 0)
-        : [];
-
-    const blacklistedEmailDomainTermsRegex =
-      escapedDomainTerms.length > 0
-        ? new RegExp(escapedDomainTerms.join("|"))
-        : null;
+    const domainBlocked = await isEmailDomainBlocked(email);
 
     // if any of the flags match, run one final edge case check, before throwing an error
-    if (
-      isGenericEmailWithPlus ||
-      isDisposable ||
-      (blacklistedEmailDomainTermsRegex &&
-        blacklistedEmailDomainTermsRegex.test(emailDomain))
-    ) {
+    if (isGenericEmailWithPlus || domainBlocked) {
       // edge case: the user already has a partner account on Dub with this email address,
       // or they have an existing application for a program, we can allow them to continue
       const [isPartnerAccount, hasExistingApplications] = await Promise.all([

--- a/apps/web/lib/auth/request-email-change.ts
+++ b/apps/web/lib/auth/request-email-change.ts
@@ -39,7 +39,7 @@ export const requestEmailChange = async ({
     throw new DubApiError({
       code: "bad_request",
       message:
-        "This email domain is not allowed. Please use a different email address.",
+        "Invalid email address – please use your work email instead. If you think this is a mistake, please contact us at dub.co/support",
     });
   }
 

--- a/apps/web/lib/auth/request-email-change.ts
+++ b/apps/web/lib/auth/request-email-change.ts
@@ -5,6 +5,7 @@ import { waitUntil } from "@vercel/functions";
 import { randomBytes } from "crypto";
 import { hashToken } from ".";
 import { DubApiError } from "../api/errors";
+import { isEmailDomainBlocked } from "../email/is-email-domain-blocked";
 import { ratelimit, redis } from "../upstash";
 
 // Send the OTP to confirm the email address change for existing users/partners
@@ -31,6 +32,14 @@ export const requestEmailChange = async ({
     throw new DubApiError({
       code: "bad_request",
       message: "Partner ID is required when syncing identity.",
+    });
+  }
+
+  if (await isEmailDomainBlocked(newEmail)) {
+    throw new DubApiError({
+      code: "bad_request",
+      message:
+        "This email domain is not allowed. Please use a different email address.",
     });
   }
 

--- a/apps/web/lib/auth/request-email-change.ts
+++ b/apps/web/lib/auth/request-email-change.ts
@@ -6,6 +6,7 @@ import { randomBytes } from "crypto";
 import { hashToken } from ".";
 import { DubApiError } from "../api/errors";
 import { isEmailDomainBlocked } from "../email/is-email-domain-blocked";
+import { isGenericEmail } from "../is-generic-email";
 import { ratelimit, redis } from "../upstash";
 
 // Send the OTP to confirm the email address change for existing users/partners
@@ -35,14 +36,6 @@ export const requestEmailChange = async ({
     });
   }
 
-  if (await isEmailDomainBlocked(newEmail)) {
-    throw new DubApiError({
-      code: "bad_request",
-      message:
-        "Invalid email address – please use your work email instead. If you think this is a mistake, please contact us at dub.co/support",
-    });
-  }
-
   const { success } = await ratelimit(3, "1 d").limit(
     `email-change-request:${identifier}`,
   );
@@ -52,6 +45,16 @@ export const requestEmailChange = async ({
       code: "rate_limit_exceeded",
       message:
         "You've requested too many email change requests. Please try again later.",
+    });
+  }
+
+  const isGenericEmailWithPlus = email.includes("+") && isGenericEmail(email);
+  const emailDomainBlocked = await isEmailDomainBlocked(newEmail);
+  if (isGenericEmailWithPlus || emailDomainBlocked) {
+    throw new DubApiError({
+      code: "bad_request",
+      message:
+        "Invalid email address – please use your work email instead. If you think this is a mistake, please contact us at dub.co/support",
     });
   }
 

--- a/apps/web/lib/email/is-email-domain-blocked.ts
+++ b/apps/web/lib/email/is-email-domain-blocked.ts
@@ -1,0 +1,42 @@
+import { redis } from "@/lib/upstash";
+import { get } from "@vercel/edge-config";
+import { extractEmailDomain } from "./extract-email-domain";
+
+/**
+ * True when the email's domain is in Redis disposableEmailDomains
+ * or matches Edge Config emailDomainTerms (substring regex).
+ */
+export async function isEmailDomainBlocked(email: string): Promise<boolean> {
+  const emailDomain = extractEmailDomain(email);
+  if (!emailDomain) {
+    return false;
+  }
+
+  const [isDisposable, emailDomainTerms] = await Promise.all([
+    redis.sismember("disposableEmailDomains", emailDomain),
+    process.env.EDGE_CONFIG ? get("emailDomainTerms") : [],
+  ]);
+
+  const escapedDomainTerms =
+    emailDomainTerms && Array.isArray(emailDomainTerms)
+      ? emailDomainTerms
+          .map((term: string) =>
+            String(term)
+              .trim()
+              .toLowerCase()
+              .replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
+          )
+          .filter((term) => term.length > 0)
+      : [];
+
+  const blacklistedEmailDomainTermsRegex =
+    escapedDomainTerms.length > 0
+      ? new RegExp(escapedDomainTerms.join("|"))
+      : null;
+
+  return Boolean(
+    isDisposable ||
+      (blacklistedEmailDomainTermsRegex &&
+        blacklistedEmailDomainTermsRegex.test(emailDomain)),
+  );
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added centralized detection for disposable and blocked email domains.
  * Email change requests now reject blocked email addresses.
  * OTP requests now apply blocked-domain checks consistently while preserving applicable exceptions.

* **Bug Fixes**
  * Prevented email changes from proceeding when the current address is a generic address with a plus sign.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->