### PR TITLE
Fix `restoreCanceledCommissions` logic

### DIFF
--- a/apps/web/lib/jobs/handlers/unban-partner-job.ts
+++ b/apps/web/lib/jobs/handlers/unban-partner-job.ts
@@ -202,7 +202,7 @@ async function restoreCanceledCommissions({
       await trackCommissionStatusUpdate({
         workspaceId,
         programId,
-        commissions,
+        commissions: commissionsWithPayouts,
         newStatus: CommissionStatus.processed,
       });
     }
@@ -217,6 +217,7 @@ async function restoreCanceledCommissions({
             id: {
               in: commissionsWithoutPayouts.map(({ id }) => id),
             },
+            status: CommissionStatus.canceled,
           },
           data: {
             status: CommissionStatus.pending,

--- a/apps/web/lib/jobs/handlers/unban-partner-job.ts
+++ b/apps/web/lib/jobs/handlers/unban-partner-job.ts
@@ -168,6 +168,7 @@ async function restoreCanceledCommissions({
         amount: true,
         earnings: true,
         status: true,
+        payoutId: true,
       },
       orderBy: {
         id: "asc",
@@ -179,26 +180,57 @@ async function restoreCanceledCommissions({
       break;
     }
 
-    const { count } = await prisma.commission.updateMany({
-      where: {
-        id: {
-          in: commissions.map(({ id }) => id),
-        },
-        status: CommissionStatus.canceled,
-      },
-      data: {
-        status: CommissionStatus.pending,
-      },
-    });
+    const commissionsWithPayouts = commissions.filter(
+      (commission) => commission.payoutId,
+    );
 
-    await trackCommissionStatusUpdate({
-      workspaceId,
-      programId,
-      commissions,
-      newStatus: CommissionStatus.pending,
-    });
+    if (commissionsWithPayouts.length > 0) {
+      const { count: restoredProcessedCommissions } =
+        await prisma.commission.updateMany({
+          where: {
+            id: {
+              in: commissionsWithPayouts.map(({ id }) => id),
+            },
+            status: CommissionStatus.canceled,
+          },
+          data: {
+            status: CommissionStatus.processed,
+          },
+        });
+      restoredCommissions += restoredProcessedCommissions;
 
-    restoredCommissions += count;
+      await trackCommissionStatusUpdate({
+        workspaceId,
+        programId,
+        commissions,
+        newStatus: CommissionStatus.processed,
+      });
+    }
+
+    const commissionsWithoutPayouts = commissions.filter(
+      (commission) => !commission.payoutId,
+    );
+    if (commissionsWithoutPayouts.length > 0) {
+      const { count: restoredPendingCommissions } =
+        await prisma.commission.updateMany({
+          where: {
+            id: {
+              in: commissionsWithoutPayouts.map(({ id }) => id),
+            },
+          },
+          data: {
+            status: CommissionStatus.pending,
+          },
+        });
+      restoredCommissions += restoredPendingCommissions;
+
+      await trackCommissionStatusUpdate({
+        workspaceId,
+        programId,
+        commissions: commissionsWithoutPayouts,
+        newStatus: CommissionStatus.pending,
+      });
+    }
   }
 
   console.info(

--- a/apps/web/ui/modals/unban-partner-modal.tsx
+++ b/apps/web/ui/modals/unban-partner-modal.tsx
@@ -67,9 +67,7 @@ function UnbanPartnerModal({
   }, [executeAsync, partner.id, workspaceId]);
 
   const isDisabled = useMemo(() => {
-    return (
-      !workspaceId || !partner.id || confirm !== `confirm unban ${partner.name}`
-    );
+    return !workspaceId || !partner.id || confirm !== "confirm unban partner";
   }, [workspaceId, partner.id, confirm]);
 
   return (
@@ -104,8 +102,7 @@ function UnbanPartnerModal({
 
           <div>
             <label className="block text-sm font-medium text-neutral-900">
-              To verify, type <strong>confirm unban {partner.name}</strong>{" "}
-              below
+              To verify, type <strong>confirm unban partner</strong> below
             </label>
             <div className="relative mt-1.5 rounded-md shadow-sm">
               <input
@@ -113,7 +110,7 @@ function UnbanPartnerModal({
                   "block w-full rounded-md border-neutral-300 text-neutral-900 placeholder-neutral-400 focus:border-neutral-500 focus:outline-none focus:ring-neutral-500 sm:text-sm",
                   errors.confirm && "border-red-600",
                 )}
-                placeholder={`confirm unban ${partner.name}`}
+                placeholder="confirm unban partner"
                 type="text"
                 autoComplete="off"
                 {...register("confirm", {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored commissions now return to the appropriate status based on whether a payout exists.
  * Commissions with payouts are restored as processed, while those without payouts return to pending.
  * Restoration counts and activity records are now tracked separately for each status.
  * Unbanning a partner now requires the fixed confirmation phrase “confirm unban partner.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->