### PR TITLE
Add internal backlinks between custom commission description <> payouts

### DIFF
--- a/apps/web/app/(ee)/api/cron/payouts/charge-succeeded/utils.ts
+++ b/apps/web/app/(ee)/api/cron/payouts/charge-succeeded/utils.ts
@@ -38,7 +38,7 @@ export async function scheduleDelayedPayouts({
     label: invoice.id,
     flowControl: {
       key: invoice.id,
-      rate: 1,
+      parallelism: 1,
     },
     body: {
       invoiceId: invoice.id,

--- a/apps/web/app/(ee)/api/stripe/webhook/charge-succeeded.ts
+++ b/apps/web/app/(ee)/api/stripe/webhook/charge-succeeded.ts
@@ -92,7 +92,7 @@ async function processPayoutInvoice({ invoice }: { invoice: Invoice }) {
     label: invoice.id,
     flowControl: {
       key: invoice.id,
-      rate: 1,
+      parallelism: 1,
     },
     body: {
       invoiceId: invoice.id,

--- a/apps/web/app/(ee)/partners.dub.co/(dashboard)/payouts/partner-payout-details-sheet.tsx
+++ b/apps/web/app/(ee)/partners.dub.co/(dashboard)/payouts/partner-payout-details-sheet.tsx
@@ -5,14 +5,14 @@ import {
   PAYOUTS_SHEET_ITEMS_LIMIT,
   STABLECOIN_PAYOUT_FEE_RATE,
 } from "@/lib/constants/payouts";
+import { formatCommissionDescriptionTooltip } from "@/lib/commissions/format-commission-description-tooltip";
 import usePartnerProfile from "@/lib/swr/use-partner-profile";
 import { PartnerEarningsResponse, PartnerPayoutResponse } from "@/lib/types";
-import { CLAWBACK_REASONS_MAP } from "@/lib/zod/schemas/commissions";
 import { CustomerAvatar } from "@/ui/customers/customer-avatar";
 import { CommissionTypeIcon } from "@/ui/partners/comission-type-icon";
+import { CommissionDescriptionLabel } from "@/ui/partners/commission-description-label";
 import {
   CommissionTypeBadge,
-  getCommissionTypeLabel,
 } from "@/ui/partners/commission-type-badge";
 import { PayoutStatusBadges } from "@/ui/partners/payout-status-badges";
 import { ConditionalLink } from "@/ui/shared/conditional-link";
@@ -297,17 +297,10 @@ function PayoutDetailsSheetContent({ payout }: PayoutDetailsSheetProps) {
             )}
 
             <div className="flex min-w-0 flex-col">
-              {row.original.type === "custom" && row.original.description ? (
-                <Tooltip content={row.original.description}>
-                  <span className="min-w-0 truncate text-sm text-neutral-700">
-                    {row.original.description}
-                  </span>
-                </Tooltip>
-              ) : (
-                <span className="min-w-0 truncate text-sm text-neutral-700">
-                  {getCommissionTypeLabel(row.original)}
-                </span>
-              )}
+              <CommissionDescriptionLabel
+                commission={row.original}
+                context={{ variant: "partner" }}
+              />
               <span className="text-xs text-neutral-500">
                 {formatDateTime(row.original.createdAt)}
               </span>
@@ -324,12 +317,13 @@ function PayoutDetailsSheetContent({ payout }: PayoutDetailsSheetProps) {
           const earnings = currencyFormatter(commission.earnings);
 
           if (commission.description) {
-            const reason =
-              CLAWBACK_REASONS_MAP[commission.description]?.description ??
-              commission.description;
-
             return (
-              <Tooltip content={reason}>
+              <Tooltip
+                content={formatCommissionDescriptionTooltip(
+                  commission.description,
+                  { variant: "partner" },
+                )}
+              >
                 <span
                   className={cn(
                     "cursor-help truncate underline decoration-dotted underline-offset-2",

--- a/apps/web/app/(ee)/partners.dub.co/(dashboard)/payouts/payout-stats.tsx
+++ b/apps/web/app/(ee)/partners.dub.co/(dashboard)/payouts/payout-stats.tsx
@@ -86,7 +86,7 @@ function PayoutStatsCard({
                 {error ? (
                   "-"
                 ) : (
-                  <>{amount > 0 ? currencyFormatter(amount) : "$0.00"}</>
+                  <>{amount !== 0 ? currencyFormatter(amount) : "$0.00"}</>
                 )}
               </span>
               {label === "Processed" && amount > 0 && (

--- a/apps/web/app/(ee)/partners.dub.co/(dashboard)/programs/[programSlug]/(enrolled)/earnings/earnings-table.tsx
+++ b/apps/web/app/(ee)/partners.dub.co/(dashboard)/programs/[programSlug]/(enrolled)/earnings/earnings-table.tsx
@@ -4,7 +4,7 @@ import usePartnerEarningsCount from "@/lib/swr/use-partner-earnings-count";
 import usePartnerProfile from "@/lib/swr/use-partner-profile";
 import useProgramEnrollment from "@/lib/swr/use-program-enrollment";
 import { PartnerEarningsResponse } from "@/lib/types";
-import { CLAWBACK_REASONS_MAP } from "@/lib/zod/schemas/commissions";
+import { formatCommissionDescriptionTooltip } from "@/lib/commissions/format-commission-description-tooltip";
 import { CustomerRowItem } from "@/ui/customers/customer-row-item";
 import { CommissionStatusBadges } from "@/ui/partners/commission-status-badges";
 import { CommissionTypeBadge } from "@/ui/partners/commission-type-badge";
@@ -223,12 +223,13 @@ export function EarningsTablePartner({ limit }: { limit?: number }) {
           const earnings = currencyFormatter(commission.earnings);
 
           if (commission.description) {
-            const reason =
-              CLAWBACK_REASONS_MAP[commission.description]?.description ??
-              commission.description;
-
             return (
-              <Tooltip content={reason}>
+              <Tooltip
+                content={formatCommissionDescriptionTooltip(
+                  commission.description,
+                  { variant: "partner" },
+                )}
+              >
                 <span
                   className={cn(
                     "cursor-help truncate underline decoration-dotted underline-offset-2",

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/commissions/[commissionId]/page.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/commissions/[commissionId]/page.tsx
@@ -11,9 +11,9 @@ import { PageWidthWrapper } from "@/ui/layout/page-width-wrapper";
 import { CommissionTypeIcon } from "@/ui/partners/comission-type-icon";
 import { CommissionRowMenu } from "@/ui/partners/commission-row-menu";
 import { CommissionStatusBadges } from "@/ui/partners/commission-status-badges";
+import { CommissionDescriptionLabel } from "@/ui/partners/commission-description-label";
 import {
   CommissionTypeBadge,
-  getCommissionTypeLabel,
 } from "@/ui/partners/commission-type-badge";
 import { useEditCommissionModal } from "@/ui/partners/edit-commission-modal";
 import { GroupColorCircle } from "@/ui/partners/groups/group-color-circle";
@@ -153,9 +153,11 @@ function CommissionDetailsContent({
                     {customer?.email || customer?.name}
                   </Link>
                 ) : (
-                  <span className="min-w-0 max-w-[13rem] truncate text-xs font-medium text-neutral-700">
-                    {getCommissionTypeLabel(row.original)}
-                  </span>
+                  <CommissionDescriptionLabel
+                    commission={row.original}
+                    context={{ variant: "program", workspaceSlug: slug }}
+                    className="min-w-0 max-w-[13rem] truncate text-xs font-medium text-neutral-700"
+                  />
                 )}
                 <span className="text-xs text-neutral-500">
                   {formatDateTime(row.original.createdAt)}

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/commissions/commissions-table.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/commissions/commissions-table.tsx
@@ -5,7 +5,7 @@ import useGroups from "@/lib/swr/use-groups";
 import useProgram from "@/lib/swr/use-program";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { CommissionResponse } from "@/lib/types";
-import { CLAWBACK_REASONS_MAP } from "@/lib/zod/schemas/commissions";
+import { formatCommissionDescriptionTooltip } from "@/lib/commissions/format-commission-description-tooltip";
 import { CustomerRowItem } from "@/ui/customers/customer-row-item";
 import { useBulkEditCommissionsModal } from "@/ui/partners/bulk-edit-commissions-modal";
 import { CommissionRowMenu } from "@/ui/partners/commission-row-menu";
@@ -237,12 +237,13 @@ export function CommissionsTable() {
             const earnings = currencyFormatter(commission.earnings);
 
             if (commission.description) {
-              const reason =
-                CLAWBACK_REASONS_MAP[commission.description]?.description ??
-                commission.description;
-
               return (
-                <Tooltip content={reason}>
+                <Tooltip
+                  content={formatCommissionDescriptionTooltip(
+                    commission.description,
+                    { variant: "program", workspaceSlug: slug! },
+                  )}
+                >
                   <span
                     className={cn(
                       "cursor-help truncate underline decoration-dotted underline-offset-2",

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/payouts/[payoutId]/page.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/payouts/[payoutId]/page.tsx
@@ -4,16 +4,16 @@ import { clientAccessCheck } from "@/lib/client-access-check";
 import { usePayout } from "@/lib/swr/use-payout";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { CommissionResponse, PayoutResponse } from "@/lib/types";
-import { CLAWBACK_REASONS_MAP } from "@/lib/zod/schemas/commissions";
+import { formatCommissionDescriptionTooltip } from "@/lib/commissions/format-commission-description-tooltip";
 import { CustomerAvatar } from "@/ui/customers/customer-avatar";
 import { PageContent } from "@/ui/layout/page-content";
 import { PageWidthWrapper } from "@/ui/layout/page-width-wrapper";
 import { ActivityEvent } from "@/ui/partners/activity-event";
 import { CommissionTypeIcon } from "@/ui/partners/comission-type-icon";
 import { CommissionRowMenu } from "@/ui/partners/commission-row-menu";
+import { CommissionDescriptionLabel } from "@/ui/partners/commission-description-label";
 import {
   CommissionTypeBadge,
-  getCommissionTypeLabel,
 } from "@/ui/partners/commission-type-badge";
 import { PartnerAvatar } from "@/ui/partners/partner-avatar";
 import { PayoutStatusBadges } from "@/ui/partners/payout-status-badges";
@@ -325,11 +325,11 @@ function PayoutDetailsContent({
                   {row.original.customer.email || row.original.customer.name}
                 </Link>
               ) : (
-                <span className="max-w-xs truncate text-sm text-neutral-700">
-                  {row.original.type === "custom" && row.original.description
-                    ? row.original.description
-                    : getCommissionTypeLabel(row.original)}
-                </span>
+                <CommissionDescriptionLabel
+                  commission={row.original}
+                  context={{ variant: "program", workspaceSlug: slug }}
+                  className="max-w-xs truncate text-sm text-neutral-700"
+                />
               )}
               <span className="text-xs text-neutral-500">
                 {formatDateTime(row.original.createdAt)}
@@ -359,12 +359,13 @@ function PayoutDetailsContent({
           const earnings = currencyFormatter(commission.earnings);
 
           if (commission.description) {
-            const reason =
-              CLAWBACK_REASONS_MAP[commission.description]?.description ??
-              commission.description;
-
             return (
-              <Tooltip content={reason}>
+              <Tooltip
+                content={formatCommissionDescriptionTooltip(
+                  commission.description,
+                  { variant: "program", workspaceSlug: slug },
+                )}
+              >
                 <span
                   className={cn(
                     "cursor-help truncate underline decoration-dotted underline-offset-2",

--- a/apps/web/lib/commissions/format-commission-description-tooltip.ts
+++ b/apps/web/lib/commissions/format-commission-description-tooltip.ts
@@ -1,0 +1,28 @@
+import { CLAWBACK_REASONS_MAP } from "@/lib/zod/schemas/commissions";
+import { APP_DOMAIN, PARTNERS_DOMAIN } from "@dub/utils";
+
+const PAYOUT_ID_REGEX = /po_[^\s]+/g;
+
+export type CommissionDescriptionTooltipContext =
+  | { variant: "program"; workspaceSlug: string }
+  | { variant: "partner" };
+
+export function getCommissionDescriptionText(description: string): string {
+  return CLAWBACK_REASONS_MAP[description]?.description ?? description;
+}
+
+export function formatCommissionDescriptionTooltip(
+  description: string,
+  context: CommissionDescriptionTooltipContext,
+): string {
+  const text = getCommissionDescriptionText(description);
+
+  return text.replace(PAYOUT_ID_REGEX, (payoutId) => {
+    const href =
+      context.variant === "program"
+        ? `${APP_DOMAIN}/${context.workspaceSlug}/program/payouts/${payoutId}`
+        : `${PARTNERS_DOMAIN}/payouts?payoutId=${payoutId}`;
+
+    return `[${payoutId}](${href})`;
+  });
+}

--- a/apps/web/lib/commissions/format-commission-description-tooltip.ts
+++ b/apps/web/lib/commissions/format-commission-description-tooltip.ts
@@ -1,7 +1,8 @@
 import { CLAWBACK_REASONS_MAP } from "@/lib/zod/schemas/commissions";
 import { APP_DOMAIN, PARTNERS_DOMAIN } from "@dub/utils";
 
-const PAYOUT_ID_REGEX = /po_[^\s]+/g;
+// Canonical payout IDs: `po_` + 25-char base32 ULID body.
+const PAYOUT_ID_REGEX = /po_[0-9A-HJKMNP-TV-Z]{25}/g;
 
 export type CommissionDescriptionTooltipContext =
   | { variant: "program"; workspaceSlug: string }
@@ -18,10 +19,11 @@ export function formatCommissionDescriptionTooltip(
   const text = getCommissionDescriptionText(description);
 
   return text.replace(PAYOUT_ID_REGEX, (payoutId) => {
+    const encodedPayoutId = encodeURIComponent(payoutId);
     const href =
       context.variant === "program"
-        ? `${APP_DOMAIN}/${context.workspaceSlug}/program/payouts/${payoutId}`
-        : `${PARTNERS_DOMAIN}/payouts?payoutId=${payoutId}`;
+        ? `${APP_DOMAIN}/${context.workspaceSlug}/program/payouts/${encodedPayoutId}`
+        : `${PARTNERS_DOMAIN}/payouts?payoutId=${encodedPayoutId}`;
 
     return `[${payoutId}](${href})`;
   });

--- a/apps/web/ui/partners/commission-description-label.tsx
+++ b/apps/web/ui/partners/commission-description-label.tsx
@@ -1,0 +1,36 @@
+import {
+  CommissionDescriptionTooltipContext,
+  formatCommissionDescriptionTooltip,
+} from "@/lib/commissions/format-commission-description-tooltip";
+import { CommissionProps, CustomerProps } from "@/lib/types";
+import { Tooltip } from "@dub/ui";
+import { getCommissionTypeLabel } from "./commission-type-badge";
+
+export function CommissionDescriptionLabel({
+  commission,
+  context,
+  className = "min-w-0 truncate text-sm text-neutral-700",
+}: {
+  commission: Pick<CommissionProps, "type" | "quantity" | "description"> & {
+    customer?: Pick<CustomerProps, "email" | "name"> | null;
+  };
+  context: CommissionDescriptionTooltipContext;
+  className?: string;
+}) {
+  if (commission.type === "custom" && commission.description) {
+    return (
+      <Tooltip
+        content={formatCommissionDescriptionTooltip(
+          commission.description,
+          context,
+        )}
+      >
+        <span className={className}>{commission.description}</span>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <span className={className}>{getCommissionTypeLabel(commission)}</span>
+  );
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clearer, context-aware commission descriptions and tooltips across earnings, commissions, and payout views.
  - Payout references in tooltips now link to relevant payout details.
  - Standardized commission labels, including customer information where available.

- **Bug Fixes**
  - Corrected payout statistics so negative amounts display accurately.
  - Improved delayed payout processing to ensure payouts are handled sequentially.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->