### PR TITLE
Hide reward history skeleton

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/groups/[groupSlug]/rewards/group-rewards.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/groups/[groupSlug]/rewards/group-rewards.tsx
@@ -147,6 +147,7 @@ const RewardItem = ({
   });
 
   const {
+    loading: activityLogsLoading,
     hasActivityLogs,
     finalActivityLogDate,
     rewardHistorySheet,
@@ -213,9 +214,9 @@ const RewardItem = ({
                     </TimestampTooltip>
                   )}
 
-                  {!hasActivityLogs ? (
+                  {activityLogsLoading ? (
                     <div className="ml-1 h-3 w-20 animate-pulse rounded bg-neutral-100" />
-                  ) : (
+                  ) : hasActivityLogs ? (
                     <>
                       <span
                         className="ml-1 size-1 shrink-0 rounded-full bg-neutral-400"
@@ -232,7 +233,7 @@ const RewardItem = ({
                         }}
                       />
                     </>
-                  )}
+                  ) : null}
                 </div>
               </div>
             ) : (

--- a/apps/web/ui/activity-logs/reward-history-sheet.tsx
+++ b/apps/web/ui/activity-logs/reward-history-sheet.tsx
@@ -65,7 +65,7 @@ export function useRewardHistorySheet({
 
   const [isOpen, setIsOpen] = useState(false);
 
-  const { activityLogs } = useActivityLogs({
+  const { activityLogs, loading } = useActivityLogs({
     query: reward
       ? {
           resourceType: REWARD_EVENT_TO_RESOURCE_TYPE[reward.event],
@@ -76,6 +76,7 @@ export function useRewardHistorySheet({
   });
 
   return {
+    loading,
     hasActivityLogs: (activityLogs?.length ?? 0) > 0,
     finalActivityLogDate: activityLogs?.[0]?.createdAt,
     rewardHistorySheet: reward ? (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Reward activity history indicators now show a loading state while history is being retrieved.
  - History controls appear only when activity logs are available, reducing empty or misleading UI elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->