### PR TITLE
Log email change auth failures to Axiom with structured reason codes

### DIFF
--- a/apps/web/lib/actions/confirm-email-change.ts
+++ b/apps/web/lib/actions/confirm-email-change.ts
@@ -5,6 +5,10 @@ import {
   assertCanConfirmEmailChange,
   EmailChangeRequestData,
 } from "@/lib/auth/confirm-email-change";
+import {
+  logAuthFailure,
+  withAuthFailureLogging,
+} from "@/lib/auth/log-auth-failure";
 import { syncPlainCustomerEmail } from "@/lib/plain/upsert-plain-customer";
 import { prisma } from "@/lib/prisma";
 import { redis } from "@/lib/upstash";
@@ -40,9 +44,17 @@ export const confirmEmailChangeAction = authUserActionClient
     });
 
     if (!tokenFound || tokenFound.expires < new Date()) {
-      throw new Error(
+      const error = new Error(
         "This token is invalid or expired. Please request a new one.",
       );
+      logAuthFailure({
+        action: "email_change_confirm",
+        reason: !tokenFound ? "invalid-token" : "expired-token",
+        userId: user.id,
+        email: user.email ?? undefined,
+        error,
+      });
+      throw error;
     }
 
     const data = await redis.get<EmailChangeRequestData>(
@@ -50,16 +62,34 @@ export const confirmEmailChangeAction = authUserActionClient
     );
 
     if (!data) {
-      throw new Error(
+      const error = new Error(
         "This token is invalid or expired. Please request a new one.",
       );
+      logAuthFailure({
+        action: "email_change_confirm",
+        reason: "invalid-token",
+        userId: user.id,
+        email: user.email ?? undefined,
+        error,
+      });
+      throw error;
     }
 
-    await assertCanConfirmEmailChange({
-      userId: user.id,
-      tokenFound,
-      data,
-    });
+    await withAuthFailureLogging(
+      {
+        action: "email_change_confirm",
+        reason: "unauthorized",
+        userId: user.id,
+        email: user.email ?? undefined,
+      },
+      async () => {
+        await assertCanConfirmEmailChange({
+          userId: user.id,
+          tokenFound,
+          data,
+        });
+      },
+    );
 
     // Consume the token before mutating so concurrent confirms fail closed
     const deleted = await prisma.verificationToken.deleteMany({
@@ -72,9 +102,17 @@ export const confirmEmailChangeAction = authUserActionClient
     });
 
     if (deleted.count !== 1) {
-      throw new Error(
+      const error = new Error(
         "This token is invalid or expired. Please request a new one.",
       );
+      logAuthFailure({
+        action: "email_change_confirm",
+        reason: "invalid-token",
+        userId: user.id,
+        email: user.email ?? undefined,
+        error,
+      });
+      throw error;
     }
 
     const tokenIdentifier = tokenFound.identifier;

--- a/apps/web/lib/auth/log-auth-failure.ts
+++ b/apps/web/lib/auth/log-auth-failure.ts
@@ -1,0 +1,103 @@
+import { waitUntil } from "@vercel/functions";
+import { headers } from "next/headers";
+import { DubApiError } from "../api/errors";
+import { getIP } from "../api/utils/get-ip";
+import { logger, toErrorFields } from "../axiom/server";
+
+const AUTH_FAILURE_MESSAGE = "auth.failure";
+
+type AuthAction = "email_change_request" | "email_change_confirm";
+
+const AUTH_FAILURE_REASONS = [
+  "rate-limit-exceeded",
+  "email-domain-blocked",
+  "invalid-token",
+  "expired-token",
+  "missing-partner-id",
+  "unauthorized",
+  "unknown",
+] as const;
+
+type AuthFailureReason = (typeof AUTH_FAILURE_REASONS)[number];
+
+const KNOWN_REASONS = new Set<string>(AUTH_FAILURE_REASONS);
+
+// Maps errors whose message is already a reason code and rate-limit
+// DubApiErrors to a typed reason, so catch blocks don't need their own
+// mapping logic.
+const authFailureReasonFromError = (error: unknown): AuthFailureReason => {
+  if (error instanceof DubApiError && error.code === "rate_limit_exceeded") {
+    return "rate-limit-exceeded";
+  }
+
+  if (error instanceof Error && KNOWN_REASONS.has(error.message)) {
+    return error.message as AuthFailureReason;
+  }
+
+  return "unknown";
+};
+
+interface LogAuthFailureParams {
+  action: AuthAction;
+  reason?: AuthFailureReason;
+  email?: string;
+  userId?: string;
+  error?: unknown;
+}
+
+export const logAuthFailure = ({
+  action,
+  reason: reasonProp,
+  email,
+  userId,
+  error,
+}: LogAuthFailureParams) => {
+  const reason = reasonProp ?? authFailureReasonFromError(error);
+
+  waitUntil(
+    (async () => {
+      let ip: string | undefined;
+      let userAgent: string | undefined;
+
+      // headers() is unavailable in some NextAuth callback contexts
+      try {
+        ip = await getIP();
+        userAgent = (await headers()).get("user-agent") ?? undefined;
+      } catch {
+        // Ignore — request context may not be available
+      }
+
+      logger.warn(AUTH_FAILURE_MESSAGE, {
+        source: "auth",
+        outcome: "failure",
+        action,
+        reason,
+        rateLimited: reason === "rate-limit-exceeded",
+        ip,
+        userAgent,
+        userId,
+        email,
+        ...(error !== undefined && { error: toErrorFields(error) }),
+      });
+
+      await logger.flush();
+    })(),
+  );
+};
+
+export const withAuthFailureLogging = async <T>(
+  context: Omit<LogAuthFailureParams, "error">,
+  callback: () => Promise<T>,
+): Promise<T> => {
+  try {
+    return await callback();
+  } catch (error) {
+    logAuthFailure({
+      ...context,
+      reason: context.reason ?? authFailureReasonFromError(error),
+      error,
+    });
+
+    throw error;
+  }
+};

--- a/apps/web/lib/auth/log-auth-failure.ts
+++ b/apps/web/lib/auth/log-auth-failure.ts
@@ -13,7 +13,6 @@ const AUTH_FAILURE_REASONS = [
   "email-domain-blocked",
   "invalid-token",
   "expired-token",
-  "missing-partner-id",
   "unauthorized",
   "unknown",
 ] as const;

--- a/apps/web/lib/auth/request-email-change.ts
+++ b/apps/web/lib/auth/request-email-change.ts
@@ -35,18 +35,10 @@ export const requestEmailChange = async ({
   hostName: string;
 }) => {
   if (syncIdentity && !partnerId) {
-    const error = new DubApiError({
+    throw new DubApiError({
       code: "bad_request",
       message: "Partner ID is required when syncing identity.",
     });
-    logAuthFailure({
-      action: "email_change_request",
-      reason: "missing-partner-id",
-      email,
-      userId,
-      error,
-    });
-    throw error;
   }
 
   await withAuthFailureLogging(

--- a/apps/web/lib/auth/request-email-change.ts
+++ b/apps/web/lib/auth/request-email-change.ts
@@ -7,8 +7,10 @@ import { hashToken } from ".";
 import { DubApiError } from "../api/errors";
 import { isEmailDomainBlocked } from "../email/is-email-domain-blocked";
 import { isGenericEmail } from "../is-generic-email";
-import { assertRateLimit, redis } from "../upstash";
+import { redis } from "../upstash";
+import { assertRateLimit } from "../upstash/assert-rate-limit";
 import { RATELIMIT_POLICIES } from "../upstash/ratelimit-policies";
+import { logAuthFailure, withAuthFailureLogging } from "./log-auth-failure";
 
 // Send the OTP to confirm the email address change for existing users/partners
 export const requestEmailChange = async ({
@@ -33,30 +35,55 @@ export const requestEmailChange = async ({
   hostName: string;
 }) => {
   if (syncIdentity && !partnerId) {
-    throw new DubApiError({
+    const error = new DubApiError({
       code: "bad_request",
       message: "Partner ID is required when syncing identity.",
     });
+    logAuthFailure({
+      action: "email_change_request",
+      reason: "missing-partner-id",
+      email,
+      userId,
+      error,
+    });
+    throw error;
   }
 
-  await assertRateLimit({
-    policy: RATELIMIT_POLICIES.emailChangeRequest,
-    identifier: userId,
-  });
+  await withAuthFailureLogging(
+    {
+      action: "email_change_request",
+      email,
+      userId,
+    },
+    async () => {
+      await assertRateLimit({
+        policy: RATELIMIT_POLICIES.emailChangeRequest,
+        identifier: userId,
+      });
 
-  await assertRateLimit({
-    policy: RATELIMIT_POLICIES.emailChangeRequestTarget,
-    identifier: newEmail.toLowerCase(),
-  });
+      await assertRateLimit({
+        policy: RATELIMIT_POLICIES.emailChangeRequestTarget,
+        identifier: newEmail.toLowerCase(),
+      });
+    },
+  );
 
   const isGenericEmailWithPlus = email.includes("+") && isGenericEmail(email);
   const emailDomainBlocked = await isEmailDomainBlocked(newEmail);
   if (isGenericEmailWithPlus || emailDomainBlocked) {
-    throw new DubApiError({
+    const error = new DubApiError({
       code: "bad_request",
       message:
         "Invalid email address – please use your work email instead. If you think this is a mistake, please contact us at dub.co/support",
     });
+    logAuthFailure({
+      action: "email_change_request",
+      reason: "email-domain-blocked",
+      email,
+      userId,
+      error,
+    });
+    throw error;
   }
 
   // Remove existing verification tokens


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication failure tracking for email-change requests and confirmations.
  * Invalid, expired, missing, or already-used confirmation links now generate structured failure records.
  * Unauthorized attempts and rate-limit violations are logged with relevant request context.
  * Invalid email-domain requests now consistently record the failure before displaying an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->