### PR TITLE
Modal rerendering fix

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/partners-table.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/partners-table.tsx
@@ -803,7 +803,7 @@ function RowMenuButton({
 
   return (
     <>
-      <ChangeGroupModal />
+      {ChangeGroupModal}
       <UpdatePartnerTagsModal
         showUpdatePartnerTagsModal={showUpdatePartnerTagsModal}
         setShowUpdatePartnerTagsModal={setShowUpdatePartnerTagsModal}
@@ -1064,7 +1064,7 @@ const PartnersBulkActionsBar = memo(function PartnersBulkActionsBar({
 
   return (
     <>
-      <ChangeGroupModal />
+      {ChangeGroupModal}
       <UpdatePartnerTagsModal
         showUpdatePartnerTagsModal={showUpdatePartnerTagsModal}
         setShowUpdatePartnerTagsModal={setShowUpdatePartnerTagsModal}

--- a/apps/web/ui/modals/change-group-modal.tsx
+++ b/apps/web/ui/modals/change-group-modal.tsx
@@ -11,7 +11,6 @@ import {
   SetStateAction,
   useCallback,
   useEffect,
-  useMemo,
   useState,
 } from "react";
 import { toast } from "sonner";
@@ -48,6 +47,12 @@ function ChangeGroupModal({
       : false,
   );
 
+  // Key on the partner data itself so re-renders that recreate the `partners`
+  // array don't re-run the sync and stomp an in-progress selection
+  const partnersKey = partners
+    .map((p) => `${p.id}:${p.groupId}:${p.groupMoveDisabledAt ?? ""}`)
+    .join(",");
+
   // Sync state from the DB value whenever the modal opens or partners change
   useEffect(() => {
     if (partners.length === 1) {
@@ -58,7 +63,8 @@ function ChangeGroupModal({
     } else {
       setGroupMoveDisabled(false);
     }
-  }, [showChangeGroupModal, partners, canUseGroupMoveRule]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showChangeGroupModal, partnersKey, canUseGroupMoveRule]);
 
   const { makeRequest: changeGroup, isSubmitting } = useApiMutation();
 
@@ -211,22 +217,18 @@ export function useChangeGroupModal({
 }: Pick<ChangeGroupModalProps, "partners" | "onChangeGroup">) {
   const [showChangeGroupModal, setShowChangeGroupModal] = useState(false);
 
-  const ChangeGroupModalCallback = useCallback(() => {
-    return (
+  // Return an element (rendered as `{ChangeGroupModal}`) rather than a
+  // per-render component type, which would remount the modal – and reset its
+  // state – on every parent render
+  return {
+    setShowChangeGroupModal,
+    ChangeGroupModal: (
       <ChangeGroupModal
         showChangeGroupModal={showChangeGroupModal}
         setShowChangeGroupModal={setShowChangeGroupModal}
         partners={partners}
         onChangeGroup={onChangeGroup}
       />
-    );
-  }, [showChangeGroupModal, setShowChangeGroupModal, partners]);
-
-  return useMemo(
-    () => ({
-      setShowChangeGroupModal,
-      ChangeGroupModal: ChangeGroupModalCallback,
-    }),
-    [setShowChangeGroupModal, ChangeGroupModalCallback],
-  );
+    ),
+  };
 }

--- a/apps/web/ui/partners/partner-info-group.tsx
+++ b/apps/web/ui/partners/partner-info-group.tsx
@@ -55,7 +55,7 @@ export function PartnerInfoGroup({
         className,
       )}
     >
-      <ChangeGroupModal />
+      {ChangeGroupModal}
       <div className="flex min-w-0 items-center gap-2">
         {group ? (
           <GroupColorCircle group={group} />


### PR DESCRIPTION
Fixes the remounting of the `change partner group`

https://github.com/user-attachments/assets/d34e15a4-a419-4ab6-9366-84f61b0b01a1



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved partner group-change workflows by preventing unnecessary modal remounts.
  * Preserved modal state more reliably while the surrounding page updates.
  * Improved synchronization when partner information changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->