### PR TITLE
Delete orphaned PartnerUser rows

### DIFF
--- a/apps/web/scripts/fix-broken-partner-users.ts
+++ b/apps/web/scripts/fix-broken-partner-users.ts
@@ -1,43 +1,71 @@
-import { prisma } from "@/lib/prisma";
+// @ts-ignore
 import "dotenv-flow/config";
 
-async function main() {
-  let batch = 0;
-  while (true) {
-    const partnerUserIds = await prisma.partnerUser.findMany({
-      select: {
-        userId: true,
-      },
-      take: 5000,
-      skip: batch * 5000,
-    });
-    if (partnerUserIds.length === 0) {
-      break;
-    }
-    const users = await prisma.user.findMany({
-      where: {
-        id: {
-          in: partnerUserIds.map((partnerUser) => partnerUser.userId),
-        },
-      },
-    });
-    const usersThatDontExist = partnerUserIds.filter(
-      (partnerUser) => !users.some((user) => user.id === partnerUser.userId),
-    );
-    console.log(usersThatDontExist);
+import { prisma } from "@/lib/prisma";
 
-    if (usersThatDontExist.length > 0) {
-      const deletedPartnerUsers = await prisma.partnerUser.deleteMany({
-        where: {
-          userId: {
-            in: usersThatDontExist.map((partnerUser) => partnerUser.userId),
-          },
-        },
-      });
-      console.log(`Deleted ${deletedPartnerUsers.count} partner users`);
-    }
-    batch++;
+const DRY_RUN = true;
+
+async function main() {
+  const orphans = await prisma.$queryRaw<
+    { id: string; userId: string; partnerId: string; role: string }[]
+  >`
+    SELECT pu.id, pu.userId, pu.partnerId, pu.role
+    FROM PartnerUser pu
+    LEFT JOIN User u ON u.id = pu.userId
+    WHERE u.id IS NULL
+  `;
+
+  console.log(`Found ${orphans.length} orphaned PartnerUser row(s).`);
+  console.table(orphans);
+
+  if (orphans.length === 0) {
+    return;
   }
+
+  // Double-confirm: none of these userIds should exist in User
+  const users = await prisma.user.findMany({
+    where: {
+      id: {
+        in: orphans.map((o) => o.userId),
+      },
+    },
+    select: {
+      id: true,
+      email: true,
+    },
+  });
+
+  console.log(`Users found for orphan userIds: ${users.length}`);
+  console.table(users);
+
+  if (users.length > 0) {
+    console.error("Aborting: some userIds still exist. Query is wrong.");
+    return;
+  }
+
+  if (DRY_RUN) {
+    return;
+  }
+
+  const ids = orphans.map((o) => o.id);
+
+  await prisma.partnerNotificationPreferences.deleteMany({
+    where: {
+      partnerUserId: {
+        in: ids,
+      },
+    },
+  });
+
+  const deleted = await prisma.partnerUser.deleteMany({
+    where: {
+      id: {
+        in: ids,
+      },
+    },
+  });
+
+  console.log(`Deleted ${deleted.count} PartnerUser row(s).`);
 }
 
 main();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved cleanup of orphaned partner records.
  * Added verification safeguards to prevent deleting records associated with active users.
  * Added dry-run support so cleanup operations can be reviewed before changes are applied.
  * Updated cleanup ordering to remove notification preferences before associated orphaned records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->