### PR TITLE
Add “Set as default product” to sidebar product hover tooltips

### DIFF
--- a/apps/web/ui/layout/sidebar/app-sidebar-nav.tsx
+++ b/apps/web/ui/layout/sidebar/app-sidebar-nav.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { clientAccessCheck } from "@/lib/client-access-check";
 import { usePartnerMessagesCount } from "@/lib/messages/hooks/use-partner-messages-count";
 import { getPlanCapabilities } from "@/lib/plan-capabilities";
 import { SUBMITTED_LEADS_ENABLED_PROGRAM_IDS } from "@/lib/submitted-leads/constants";
@@ -46,10 +47,13 @@ import {
   Webhook,
 } from "@dub/ui/icons";
 import { isWorkspaceBillingTrialActive } from "@dub/utils";
+import { DubProduct } from "@prisma/client";
 import { Session } from "next-auth";
 import { useSession } from "next-auth/react";
 import { useParams, usePathname } from "next/navigation";
 import { ReactNode, useMemo } from "react";
+import { toast } from "sonner";
+import { mutate } from "swr";
 import { DubPartnersPopup } from "./dub-partners-popup";
 import { Compass } from "./icons/compass";
 import { ConnectedDots4 } from "./icons/connected-dots4";
@@ -67,6 +71,8 @@ type SidebarNavData = {
   pathname: string;
   queryString: string;
   defaultProduct?: "program" | "links";
+  canSetDefaultProduct?: boolean;
+  onSetDefaultProduct?: (product: DubProduct) => Promise<void>;
   session?: Session | null;
   showNews?: boolean;
   pendingPayoutsCount?: number;
@@ -83,9 +89,10 @@ const NAV_GROUPS: SidebarNavGroups<SidebarNavData> = ({
   slug,
   pathname,
   defaultProduct,
+  canSetDefaultProduct,
+  onSetDefaultProduct,
 }) => {
   const programGroup = {
-    id: "program",
     name: "Partner Program",
     description:
       "Kickstart viral product-led growth with powerful, branded referral and affiliate programs.",
@@ -98,9 +105,13 @@ const NAV_GROUPS: SidebarNavGroups<SidebarNavData> = ({
       !pathname.startsWith(`/${slug}/links`) &&
       !pathname.startsWith(`/${slug}/settings`),
     popup: DubPartnersPopup,
+    isDefault: defaultProduct === "program",
+    onSetDefault:
+      canSetDefaultProduct && onSetDefaultProduct
+        ? () => onSetDefaultProduct("program")
+        : undefined,
   };
   const linksGroup = {
-    id: "links",
     name: "Short Links",
     description:
       "Create, organize, and measure the performance of your short links.",
@@ -108,6 +119,11 @@ const NAV_GROUPS: SidebarNavGroups<SidebarNavData> = ({
     icon: Compass,
     href: slug ? `/${slug}/links` : "/links",
     active: pathname.startsWith(`/${slug}/links`),
+    isDefault: (defaultProduct ?? "links") === "links",
+    onSetDefault:
+      canSetDefaultProduct && onSetDefaultProduct
+        ? () => onSetDefaultProduct("links")
+        : undefined,
   };
 
   return defaultProduct === "links"
@@ -502,8 +518,51 @@ export function AppSidebarNav({
   const pathname = usePathname();
   const { router, getQueryString } = useRouterStuff();
   const { data: session } = useSession();
-  const { plan, defaultProduct, defaultProgramId, trialEndsAt } =
-    useWorkspace();
+  const {
+    id: workspaceId,
+    plan,
+    defaultProduct,
+    defaultProgramId,
+    trialEndsAt,
+    role,
+  } = useWorkspace();
+
+  const canSetDefaultProduct = !clientAccessCheck({
+    action: "workspaces.write",
+    role,
+  }).error;
+
+  async function onSetDefaultProduct(product: DubProduct) {
+    if (!workspaceId || !slug) {
+      return;
+    }
+
+    await toast.promise(
+      (async () => {
+        const response = await fetch(`/api/workspaces/${workspaceId}`, {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            defaultProduct: product,
+          }),
+        });
+
+        if (!response.ok) {
+          const { error } = await response.json();
+          throw new Error(error.message);
+        }
+
+        await mutate(`/api/workspaces/${slug}`);
+      })(),
+      {
+        loading: "Setting default product...",
+        success: "Successfully updated your default product!",
+        error: (error) => error.message,
+      },
+    );
+  }
 
   const currentArea = useMemo(() => {
     return pathname.startsWith("/account/settings")
@@ -597,6 +656,8 @@ export function AppSidebarNav({
         session: session || undefined,
         showNews: true,
         defaultProduct,
+        canSetDefaultProduct,
+        onSetDefaultProduct,
         pendingPayoutsCount: pendingPayoutsCount?.[0]?.count ?? 0,
         applicationsCount,
         submittedBountiesCount,

--- a/apps/web/ui/layout/sidebar/app-sidebar-nav.tsx
+++ b/apps/web/ui/layout/sidebar/app-sidebar-nav.tsx
@@ -16,6 +16,7 @@ import useWorkspace from "@/lib/swr/use-workspace";
 import { useKeyboardShortcut, useRouterStuff } from "@dub/ui";
 import {
   Bell,
+  BookOpen,
   Brush,
   ConnectedDots,
   CubeSettings,
@@ -26,6 +27,7 @@ import {
   Gear2,
   Gift,
   Globe,
+  GridPlus,
   InvoiceDollar,
   Key,
   LifeRing,
@@ -50,6 +52,7 @@ import { isWorkspaceBillingTrialActive } from "@dub/utils";
 import { DubProduct } from "@prisma/client";
 import { Session } from "next-auth";
 import { useSession } from "next-auth/react";
+import Link from "next/link";
 import { useParams, usePathname } from "next/navigation";
 import { ReactNode, useMemo } from "react";
 import { toast } from "sonner";
@@ -71,17 +74,13 @@ type SidebarNavData = {
   pathname: string;
   queryString: string;
   defaultProduct?: "program" | "links";
-  canSetDefaultProduct?: boolean;
-  onSetDefaultProduct?: (product: DubProduct) => Promise<void>;
   session?: Session | null;
-  showNews?: boolean;
   pendingPayoutsCount?: number;
   applicationsCount?: number;
   submittedBountiesCount?: number;
   unreadMessagesCount?: number;
   pendingFraudEventsCount?: number;
   pendingLeadsCount?: number;
-  showConversionGuides?: boolean;
   partnerNetworkEnabled?: boolean;
 };
 
@@ -89,8 +88,6 @@ const NAV_GROUPS: SidebarNavGroups<SidebarNavData> = ({
   slug,
   pathname,
   defaultProduct,
-  canSetDefaultProduct,
-  onSetDefaultProduct,
 }) => {
   const programGroup = {
     name: "Partner Program",
@@ -105,11 +102,6 @@ const NAV_GROUPS: SidebarNavGroups<SidebarNavData> = ({
       !pathname.startsWith(`/${slug}/links`) &&
       !pathname.startsWith(`/${slug}/settings`),
     popup: DubPartnersPopup,
-    isDefault: defaultProduct === "program",
-    onSetDefault:
-      canSetDefaultProduct && onSetDefaultProduct
-        ? () => onSetDefaultProduct("program")
-        : undefined,
   };
   const linksGroup = {
     name: "Short Links",
@@ -119,11 +111,6 @@ const NAV_GROUPS: SidebarNavGroups<SidebarNavData> = ({
     icon: Compass,
     href: slug ? `/${slug}/links` : "/links",
     active: pathname.startsWith(`/${slug}/links`),
-    isDefault: (defaultProduct ?? "links") === "links",
-    onSetDefault:
-      canSetDefaultProduct && onSetDefaultProduct
-        ? () => onSetDefaultProduct("links")
-        : undefined,
   };
 
   return (defaultProduct ?? "links") === "links"
@@ -135,7 +122,6 @@ const NAV_AREAS: SidebarNavAreas<SidebarNavData> = {
   // partner program
   program: ({
     slug,
-    showNews,
     pendingPayoutsCount,
     applicationsCount,
     submittedBountiesCount,
@@ -145,7 +131,6 @@ const NAV_AREAS: SidebarNavAreas<SidebarNavData> = {
     partnerNetworkEnabled,
   }) => ({
     title: "Partner Program",
-    showNews,
     direction: "left",
     content: [
       {
@@ -308,9 +293,9 @@ const NAV_AREAS: SidebarNavAreas<SidebarNavData> = {
     ],
   }),
   // short links
-  links: ({ slug, pathname, queryString, showNews }) => ({
+  links: ({ slug, pathname, queryString }) => ({
     title: "Short Links",
-    showNews,
+    showNews: true,
     direction: "left",
     content: [
       {
@@ -555,6 +540,7 @@ export function AppSidebarNav({
         }
 
         await mutate(`/api/workspaces/${slug}`);
+        router.push(`/${slug}/${product}`);
       })(),
       {
         loading: "Setting default product...",
@@ -642,6 +628,28 @@ export function AppSidebarNav({
 
   const { canTrackConversions } = getPlanCapabilities(plan);
 
+  const setDefaultProductButton =
+    canSetDefaultProduct &&
+    (currentArea === "program" || currentArea === "links") &&
+    (defaultProduct ?? "links") !== currentArea ? (
+      <button
+        type="button"
+        onClick={() => onSetDefaultProduct(currentArea)}
+        className="flex w-full items-center justify-center gap-2 rounded-lg bg-neutral-200/75 px-2.5 py-2 text-xs font-medium text-neutral-700 transition-colors hover:bg-neutral-200"
+      >
+        <GridPlus className="size-4" />
+        Set as default product tab
+      </button>
+    ) : canTrackConversions && pathname.startsWith(`/${slug}/links`) ? (
+      <Link
+        href={`/${slug}/settings/tracking`}
+        className="flex w-full items-center justify-center gap-2 rounded-lg bg-neutral-200/75 px-2.5 py-2 text-xs font-medium text-neutral-700 transition-colors hover:bg-neutral-200"
+      >
+        <BookOpen className="size-4" />
+        Set up conversion tracking
+      </Link>
+    ) : null;
+
   return (
     <SidebarNav
       groups={NAV_GROUPS}
@@ -654,18 +662,13 @@ export function AppSidebarNav({
           include: ["folderId"],
         }),
         session: session || undefined,
-        showNews: true,
         defaultProduct,
-        canSetDefaultProduct,
-        onSetDefaultProduct,
         pendingPayoutsCount: pendingPayoutsCount?.[0]?.count ?? 0,
         applicationsCount,
         submittedBountiesCount,
         unreadMessagesCount,
         pendingFraudEventsCount,
         pendingLeadsCount,
-        showConversionGuides:
-          canTrackConversions && pathname.startsWith(`/${slug}/links`),
         partnerNetworkEnabled:
           program && program.partnerNetworkEnabledAt !== null,
       }}
@@ -679,6 +682,7 @@ export function AppSidebarNav({
         ))
       }
       switcher={<WorkspaceDropdown />}
+      bottom={setDefaultProductButton}
     />
   );
 }

--- a/apps/web/ui/layout/sidebar/app-sidebar-nav.tsx
+++ b/apps/web/ui/layout/sidebar/app-sidebar-nav.tsx
@@ -126,7 +126,7 @@ const NAV_GROUPS: SidebarNavGroups<SidebarNavData> = ({
         : undefined,
   };
 
-  return defaultProduct === "links"
+  return (defaultProduct ?? "links") === "links"
     ? [linksGroup, programGroup]
     : [programGroup, linksGroup];
 };

--- a/apps/web/ui/layout/sidebar/news.tsx
+++ b/apps/web/ui/layout/sidebar/news.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useLocalStorage, useMediaQuery } from "@dub/ui";
+import { Xmark } from "@dub/ui/icons";
 import { cn } from "@dub/utils";
 import Image from "next/image";
 import Link from "next/link";
@@ -38,7 +39,10 @@ export function News({ articles }: { articles: NewsArticle[] }) {
 
   return cards.length || showCompleted ? (
     <div
-      className="group overflow-hidden border-t border-neutral-200 p-3 pt-6 transition-all duration-200 hover:pt-10"
+      className={cn(
+        "group overflow-hidden border-t border-neutral-200 p-3 pt-6 transition-all duration-200",
+        cardCount > 0 ? "hover:pt-10" : "pt-3",
+      )}
       data-active={cardCount !== 0}
     >
       <div className="relative size-full">
@@ -47,6 +51,7 @@ export function News({ articles }: { articles: NewsArticle[] }) {
             key={href}
             className={cn(
               "absolute left-0 top-0 size-full scale-[var(--scale)] transition-[opacity,transform] duration-200",
+              idx === cardCount - 1 && "overflow-visible",
               cardCount - idx > 3
                 ? [
                     "opacity-0 sm:group-hover:translate-y-[var(--y)] sm:group-hover:opacity-[var(--opacity)]",
@@ -78,6 +83,17 @@ export function News({ articles }: { articles: NewsArticle[] }) {
               onDismiss={
                 () => setDismissedNews([href, ...dismissedNews.slice(0, 50)]) // Limit to keep storage size low
               }
+              onDismissAll={
+                cardCount > 1
+                  ? () =>
+                      setDismissedNews(
+                        [
+                          ...cards.map((card) => card.href),
+                          ...dismissedNews,
+                        ].slice(0, 50),
+                      )
+                  : undefined
+              }
             />
           </div>
         ))}
@@ -106,6 +122,7 @@ function NewsCard({
   description,
   image,
   onDismiss,
+  onDismissAll,
   hideContent,
   href,
   active,
@@ -114,6 +131,7 @@ function NewsCard({
   description: string;
   image?: string;
   onDismiss?: () => void;
+  onDismissAll?: () => void;
   hideContent?: boolean;
   href?: string;
   active?: boolean;
@@ -231,6 +249,20 @@ function NewsCard({
       onPointerDown={onPointerDown}
       onClick={onClick}
     >
+      {active && onDismissAll && (
+        <button
+          type="button"
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={(e) => {
+            e.stopPropagation();
+            onDismissAll();
+          }}
+          className="absolute -right-2 -top-2 z-10 flex items-center gap-1 rounded-full border border-neutral-200 bg-white px-2 py-1 text-[0.625rem] font-medium leading-none text-neutral-500 opacity-0 shadow-sm transition-[border-color,color,box-shadow,opacity] duration-150 hover:border-neutral-300 hover:text-neutral-700 hover:shadow max-sm:opacity-100 sm:group-hover:opacity-100"
+        >
+          <Xmark className="size-2.5 shrink-0" />
+          Dismiss all
+        </button>
+      )}
       <div className={cn(hideContent && "invisible")}>
         <div className="flex flex-col gap-1">
           <span className="line-clamp-1 font-medium text-neutral-900">

--- a/apps/web/ui/layout/sidebar/sidebar-nav.tsx
+++ b/apps/web/ui/layout/sidebar/sidebar-nav.tsx
@@ -1,7 +1,6 @@
 import {
   AnimatedSizeContainer,
   ArrowUpRight2,
-  BookOpen,
   ChevronLeft,
   ClientOnly,
   Icon,
@@ -12,7 +11,7 @@ import {
 } from "@dub/ui";
 import { cn } from "@dub/utils";
 import { ChevronDown } from "lucide-react";
-import { AnimatePresence, motion } from "motion/react";
+import { motion } from "motion/react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import {
@@ -57,8 +56,6 @@ export type NavGroupType = {
   badge?: ReactNode;
   description: string;
   learnMoreHref?: string;
-  isDefault?: boolean;
-  onSetDefault?: () => Promise<void> | void;
 };
 
 export type SidebarNavGroups<T extends Record<any, any>> = (
@@ -280,37 +277,13 @@ function SidebarAreasPanel<T extends Record<any, any>>({
       </div>
 
       {/* Fixed bottom sections - always visible */}
-      <div className="flex flex-shrink-0 flex-col gap-2 rounded-b-xl">
-        {data.showConversionGuides && (
-          <div className="px-3 pb-2">
-            <Link
-              href={`/${data.slug}/settings/tracking`}
-              className="flex items-center gap-2 rounded-lg bg-neutral-200/75 px-2.5 py-2 text-xs text-neutral-700 transition-colors hover:bg-neutral-200"
-            >
-              <BookOpen className="size-4" />
-              Set up conversion tracking
-            </Link>
-          </div>
-        )}
-
-        <AnimatePresence>
-          {showNews && (
-            <motion.div
-              initial={{ opacity: 0, y: 10 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: 10 }}
-              transition={{
-                duration: 0.1,
-                ease: "easeInOut",
-              }}
-            >
-              {newsContent}
-            </motion.div>
-          )}
-        </AnimatePresence>
-
-        {bottom && <div className="flex flex-col">{bottom}</div>}
-      </div>
+      <AnimatedSizeContainer
+        height
+        className="flex flex-shrink-0 flex-col gap-2 rounded-b-xl"
+      >
+        {bottom && <div className="px-3 pb-2">{bottom}</div>}
+        {showNews && newsContent}
+      </AnimatedSizeContainer>
     </div>
   );
 }
@@ -319,27 +292,21 @@ export function NavGroupTooltip({
   name,
   description,
   learnMoreHref,
-  isDefault,
-  onSetDefault,
   disabled,
   children,
 }: PropsWithChildren<{
   name: string;
   description?: string;
   learnMoreHref?: string;
-  isDefault?: boolean;
-  onSetDefault?: () => Promise<void> | void;
   disabled?: boolean;
 }>) {
-  const [settingDefault, setSettingDefault] = useState(false);
-
   return (
     <Tooltip
       side="right"
       delayDuration={100}
       disabled={disabled}
       className="rounded-lg bg-black px-3 py-1.5 text-sm font-medium text-white"
-      content={({ setOpen }) => (
+      content={
         <div>
           <span>{name}</span>
           {description && (
@@ -351,54 +318,22 @@ export function NavGroupTooltip({
             >
               <div className="w-44 py-1 text-xs tracking-tight">
                 <p className="text-content-muted">{description}</p>
-                {(learnMoreHref || onSetDefault || isDefault) && (
-                  <div className="mt-2.5 flex flex-col gap-2">
-                    {learnMoreHref && (
-                      <Link
-                        href={learnMoreHref}
-                        target="_blank"
-                        className="font-semibold text-white underline"
-                      >
-                        Learn more
-                      </Link>
-                    )}
-                    {isDefault ? (
-                      <p className="text-content-muted font-medium">
-                        Default product
-                      </p>
-                    ) : (
-                      onSetDefault && (
-                        <button
-                          type="button"
-                          disabled={settingDefault}
-                          onClick={async (e) => {
-                            e.preventDefault();
-                            e.stopPropagation();
-                            setSettingDefault(true);
-                            try {
-                              await onSetDefault();
-                              setOpen(false);
-                            } catch {
-                              // Error toast is handled by the caller
-                            } finally {
-                              setSettingDefault(false);
-                            }
-                          }}
-                          className="w-full rounded-md bg-white/10 px-2 py-1.5 text-left text-xs font-semibold text-white transition-colors hover:bg-white/20 disabled:cursor-not-allowed disabled:opacity-60"
-                        >
-                          {settingDefault
-                            ? "Setting default..."
-                            : "Set as default product"}
-                        </button>
-                      )
-                    )}
+                {learnMoreHref && (
+                  <div className="mt-2.5">
+                    <Link
+                      href={learnMoreHref}
+                      target="_blank"
+                      className="font-semibold text-white underline"
+                    >
+                      Learn more
+                    </Link>
                   </div>
                 )}
               </div>
             </motion.div>
           )}
         </div>
-      )}
+      }
     >
       {children}
     </Tooltip>
@@ -410,8 +345,6 @@ function NavGroupItem({
     name,
     description,
     learnMoreHref,
-    isDefault,
-    onSetDefault,
     icon: Icon,
     href,
     active,
@@ -431,8 +364,6 @@ function NavGroupItem({
         name={name}
         description={description}
         learnMoreHref={learnMoreHref}
-        isDefault={isDefault}
-        onSetDefault={onSetDefault}
       >
         <div>
           <Link

--- a/apps/web/ui/layout/sidebar/sidebar-nav.tsx
+++ b/apps/web/ui/layout/sidebar/sidebar-nav.tsx
@@ -57,6 +57,8 @@ export type NavGroupType = {
   badge?: ReactNode;
   description: string;
   learnMoreHref?: string;
+  isDefault?: boolean;
+  onSetDefault?: () => Promise<void> | void;
 };
 
 export type SidebarNavGroups<T extends Record<any, any>> = (
@@ -317,21 +319,27 @@ export function NavGroupTooltip({
   name,
   description,
   learnMoreHref,
+  isDefault,
+  onSetDefault,
   disabled,
   children,
 }: PropsWithChildren<{
   name: string;
   description?: string;
   learnMoreHref?: string;
+  isDefault?: boolean;
+  onSetDefault?: () => Promise<void> | void;
   disabled?: boolean;
 }>) {
+  const [settingDefault, setSettingDefault] = useState(false);
+
   return (
     <Tooltip
       side="right"
       delayDuration={100}
       disabled={disabled}
       className="rounded-lg bg-black px-3 py-1.5 text-sm font-medium text-white"
-      content={
+      content={({ setOpen }) => (
         <div>
           <span>{name}</span>
           {description && (
@@ -343,22 +351,54 @@ export function NavGroupTooltip({
             >
               <div className="w-44 py-1 text-xs tracking-tight">
                 <p className="text-content-muted">{description}</p>
-                {learnMoreHref && (
-                  <div className="mt-2.5">
-                    <Link
-                      href={learnMoreHref}
-                      target="_blank"
-                      className="font-semibold text-white underline"
-                    >
-                      Learn more
-                    </Link>
+                {(learnMoreHref || onSetDefault || isDefault) && (
+                  <div className="mt-2.5 flex flex-col gap-2">
+                    {learnMoreHref && (
+                      <Link
+                        href={learnMoreHref}
+                        target="_blank"
+                        className="font-semibold text-white underline"
+                      >
+                        Learn more
+                      </Link>
+                    )}
+                    {isDefault ? (
+                      <p className="text-content-muted font-medium">
+                        Default product
+                      </p>
+                    ) : (
+                      onSetDefault && (
+                        <button
+                          type="button"
+                          disabled={settingDefault}
+                          onClick={async (e) => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            setSettingDefault(true);
+                            try {
+                              await onSetDefault();
+                              setOpen(false);
+                            } catch {
+                              // Error toast is handled by the caller
+                            } finally {
+                              setSettingDefault(false);
+                            }
+                          }}
+                          className="w-full rounded-md bg-white/10 px-2 py-1.5 text-left text-xs font-semibold text-white transition-colors hover:bg-white/20 disabled:cursor-not-allowed disabled:opacity-60"
+                        >
+                          {settingDefault
+                            ? "Setting default..."
+                            : "Set as default product"}
+                        </button>
+                      )
+                    )}
                   </div>
                 )}
               </div>
             </motion.div>
           )}
         </div>
-      }
+      )}
     >
       {children}
     </Tooltip>
@@ -370,6 +410,8 @@ function NavGroupItem({
     name,
     description,
     learnMoreHref,
+    isDefault,
+    onSetDefault,
     icon: Icon,
     href,
     active,
@@ -389,6 +431,8 @@ function NavGroupItem({
         name={name}
         description={description}
         learnMoreHref={learnMoreHref}
+        isDefault={isDefault}
+        onSetDefault={onSetDefault}
       >
         <div>
           <Link


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When hovering a product tab (Short Links / Partner Program) in the app sidebar, the expanded info tooltip now includes a **Set as default product** action.

- Reuses the existing `PATCH /api/workspaces/:id` `defaultProduct` update path (same as Settings → Default Product)
- Gated by `workspaces.write`
- Already-default product shows a **Default product** label instead of the button
- On success, SWR mutates workspace data so tab order updates immediately

## Test plan

1. Open a workspace where you have write access
2. Hover a non-default product tab until the description expands
3. Click **Set as default product** and confirm the toast success + tab order updates
4. Hover the new default product and confirm it shows **Default product**
5. As a member without `workspaces.write`, confirm the button does not appear
6. Confirm Partners sidebar product tooltips are unchanged (no default-product action)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe2f7-cbb2-77e9-9982-f7d21cf7577e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe2f7-cbb2-77e9-9982-f7d21cf7577e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

