### PR TITLE
Add `TREMENDOUS_MIN_PAYOUT_AMOUNT_CENTS`

### DIFF
--- a/apps/web/app/(ee)/api/cron/payouts/charge-succeeded/queue-tremendous-payouts.ts
+++ b/apps/web/app/(ee)/api/cron/payouts/charge-succeeded/queue-tremendous-payouts.ts
@@ -1,7 +1,10 @@
 import { logger } from "@/lib/axiom/server";
 import { qstash } from "@/lib/cron";
 import { prisma } from "@/lib/prisma";
-import { TREMENDOUS_MAX_PAYOUT_AMOUNT_CENTS } from "@/lib/tremendous/constants";
+import {
+  TREMENDOUS_MAX_PAYOUT_AMOUNT_CENTS,
+  TREMENDOUS_MIN_PAYOUT_AMOUNT_CENTS,
+} from "@/lib/tremendous/constants";
 import { APP_DOMAIN_WITH_NGROK, chunk } from "@dub/utils";
 import {
   Invoice,
@@ -42,6 +45,7 @@ export async function queueTremendousPayouts({
       mode: PayoutMode.internal,
       method: PartnerPayoutMethod.tremendous,
       amount: {
+        gte: TREMENDOUS_MIN_PAYOUT_AMOUNT_CENTS,
         lte: TREMENDOUS_MAX_PAYOUT_AMOUNT_CENTS,
       },
       partner: {

--- a/apps/web/app/(ee)/app.dub.co/embed/referrals/settings.tsx
+++ b/apps/web/app/(ee)/app.dub.co/embed/referrals/settings.tsx
@@ -1,6 +1,9 @@
 "use client";
 
-import { TREMENDOUS_MAX_PAYOUT_AMOUNT_CENTS } from "@/lib/tremendous/constants";
+import {
+  TREMENDOUS_MAX_PAYOUT_AMOUNT_CENTS,
+  TREMENDOUS_MIN_PAYOUT_AMOUNT_CENTS,
+} from "@/lib/tremendous/constants";
 import { AlertCircleFill } from "@/ui/shared/icons";
 import {
   AnimatedSizeContainer,
@@ -403,9 +406,15 @@ function TremendousGiftCardOption({
               )}
             </div>
             <p className="text-content-subtle mt-0.5 text-xs">
-              Gift card payouts are limited to{" "}
-              {currencyFormatter(TREMENDOUS_MAX_PAYOUT_AMOUNT_CENTS)} per
-              payout.
+              Gift card payouts have a minimum of{" "}
+              {currencyFormatter(TREMENDOUS_MIN_PAYOUT_AMOUNT_CENTS, {
+                trailingZeroDisplay: "stripIfInteger",
+              })}{" "}
+              and a maximum of{" "}
+              {currencyFormatter(TREMENDOUS_MAX_PAYOUT_AMOUNT_CENTS, {
+                trailingZeroDisplay: "stripIfInteger",
+              })}
+              .
             </p>
           </div>
         </div>

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/payouts/payout-table.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/payouts/payout-table.tsx
@@ -4,7 +4,10 @@ import useGroups from "@/lib/swr/use-groups";
 import { usePayoutsCount } from "@/lib/swr/use-payouts-count";
 import useProgram from "@/lib/swr/use-program";
 import useWorkspace from "@/lib/swr/use-workspace";
-import { TREMENDOUS_MAX_PAYOUT_AMOUNT_CENTS } from "@/lib/tremendous/constants";
+import {
+  TREMENDOUS_MAX_PAYOUT_AMOUNT_CENTS,
+  TREMENDOUS_MIN_PAYOUT_AMOUNT_CENTS,
+} from "@/lib/tremendous/constants";
 import { PayoutResponse } from "@/lib/types";
 import { ExternalPayoutsIndicator } from "@/ui/partners/external-payouts-indicator";
 import { GroupColorCircle } from "@/ui/partners/groups/group-color-circle";
@@ -78,7 +81,8 @@ function isPayoutEligibleForBatchConfirm(
 
   if (
     payout.partner.defaultPayoutMethod === PartnerPayoutMethod.tremendous &&
-    payout.amount > TREMENDOUS_MAX_PAYOUT_AMOUNT_CENTS
+    (payout.amount < TREMENDOUS_MIN_PAYOUT_AMOUNT_CENTS ||
+      payout.amount > TREMENDOUS_MAX_PAYOUT_AMOUNT_CENTS)
   ) {
     return false;
   }
@@ -92,6 +96,19 @@ const payoutsColumns = {
   all: ["periodEnd", "partner", "group", "status", "initiatedAt", "amount"],
   defaultVisible: ["periodEnd", "partner", "status", "initiatedAt", "amount"],
 };
+
+const MIN_GIFT_CARD_PAYOUT_AMOUNT = currencyFormatter(
+  TREMENDOUS_MIN_PAYOUT_AMOUNT_CENTS,
+  {
+    trailingZeroDisplay: "stripIfInteger",
+  },
+);
+const MAX_GIFT_CARD_PAYOUT_AMOUNT = currencyFormatter(
+  TREMENDOUS_MAX_PAYOUT_AMOUNT_CENTS,
+  {
+    trailingZeroDisplay: "stripIfInteger",
+  },
+);
 
 export function PayoutTable() {
   const router = useRouter();
@@ -298,13 +315,6 @@ export function PayoutTable() {
           (payout) => !isPayoutEligibleForBatchConfirm(payout, eligibilityCtx),
         );
 
-      const maxGiftCardPayoutAmount = currencyFormatter(
-        TREMENDOUS_MAX_PAYOUT_AMOUNT_CENTS,
-        {
-          trailingZeroDisplay: "stripIfInteger",
-        },
-      );
-
       return (
         <Button
           variant="primary"
@@ -331,8 +341,9 @@ export function PayoutTable() {
                   </li>
                   <li>Partner has not connected payouts</li>
                   <li>
-                    Exceeds the {maxGiftCardPayoutAmount} cap for gift card
-                    payouts
+                    Not within the gift card payout amount range of{" "}
+                    {MIN_GIFT_CARD_PAYOUT_AMOUNT} –{" "}
+                    {MAX_GIFT_CARD_PAYOUT_AMOUNT}
                   </li>
                 </ul>
               </div>
@@ -511,18 +522,12 @@ function AmountRowItem({
 
     if (
       payout.partner.defaultPayoutMethod === PartnerPayoutMethod.tremendous &&
-      payout.amount > TREMENDOUS_MAX_PAYOUT_AMOUNT_CENTS
+      (payout.amount < TREMENDOUS_MIN_PAYOUT_AMOUNT_CENTS ||
+        payout.amount > TREMENDOUS_MAX_PAYOUT_AMOUNT_CENTS)
     ) {
-      const maxPayoutAmount = currencyFormatter(
-        TREMENDOUS_MAX_PAYOUT_AMOUNT_CENTS,
-        {
-          trailingZeroDisplay: "stripIfInteger",
-        },
-      );
-
       return (
         <Tooltip
-          content={`This payout exceeds the ${maxPayoutAmount} cap for gift card payouts. The partner must connect another payout method to receive this amount.`}
+          content={`This payout ${payout.amount < TREMENDOUS_MIN_PAYOUT_AMOUNT_CENTS ? `is below the minimum amount (${MIN_GIFT_CARD_PAYOUT_AMOUNT})` : `exceeds the ${MAX_GIFT_CARD_PAYOUT_AMOUNT} cap`} for gift card payouts. The partner must connect another payout method to receive this payout.`}
         >
           <span className="cursor-help truncate text-neutral-400 underline decoration-dotted underline-offset-2">
             {display}

--- a/apps/web/lib/api/payouts/get-eligible-payouts.ts
+++ b/apps/web/lib/api/payouts/get-eligible-payouts.ts
@@ -76,13 +76,16 @@ export async function getEligiblePayouts({
         };
       })
       .filter((payout) => {
-        if (payout.partner.defaultPayoutMethod === "tremendous") {
-          return (
-            payout.amount >= TREMENDOUS_MIN_PAYOUT_AMOUNT_CENTS &&
-            payout.amount <= TREMENDOUS_MAX_PAYOUT_AMOUNT_CENTS
-          );
+        if (payout.amount >= program.minPayoutAmount) {
+          if (payout.partner.defaultPayoutMethod === "tremendous") {
+            return (
+              payout.amount >= TREMENDOUS_MIN_PAYOUT_AMOUNT_CENTS &&
+              payout.amount <= TREMENDOUS_MAX_PAYOUT_AMOUNT_CENTS
+            );
+          }
+          return true;
         }
-        return payout.amount >= program.minPayoutAmount;
+        return false;
       });
   }
 

--- a/apps/web/lib/api/payouts/get-eligible-payouts.ts
+++ b/apps/web/lib/api/payouts/get-eligible-payouts.ts
@@ -1,6 +1,10 @@
 import { CUTOFF_PERIOD } from "@/lib/partners/cutoff-period";
 import { prisma } from "@/lib/prisma";
 import {
+  TREMENDOUS_MAX_PAYOUT_AMOUNT_CENTS,
+  TREMENDOUS_MIN_PAYOUT_AMOUNT_CENTS,
+} from "@/lib/tremendous/constants";
+import {
   eligiblePayoutsQuerySchema,
   PayoutResponseSchema,
 } from "@/lib/zod/schemas/payouts";
@@ -33,16 +37,11 @@ export async function getEligiblePayouts({
       ...getPayoutEligibilityFilter({ program }),
     },
     include: {
-      partner: {
-        include: {
-          programs: {
-            where: {
-              programId: program.id,
-            },
-            select: {
-              tenantId: true,
-            },
-          },
+      partner: true,
+      programEnrollment: {
+        select: {
+          groupId: true,
+          tenantId: true,
         },
       },
       ...(cutoffPeriodValue && {
@@ -76,21 +75,31 @@ export async function getEligiblePayouts({
           amount: newPayoutAmount,
         };
       })
-      .filter((payout) => payout.amount >= program.minPayoutAmount);
+      .filter((payout) => {
+        if (payout.partner.defaultPayoutMethod === "tremendous") {
+          return (
+            payout.amount >= TREMENDOUS_MIN_PAYOUT_AMOUNT_CENTS &&
+            payout.amount <= TREMENDOUS_MAX_PAYOUT_AMOUNT_CENTS
+          );
+        }
+        return payout.amount >= program.minPayoutAmount;
+      });
   }
 
-  const eligiblePayouts = payouts.map(({ partner, ...payout }) => ({
-    ...payout,
-    traceId: payout.stripePayoutTraceId,
-    partner: {
-      ...partner,
-      ...partner.programs[0],
-    },
-    mode: getEffectivePayoutMode({
-      payoutMode: program.payoutMode,
-      payoutsEnabledAt: partner.payoutsEnabledAt,
+  const eligiblePayouts = payouts.map(
+    ({ partner, programEnrollment, ...payout }) => ({
+      ...payout,
+      traceId: payout.stripePayoutTraceId,
+      partner: {
+        ...partner,
+        ...programEnrollment,
+      },
+      mode: getEffectivePayoutMode({
+        payoutMode: program.payoutMode,
+        payoutsEnabledAt: partner.payoutsEnabledAt,
+      }),
     }),
-  }));
+  );
 
   return z.array(PayoutResponseSchema).parse(eligiblePayouts);
 }

--- a/apps/web/lib/api/payouts/payout-eligibility-filter.ts
+++ b/apps/web/lib/api/payouts/payout-eligibility-filter.ts
@@ -16,15 +16,15 @@ export function getPayoutEligibilityFilter({
     amount: {
       gte: program.minPayoutAmount,
     },
-    // Gift card payouts are capped at $2,000 per payout
+    // Gift card payouts must be within the Tremendous allowed range
     NOT: {
       partner: {
         defaultPayoutMethod: "tremendous",
       },
-      amount: {
-        lt: TREMENDOUS_MIN_PAYOUT_AMOUNT_CENTS,
-        gt: TREMENDOUS_MAX_PAYOUT_AMOUNT_CENTS,
-      },
+      OR: [
+        { amount: { lt: TREMENDOUS_MIN_PAYOUT_AMOUNT_CENTS } },
+        { amount: { gt: TREMENDOUS_MAX_PAYOUT_AMOUNT_CENTS } },
+      ],
     },
   };
 

--- a/apps/web/lib/api/payouts/payout-eligibility-filter.ts
+++ b/apps/web/lib/api/payouts/payout-eligibility-filter.ts
@@ -1,4 +1,7 @@
-import { TREMENDOUS_MAX_PAYOUT_AMOUNT_CENTS } from "@/lib/tremendous/constants";
+import {
+  TREMENDOUS_MAX_PAYOUT_AMOUNT_CENTS,
+  TREMENDOUS_MIN_PAYOUT_AMOUNT_CENTS,
+} from "@/lib/tremendous/constants";
 import { Prisma, Program } from "@prisma/client";
 
 export function getPayoutEligibilityFilter({
@@ -19,6 +22,7 @@ export function getPayoutEligibilityFilter({
         defaultPayoutMethod: "tremendous",
       },
       amount: {
+        lt: TREMENDOUS_MIN_PAYOUT_AMOUNT_CENTS,
         gt: TREMENDOUS_MAX_PAYOUT_AMOUNT_CENTS,
       },
     },

--- a/apps/web/lib/tremendous/constants.ts
+++ b/apps/web/lib/tremendous/constants.ts
@@ -5,7 +5,8 @@ export const TREMENDOUS_ENABLED_PROGRAM_IDS = [
   "prog_1KPAZMF49X9A1WEWRBM55KZY7", // Upheal
 ];
 
-export const TREMENDOUS_MAX_PAYOUT_AMOUNT_CENTS = 200_000;
+export const TREMENDOUS_MIN_PAYOUT_AMOUNT_CENTS = 500; // $5
+export const TREMENDOUS_MAX_PAYOUT_AMOUNT_CENTS = 2000_00; // $2,000
 
 // https://api.tremendous.com/prohibited_top_level_domains.txt
 export const TREMENDOUS_PROHIBITED_TOP_LEVEL_DOMAINS = [

--- a/apps/web/lib/tremendous/send-tremendous-payouts.ts
+++ b/apps/web/lib/tremendous/send-tremendous-payouts.ts
@@ -15,7 +15,10 @@ import { enqueueBatchJobs } from "../cron/enqueue-batch-jobs";
 import { createPayoutsIdempotencyKey } from "../payouts/create-payouts-idempotency-key";
 import { markPayoutsAsProcessed } from "../payouts/mark-payouts-as-processed";
 import { tremendousConfiguration } from "./configuration";
-import { TREMENDOUS_MAX_PAYOUT_AMOUNT_CENTS } from "./constants";
+import {
+  TREMENDOUS_MAX_PAYOUT_AMOUNT_CENTS,
+  TREMENDOUS_MIN_PAYOUT_AMOUNT_CENTS,
+} from "./constants";
 
 export async function sendTremendousPayouts({
   partnerId,
@@ -73,6 +76,7 @@ export async function sendTremendousPayouts({
           mode: "internal",
           method: "tremendous",
           amount: {
+            gte: TREMENDOUS_MIN_PAYOUT_AMOUNT_CENTS,
             lte: TREMENDOUS_MAX_PAYOUT_AMOUNT_CENTS,
           },
         },
@@ -91,6 +95,7 @@ export async function sendTremendousPayouts({
               method: "tremendous",
               tremendousOrderId: null,
               amount: {
+                gte: TREMENDOUS_MIN_PAYOUT_AMOUNT_CENTS,
                 lte: TREMENDOUS_MAX_PAYOUT_AMOUNT_CENTS,
               },
             },
@@ -120,9 +125,15 @@ export async function sendTremendousPayouts({
     return;
   }
 
+  if (totalTransferableAmount < TREMENDOUS_MIN_PAYOUT_AMOUNT_CENTS) {
+    throw new Error(
+      `Tremendous payout amount is less than the minimum amount of ${currencyFormatter(TREMENDOUS_MIN_PAYOUT_AMOUNT_CENTS)}.`,
+    );
+  }
+
   if (totalTransferableAmount > TREMENDOUS_MAX_PAYOUT_AMOUNT_CENTS) {
     throw new Error(
-      `Tremendous payout amount is greater than the maximum allowed amount of ${currencyFormatter(TREMENDOUS_MAX_PAYOUT_AMOUNT_CENTS)}.`,
+      `Tremendous payout amount is greater than the maximum amount of ${currencyFormatter(TREMENDOUS_MAX_PAYOUT_AMOUNT_CENTS)}.`,
     );
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Established a valid Tremendous gift-card payout range of $5–$2,000.
  * Displayed minimum and maximum payout amounts in referral settings.
  * Added clearer payout eligibility messages, including separate guidance for amounts below or above the allowed range.

* **Bug Fixes**
  * Prevented Tremendous payouts below $5 from being selected, batched, or submitted.
  * Improved validation and messaging for payouts exceeding the $2,000 maximum.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->