### PR TITLE
Allow null customer on fraud event schemas

### DIFF
--- a/apps/web/lib/zod/schemas/fraud.ts
+++ b/apps/web/lib/zod/schemas/fraud.ts
@@ -268,7 +268,7 @@ const fraudEventCustomerSchema = z.object({
 
 export const fraudEventSchemas = {
   referralSourceBanned: baseFraudEventSchema.extend({
-    customer: fraudEventCustomerSchema,
+    customer: fraudEventCustomerSchema.nullable(),
     metadata: z
       .object({
         source: z.string(),
@@ -277,7 +277,7 @@ export const fraudEventSchemas = {
   }),
 
   paidTrafficDetected: baseFraudEventSchema.extend({
-    customer: fraudEventCustomerSchema,
+    customer: fraudEventCustomerSchema.nullable(),
     metadata: z
       .object({
         source: z.string(),
@@ -287,7 +287,7 @@ export const fraudEventSchemas = {
   }),
 
   customerEmailMatch: baseFraudEventSchema.extend({
-    customer: fraudEventCustomerSchema,
+    customer: fraudEventCustomerSchema.nullable(),
     metadata: z
       .object({
         matchType: z.enum(CustomerEmailMatchType),
@@ -297,7 +297,7 @@ export const fraudEventSchemas = {
   }),
 
   customerEmailSuspiciousDomain: baseFraudEventSchema.extend({
-    customer: fraudEventCustomerSchema,
+    customer: fraudEventCustomerSchema.nullable(),
   }),
 
   partnerCrossProgramBan: baseFraudEventSchema.extend({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fraud event data now supports cases where customer information is unavailable, improving reliability for affected fraud events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->