### PR TITLE
Show referred partner emails when data sharing is enabled

### DIFF
--- a/apps/web/app/(ee)/api/partner-profile/programs/[programId]/referrals/route.ts
+++ b/apps/web/app/(ee)/api/partner-profile/programs/[programId]/referrals/route.ts
@@ -94,7 +94,11 @@ export const GET = withPartnerProfile(
 
     const result = enrollments.map((enrollment) => ({
       id: enrollment.partner.id,
-      email: obfuscateCustomerEmail(enrollment.partner.email ?? ""),
+      email: enrollment.partner.email
+        ? programEnrollment.customerDataSharingEnabledAt
+          ? enrollment.partner.email
+          : obfuscateCustomerEmail(enrollment.partner.email)
+        : "",
       country: enrollment.partner.country,
       programEnrollment: {
         ...enrollment,

--- a/apps/web/ui/partners/partner-advanced-settings-modal.tsx
+++ b/apps/web/ui/partners/partner-advanced-settings-modal.tsx
@@ -185,7 +185,8 @@ function PartnerAdvancedSettingsModal({
                   Enable customer data sharing
                 </h3>
                 <p className="text-xs text-neutral-500">
-                  Allow this partner to access customer data and analytics
+                  Allow this partner to access customer data, referred partner
+                  emails, and analytics
                 </p>
               </div>
             </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Partner referral email visibility now respects customer data-sharing settings.
  * Emails are shown in full when sharing is enabled, obfuscated when disabled, and blank when unavailable.
  * Updated settings text clarifies that partners may access referred partner emails, customer data, and analytics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->