### PR TITLE
Matching the analytics icon

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/commissions/commissions-table.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/commissions/commissions-table.tsx
@@ -19,9 +19,9 @@ import SimpleDateRangePicker from "@/ui/shared/simple-date-range-picker";
 import {
   AnimatedSizeContainer,
   Button,
-  ChartLine,
   EditColumnsButton,
   Filter,
+  LinesY,
   StatusBadge,
   Table,
   TimestampTooltip,
@@ -471,7 +471,7 @@ function CommissionsFilters() {
               <Button
                 variant="secondary"
                 className="w-fit"
-                icon={<ChartLine className="h-4 w-4 text-neutral-600" />}
+                icon={<LinesY className="h-4 w-4 text-neutral-600" />}
                 text={isMobile ? undefined : "View Analytics"}
               />
             </Link>

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/applications/page-client.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/applications/page-client.tsx
@@ -21,9 +21,9 @@ import { SearchBoxPersisted } from "@/ui/shared/search-box";
 import {
   AnimatedSizeContainer,
   Button,
-  ChartLine,
   EditColumnsButton,
   Filter,
+  LinesY,
   MenuItem,
   Popover,
   Table,
@@ -480,7 +480,7 @@ export function ProgramPartnersApplicationsPageClient() {
                 <Button
                   variant="secondary"
                   className="w-fit"
-                  icon={<ChartLine className="h-4 w-4 text-neutral-600" />}
+                  icon={<LinesY className="h-4 w-4 text-neutral-600" />}
                   text={isMobile ? undefined : "View Analytics"}
                 />
               </Link>

--- a/apps/web/ui/analytics/toggle.tsx
+++ b/apps/web/ui/analytics/toggle.tsx
@@ -8,9 +8,9 @@ import useWorkspace from "@/lib/swr/use-workspace";
 import {
   BlurImage,
   Button,
-  ChartLine,
   DateRangePicker,
   Filter,
+  LinesY,
   SquareLayoutGrid6,
   TooltipContent,
   useCurrentProduct,
@@ -266,7 +266,7 @@ export function AnalyticsToggle({
                             variant="secondary"
                             className="w-fit"
                             icon={
-                              <ChartLine className="h-4 w-4 text-neutral-600" />
+                              <LinesY className="h-4 w-4 text-neutral-600" />
                             }
                             text={isMobile ? undefined : "View Analytics"}
                           />


### PR DESCRIPTION
Updated the view analytics button icon to match the navigation icon for both the workspace and the partner.

<img width="1514" height="652" alt="CleanShot 2026-08-10 at 15 15 08@2x" src="https://github.com/user-attachments/assets/7b71bc3a-079b-4307-903d-357a8cb5be20" />

<img width="1514" height="624" alt="CleanShot 2026-08-10 at 15 15 01@2x" src="https://github.com/user-attachments/assets/db00e597-3ab2-4b3c-ba76-e45bb298d15c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated analytics links and “View Analytics” buttons with a clearer, consistent icon across the dashboard.
  * Applied the updated icon in commissions, partner applications, and analytics views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->