### PR TITLE
Improve partner invites / default link updates

### DIFF
--- a/apps/web/app/(ee)/api/groups/[groupIdOrSlug]/default-links/[defaultLinkId]/route.ts
+++ b/apps/web/app/(ee)/api/groups/[groupIdOrSlug]/default-links/[defaultLinkId]/route.ts
@@ -102,8 +102,21 @@ export const PATCH = withWorkspace(
 
     if (url !== defaultLink.url) {
       try {
-        const [updatedDefaultLink] = await prisma.$transaction([
-          prisma.partnerGroupDefaultLink.update({
+        const updatedDefaultLink = await prisma.$transaction(async (tx) => {
+          // if the group being updated is the default partner group,
+          // also update the program's URL to the new default link destination URL
+          if (group.slug === DEFAULT_PARTNER_GROUP.slug) {
+            await tx.program.update({
+              where: {
+                id: programId,
+              },
+              data: {
+                url,
+              },
+            });
+          }
+
+          return tx.partnerGroupDefaultLink.update({
             where: {
               id: defaultLink.id,
             },
@@ -115,20 +128,8 @@ export const PATCH = withWorkspace(
                   )
                 : url,
             },
-          }),
-          // if the group being updated is the default partner group,
-          // also update the program's URL to the new default link destination URL
-          group.slug === DEFAULT_PARTNER_GROUP.slug
-            ? prisma.program.update({
-                where: {
-                  id: programId,
-                },
-                data: {
-                  url,
-                },
-              })
-            : null,
-        ]);
+          });
+        });
 
         waitUntil(
           qstash.publishJSON({
@@ -159,7 +160,12 @@ export const PATCH = withWorkspace(
     }
 
     // if no url changes were made, just return defaultLink (no changes needed)
-    return NextResponse.json(PartnerGroupDefaultLinkSchema.parse(defaultLink));
+    return NextResponse.json(
+      PartnerGroupDefaultLinkSchema.parse({
+        ...defaultLink,
+        domain,
+      }),
+    );
   },
   {
     requiredPermissions: ["groups.write"],

--- a/apps/web/app/(ee)/api/groups/[groupIdOrSlug]/default-links/[defaultLinkId]/route.ts
+++ b/apps/web/app/(ee)/api/groups/[groupIdOrSlug]/default-links/[defaultLinkId]/route.ts
@@ -9,6 +9,7 @@ import { defaultLinkDeletedJob } from "@/lib/jobs/handlers/default-link-deleted-
 import { prisma } from "@/lib/prisma";
 import {
   createOrUpdateDefaultLinkSchema,
+  DEFAULT_PARTNER_GROUP,
   PartnerGroupDefaultLinkSchema,
 } from "@/lib/zod/schemas/groups";
 import { APP_DOMAIN_WITH_NGROK, constructURLFromUTMParams } from "@dub/utils";
@@ -58,7 +59,7 @@ export const PATCH = withWorkspace(
     if (group.partnerGroupDefaultLinks.length === 0) {
       throw new DubApiError({
         code: "bad_request",
-        message: `Default link ${params.defaultLinkId} not found for this group.`,
+        message: `Default link ${params.defaultLinkId} not found for this partner group.`,
       });
     }
 
@@ -68,7 +69,7 @@ export const PATCH = withWorkspace(
     // - Update the program's domain
     // - Update all default links across groups to use the new domain
     // - Update all partner links to use the new domain (via cron job)
-    if (domain !== group.program.domain) {
+    if (domain !== defaultLink.domain) {
       await prisma.$transaction([
         prisma.program.update({
           where: {
@@ -99,23 +100,36 @@ export const PATCH = withWorkspace(
       );
     }
 
-    try {
-      const updatedDefaultLink = await prisma.partnerGroupDefaultLink.update({
-        where: {
-          id: defaultLink.id,
-        },
-        data: {
-          domain,
-          url: group.utmTemplate
-            ? constructURLFromUTMParams(
-                url,
-                extractUtmParams(group.utmTemplate),
-              )
-            : url,
-        },
-      });
+    if (url !== defaultLink.url) {
+      try {
+        const [updatedDefaultLink] = await prisma.$transaction([
+          prisma.partnerGroupDefaultLink.update({
+            where: {
+              id: defaultLink.id,
+            },
+            data: {
+              url: group.utmTemplate
+                ? constructURLFromUTMParams(
+                    url,
+                    extractUtmParams(group.utmTemplate),
+                  )
+                : url,
+            },
+          }),
+          // if the group being updated is the default partner group,
+          // also update the program's URL to the new default link destination URL
+          group.slug === DEFAULT_PARTNER_GROUP.slug
+            ? prisma.program.update({
+                where: {
+                  id: programId,
+                },
+                data: {
+                  url,
+                },
+              })
+            : null,
+        ]);
 
-      if (updatedDefaultLink.url !== defaultLink.url) {
         waitUntil(
           qstash.publishJSON({
             url: `${APP_DOMAIN_WITH_NGROK}/api/cron/groups/update-default-links`,
@@ -124,24 +138,28 @@ export const PATCH = withWorkspace(
             },
           }),
         );
-      }
 
-      return NextResponse.json(
-        PartnerGroupDefaultLinkSchema.parse(updatedDefaultLink),
-      );
-    } catch (error) {
-      if (error.code === "P2002") {
+        return NextResponse.json(
+          PartnerGroupDefaultLinkSchema.parse(updatedDefaultLink),
+        );
+      } catch (error) {
+        if (error.code === "P2002") {
+          throw new DubApiError({
+            code: "conflict",
+            message:
+              "A default link with this destination URL already exists in this partner group.",
+          });
+        }
+
         throw new DubApiError({
-          code: "conflict",
-          message: "A default link with this URL already exists.",
+          code: "unprocessable_entity",
+          message: error.message,
         });
       }
-
-      throw new DubApiError({
-        code: "unprocessable_entity",
-        message: error.message,
-      });
     }
+
+    // if no url changes were made, just return defaultLink (no changes needed)
+    return NextResponse.json(PartnerGroupDefaultLinkSchema.parse(defaultLink));
   },
   {
     requiredPermissions: ["groups.write"],

--- a/apps/web/app/(ee)/api/partner-profile/invites/route.ts
+++ b/apps/web/app/(ee)/api/partner-profile/invites/route.ts
@@ -7,6 +7,8 @@ import {
   MAX_PARTNER_USERS,
 } from "@/lib/constants/partner-profile";
 import { prisma } from "@/lib/prisma";
+import { assertRateLimit } from "@/lib/upstash/assert-rate-limit";
+import { RATELIMIT_POLICIES } from "@/lib/upstash/ratelimit-policies";
 import {
   getPartnerUsersQuerySchema,
   invitePartnerUserSchema,
@@ -55,6 +57,11 @@ export const POST = withPartnerProfile(
         message: "You can only invite up to 5 members at a time.",
       });
     }
+
+    await assertRateLimit({
+      policy: RATELIMIT_POLICIES.partnerProfileInvite,
+      identifier: partner.id,
+    });
 
     const emails = Array.from(new Set([...invites.map(({ email }) => email)]));
 

--- a/apps/web/lib/api/partners/invite-partner-user.ts
+++ b/apps/web/lib/api/partners/invite-partner-user.ts
@@ -38,6 +38,7 @@ export async function invitePartnerUser({
         message: "User has already been invited to this partner profile.",
       });
     }
+    throw error;
   }
 
   await prisma.verificationToken.create({

--- a/apps/web/lib/upstash/ratelimit-policies.ts
+++ b/apps/web/lib/upstash/ratelimit-policies.ts
@@ -16,18 +16,6 @@ export type RatelimitPolicy = {
 };
 
 export const RATELIMIT_POLICIES = {
-  programImageUpload: {
-    attempts: 10,
-    window: "24 h",
-    keyPrefix: "rl:program:application:image:upload",
-  },
-
-  messageAttachmentUpload: {
-    attempts: 20,
-    window: "1 h",
-    keyPrefix: "rl:message:attachment:upload",
-  },
-
   login: {
     attempts: 5,
     window: "1 m",
@@ -82,5 +70,23 @@ export const RATELIMIT_POLICIES = {
     attempts: 10,
     window: "1 m",
     keyPrefix: "rl:auth:saml-verify",
+  },
+
+  programImageUpload: {
+    attempts: 10,
+    window: "24 h",
+    keyPrefix: "rl:program:application:image:upload",
+  },
+
+  messageAttachmentUpload: {
+    attempts: 20,
+    window: "1 h",
+    keyPrefix: "rl:message:attachment:upload",
+  },
+
+  partnerProfileInvite: {
+    attempts: 5,
+    window: "1 h",
+    keyPrefix: "rl:partner-profile:invite",
   },
 } as const satisfies Record<string, RatelimitPolicy>;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Partner profile invitations are limited to five attempts per hour.
  * Updating a default link can also update the associated program URL when applicable.
  * Updated link URLs now preserve configured UTM parameters.

* **Bug Fixes**
  * Unchanged and duplicate default-link URLs receive clearer responses.
  * Missing links and domain changes are detected more accurately.
  * Invitation errors are surfaced correctly, while duplicate invitations retain their existing handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->