### PR TITLE
Partner import modal

### DIFF
--- a/apps/web/ui/modals/import-firstpromoter-modal.tsx
+++ b/apps/web/ui/modals/import-firstpromoter-modal.tsx
@@ -1,5 +1,6 @@
 import { startFirstPromoterImportAction } from "@/lib/actions/partners/start-firstpromoter-import";
 import useWorkspace from "@/lib/swr/use-workspace";
+import { X } from "@/ui/shared/icons";
 import { Button, Logo, Modal, useMediaQuery, useRouterStuff } from "@dub/ui";
 import { ArrowRight } from "lucide-react";
 import { useAction } from "next-safe-action/hooks";
@@ -23,15 +24,6 @@ function ImportFirstPromoterModal({
   setShowImportFirstPromoterModal: Dispatch<SetStateAction<boolean>>;
 }) {
   const { queryParams } = useRouterStuff();
-  const searchParams = useSearchParams();
-
-  useEffect(() => {
-    if (searchParams?.get("import") === "firstpromoter") {
-      setShowImportFirstPromoterModal(true);
-    } else {
-      setShowImportFirstPromoterModal(false);
-    }
-  }, [searchParams]);
 
   return (
     <Modal
@@ -39,6 +31,17 @@ function ImportFirstPromoterModal({
       setShowModal={setShowImportFirstPromoterModal}
       onClose={() => queryParams({ del: "import" })}
     >
+      <Button
+        variant="outline"
+        icon={<X className="size-5" />}
+        className="absolute right-4 top-4 h-auto w-fit p-1"
+        onClick={() => {
+          setShowImportFirstPromoterModal(false);
+          queryParams({
+            del: "import",
+          });
+        }}
+      />
       <div className="flex flex-col items-center justify-center space-y-3 border-b border-neutral-200 px-4 py-8 sm:px-16">
         <div className="flex items-center space-x-3 py-4">
           <img
@@ -178,6 +181,16 @@ function CredentialsForm({ onClose }: { onClose: () => void }) {
 export function useImportFirstPromoterModal() {
   const [showImportFirstPromoterModal, setShowImportFirstPromoterModal] =
     useState(false);
+  const searchParams = useSearchParams();
+
+  // Sync the modal state with the `?import=` query param here in the hook
+  // rather than in the modal itself, which remounts on every open/close
+  // and would re-open from a stale param mid-navigation
+  useEffect(() => {
+    setShowImportFirstPromoterModal(
+      searchParams?.get("import") === "firstpromoter",
+    );
+  }, [searchParams]);
 
   const ImportFirstPromoterModalCallback = useCallback(() => {
     return (

--- a/apps/web/ui/modals/import-partnerstack-modal.tsx
+++ b/apps/web/ui/modals/import-partnerstack-modal.tsx
@@ -1,5 +1,6 @@
 import { startPartnerStackImportAction } from "@/lib/actions/partners/start-partnerstack-import";
 import useWorkspace from "@/lib/swr/use-workspace";
+import { X } from "@/ui/shared/icons";
 import { Button, Logo, Modal, useMediaQuery, useRouterStuff } from "@dub/ui";
 import { ArrowRight } from "lucide-react";
 import { useAction } from "next-safe-action/hooks";
@@ -21,16 +22,7 @@ function ImportPartnerStackModal({
   showImportPartnerStackModal: boolean;
   setShowImportPartnerStackModal: Dispatch<SetStateAction<boolean>>;
 }) {
-  const searchParams = useSearchParams();
   const { queryParams } = useRouterStuff();
-
-  useEffect(() => {
-    if (searchParams?.get("import") === "partnerstack") {
-      setShowImportPartnerStackModal(true);
-    } else {
-      setShowImportPartnerStackModal(false);
-    }
-  }, [searchParams]);
 
   return (
     <Modal
@@ -42,6 +34,17 @@ function ImportPartnerStackModal({
         })
       }
     >
+      <Button
+        variant="outline"
+        icon={<X className="size-5" />}
+        className="absolute right-4 top-4 h-auto w-fit p-1"
+        onClick={() => {
+          setShowImportPartnerStackModal(false);
+          queryParams({
+            del: "import",
+          });
+        }}
+      />
       <div className="flex flex-col items-center justify-center space-y-3 border-b border-neutral-200 px-4 py-8 sm:px-16">
         <div className="flex items-center space-x-3 py-4">
           <img
@@ -171,6 +174,16 @@ function TokenForm({ onClose }: { onClose: () => void }) {
 export function useImportPartnerStackModal() {
   const [showImportPartnerStackModal, setShowImportPartnerStackModal] =
     useState(false);
+  const searchParams = useSearchParams();
+
+  // Sync the modal state with the `?import=` query param here in the hook
+  // rather than in the modal itself, which remounts on every open/close
+  // and would re-open from a stale param mid-navigation
+  useEffect(() => {
+    setShowImportPartnerStackModal(
+      searchParams?.get("import") === "partnerstack",
+    );
+  }, [searchParams]);
 
   const ImportPartnerStackModalCallback = useCallback(
     () => (

--- a/apps/web/ui/modals/import-rewardful-modal.tsx
+++ b/apps/web/ui/modals/import-rewardful-modal.tsx
@@ -16,6 +16,7 @@ import {
   useMediaQuery,
   useRouterStuff,
 } from "@dub/ui";
+import { X } from "@/ui/shared/icons";
 import { cn, currencyFormatter, fetcher } from "@dub/utils";
 import { Command } from "cmdk";
 import { ArrowRight, ServerOff, Users } from "lucide-react";
@@ -43,7 +44,6 @@ function ImportRewardfulModal({
 }) {
   const router = useRouter();
   const { program } = useProgram();
-  const searchParams = useSearchParams();
   const { queryParams } = useRouterStuff();
   const { id: workspaceId } = useWorkspace();
   const [apiToken, setApiToken] = useState("");
@@ -98,14 +98,6 @@ function ImportRewardfulModal({
     fetcher,
   );
 
-  useEffect(() => {
-    if (searchParams?.get("import") === "rewardful") {
-      setShowImportRewardfulModal(true);
-    } else {
-      setShowImportRewardfulModal(false);
-    }
-  }, [searchParams]);
-
   // submit the api token to get the campaigns
   const handleTokenSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -152,6 +144,17 @@ function ImportRewardfulModal({
         })
       }
     >
+      <Button
+        variant="outline"
+        icon={<X className="size-5" />}
+        className="absolute right-4 top-4 h-auto w-fit p-1"
+        onClick={() => {
+          setShowImportRewardfulModal(false);
+          queryParams({
+            del: "import",
+          });
+        }}
+      />
       <div className="flex flex-col items-center justify-center space-y-3 border-b border-neutral-200 px-4 py-4 pt-8 sm:px-8">
         <div className="flex items-center space-x-3">
           <img
@@ -530,6 +533,14 @@ function CampaignsStep({
 export function useImportRewardfulModal() {
   const [showImportRewardfulModal, setShowImportRewardfulModal] =
     useState(false);
+  const searchParams = useSearchParams();
+
+  // Sync the modal state with the `?import=` query param here in the hook
+  // rather than in the modal itself, which remounts on every open/close
+  // and would re-open from a stale param mid-navigation
+  useEffect(() => {
+    setShowImportRewardfulModal(searchParams?.get("import") === "rewardful");
+  }, [searchParams]);
 
   const ImportRewardfulModalCallback = useCallback(() => {
     return (

--- a/apps/web/ui/modals/import-tapfiliate-modal.tsx
+++ b/apps/web/ui/modals/import-tapfiliate-modal.tsx
@@ -2,6 +2,7 @@ import { setTapfiliateTokenAction } from "@/lib/actions/partners/set-tapfiliate-
 import { startTapfiliateImportAction } from "@/lib/actions/partners/start-tapfiliate-import";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { TapfiliateProgram } from "@/lib/tapfiliate/types";
+import { X } from "@/ui/shared/icons";
 import {
   Button,
   Check2,
@@ -36,18 +37,9 @@ function ImportTapfiliateModal({
   showImportTapfiliateModal: boolean;
   setShowImportTapfiliateModal: Dispatch<SetStateAction<boolean>>;
 }) {
-  const searchParams = useSearchParams();
   const { queryParams } = useRouterStuff();
   const [step, setStep] = useState<Step>("set-token");
   const [programs, setPrograms] = useState<TapfiliateProgram[]>([]);
-
-  useEffect(() => {
-    if (searchParams?.get("import") === "tapfiliate") {
-      setShowImportTapfiliateModal(true);
-    } else {
-      setShowImportTapfiliateModal(false);
-    }
-  }, [searchParams]);
 
   // Reset the step and programs when the modal is closed
   useEffect(() => {
@@ -67,6 +59,17 @@ function ImportTapfiliateModal({
         })
       }
     >
+      <Button
+        variant="outline"
+        icon={<X className="size-5" />}
+        className="absolute right-4 top-4 h-auto w-fit p-1"
+        onClick={() => {
+          setShowImportTapfiliateModal(false);
+          queryParams({
+            del: "import",
+          });
+        }}
+      />
       <div className="flex flex-col items-center justify-center space-y-3 border-b border-neutral-200 px-4 py-8 sm:px-16">
         <div className="flex items-center space-x-3 py-4">
           <img
@@ -303,6 +306,14 @@ function SelectProgram({
 export function useImportTapfiliateModal() {
   const [showImportTapfiliateModal, setShowImportTapfiliateModal] =
     useState(false);
+  const searchParams = useSearchParams();
+
+  // Sync the modal state with the `?import=` query param here in the hook
+  // rather than in the modal itself, which remounts on every open/close
+  // and would re-open from a stale param mid-navigation
+  useEffect(() => {
+    setShowImportTapfiliateModal(searchParams?.get("import") === "tapfiliate");
+  }, [searchParams]);
 
   const ImportTapfiliateModalCallback = useCallback(() => {
     return (

--- a/apps/web/ui/modals/import-tolt-modal.tsx
+++ b/apps/web/ui/modals/import-tolt-modal.tsx
@@ -2,6 +2,7 @@ import { setToltTokenAction } from "@/lib/actions/partners/set-tolt-token";
 import { startToltImportAction } from "@/lib/actions/partners/start-tolt-import";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { ToltProgram } from "@/lib/tolt/types";
+import { X } from "@/ui/shared/icons";
 import { Button, Logo, Modal, useMediaQuery, useRouterStuff } from "@dub/ui";
 import { ArrowRight } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
@@ -27,18 +28,9 @@ function ImportToltModal({
   showImportToltModal: boolean;
   setShowImportToltModal: Dispatch<SetStateAction<boolean>>;
 }) {
-  const searchParams = useSearchParams();
   const { queryParams } = useRouterStuff();
   const [step, setStep] = useState<Step>("set-token");
   const [toltProgram, setToltProgram] = useState<ToltProgram | null>(null);
-
-  useEffect(() => {
-    if (searchParams?.get("import") === "tolt") {
-      setShowImportToltModal(true);
-    } else {
-      setShowImportToltModal(false);
-    }
-  }, [searchParams]);
 
   return (
     <Modal
@@ -50,6 +42,17 @@ function ImportToltModal({
         })
       }
     >
+      <Button
+        variant="outline"
+        icon={<X className="size-5" />}
+        className="absolute right-4 top-4 h-auto w-fit p-1"
+        onClick={() => {
+          setShowImportToltModal(false);
+          queryParams({
+            del: "import",
+          });
+        }}
+      />
       <div className="flex flex-col items-center justify-center space-y-3 border-b border-neutral-200 px-4 py-8 sm:px-16">
         <div className="flex items-center space-x-3 py-4">
           <img
@@ -292,6 +295,14 @@ function ProgramInfo({
 
 export function useImportToltModal() {
   const [showImportToltModal, setShowImportToltModal] = useState(false);
+  const searchParams = useSearchParams();
+
+  // Sync the modal state with the `?import=` query param here in the hook
+  // rather than in the modal itself, which remounts on every open/close
+  // and would re-open from a stale param mid-navigation
+  useEffect(() => {
+    setShowImportToltModal(searchParams?.get("import") === "tolt");
+  }, [searchParams]);
 
   const ImportToltModalCallback = useCallback(() => {
     return (

--- a/apps/web/ui/modals/modal-provider.tsx
+++ b/apps/web/ui/modals/modal-provider.tsx
@@ -24,11 +24,7 @@ import {
 } from "react";
 import { toast } from "sonner";
 import { useAddEditTagModal } from "./add-edit-tag-modal";
-import { useImportPartnerStackModal } from "./import-partnerstack-modal";
 import { useImportRebrandlyModal } from "./import-rebrandly-modal";
-import { useImportRewardfulModal } from "./import-rewardful-modal";
-import { useImportTapfiliateModal } from "./import-tapfiliate-modal";
-import { useImportToltModal } from "./import-tolt-modal";
 import { useLinkBuilder } from "./link-builder";
 import { useProgramWelcomeModal } from "./program-welcome-modal";
 import { useUpgradedModal } from "./upgraded-modal";
@@ -42,10 +38,6 @@ export const ModalContext = createContext<{
   setShowImportShortModal: Dispatch<SetStateAction<boolean>>;
   setShowImportRebrandlyModal: Dispatch<SetStateAction<boolean>>;
   setShowImportCsvModal: Dispatch<SetStateAction<boolean>>;
-  setShowImportPartnerStackModal: Dispatch<SetStateAction<boolean>>;
-  setShowImportRewardfulModal: Dispatch<SetStateAction<boolean>>;
-  setShowImportToltModal: Dispatch<SetStateAction<boolean>>;
-  setShowImportTapfiliateModal: Dispatch<SetStateAction<boolean>>;
 }>({
   setShowAddWorkspaceModal: () => {},
   setShowAddEditDomainModal: () => {},
@@ -55,10 +47,6 @@ export const ModalContext = createContext<{
   setShowImportShortModal: () => {},
   setShowImportRebrandlyModal: () => {},
   setShowImportCsvModal: () => {},
-  setShowImportPartnerStackModal: () => {},
-  setShowImportRewardfulModal: () => {},
-  setShowImportToltModal: () => {},
-  setShowImportTapfiliateModal: () => {},
 });
 
 export function ModalProvider({ children }: { children: ReactNode }) {
@@ -107,13 +95,6 @@ function ModalProviderClient({ children }: { children: ReactNode }) {
   const { setShowUpgradedModal, UpgradedModal } = useUpgradedModal();
   const { setShowProgramWelcomeModal, ProgramWelcomeModal } =
     useProgramWelcomeModal();
-  const { setShowImportPartnerStackModal, ImportPartnerStackModal } =
-    useImportPartnerStackModal();
-  const { setShowImportRewardfulModal, ImportRewardfulModal } =
-    useImportRewardfulModal();
-  const { setShowImportToltModal, ImportToltModal } = useImportToltModal();
-  const { setShowImportTapfiliateModal, ImportTapfiliateModal } =
-    useImportTapfiliateModal();
 
   useEffect(() => {
     setShowProgramWelcomeModal(searchParams.has("onboarded-program"));
@@ -196,10 +177,6 @@ function ModalProviderClient({ children }: { children: ReactNode }) {
         setShowImportShortModal,
         setShowImportRebrandlyModal,
         setShowImportCsvModal,
-        setShowImportPartnerStackModal,
-        setShowImportRewardfulModal,
-        setShowImportToltModal,
-        setShowImportTapfiliateModal,
       }}
     >
       <AddWorkspaceModal />
@@ -210,10 +187,6 @@ function ModalProviderClient({ children }: { children: ReactNode }) {
       <ImportShortModal />
       <ImportRebrandlyModal />
       <ImportCsvModal />
-      <ImportPartnerStackModal />
-      <ImportRewardfulModal />
-      <ImportToltModal />
-      <ImportTapfiliateModal />
       <UpgradedModal />
       <ProgramWelcomeModal />
       {children}


### PR DESCRIPTION
- When closing the partner import modal, the modal was mounted twice causing a refresh when closing
- Added a button to the modal to make it more clear how to close

### After
https://github.com/user-attachments/assets/18bdc002-59c3-4979-a4fa-2ea5830efdf9

### Before
https://github.com/user-attachments/assets/2b1115ae-b069-4a00-ade2-89a816576ef2



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear close buttons to the FirstPromoter, PartnerStack, Rewardful, Tapfiliate, and Tolt import modals.
  * Closing an import modal now also clears its import URL parameter.
* **Bug Fixes**
  * Improved modal state handling so closed import modals do not reopen unexpectedly after remounting.
* **Changes**
  * Removed PartnerStack, Rewardful, Tolt, and Tapfiliate import modals from the shared modal interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->