### PR TITLE
Remap sandbox Connect webhooks to staging and hide Invite members in staging

### DIFF
--- a/apps/web/app/(ee)/api/stripe/integration/webhook/utils/resolve-webhook-workspace.ts
+++ b/apps/web/app/(ee)/api/stripe/integration/webhook/utils/resolve-webhook-workspace.ts
@@ -29,7 +29,7 @@ export async function resolveWebhookWorkspace({
     return null;
   }
 
-  if (mode === "test" && workspace.stagingWorkspaceId) {
+  if ((mode === "test" || mode === "sandbox") && workspace.stagingWorkspaceId) {
     const stagingWorkspace = await prisma.project.findUnique({
       where: {
         id: workspace.stagingWorkspaceId,

--- a/apps/web/ui/layout/sidebar/workspace-dropdown.tsx
+++ b/apps/web/ui/layout/sidebar/workspace-dropdown.tsx
@@ -203,7 +203,7 @@ function WorkspaceList({
             <Gear className="size-4 text-neutral-800" />
             <span className="block truncate text-sm">Settings</span>
           </Link>
-          {selected.slug && (
+          {selected.slug && !isStagingEnvironment(current?.environment) && (
             <Link
               href={`/${selected.slug}/settings/people`}
               className="flex items-center justify-start gap-x-2 rounded-lg border border-neutral-200 px-2 py-1 text-neutral-700 outline-none transition-all duration-75 hover:bg-neutral-100/50 focus-visible:ring-2 focus-visible:ring-black/50 active:bg-neutral-200/80"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stripe webhook events in test and sandbox modes now resolve to the configured staging workspace.
  * The “Invite members” option is hidden when viewing a staging workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->