### PR TITLE
Escape store links from in-app browsers

### DIFF
--- a/apps/web/app/in-app-browser/[url]/action-button.tsx
+++ b/apps/web/app/in-app-browser/[url]/action-button.tsx
@@ -25,6 +25,7 @@ export function InAppBrowserActionButton({
   const [copied, copyToClipboard] = useCopyToClipboard();
   const [showUrlFallback, setShowUrlFallback] = useState(false);
   const canEscape = Boolean(extBrowserScheme);
+  const hasCustomBackground = Boolean(buttonStyle?.backgroundColor);
 
   const handleOpen = () => {
     if (!extBrowserScheme) {
@@ -48,7 +49,11 @@ export function InAppBrowserActionButton({
       {canEscape ? (
         <Button
           text={label}
-          className="h-12 w-full font-medium text-white"
+          className={
+            hasCustomBackground
+              ? "h-12 w-full font-medium text-neutral-900"
+              : "h-12 w-full font-medium text-white"
+          }
           onClick={handleOpen}
           {...(buttonStyle && {
             style: {

--- a/apps/web/app/in-app-browser/[url]/action-button.tsx
+++ b/apps/web/app/in-app-browser/[url]/action-button.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { DeepViewData } from "@/lib/zod/schemas/deep-links";
+import { Button, useCopyToClipboard } from "@dub/ui";
+
+export function InAppBrowserActionButton({
+  label,
+  copyLabel,
+  copiedLabel,
+  copyUrl,
+  destinationUrl,
+  extBrowserScheme,
+  buttonStyle,
+}: {
+  label: string;
+  copyLabel: string;
+  copiedLabel: string;
+  copyUrl: string;
+  destinationUrl: string;
+  extBrowserScheme: string | null;
+  buttonStyle?: DeepViewData["buttonStyle"];
+}) {
+  const [copied, copyToClipboard] = useCopyToClipboard();
+
+  const handleOpen = () => {
+    if (extBrowserScheme) {
+      window.location.href = extBrowserScheme;
+      return;
+    }
+
+    window.location.href = destinationUrl;
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <Button
+        text={label}
+        className="h-12 w-full font-medium text-white"
+        onClick={handleOpen}
+        {...(buttonStyle && {
+          style: {
+            backgroundColor: buttonStyle.backgroundColor,
+            borderRadius: buttonStyle.borderRadius,
+            borderColor: buttonStyle.borderColor,
+          },
+        })}
+      />
+      <Button
+        text={copied ? copiedLabel : copyLabel}
+        variant="secondary"
+        className="h-12 w-full font-medium"
+        onClick={() => copyToClipboard(copyUrl)}
+      />
+    </div>
+  );
+}

--- a/apps/web/app/in-app-browser/[url]/action-button.tsx
+++ b/apps/web/app/in-app-browser/[url]/action-button.tsx
@@ -11,6 +11,7 @@ export function InAppBrowserActionButton({
   copiedLabel,
   copyFailedLabel,
   copyUrl,
+  intentFallbackUrl,
   extBrowserScheme,
   buttonStyle,
 }: {
@@ -19,6 +20,7 @@ export function InAppBrowserActionButton({
   copiedLabel: string;
   copyFailedLabel: string;
   copyUrl: string;
+  intentFallbackUrl: string;
   extBrowserScheme: string | null;
   buttonStyle?: DeepViewData["buttonStyle"];
 }) {
@@ -29,6 +31,22 @@ export function InAppBrowserActionButton({
 
   const handleOpen = () => {
     if (!extBrowserScheme) {
+      return;
+    }
+
+    if (extBrowserScheme.startsWith("intent://")) {
+      const onVisibilityChange = () => {
+        if (document.visibilityState === "hidden") {
+          clearTimeout(timer);
+          document.removeEventListener("visibilitychange", onVisibilityChange);
+        }
+      };
+      const timer = window.setTimeout(() => {
+        document.removeEventListener("visibilitychange", onVisibilityChange);
+        window.location.href = intentFallbackUrl;
+      }, 1500);
+      document.addEventListener("visibilitychange", onVisibilityChange);
+      window.location.href = extBrowserScheme;
       return;
     }
 

--- a/apps/web/app/in-app-browser/[url]/action-button.tsx
+++ b/apps/web/app/in-app-browser/[url]/action-button.tsx
@@ -2,55 +2,74 @@
 
 import { DeepViewData } from "@/lib/zod/schemas/deep-links";
 import { Button, useCopyToClipboard } from "@dub/ui";
+import { useState } from "react";
+import { toast } from "sonner";
 
 export function InAppBrowserActionButton({
   label,
   copyLabel,
   copiedLabel,
+  copyFailedLabel,
   copyUrl,
-  destinationUrl,
   extBrowserScheme,
   buttonStyle,
 }: {
   label: string;
   copyLabel: string;
   copiedLabel: string;
+  copyFailedLabel: string;
   copyUrl: string;
-  destinationUrl: string;
   extBrowserScheme: string | null;
   buttonStyle?: DeepViewData["buttonStyle"];
 }) {
   const [copied, copyToClipboard] = useCopyToClipboard();
+  const [showUrlFallback, setShowUrlFallback] = useState(false);
+  const canEscape = Boolean(extBrowserScheme);
 
   const handleOpen = () => {
-    if (extBrowserScheme) {
-      window.location.href = extBrowserScheme;
+    if (!extBrowserScheme) {
       return;
     }
 
-    window.location.href = destinationUrl;
+    window.location.href = extBrowserScheme;
+  };
+
+  const handleCopy = async () => {
+    try {
+      await copyToClipboard(copyUrl, { throwOnError: true });
+    } catch {
+      toast.error(copyFailedLabel);
+      setShowUrlFallback(true);
+    }
   };
 
   return (
     <div className="flex flex-col gap-3">
-      <Button
-        text={label}
-        className="h-12 w-full font-medium text-white"
-        onClick={handleOpen}
-        {...(buttonStyle && {
-          style: {
-            backgroundColor: buttonStyle.backgroundColor,
-            borderRadius: buttonStyle.borderRadius,
-            borderColor: buttonStyle.borderColor,
-          },
-        })}
-      />
+      {canEscape ? (
+        <Button
+          text={label}
+          className="h-12 w-full font-medium text-white"
+          onClick={handleOpen}
+          {...(buttonStyle && {
+            style: {
+              backgroundColor: buttonStyle.backgroundColor,
+              borderRadius: buttonStyle.borderRadius,
+              borderColor: buttonStyle.borderColor,
+            },
+          })}
+        />
+      ) : null}
       <Button
         text={copied ? copiedLabel : copyLabel}
-        variant="secondary"
+        variant={canEscape ? "secondary" : "default"}
         className="h-12 w-full font-medium"
-        onClick={() => copyToClipboard(copyUrl)}
+        onClick={handleCopy}
       />
+      {showUrlFallback && (
+        <p className="select-all break-all text-center text-sm text-neutral-500">
+          {copyUrl}
+        </p>
+      )}
     </div>
   );
 }

--- a/apps/web/app/in-app-browser/[url]/page.tsx
+++ b/apps/web/app/in-app-browser/[url]/page.tsx
@@ -52,13 +52,35 @@ function getDestinationUrl(param: string): string {
   return param;
 }
 
-function getCopyUrl(shortLink: string | undefined, destinationUrl: string) {
+const COPY_URL_EXCLUDED_PARAMS = new Set(["source", "domain", "key"]);
+
+function getCopyUrl({
+  shortLink,
+  destinationUrl,
+  searchParams,
+}: {
+  shortLink: string | undefined;
+  destinationUrl: string;
+  searchParams: Record<string, string | string[] | undefined>;
+}) {
   if (!shortLink) {
     return destinationUrl;
   }
 
   try {
     const copyUrl = new URL(shortLink);
+
+    for (const [param, value] of Object.entries(searchParams)) {
+      if (COPY_URL_EXCLUDED_PARAMS.has(param) || value == null) {
+        continue;
+      }
+      const paramValue = Array.isArray(value) ? value[0] : value;
+      if (paramValue == null) {
+        continue;
+      }
+      copyUrl.searchParams.set(param, paramValue);
+    }
+
     copyUrl.searchParams.set("skip_deeplink_preview", "1");
     return copyUrl.toString();
   } catch {
@@ -108,13 +130,15 @@ function getExtBrowserScheme(
 
 export default async function InAppBrowserEscapePage(props: {
   params: Promise<{ url: string }>;
-  searchParams: Promise<{ source?: string; domain?: string; key?: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const params = await props.params;
   const searchParams = await props.searchParams;
 
   const destinationUrl = getDestinationUrl(params.url);
-  const rawSource = searchParams.source;
+  const rawSource = Array.isArray(searchParams.source)
+    ? searchParams.source[0]
+    : searchParams.source;
   const source: InAppBrowserSource | null = VALID_SOURCES.has(
     rawSource as InAppBrowserSource,
   )
@@ -130,8 +154,12 @@ export default async function InAppBrowserEscapePage(props: {
   const platform: "ios" | "android" =
     ua.os?.name === "Android" ? "android" : "ios";
 
-  const domain = searchParams.domain;
-  const key = searchParams.key;
+  const domain = Array.isArray(searchParams.domain)
+    ? searchParams.domain[0]
+    : searchParams.domain;
+  const key = Array.isArray(searchParams.key)
+    ? searchParams.key[0]
+    : searchParams.key;
 
   let link: {
     domain: string;
@@ -187,7 +215,11 @@ export default async function InAppBrowserEscapePage(props: {
     shortLink: link?.shortLink ?? destinationUrl,
     url: destinationUrl,
   };
-  const copyUrl = getCopyUrl(link?.shortLink, destinationUrl);
+  const copyUrl = getCopyUrl({
+    shortLink: link?.shortLink,
+    destinationUrl,
+    searchParams,
+  });
 
   return (
     <>
@@ -288,6 +320,7 @@ export default async function InAppBrowserEscapePage(props: {
               copiedLabel={t.copied}
               copyFailedLabel={t.copyFailed}
               copyUrl={copyUrl}
+              intentFallbackUrl={destinationUrl}
               extBrowserScheme={extBrowserScheme}
               buttonStyle={buttonStyle}
             />

--- a/apps/web/app/in-app-browser/[url]/page.tsx
+++ b/apps/web/app/in-app-browser/[url]/page.tsx
@@ -4,6 +4,7 @@ import {
 } from "@/lib/api/links/case-sensitivity";
 import type { InAppBrowserSource } from "@/lib/middleware/utils/detect-in-app-browser";
 import { isGooglePlayStoreUrl } from "@/lib/middleware/utils/is-google-play-store-url";
+import { isIosAppStoreUrl } from "@/lib/middleware/utils/is-ios-app-store-url";
 import { prisma } from "@/lib/prisma";
 import { parseDeepViewData } from "@/lib/zod/schemas/deep-links";
 import { Grid, Wordmark } from "@dub/ui";
@@ -51,17 +52,57 @@ function getDestinationUrl(param: string): string {
   return param;
 }
 
+function getCopyUrl(shortLink: string | undefined, destinationUrl: string) {
+  if (!shortLink) {
+    return destinationUrl;
+  }
+
+  try {
+    const copyUrl = new URL(shortLink);
+    copyUrl.searchParams.set("skip_deeplink_preview", "1");
+    return copyUrl.toString();
+  } catch {
+    return destinationUrl;
+  }
+}
+
 function getExtBrowserScheme(
-  source: InAppBrowserSource,
+  source: InAppBrowserSource | null,
   destinationUrl: string,
+  platform: "ios" | "android",
 ): string | null {
-  const encoded = encodeURIComponent(destinationUrl);
-  if (source === "instagram") {
-    return `instagram://extbrowser/?url=${encoded}`;
+  if (!source) {
+    return null;
   }
-  if (source === "facebook") {
-    return `fb://extbrowser/?url=${encoded}`;
+
+  const isStoreUrl =
+    isIosAppStoreUrl(destinationUrl) || isGooglePlayStoreUrl(destinationUrl);
+  if (!isStoreUrl) {
+    return null;
   }
+
+  if (source === "tiktok") {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(destinationUrl);
+
+    if (platform === "android") {
+      return `intent://${parsed.host}${parsed.pathname}${parsed.search}#Intent;scheme=https;end`;
+    }
+
+    if (source === "instagram") {
+      return `instagram://extbrowser/?url=${encodeURIComponent(destinationUrl)}`;
+    }
+
+    if (source === "facebook") {
+      return `x-safari-https://${parsed.host}${parsed.pathname}${parsed.search}`;
+    }
+  } catch {
+    return null;
+  }
+
   return null;
 }
 
@@ -74,11 +115,11 @@ export default async function InAppBrowserEscapePage(props: {
 
   const destinationUrl = getDestinationUrl(params.url);
   const rawSource = searchParams.source;
-  const source: InAppBrowserSource = VALID_SOURCES.has(
+  const source: InAppBrowserSource | null = VALID_SOURCES.has(
     rawSource as InAppBrowserSource,
   )
     ? (rawSource as InAppBrowserSource)
-    : "instagram";
+    : null;
 
   const headersList = await headers();
   const acceptLanguage = headersList.get("accept-language");
@@ -132,7 +173,11 @@ export default async function InAppBrowserEscapePage(props: {
 
   const isPlayStore = isGooglePlayStoreUrl(destinationUrl);
   const storeName = isPlayStore ? "Google Play" : "App Store";
-  const extBrowserScheme = getExtBrowserScheme(source, destinationUrl);
+  const extBrowserScheme = getExtBrowserScheme(
+    source,
+    destinationUrl,
+    platform,
+  );
   const description = (
     extBrowserScheme ? t.description : t.manualEscapeDescription
   ).replace("{storeName}", storeName);
@@ -142,6 +187,7 @@ export default async function InAppBrowserEscapePage(props: {
     shortLink: link?.shortLink ?? destinationUrl,
     url: destinationUrl,
   };
+  const copyUrl = getCopyUrl(link?.shortLink, destinationUrl);
 
   return (
     <>
@@ -241,7 +287,7 @@ export default async function InAppBrowserEscapePage(props: {
               copyLabel={t.copyLink}
               copiedLabel={t.copied}
               copyFailedLabel={t.copyFailed}
-              copyUrl={badgeLink.shortLink}
+              copyUrl={copyUrl}
               extBrowserScheme={extBrowserScheme}
               buttonStyle={buttonStyle}
             />

--- a/apps/web/app/in-app-browser/[url]/page.tsx
+++ b/apps/web/app/in-app-browser/[url]/page.tsx
@@ -1,0 +1,253 @@
+import {
+  decodeLinkIfCaseSensitive,
+  encodeKeyIfCaseSensitive,
+} from "@/lib/api/links/case-sensitivity";
+import { isGooglePlayStoreUrl } from "@/lib/middleware/utils/is-google-play-store-url";
+import type { InAppBrowserSource } from "@/lib/middleware/utils/detect-in-app-browser";
+import { prisma } from "@/lib/prisma";
+import { parseDeepViewData } from "@/lib/zod/schemas/deep-links";
+import { Grid, Wordmark } from "@dub/ui";
+import {
+  AndroidLogo,
+  ArrowRight,
+  Copy,
+  IOSAppStore,
+  MobilePhone,
+} from "@dub/ui/icons";
+import { cn, constructMetadata } from "@dub/utils";
+import { headers } from "next/headers";
+import Link from "next/link";
+import { userAgent } from "next/server";
+import { BrandLogoBadge } from "../../app.dub.co/(deeplink)/deeplink/[domain]/[[...key]]/brand-logo-badge";
+import { InAppBrowserActionButton } from "./action-button";
+import { getLanguage, getTranslations } from "./translations";
+
+export const revalidate = false;
+
+export function generateStaticParams() {
+  return [];
+}
+
+export const metadata = constructMetadata({
+  title: "Open link",
+  noIndex: true,
+});
+
+const VALID_SOURCES = new Set<InAppBrowserSource>([
+  "instagram",
+  "facebook",
+  "tiktok",
+]);
+
+function getDestinationUrl(param: string): string {
+  if (/^https?%3A/i.test(param)) {
+    try {
+      return decodeURIComponent(param);
+    } catch {
+      return param;
+    }
+  }
+
+  return param;
+}
+
+function getExtBrowserScheme(
+  source: InAppBrowserSource,
+  destinationUrl: string,
+): string | null {
+  const encoded = encodeURIComponent(destinationUrl);
+  if (source === "instagram") {
+    return `instagram://extbrowser/?url=${encoded}`;
+  }
+  if (source === "facebook") {
+    return `fb://extbrowser/?url=${encoded}`;
+  }
+  return null;
+}
+
+export default async function InAppBrowserEscapePage(props: {
+  params: Promise<{ url: string }>;
+  searchParams: Promise<{ source?: string; domain?: string; key?: string }>;
+}) {
+  const params = await props.params;
+  const searchParams = await props.searchParams;
+
+  const destinationUrl = getDestinationUrl(params.url);
+  const rawSource = searchParams.source;
+  const source: InAppBrowserSource = VALID_SOURCES.has(
+    rawSource as InAppBrowserSource,
+  )
+    ? (rawSource as InAppBrowserSource)
+    : "instagram";
+
+  const headersList = await headers();
+  const acceptLanguage = headersList.get("accept-language");
+  const language = getLanguage(acceptLanguage);
+  const t = getTranslations(language);
+
+  const ua = userAgent({ headers: headersList });
+  const platform: "ios" | "android" =
+    ua.os?.name === "Android" ? "android" : "ios";
+
+  const domain = searchParams.domain;
+  const key = searchParams.key
+    ? decodeURIComponent(searchParams.key)
+    : undefined;
+
+  let link: {
+    domain: string;
+    key: string;
+    shortLink: string;
+    url: string;
+    shortDomain: { deepviewData: unknown } | null;
+  } | null = null;
+
+  if (domain && key) {
+    const encodedKey = encodeKeyIfCaseSensitive({ domain, key });
+    const found = await prisma.link.findUnique({
+      where: {
+        domain_key: {
+          domain,
+          key: encodedKey,
+        },
+      },
+      select: {
+        domain: true,
+        key: true,
+        shortLink: true,
+        url: true,
+        shortDomain: {
+          select: {
+            deepviewData: true,
+          },
+        },
+      },
+    });
+
+    if (found) {
+      link = decodeLinkIfCaseSensitive(found) ?? found;
+    }
+  }
+
+  const deepViewData = parseDeepViewData(link?.shortDomain?.deepviewData);
+  const { hidePoweredByBadge = false, variant, buttonStyle } = deepViewData;
+
+  const isPlayStore = isGooglePlayStoreUrl(destinationUrl);
+  const storeName = isPlayStore ? "Google Play" : "App Store";
+  const description = t.description.replace("{storeName}", storeName);
+  const ctaLabel = t.openInStore.replace("{storeName}", storeName);
+  const extBrowserScheme = getExtBrowserScheme(source, destinationUrl);
+
+  const badgeLink = {
+    shortLink: link?.shortLink ?? destinationUrl,
+    url: destinationUrl,
+  };
+
+  return (
+    <>
+      {extBrowserScheme ? (
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `window.location.href=${JSON.stringify(extBrowserScheme)};`,
+          }}
+        />
+      ) : null}
+      <main className="mx-auto flex h-dvh w-full max-w-md flex-col bg-white">
+        {variant !== "minimal" && (
+          <div className="absolute inset-0 isolate overflow-hidden bg-white">
+            <div
+              className={cn(
+                "absolute inset-y-0 left-1/2 w-[1200px] -translate-x-1/2",
+                "[mask-composite:intersect] [mask-image:linear-gradient(black,transparent_320px),linear-gradient(90deg,transparent,black_5%,black_95%,transparent)]",
+              )}
+            >
+              <Grid
+                cellSize={60}
+                patternOffset={[0.75, 0]}
+                className="text-neutral-200"
+              />
+            </div>
+
+            {[...Array(2)].map((_, idx) => (
+              <div
+                key={idx}
+                className={cn(
+                  "absolute left-1/2 top-6 size-[80px] -translate-x-1/2 -translate-y-1/2 scale-x-[1.6]",
+                  idx === 0 ? "mix-blend-overlay" : "opacity-10",
+                )}
+              >
+                {[...Array(idx === 0 ? 2 : 1)].map((_, idx) => (
+                  <div
+                    key={idx}
+                    className={cn(
+                      "absolute -inset-16 mix-blend-overlay blur-[50px] saturate-[2]",
+                      "bg-[conic-gradient(from_90deg,#F00_5deg,#EAB308_63deg,#5CFF80_115deg,#1E00FF_170deg,#855AFC_220deg,#3A8BFD_286deg,#F00_360deg)]",
+                    )}
+                  />
+                ))}
+              </div>
+            ))}
+          </div>
+        )}
+
+        <div className="relative z-10 flex flex-1 flex-col px-8 py-8">
+          {!hidePoweredByBadge && (
+            <div className="flex justify-center">
+              <Link
+                href="https://dub.co/docs/concepts/deep-links/quickstart"
+                target="_blank"
+                className={cn(
+                  "flex items-center gap-1 whitespace-nowrap text-sm font-medium text-neutral-900",
+                  t["poweredByOrder"] === "inverted" ? "flex-row-reverse" : "",
+                )}
+              >
+                {t.poweredBy}{" "}
+                <Wordmark className="text-content-emphasis h-3.5" />
+              </Link>
+            </div>
+          )}
+
+          <div className="flex flex-1 flex-col justify-center gap-8">
+            <div className="flex flex-col items-center gap-y-3">
+              <BrandLogoBadge link={badgeLink} appName={storeName} />
+
+              {variant === "minimal" ? (
+                <p className="text-pretty text-center font-light text-neutral-500">
+                  {description}
+                </p>
+              ) : (
+                <div className="flex h-40 w-full max-w-xs flex-col gap-6 rounded-xl border border-neutral-300 px-10 py-8">
+                  <p className="text-pretty text-center text-sm text-neutral-600">
+                    {description}
+                  </p>
+
+                  <div className="flex items-center justify-center gap-3">
+                    <Copy className="text-content-default size-6" />
+                    <ArrowRight className="text-content-subtle size-3" />
+                    {isPlayStore || platform === "android" ? (
+                      <AndroidLogo className="text-content-default size-6" />
+                    ) : (
+                      <IOSAppStore className="text-content-default size-6" />
+                    )}
+                    <ArrowRight className="text-content-subtle size-3" />
+                    <MobilePhone className="text-content-default size-6" />
+                  </div>
+                </div>
+              )}
+            </div>
+
+            <InAppBrowserActionButton
+              label={ctaLabel}
+              copyLabel={t.copyLink}
+              copiedLabel={t.copied}
+              copyUrl={badgeLink.shortLink}
+              destinationUrl={destinationUrl}
+              extBrowserScheme={extBrowserScheme}
+              buttonStyle={buttonStyle}
+            />
+          </div>
+        </div>
+      </main>
+    </>
+  );
+}

--- a/apps/web/app/in-app-browser/[url]/page.tsx
+++ b/apps/web/app/in-app-browser/[url]/page.tsx
@@ -2,8 +2,8 @@ import {
   decodeLinkIfCaseSensitive,
   encodeKeyIfCaseSensitive,
 } from "@/lib/api/links/case-sensitivity";
-import { isGooglePlayStoreUrl } from "@/lib/middleware/utils/is-google-play-store-url";
 import type { InAppBrowserSource } from "@/lib/middleware/utils/detect-in-app-browser";
+import { isGooglePlayStoreUrl } from "@/lib/middleware/utils/is-google-play-store-url";
 import { prisma } from "@/lib/prisma";
 import { parseDeepViewData } from "@/lib/zod/schemas/deep-links";
 import { Grid, Wordmark } from "@dub/ui";
@@ -90,9 +90,7 @@ export default async function InAppBrowserEscapePage(props: {
     ua.os?.name === "Android" ? "android" : "ios";
 
   const domain = searchParams.domain;
-  const key = searchParams.key
-    ? decodeURIComponent(searchParams.key)
-    : undefined;
+  const key = searchParams.key;
 
   let link: {
     domain: string;
@@ -134,9 +132,11 @@ export default async function InAppBrowserEscapePage(props: {
 
   const isPlayStore = isGooglePlayStoreUrl(destinationUrl);
   const storeName = isPlayStore ? "Google Play" : "App Store";
-  const description = t.description.replace("{storeName}", storeName);
-  const ctaLabel = t.openInStore.replace("{storeName}", storeName);
   const extBrowserScheme = getExtBrowserScheme(source, destinationUrl);
+  const description = (
+    extBrowserScheme ? t.description : t.manualEscapeDescription
+  ).replace("{storeName}", storeName);
+  const ctaLabel = t.openInStore.replace("{storeName}", storeName);
 
   const badgeLink = {
     shortLink: link?.shortLink ?? destinationUrl,
@@ -240,8 +240,8 @@ export default async function InAppBrowserEscapePage(props: {
               label={ctaLabel}
               copyLabel={t.copyLink}
               copiedLabel={t.copied}
+              copyFailedLabel={t.copyFailed}
               copyUrl={badgeLink.shortLink}
-              destinationUrl={destinationUrl}
               extBrowserScheme={extBrowserScheme}
               buttonStyle={buttonStyle}
             />

--- a/apps/web/app/in-app-browser/[url]/translations.ts
+++ b/apps/web/app/in-app-browser/[url]/translations.ts
@@ -2,59 +2,82 @@ export const translations = {
   en: {
     poweredBy: "Powered by",
     description: "Click below to continue to {storeName}.",
+    manualEscapeDescription:
+      "Copy the link, then open it in your browser to continue to {storeName}.",
     openInStore: "Open in {storeName}",
     copyLink: "Copy link",
     copied: "Copied",
+    copyFailed: "Couldn't copy — select the link below",
   },
   zh: {
     poweredBy: "由",
     description: "点击下方继续前往{storeName}。",
+    manualEscapeDescription: "请复制链接，然后在浏览器中打开以继续前往{storeName}。",
     openInStore: "在{storeName}中打开",
     copyLink: "复制链接",
     copied: "已复制",
+    copyFailed: "无法复制 — 请选择下方链接",
   },
   es: {
     poweredBy: "Desarrollado por",
     description: "Haz clic abajo para continuar a {storeName}.",
+    manualEscapeDescription:
+      "Copia el enlace y ábrelo en tu navegador para continuar a {storeName}.",
     openInStore: "Abrir en {storeName}",
     copyLink: "Copiar enlace",
     copied: "Copiado",
+    copyFailed: "No se pudo copiar — selecciona el enlace abajo",
   },
   fr: {
     poweredBy: "Propulsé par",
-    description: "Cliquez ci-dessous pour continuer vers le {storeName}.",
-    openInStore: "Ouvrir dans le {storeName}",
+    description: "Cliquez ci-dessous pour continuer vers {storeName}.",
+    manualEscapeDescription:
+      "Copiez le lien, puis ouvrez-le dans votre navigateur pour continuer vers {storeName}.",
+    openInStore: "Ouvrir dans {storeName}",
     copyLink: "Copier le lien",
     copied: "Copié",
+    copyFailed: "Impossible de copier — sélectionnez le lien ci-dessous",
   },
   it: {
     poweredBy: "Offerto da",
     description: "Clicca qui sotto per continuare su {storeName}.",
+    manualEscapeDescription:
+      "Copia il link e aprilo nel browser per continuare su {storeName}.",
     openInStore: "Apri in {storeName}",
     copyLink: "Copia link",
     copied: "Copiato",
+    copyFailed: "Impossibile copiare — seleziona il link qui sotto",
   },
   pt: {
     poweredBy: "Desenvolvido por",
-    description: "Clique abaixo para continuar na {storeName}.",
-    openInStore: "Abrir na {storeName}",
+    description: "Clique abaixo para continuar em {storeName}.",
+    manualEscapeDescription:
+      "Copie o link e abra no navegador para continuar em {storeName}.",
+    openInStore: "Abrir em {storeName}",
     copyLink: "Copiar link",
     copied: "Copiado",
+    copyFailed: "Não foi possível copiar — selecione o link abaixo",
   },
   de: {
     poweredBy: "Bereitgestellt von",
-    description: "Klicke unten, um zum {storeName} zu gelangen.",
-    openInStore: "Im {storeName} öffnen",
+    description: "Klicke unten, um zu {storeName} zu gelangen.",
+    manualEscapeDescription:
+      "Kopiere den Link und öffne ihn im Browser, um zu {storeName} zu gelangen.",
+    openInStore: "In {storeName} öffnen",
     copyLink: "Link kopieren",
     copied: "Kopiert",
+    copyFailed: "Kopieren fehlgeschlagen — Link unten auswählen",
   },
   tr: {
     poweredBy: "tarafından desteklenmektedir",
     poweredByOrder: "inverted",
     description: "{storeName} için aşağıya tıklayın.",
-    openInStore: "{storeName}'da aç",
+    manualEscapeDescription:
+      "Bağlantıyı kopyalayıp tarayıcınızda açarak {storeName} ile devam edin.",
+    openInStore: "{storeName} içinde aç",
     copyLink: "Bağlantıyı kopyala",
     copied: "Kopyalandı",
+    copyFailed: "Kopyalanamadı — aşağıdaki bağlantıyı seçin",
   },
 } as const;
 

--- a/apps/web/app/in-app-browser/[url]/translations.ts
+++ b/apps/web/app/in-app-browser/[url]/translations.ts
@@ -12,7 +12,8 @@ export const translations = {
   zh: {
     poweredBy: "由",
     description: "点击下方继续前往{storeName}。",
-    manualEscapeDescription: "请复制链接，然后在浏览器中打开以继续前往{storeName}。",
+    manualEscapeDescription:
+      "请复制链接，然后在浏览器中打开以继续前往{storeName}。",
     openInStore: "在{storeName}中打开",
     copyLink: "复制链接",
     copied: "已复制",
@@ -83,6 +84,8 @@ export const translations = {
 
 export type Language = keyof typeof translations;
 
+const SUPPORTED_LANGUAGES = new Set(Object.keys(translations));
+
 export function getLanguage(acceptLanguage?: string | null): Language {
   if (!acceptLanguage) return "en";
 
@@ -95,7 +98,7 @@ export function getLanguage(acceptLanguage?: string | null): Language {
     });
 
   for (const lang of languages) {
-    if (lang in translations) {
+    if (SUPPORTED_LANGUAGES.has(lang)) {
       return lang as Language;
     }
   }

--- a/apps/web/app/in-app-browser/[url]/translations.ts
+++ b/apps/web/app/in-app-browser/[url]/translations.ts
@@ -1,0 +1,85 @@
+export const translations = {
+  en: {
+    poweredBy: "Powered by",
+    description: "Click below to continue to {storeName}.",
+    openInStore: "Open in {storeName}",
+    copyLink: "Copy link",
+    copied: "Copied",
+  },
+  zh: {
+    poweredBy: "由",
+    description: "点击下方继续前往{storeName}。",
+    openInStore: "在{storeName}中打开",
+    copyLink: "复制链接",
+    copied: "已复制",
+  },
+  es: {
+    poweredBy: "Desarrollado por",
+    description: "Haz clic abajo para continuar a {storeName}.",
+    openInStore: "Abrir en {storeName}",
+    copyLink: "Copiar enlace",
+    copied: "Copiado",
+  },
+  fr: {
+    poweredBy: "Propulsé par",
+    description: "Cliquez ci-dessous pour continuer vers le {storeName}.",
+    openInStore: "Ouvrir dans le {storeName}",
+    copyLink: "Copier le lien",
+    copied: "Copié",
+  },
+  it: {
+    poweredBy: "Offerto da",
+    description: "Clicca qui sotto per continuare su {storeName}.",
+    openInStore: "Apri in {storeName}",
+    copyLink: "Copia link",
+    copied: "Copiato",
+  },
+  pt: {
+    poweredBy: "Desenvolvido por",
+    description: "Clique abaixo para continuar na {storeName}.",
+    openInStore: "Abrir na {storeName}",
+    copyLink: "Copiar link",
+    copied: "Copiado",
+  },
+  de: {
+    poweredBy: "Bereitgestellt von",
+    description: "Klicke unten, um zum {storeName} zu gelangen.",
+    openInStore: "Im {storeName} öffnen",
+    copyLink: "Link kopieren",
+    copied: "Kopiert",
+  },
+  tr: {
+    poweredBy: "tarafından desteklenmektedir",
+    poweredByOrder: "inverted",
+    description: "{storeName} için aşağıya tıklayın.",
+    openInStore: "{storeName}'da aç",
+    copyLink: "Bağlantıyı kopyala",
+    copied: "Kopyalandı",
+  },
+} as const;
+
+export type Language = keyof typeof translations;
+
+export function getLanguage(acceptLanguage?: string | null): Language {
+  if (!acceptLanguage) return "en";
+
+  const languages = acceptLanguage
+    .toLowerCase()
+    .split(",")
+    .map((lang) => {
+      const [code] = lang.trim().split(";");
+      return code.split("-")[0];
+    });
+
+  for (const lang of languages) {
+    if (lang in translations) {
+      return lang as Language;
+    }
+  }
+
+  return "en";
+}
+
+export function getTranslations(language: Language) {
+  return translations[language];
+}

--- a/apps/web/lib/middleware/link.ts
+++ b/apps/web/lib/middleware/link.ts
@@ -411,66 +411,93 @@ export async function LinkMiddleware(req: NextRequest, ev: NextFetchEvent) {
     );
   }
 
-  const finalUrlOptions = {
-    req,
-    ...(shouldCacheClickId && { clickId }),
-    ...(isPartnerLink && { via: key }),
-  };
+  {
+    let destinationForEscape = url;
+    if (ios && ua.os?.name === "iOS") {
+      destinationForEscape = ios;
+    } else if (android && ua.os?.name === "Android") {
+      destinationForEscape = android;
+    } else if (geoTargeting && country && country in geoTargeting) {
+      destinationForEscape = geoTargeting[country];
+    }
 
-  let destinationForEscape = url;
-  if (ios && ua.os?.name === "iOS") {
-    destinationForEscape = ios;
-  } else if (android && ua.os?.name === "Android") {
-    destinationForEscape = android;
-  } else if (geoTargeting && country && country in geoTargeting) {
-    destinationForEscape = geoTargeting[country];
-  }
+    const escapeFinalUrl = getFinalUrl(destinationForEscape, {
+      req,
+      ...(shouldCacheClickId && { clickId }),
+      ...(isPartnerLink && { via: key }),
+    });
+    const inAppBrowserSource = shouldEscapeInAppBrowser({
+      userAgentString: ua.ua,
+      destinationUrl: escapeFinalUrl,
+    });
 
-  const escapeFinalUrl = getFinalUrl(destinationForEscape, finalUrlOptions);
-  const inAppBrowserSource = shouldEscapeInAppBrowser({
-    userAgentString: ua.ua,
-    destinationUrl: escapeFinalUrl,
-  });
-
-  if (inAppBrowserSource) {
-    ev.waitUntil(
-      recordClick({
-        req,
-        clickId,
-        workspaceId,
-        linkId,
-        domain,
-        key,
-        url: escapeFinalUrl,
-        programId: cachedLink.programId,
-        partnerId: cachedLink.partnerId,
-        shouldCacheClickId,
-      }),
-    );
-
-    return createResponseWithCookies(
-      NextResponse.rewrite(
-        getInAppBrowserEscapeUrl({
-          reqUrl: req.url,
-          destinationUrl: escapeFinalUrl,
-          source: inAppBrowserSource,
+    if (inAppBrowserSource) {
+      ev.waitUntil(
+        recordClick({
+          req,
+          clickId,
+          workspaceId,
+          linkId,
           domain,
           key,
+          url: escapeFinalUrl,
+          programId: cachedLink.programId,
+          partnerId: cachedLink.partnerId,
+          shouldCacheClickId,
         }),
-        {
-          headers: {
-            ...DUB_HEADERS,
-            ...(!shouldIndex && { "X-Robots-Tag": "googlebot: noindex" }),
+      );
+
+      // Preserve deferred deep-link caching that the iOS/Android branches below
+      // would have done (escape returns early and would otherwise skip them).
+      if (
+        !req.nextUrl.searchParams.get("skip_deeplink_preview") &&
+        ((ios && ua.os?.name === "iOS" && isIosAppStoreUrl(ios)) ||
+          (android &&
+            ua.os?.name === "Android" &&
+            isGooglePlayStoreUrl(android)))
+      ) {
+        ev.waitUntil(
+          cacheDeepLinkClickData({
+            req,
+            clickId,
+            link: {
+              id: linkId,
+              domain,
+              key,
+              url, // main destination URL for deferred deep linking
+            },
+          }),
+        );
+      }
+
+      return createResponseWithCookies(
+        NextResponse.rewrite(
+          getInAppBrowserEscapeUrl({
+            reqUrl: req.url,
+            destinationUrl: escapeFinalUrl,
+            source: inAppBrowserSource,
+            domain,
+            key,
+          }),
+          {
+            headers: {
+              ...DUB_HEADERS,
+              ...(!shouldIndex && { "X-Robots-Tag": "googlebot: noindex" }),
+            },
           },
-        },
-      ),
-      cookieData,
-    );
+        ),
+        cookieData,
+      );
+    }
   }
 
   // redirect to iOS link if it is specified and the user is on an iOS device
   if (ios && ua.os?.name === "iOS") {
-    const finalUrl = getFinalUrl(ios, finalUrlOptions);
+    const finalUrl = getFinalUrl(ios, {
+      req,
+      ...(shouldCacheClickId && { clickId }),
+      ...(isPartnerLink && { via: key }),
+    });
     ev.waitUntil(
       recordClick({
         req,
@@ -534,7 +561,11 @@ export async function LinkMiddleware(req: NextRequest, ev: NextFetchEvent) {
 
     // redirect to Android link if it is specified and the user is on an Android device
   } else if (android && ua.os?.name === "Android") {
-    const finalUrl = getFinalUrl(android, finalUrlOptions);
+    const finalUrl = getFinalUrl(android, {
+      req,
+      ...(shouldCacheClickId && { clickId }),
+      ...(isPartnerLink && { via: key }),
+    });
     ev.waitUntil(
       recordClick({
         req,
@@ -597,7 +628,11 @@ export async function LinkMiddleware(req: NextRequest, ev: NextFetchEvent) {
 
     // redirect to geo-targeting link if it is specified and the user is in the specified country
   } else if (geoTargeting && country && country in geoTargeting) {
-    const finalUrl = getFinalUrl(geoTargeting[country], finalUrlOptions);
+    const finalUrl = getFinalUrl(geoTargeting[country], {
+      req,
+      ...(shouldCacheClickId && { clickId }),
+      ...(isPartnerLink && { via: key }),
+    });
     ev.waitUntil(
       recordClick({
         req,
@@ -626,7 +661,11 @@ export async function LinkMiddleware(req: NextRequest, ev: NextFetchEvent) {
 
     // regular redirect
   } else {
-    const finalUrl = getFinalUrl(url, finalUrlOptions);
+    const finalUrl = getFinalUrl(url, {
+      req,
+      ...(shouldCacheClickId && { clickId }),
+      ...(isPartnerLink && { via: key }),
+    });
     ev.waitUntil(
       recordClick({
         req,

--- a/apps/web/lib/middleware/link.ts
+++ b/apps/web/lib/middleware/link.ts
@@ -27,6 +27,10 @@ import { cacheDeepLinkClickData } from "./utils/cache-deeplink-click-data";
 import { crawlBitly } from "./utils/crawl-bitly";
 import { createResponseWithCookies } from "./utils/create-response-with-cookies";
 import { detectBot } from "./utils/detect-bot";
+import {
+  getInAppBrowserEscapeUrl,
+  shouldEscapeInAppBrowser,
+} from "./utils/detect-in-app-browser";
 import { getFinalUrl } from "./utils/get-final-url";
 import { getIdentityHash } from "./utils/get-identity-hash";
 import { isAppsFlyerTrackingUrl } from "./utils/is-appsflyer-tracking-url";
@@ -405,14 +409,68 @@ export async function LinkMiddleware(req: NextRequest, ev: NextFetchEvent) {
       ),
       cookieData,
     );
+  }
 
-    // redirect to iOS link if it is specified and the user is on an iOS device
-  } else if (ios && ua.os?.name === "iOS") {
-    const finalUrl = getFinalUrl(ios, {
-      req,
-      ...(shouldCacheClickId && { clickId }),
-      ...(isPartnerLink && { via: key }),
-    });
+  const finalUrlOptions = {
+    req,
+    ...(shouldCacheClickId && { clickId }),
+    ...(isPartnerLink && { via: key }),
+  };
+
+  let destinationForEscape = url;
+  if (ios && ua.os?.name === "iOS") {
+    destinationForEscape = ios;
+  } else if (android && ua.os?.name === "Android") {
+    destinationForEscape = android;
+  } else if (geoTargeting && country && country in geoTargeting) {
+    destinationForEscape = geoTargeting[country];
+  }
+
+  const escapeFinalUrl = getFinalUrl(destinationForEscape, finalUrlOptions);
+  const inAppBrowserSource = shouldEscapeInAppBrowser({
+    userAgentString: ua.ua,
+    destinationUrl: escapeFinalUrl,
+  });
+
+  if (inAppBrowserSource) {
+    ev.waitUntil(
+      recordClick({
+        req,
+        clickId,
+        workspaceId,
+        linkId,
+        domain,
+        key,
+        url: escapeFinalUrl,
+        programId: cachedLink.programId,
+        partnerId: cachedLink.partnerId,
+        shouldCacheClickId,
+      }),
+    );
+
+    return createResponseWithCookies(
+      NextResponse.rewrite(
+        getInAppBrowserEscapeUrl({
+          reqUrl: req.url,
+          destinationUrl: escapeFinalUrl,
+          source: inAppBrowserSource,
+          domain,
+          key,
+        }),
+        {
+          headers: {
+            ...DUB_HEADERS,
+            ...(!shouldIndex && { "X-Robots-Tag": "googlebot: noindex" }),
+          },
+        },
+      ),
+      cookieData,
+    );
+  }
+
+  // redirect to iOS link if it is specified and the user is on an iOS device
+  if (ios && ua.os?.name === "iOS") {
+    const finalUrl = getFinalUrl(ios, finalUrlOptions);
     ev.waitUntil(
       recordClick({
         req,
@@ -476,11 +534,7 @@ export async function LinkMiddleware(req: NextRequest, ev: NextFetchEvent) {
 
     // redirect to Android link if it is specified and the user is on an Android device
   } else if (android && ua.os?.name === "Android") {
-    const finalUrl = getFinalUrl(android, {
-      req,
-      ...(shouldCacheClickId && { clickId }),
-      ...(isPartnerLink && { via: key }),
-    });
+    const finalUrl = getFinalUrl(android, finalUrlOptions);
     ev.waitUntil(
       recordClick({
         req,
@@ -543,11 +597,7 @@ export async function LinkMiddleware(req: NextRequest, ev: NextFetchEvent) {
 
     // redirect to geo-targeting link if it is specified and the user is in the specified country
   } else if (geoTargeting && country && country in geoTargeting) {
-    const finalUrl = getFinalUrl(geoTargeting[country], {
-      req,
-      ...(shouldCacheClickId && { clickId }),
-      ...(isPartnerLink && { via: key }),
-    });
+    const finalUrl = getFinalUrl(geoTargeting[country], finalUrlOptions);
     ev.waitUntil(
       recordClick({
         req,
@@ -576,11 +626,7 @@ export async function LinkMiddleware(req: NextRequest, ev: NextFetchEvent) {
 
     // regular redirect
   } else {
-    const finalUrl = getFinalUrl(url, {
-      req,
-      ...(shouldCacheClickId && { clickId }),
-      ...(isPartnerLink && { via: key }),
-    });
+    const finalUrl = getFinalUrl(url, finalUrlOptions);
     ev.waitUntil(
       recordClick({
         req,

--- a/apps/web/lib/middleware/link.ts
+++ b/apps/web/lib/middleware/link.ts
@@ -411,93 +411,87 @@ export async function LinkMiddleware(req: NextRequest, ev: NextFetchEvent) {
     );
   }
 
-  {
-    let destinationForEscape = url;
-    if (ios && ua.os?.name === "iOS") {
-      destinationForEscape = ios;
-    } else if (android && ua.os?.name === "Android") {
-      destinationForEscape = android;
-    } else if (geoTargeting && country && country in geoTargeting) {
-      destinationForEscape = geoTargeting[country];
-    }
+  const destination =
+    ios && ua.os?.name === "iOS"
+      ? ios
+      : android && ua.os?.name === "Android"
+        ? android
+        : geoTargeting && country && country in geoTargeting
+          ? geoTargeting[country]
+          : url;
 
-    const escapeFinalUrl = getFinalUrl(destinationForEscape, {
-      req,
-      ...(shouldCacheClickId && { clickId }),
-      ...(isPartnerLink && { via: key }),
-    });
-    const inAppBrowserSource = shouldEscapeInAppBrowser({
-      userAgentString: ua.ua,
-      destinationUrl: escapeFinalUrl,
-    });
+  const finalUrl = getFinalUrl(destination, {
+    req,
+    ...(shouldCacheClickId && { clickId }),
+    ...(isPartnerLink && { via: key }),
+  });
 
-    if (inAppBrowserSource) {
+  const inAppBrowserSource = shouldEscapeInAppBrowser({
+    userAgentString: ua.ua,
+    destinationUrl: finalUrl,
+  });
+
+  if (inAppBrowserSource) {
+    ev.waitUntil(
+      recordClick({
+        req,
+        clickId,
+        workspaceId,
+        linkId,
+        domain,
+        key,
+        url: finalUrl,
+        programId: cachedLink.programId,
+        partnerId: cachedLink.partnerId,
+        shouldCacheClickId,
+      }),
+    );
+
+    // Preserve deferred deep-link caching that the iOS/Android branches below
+    // would have done (escape returns early and would otherwise skip them).
+    if (
+      !req.nextUrl.searchParams.get("skip_deeplink_preview") &&
+      ((ios && ua.os?.name === "iOS" && isIosAppStoreUrl(ios)) ||
+        (android &&
+          ua.os?.name === "Android" &&
+          isGooglePlayStoreUrl(android)))
+    ) {
       ev.waitUntil(
-        recordClick({
+        cacheDeepLinkClickData({
           req,
           clickId,
-          workspaceId,
-          linkId,
-          domain,
-          key,
-          url: escapeFinalUrl,
-          programId: cachedLink.programId,
-          partnerId: cachedLink.partnerId,
-          shouldCacheClickId,
-        }),
-      );
-
-      // Preserve deferred deep-link caching that the iOS/Android branches below
-      // would have done (escape returns early and would otherwise skip them).
-      if (
-        !req.nextUrl.searchParams.get("skip_deeplink_preview") &&
-        ((ios && ua.os?.name === "iOS" && isIosAppStoreUrl(ios)) ||
-          (android &&
-            ua.os?.name === "Android" &&
-            isGooglePlayStoreUrl(android)))
-      ) {
-        ev.waitUntil(
-          cacheDeepLinkClickData({
-            req,
-            clickId,
-            link: {
-              id: linkId,
-              domain,
-              key,
-              url, // main destination URL for deferred deep linking
-            },
-          }),
-        );
-      }
-
-      return createResponseWithCookies(
-        NextResponse.rewrite(
-          getInAppBrowserEscapeUrl({
-            reqUrl: req.url,
-            destinationUrl: escapeFinalUrl,
-            source: inAppBrowserSource,
+          link: {
+            id: linkId,
             domain,
             key,
-          }),
-          {
-            headers: {
-              ...DUB_HEADERS,
-              ...(!shouldIndex && { "X-Robots-Tag": "googlebot: noindex" }),
-            },
+            url, // main destination URL for deferred deep linking
           },
-        ),
-        cookieData,
+        }),
       );
     }
+
+    return createResponseWithCookies(
+      NextResponse.rewrite(
+        getInAppBrowserEscapeUrl({
+          reqUrl: req.url,
+          destinationUrl: finalUrl,
+          source: inAppBrowserSource,
+          domain,
+          key,
+        }),
+        {
+          headers: {
+            ...DUB_HEADERS,
+            ...(!shouldIndex && { "X-Robots-Tag": "googlebot: noindex" }),
+          },
+        },
+      ),
+      cookieData,
+    );
   }
 
   // redirect to iOS link if it is specified and the user is on an iOS device
   if (ios && ua.os?.name === "iOS") {
-    const finalUrl = getFinalUrl(ios, {
-      req,
-      ...(shouldCacheClickId && { clickId }),
-      ...(isPartnerLink && { via: key }),
-    });
     ev.waitUntil(
       recordClick({
         req,
@@ -561,11 +555,6 @@ export async function LinkMiddleware(req: NextRequest, ev: NextFetchEvent) {
 
     // redirect to Android link if it is specified and the user is on an Android device
   } else if (android && ua.os?.name === "Android") {
-    const finalUrl = getFinalUrl(android, {
-      req,
-      ...(shouldCacheClickId && { clickId }),
-      ...(isPartnerLink && { via: key }),
-    });
     ev.waitUntil(
       recordClick({
         req,
@@ -628,11 +617,6 @@ export async function LinkMiddleware(req: NextRequest, ev: NextFetchEvent) {
 
     // redirect to geo-targeting link if it is specified and the user is in the specified country
   } else if (geoTargeting && country && country in geoTargeting) {
-    const finalUrl = getFinalUrl(geoTargeting[country], {
-      req,
-      ...(shouldCacheClickId && { clickId }),
-      ...(isPartnerLink && { via: key }),
-    });
     ev.waitUntil(
       recordClick({
         req,
@@ -661,11 +645,6 @@ export async function LinkMiddleware(req: NextRequest, ev: NextFetchEvent) {
 
     // regular redirect
   } else {
-    const finalUrl = getFinalUrl(url, {
-      req,
-      ...(shouldCacheClickId && { clickId }),
-      ...(isPartnerLink && { via: key }),
-    });
     ev.waitUntil(
       recordClick({
         req,

--- a/apps/web/lib/middleware/utils/detect-in-app-browser.ts
+++ b/apps/web/lib/middleware/utils/detect-in-app-browser.ts
@@ -1,0 +1,57 @@
+import { isGooglePlayStoreUrl } from "./is-google-play-store-url";
+import { isIosAppStoreUrl } from "./is-ios-app-store-url";
+
+export type InAppBrowserSource = "instagram" | "facebook" | "tiktok";
+
+export function shouldEscapeInAppBrowser({
+  userAgentString,
+  destinationUrl,
+}: {
+  userAgentString: string | null | undefined;
+  destinationUrl: string;
+}): InAppBrowserSource | null {
+  const isStoreUrl =
+    isIosAppStoreUrl(destinationUrl) || isGooglePlayStoreUrl(destinationUrl);
+  if (!isStoreUrl) return null;
+
+  if (!userAgentString) {
+    return null;
+  }
+
+  if (/\bInstagram\b/i.test(userAgentString)) {
+    return "instagram";
+  }
+
+  if (/\bFBAN\b|\bFBAV\b|\bFB_IAB\b/i.test(userAgentString)) {
+    return "facebook";
+  }
+
+  if (/musical_ly|\bTikTok\b|\bBytedanceWebview\b/i.test(userAgentString)) {
+    return "tiktok";
+  }
+
+  return null;
+}
+
+export function getInAppBrowserEscapeUrl({
+  reqUrl,
+  destinationUrl,
+  source,
+  domain,
+  key,
+}: {
+  reqUrl: string;
+  destinationUrl: string;
+  source: InAppBrowserSource;
+  domain: string;
+  key: string;
+}): URL {
+  const escapeUrl = new URL(
+    `/in-app-browser/${encodeURIComponent(destinationUrl)}`,
+    reqUrl,
+  );
+  escapeUrl.searchParams.set("source", source);
+  escapeUrl.searchParams.set("domain", domain);
+  escapeUrl.searchParams.set("key", key);
+  return escapeUrl;
+}

--- a/apps/web/lib/middleware/utils/detect-in-app-browser.ts
+++ b/apps/web/lib/middleware/utils/detect-in-app-browser.ts
@@ -1,7 +1,17 @@
+import { REDIRECTION_QUERY_PARAM } from "@dub/utils/src/constants";
 import { isGooglePlayStoreUrl } from "./is-google-play-store-url";
 import { isIosAppStoreUrl } from "./is-ios-app-store-url";
 
 export type InAppBrowserSource = "instagram" | "facebook" | "tiktok";
+
+const ESCAPE_INTERNAL_PARAMS = new Set([
+  "source",
+  "domain",
+  "key",
+  "skip_deeplink_preview",
+  "dub-no-track",
+  REDIRECTION_QUERY_PARAM,
+]);
 
 export function shouldEscapeInAppBrowser({
   userAgentString,
@@ -46,6 +56,7 @@ export function getInAppBrowserEscapeUrl({
   domain: string;
   key: string;
 }): URL {
+  const requestUrl = new URL(reqUrl);
   const escapeUrl = new URL(
     `/in-app-browser/${encodeURIComponent(destinationUrl)}`,
     reqUrl,
@@ -53,5 +64,16 @@ export function getInAppBrowserEscapeUrl({
   escapeUrl.searchParams.set("source", source);
   escapeUrl.searchParams.set("domain", domain);
   escapeUrl.searchParams.set("key", key);
+
+  for (const [param, value] of requestUrl.searchParams) {
+    if (ESCAPE_INTERNAL_PARAMS.has(param)) {
+      continue;
+    }
+    if (param === "qr" && value === "1") {
+      continue;
+    }
+    escapeUrl.searchParams.set(param, value);
+  }
+
   return escapeUrl;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an in-app browser escape experience for Instagram, Facebook, and TikTok.
  * Users can open links in an external browser or copy destination URLs.
  * Added localized messaging in eight languages, app store guidance, branded styling, badges, and deep-link support.
* **Bug Fixes**
  * Improved redirect handling across iOS, Android, and location-based destinations.
  * Added clear success messaging and a selectable fallback URL when copying fails.
  * Invalid or unsupported links now continue safely without unnecessary external-browser redirects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->