### PR TITLE
Reward icon alignment and orphan fix

### DIFF
--- a/apps/web/ui/partners/lander/lander-rewards.tsx
+++ b/apps/web/ui/partners/lander/lander-rewards.tsx
@@ -111,8 +111,8 @@ const Item = ({
   children,
 }: PropsWithChildren<{ icon: Icon }>) => {
   return (
-    <li className="flex items-center gap-2 leading-5">
-      <IconComponent className="size-4 shrink-0 text-neutral-600" />
+    <li className="flex items-start gap-2 leading-5">
+      <IconComponent className="mt-0.5 size-4 shrink-0 text-neutral-600" />
       <div>{children}</div>
     </li>
   );

--- a/apps/web/ui/partners/program-reward-description.tsx
+++ b/apps/web/ui/partners/program-reward-description.tsx
@@ -93,10 +93,12 @@ export function ProgramRewardDescription({
           {showModifiersTooltip &&
             (!!reward.modifiers?.length ||
               Boolean(reward.tooltipDescription)) && (
-              <>
-                {" "}
+              // whitespace-nowrap keeps the tooltip icon attached to the last
+              // word of the description so it never wraps on its own line
+              <span className="whitespace-nowrap">
+                {" "}
                 <ProgramRewardModifiersTooltip reward={reward} />
-              </>
+              </span>
             )}
         </>
       ) : null}

--- a/apps/web/ui/partners/program-reward-modifiers-tooltip.tsx
+++ b/apps/web/ui/partners/program-reward-modifiers-tooltip.tsx
@@ -36,7 +36,7 @@ export function ProgramRewardModifiersTooltip({
   if (!reward?.modifiers?.length && !reward?.tooltipDescription) return null;
 
   return (
-    <div className="inline-block align-text-top">
+    <span className="inline-block align-text-top">
       <InfoTooltip
         content={
           reward.tooltipDescription || (
@@ -49,7 +49,7 @@ export function ProgramRewardModifiersTooltip({
         }
         contentClassName={reward.tooltipDescription ? "text-left" : undefined}
       />
-    </div>
+    </span>
   );
 }
 

--- a/apps/web/ui/partners/program-reward-spend-limit.tsx
+++ b/apps/web/ui/partners/program-reward-spend-limit.tsx
@@ -37,7 +37,13 @@ export function ProgramRewardSpendLimit({
     return null;
   }
 
-  return `, up to ${parts.amount} ${parts.interval} ${event === "sale" ? "per customer" : ""}`;
+  return [
+    `, up to ${parts.amount}`,
+    parts.interval,
+    event === "sale" ? "per customer" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
 }
 
 export function buildCommissionDescription({

--- a/apps/web/ui/partners/program-rewards-panel.tsx
+++ b/apps/web/ui/partners/program-rewards-panel.tsx
@@ -18,13 +18,13 @@ interface ProgramRewardsPanelProps {
 // Custom tooltip with smaller icon
 function CustomRewardModifiersTooltip({ reward }: { reward: RewardProps }) {
   return (
-    <div className="inline-block align-text-top">
+    <span className="inline-block align-text-top">
       <Tooltip
         content={<ProgramRewardModifiersTooltipContent reward={reward} />}
       >
         <HelpCircle className="h-3.5 w-3.5 translate-y-px text-neutral-400" />
       </Tooltip>
-    </div>
+    </span>
   );
 }
 

--- a/apps/web/ui/partners/program-rewards-panel.tsx
+++ b/apps/web/ui/partners/program-rewards-panel.tsx
@@ -63,10 +63,12 @@ export const ProgramRewardsPanel = memo(
               </>
             ) : null}
             {!!reward.modifiers?.length && (
-              <>
+              // whitespace-nowrap keeps the tooltip icon attached to the last
+              // word of the description so it never wraps on its own line
+              <span className="whitespace-nowrap">
                 {" "}
                 <CustomRewardModifiersTooltip reward={reward} />
-              </>
+              </span>
             )}
           </>
         ),


### PR DESCRIPTION
Fix the icon alignment on the reward landing pages, as well as make it so the additional info hover is never orphaned on a single line and is always associated with the previous word of the reward. 

### After
<img width="728" height="560" alt="CleanShot 2026-08-11 at 15 41 26@2x" src="https://github.com/user-attachments/assets/ca65583b-7092-4a90-8b80-dd15b5862258" />

### Before
<img width="672" height="558" alt="CleanShot 2026-08-11 at 15 47 14@2x" src="https://github.com/user-attachments/assets/7eea1f6e-bb71-413f-ab88-00dde035ec20" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved alignment of icons in reward and bounty lists.
  * Kept reward modifier icons attached to their related descriptions when text wraps.
  * Removed unnecessary spacing in spend-limit descriptions when optional details are unavailable.
  * Improved readability and consistency of reward-related text displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->