### PR TITLE
Restrict partner lead submission

### DIFF
--- a/apps/web/lib/submitted-leads/submit-lead-action.ts
+++ b/apps/web/lib/submitted-leads/submit-lead-action.ts
@@ -18,10 +18,11 @@ import {
 } from "@/lib/zod/schemas/submitted-lead-form";
 import { submitLeadSchema } from "@/lib/zod/schemas/submitted-leads";
 import { COUNTRIES } from "@dub/utils";
-import { Prisma, ProgramEnrollmentStatus } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 import { waitUntil } from "@vercel/functions";
 import * as z from "zod/v4";
 import { authPartnerActionClient } from "../actions/safe-action";
+import { ACTIVE_ENROLLMENT_STATUSES } from "../zod/schemas/partners";
 
 /**
  * Converts field values based on field type:
@@ -67,8 +68,15 @@ export const submitLeadAction = authPartnerActionClient
     const { partner, user } = ctx;
     const { programId, formData: rawFormData } = parsedInput;
 
+    if (!SUBMITTED_LEADS_ENABLED_PROGRAM_IDS.includes(programId)) {
+      throw new DubApiError({
+        code: "forbidden",
+        message: "This program does not accept submitted leads.",
+      });
+    }
+
     const { success } = await ratelimit(10, "1 m").limit(
-      `submit-lead:${partner.id}`,
+      `rl:submitted-lead:${partner.id}`,
     );
 
     if (!success) {
@@ -78,20 +86,15 @@ export const submitLeadAction = authPartnerActionClient
       });
     }
 
-    if (!SUBMITTED_LEADS_ENABLED_PROGRAM_IDS.includes(programId)) {
-      throw new DubApiError({
-        code: "forbidden",
-        message: "This program does not accept submitted leads.",
-      });
-    }
-
     const programEnrollment = await prisma.programEnrollment.findUnique({
       where: {
         partnerId_programId: {
           partnerId: partner.id,
           programId,
         },
-        status: ProgramEnrollmentStatus.approved,
+        status: {
+          in: ACTIVE_ENROLLMENT_STATUSES,
+        },
       },
       include: {
         program: true,
@@ -102,7 +105,7 @@ export const submitLeadAction = authPartnerActionClient
     if (!programEnrollment) {
       throw new DubApiError({
         code: "not_found",
-        message: `Partner ${partner.id} is not an approved partner in program ${programId}.`,
+        message: "Partner is not eligible to submit leads in this program.",
       });
     }
 

--- a/apps/web/lib/submitted-leads/submit-lead-action.ts
+++ b/apps/web/lib/submitted-leads/submit-lead-action.ts
@@ -3,11 +3,14 @@
 import { trackActivityLog } from "@/lib/api/activity-log/track-activity-log";
 import { createId } from "@/lib/api/create-id";
 import { DubApiError } from "@/lib/api/errors";
-import { getProgramEnrollmentOrThrow } from "@/lib/api/programs/get-program-enrollment-or-throw";
 import { prisma } from "@/lib/prisma";
-import { SUBMITTED_LEAD_FORM_REQUIRED_FIELD_KEYS } from "@/lib/submitted-leads/constants";
+import {
+  SUBMITTED_LEAD_FORM_REQUIRED_FIELD_KEYS,
+  SUBMITTED_LEADS_ENABLED_PROGRAM_IDS,
+} from "@/lib/submitted-leads/constants";
 import { notifyPartnerLeadSubmitted } from "@/lib/submitted-leads/notify-partner-lead-submitted";
 import { SubmittedLeadFormDataField } from "@/lib/types";
+import { ratelimit } from "@/lib/upstash";
 import {
   formFieldSchema,
   submittedLeadFormSchema,
@@ -15,7 +18,7 @@ import {
 } from "@/lib/zod/schemas/submitted-lead-form";
 import { submitLeadSchema } from "@/lib/zod/schemas/submitted-leads";
 import { COUNTRIES } from "@dub/utils";
-import { Prisma } from "@prisma/client";
+import { Prisma, ProgramEnrollmentStatus } from "@prisma/client";
 import { waitUntil } from "@vercel/functions";
 import * as z from "zod/v4";
 import { authPartnerActionClient } from "../actions/safe-action";
@@ -64,14 +67,44 @@ export const submitLeadAction = authPartnerActionClient
     const { partner, user } = ctx;
     const { programId, formData: rawFormData } = parsedInput;
 
-    const programEnrollment = await getProgramEnrollmentOrThrow({
-      partnerId: partner.id,
-      programId,
+    const { success } = await ratelimit(10, "1 m").limit(
+      `submit-lead:${partner.id}`,
+    );
+
+    if (!success) {
+      throw new DubApiError({
+        code: "rate_limit_exceeded",
+        message: "Too many leads submitted. Please try again later.",
+      });
+    }
+
+    if (!SUBMITTED_LEADS_ENABLED_PROGRAM_IDS.includes(programId)) {
+      throw new DubApiError({
+        code: "forbidden",
+        message: "This program does not accept submitted leads.",
+      });
+    }
+
+    const programEnrollment = await prisma.programEnrollment.findUnique({
+      where: {
+        partnerId_programId: {
+          partnerId: partner.id,
+          programId,
+        },
+        status: ProgramEnrollmentStatus.approved,
+      },
       include: {
         program: true,
         partner: true,
       },
     });
+
+    if (!programEnrollment) {
+      throw new DubApiError({
+        code: "not_found",
+        message: `Partner ${partner.id} is not an approved partner in program ${programId}.`,
+      });
+    }
 
     // Make sure required fields are present
     const requiredFieldsResult =
@@ -124,13 +157,14 @@ export const submitLeadAction = authPartnerActionClient
 
       // Get field schema to extract label and handle value conversion
       const fieldSchema = fieldMap.get(key);
-      const label = fieldSchema?.label || key;
+
+      if (!fieldSchema) continue;
 
       customFormData.push({
         key,
-        label,
+        label: fieldSchema.label || key,
         value: convertFieldValue(value, fieldSchema),
-        type: fieldSchema?.type ?? "text",
+        type: fieldSchema.type,
       });
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added rate limiting to allow a maximum of 10 lead submissions per partner per minute.
  * Restricted submissions to enabled programs and partners with active enrollments.
  * Added clearer error handling for unauthorized, rate-limited, or unavailable submissions.
  * Improved custom field validation by skipping fields without schemas and preserving defined labels and field types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->