### PR TITLE
Allow null PartnerStack customer emails

### DIFF
--- a/apps/web/lib/partnerstack/import-commissions.ts
+++ b/apps/web/lib/partnerstack/import-commissions.ts
@@ -250,8 +250,10 @@ export async function createCommissionFromPS({
 
   const customer = customersData.find(
     ({ email, externalId }) =>
-      email === commission.customer?.email ||
-      externalId === commission.customer?.external_key,
+      (commission.customer?.email != null &&
+        email === commission.customer.email) ||
+      (commission.customer?.external_key != null &&
+        externalId === commission.customer.external_key),
   );
 
   if (!customer) {

--- a/apps/web/lib/partnerstack/import-customers.ts
+++ b/apps/web/lib/partnerstack/import-customers.ts
@@ -212,7 +212,7 @@ async function createCustomer({
     import_id: importId,
     source: "partnerstack",
     entity: "customer",
-    entity_id: customer.customer_key || customer.email,
+    entity_id: customer.customer_key || customer.email || customer.key,
   } as const;
 
   if (links.length === 0) {

--- a/apps/web/lib/partnerstack/schemas.ts
+++ b/apps/web/lib/partnerstack/schemas.ts
@@ -63,7 +63,7 @@ export const partnerStackLink = z.object({
 export const partnerStackCustomer = z.object({
   key: z.string(),
   name: z.string().nullable(),
-  email: z.string(),
+  email: z.string().nullable(),
   provider_key: z
     .string()
     .nullable()
@@ -85,7 +85,7 @@ export const partnerStackCommission = z.object({
   created_at: z.number(),
   customer: z
     .object({
-      email: z.string(),
+      email: z.string().nullable(),
       external_key: z.string().nullable(),
     })
     .nullable(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PartnerStack customer matching when email addresses or external IDs are missing.
  * Updated imports to accept customers without email addresses.
  * Error messages now show a fallback customer identifier when standard details are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->