### PR TITLE
Fix bulk link create crashing on unresolved tagNames

### DIFF
--- a/apps/web/app/api/links/bulk/route.ts
+++ b/apps/web/app/api/links/bulk/route.ts
@@ -118,8 +118,10 @@ export const POST = withWorkspace(
       const workspaceTags = await prisma.tag.findMany({
         where: {
           projectId: workspace.id,
-          ...(tagIds.length > 0 ? { id: { in: tagIds } } : {}),
-          ...(tagNames.length > 0 ? { name: { in: tagNames } } : {}),
+          OR: [
+            ...(tagIds.length > 0 ? [{ id: { in: tagIds } }] : []),
+            ...(tagNames.length > 0 ? [{ name: { in: tagNames } }] : []),
+          ],
         },
         select: {
           id: true,
@@ -132,7 +134,9 @@ export const POST = withWorkspace(
         name.toLowerCase(),
       );
 
-      validLinks.forEach((link, index) => {
+      const nextValidLinks: ProcessedLinkProps[] = [];
+
+      for (const link of validLinks) {
         const combinedTagIds =
           combineTagIds({
             tagId: link.tagId,
@@ -144,13 +148,12 @@ export const POST = withWorkspace(
         );
 
         if (invalidTagIds.length > 0) {
-          // remove link from validLinks and add error to errorLinks
-          validLinks = validLinks.filter((_, i) => i !== index);
           errorLinks.push({
             error: `Invalid tagIds detected: ${invalidTagIds.join(", ")}`,
             code: "unprocessable_entity",
             link,
           });
+          continue;
         }
 
         const invalidTagNames = link.tagNames?.filter(
@@ -158,14 +161,18 @@ export const POST = withWorkspace(
         );
 
         if (invalidTagNames?.length) {
-          validLinks = validLinks.filter((_, i) => i !== index);
           errorLinks.push({
             error: `Invalid tagNames detected: ${invalidTagNames.join(", ")}`,
             code: "unprocessable_entity",
             link,
           });
+          continue;
         }
-      });
+
+        nextValidLinks.push(link);
+      }
+
+      validLinks = nextValidLinks;
     }
 
     if (checkIfLinksHaveFolders(validLinks)) {
@@ -235,19 +242,26 @@ export const POST = withWorkspace(
 
       const workspaceWebhookIds = webhooks.map(({ id }) => id);
 
-      validLinks.forEach((link, index) => {
+      const nextValidLinks: ProcessedLinkProps[] = [];
+
+      for (const link of validLinks) {
         const invalidWebhookIds = link.webhookIds?.filter(
           (id) => !workspaceWebhookIds.includes(id),
         );
+
         if (invalidWebhookIds && invalidWebhookIds.length > 0) {
-          validLinks = validLinks.filter((_, i) => i !== index);
           errorLinks.push({
             error: `Invalid webhookIds detected: ${invalidWebhookIds.join(", ")}`,
             code: "unprocessable_entity",
             link,
           });
+          continue;
         }
-      });
+
+        nextValidLinks.push(link);
+      }
+
+      validLinks = nextValidLinks;
     }
 
     const validLinksResponse =

--- a/apps/web/lib/api/links/bulk-create-links.ts
+++ b/apps/web/lib/api/links/bulk-create-links.ts
@@ -148,9 +148,12 @@ export async function bulkCreateLinks({
 
         if (tagNames && tagNames.length > 0) {
           tagNames.filter(Boolean).forEach((tagName, tagIdx) => {
+            const resolvedTagId = tagNameToIdMap[tagName.toLowerCase()];
+            if (!resolvedTagId) return;
+
             linkTagsToCreate.push({
               linkId: link.id,
-              tagId: tagNameToIdMap[tagName.toLowerCase()],
+              tagId: resolvedTagId,
               createdAt: new Date(new Date().getTime() + tagIdx * 100),
             });
           });

--- a/apps/web/tests/links/bulk-create-link.test.ts
+++ b/apps/web/tests/links/bulk-create-link.test.ts
@@ -255,3 +255,81 @@ test("POST /links/bulk assigns correct tags to each link (no tag mixing)", async
   expect(link3?.tags?.map((t) => t.id)).toContain(E2E_TAG.id);
   expect(link3?.tags?.map((t) => t.id)).toContain(E2E_TAG_2.id);
 });
+
+test("POST /links/bulk rejects multiple links with invalid tagNames", async (ctx) => {
+  const testContext = await setupBulkTest(ctx);
+  const { h } = testContext;
+
+  const validUrl = `https://example.com/${randomId()}`;
+  const bulkLinks = [
+    {
+      url: `https://example.com/${randomId()}`,
+      domain,
+      tagNames: ["MissingA-DoNotExist"],
+    },
+    {
+      url: `https://example.com/${randomId()}`,
+      domain,
+      tagNames: [E2E_TAG.name, "Missing1-DoNotExist", "Missing2-DoNotExist"],
+    },
+    {
+      url: validUrl,
+      domain,
+    },
+  ];
+
+  const { status, data: links } = await testContext.http.post<
+    Array<LinkWithTags | { error: string; code: string; link: unknown }>
+  >({
+    path: "/links/bulk",
+    body: bulkLinks,
+  });
+
+  const created = links.filter(
+    (item): item is LinkWithTags => "id" in item && typeof item.id === "string",
+  );
+  const errors = links.filter(
+    (item): item is { error: string; code: string; link: unknown } =>
+      "error" in item,
+  );
+
+  onTestFinished(async () => {
+    await Promise.all(created.map((link) => h.deleteLink(link.id)));
+  });
+
+  expect(status).toEqual(200);
+  expect(errors).toHaveLength(2);
+  expect(errors.every((e) => e.code === "unprocessable_entity")).toBe(true);
+  expect(created).toHaveLength(1);
+  expect(created[0].url).toEqual(validUrl);
+});
+
+test("POST /links/bulk accepts both tagIds and tagNames", async (ctx) => {
+  const testContext = await setupBulkTest(ctx);
+  const { h } = testContext;
+
+  const bulkLinks = [
+    {
+      url: `https://example.com/${randomId()}`,
+      domain,
+      tagIds: [E2E_TAG.id],
+      tagNames: [E2E_TAG_2.name],
+    },
+  ];
+
+  const { status, data: links } = await testContext.http.post<LinkWithTags[]>({
+    path: "/links/bulk",
+    body: bulkLinks,
+  });
+
+  onTestFinished(async () => {
+    await Promise.all(links.map((link) => h.deleteLink(link.id)));
+  });
+
+  expect(status).toEqual(200);
+  expect(links).toHaveLength(1);
+  expect(links[0].tags).toHaveLength(2);
+  expect(links[0].tags?.map((t) => t.id).sort()).toEqual(
+    [E2E_TAG.id, E2E_TAG_2.id].sort(),
+  );
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved bulk link creation when applying tags by ID and name together.
  - Invalid or unrecognized tag names are now skipped without creating incomplete tag associations.
  - Bulk requests now preserve valid links while clearly reporting invalid entries.
  - Improved validation for tag and webhook data during bulk creation.
- **Enhancements**
  - Bulk creation now supports partial success: valid links are created even when some entries contain errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->