### PR TITLE
Improve subdomain claim flow

### DIFF
--- a/apps/web/app/api/domains/route.ts
+++ b/apps/web/app/api/domains/route.ts
@@ -105,6 +105,7 @@ export const POST = withWorkspace(
       assetLinks,
       appleAppSiteAssociation,
       deepviewData,
+      isOnboardingSubdomainFlow,
     } = await createDomainBodySchemaExtended.parseAsync(body);
 
     if (workspace.plan === "free") {
@@ -166,6 +167,32 @@ export const POST = withWorkspace(
 
     const domainRecord = await prisma.$transaction(
       async (tx) => {
+        if (slug.endsWith(".dub.link")) {
+          if (!isOnboardingSubdomainFlow && !workspace.defaultProgramId) {
+            throw new DubApiError({
+              code: "forbidden",
+              message:
+                "You are not allowed to claim a .dub.link subdomain. Please contact support if you think this is an error: dub.co/support",
+            });
+          }
+
+          const alreadyClaimed = await tx.domain.count({
+            where: {
+              projectId: workspace.id,
+              slug: {
+                endsWith: ".dub.link",
+              },
+            },
+          });
+          if (alreadyClaimed) {
+            throw new DubApiError({
+              code: "forbidden",
+              message:
+                "You can only claim one .dub.link subdomain per workspace.",
+            });
+          }
+        }
+
         const totalDomains = await tx.domain.count({
           where: {
             projectId: workspace.id,
@@ -182,24 +209,6 @@ export const POST = withWorkspace(
               type: "domains",
             }),
           });
-        }
-
-        if (slug.endsWith(".dub.link")) {
-          const alreadyClaimed = await tx.domain.count({
-            where: {
-              projectId: workspace.id,
-              slug: {
-                endsWith: ".dub.link",
-              },
-            },
-          });
-          if (alreadyClaimed >= 1) {
-            throw new DubApiError({
-              code: "forbidden",
-              message:
-                "You can only claim one .dub.link subdomain per workspace.",
-            });
-          }
         }
 
         return await tx.domain.create({

--- a/apps/web/app/app.dub.co/(onboarding)/onboarding/(steps)/domain/subdomain/form.tsx
+++ b/apps/web/app/app.dub.co/(onboarding)/onboarding/(steps)/domain/subdomain/form.tsx
@@ -19,6 +19,7 @@ export function Form() {
       onSuccess={() => {
         continueTo(product === "partners" ? "program" : "plan");
       }}
+      isOnboardingSubdomainFlow={true}
     />
   );
 }

--- a/apps/web/lib/zod/schemas/domains.ts
+++ b/apps/web/lib/zod/schemas/domains.ts
@@ -157,6 +157,7 @@ export const createDomainBodySchema = z.object({
 
 export const createDomainBodySchemaExtended = createDomainBodySchema.extend({
   deepviewData: z.string().nullish(),
+  isOnboardingSubdomainFlow: z.boolean().default(false),
 });
 
 export const updateDomainBodySchema = createDomainBodySchema.partial();

--- a/apps/web/ui/domains/add-edit-domain-form.tsx
+++ b/apps/web/ui/domains/add-edit-domain-form.tsx
@@ -120,12 +120,14 @@ export function AddEditDomainForm({
   enableDomainConfig = true,
   initialDomain,
   fixedDomainSuffix,
+  isOnboardingSubdomainFlow = false,
 }: {
   props?: DomainProps;
   onSuccess?: (data: DomainProps) => void;
   enableDomainConfig?: boolean;
   fixedDomainSuffix?: string;
   initialDomain?: string;
+  isOnboardingSubdomainFlow?: boolean;
 }) {
   const { id: workspaceId, plan } = useWorkspace();
   const [lockDomain, setLockDomain] = useState(true);
@@ -140,13 +142,15 @@ export function AddEditDomainForm({
     Record<string, boolean>
   >({});
 
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
   const {
     register,
     control,
     handleSubmit,
     watch,
     setValue,
-    formState: { isSubmitting, isSubmitSuccessful, isDirty },
+    formState: { isDirty },
   } = useForm<FormData>({
     defaultValues: {
       slug:
@@ -302,6 +306,7 @@ export function AddEditDomainForm({
 
   const onSubmit = async (formData: FormData) => {
     try {
+      setIsSubmitting(true);
       const res = await fetch(endpoint.url, {
         method: endpoint.method,
         headers: {
@@ -321,6 +326,7 @@ export function AddEditDomainForm({
           ...(formData.deepviewData !== undefined && {
             deepviewData: sanitizeJson(formData.deepviewData),
           }),
+          isOnboardingSubdomainFlow,
         }),
       });
 
@@ -333,6 +339,7 @@ export function AddEditDomainForm({
         toast.success(endpoint.successMessage);
         onSuccess?.(data);
       } else {
+        setIsSubmitting(false);
         const { error } = await res.json();
         if (res.status === 422) {
           setDomainStatus("conflict");
@@ -349,6 +356,7 @@ export function AddEditDomainForm({
         }
       }
     } catch (error) {
+      setIsSubmitting(false);
       toast.error(`Failed to ${props ? "update" : "add"} domain`);
     }
   };
@@ -733,7 +741,7 @@ export function AddEditDomainForm({
         <Button
           text={props ? "Save changes" : "Add domain"}
           disabled={saveDisabled}
-          loading={isSubmitting || isSubmitSuccessful}
+          loading={isSubmitting}
         />
       </div>
     </form>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for setting up `.dub.link` subdomains during onboarding.
  * Domain setup now provides clearer submission loading feedback.
* **Bug Fixes**
  * Failed domain submissions now correctly reset the loading state, allowing users to try again.
  * Improved validation for subdomain claims while preserving the one-subdomain-per-workspace limit.
  * Domain requests now consistently apply onboarding-specific subdomain validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->