### PR TITLE
Don't expire cross-program ban risk events

### DIFF
--- a/apps/web/app/(ee)/api/cron/cleanup/expired-fraud-groups/route.ts
+++ b/apps/web/app/(ee)/api/cron/cleanup/expired-fraud-groups/route.ts
@@ -1,4 +1,7 @@
-import { FRAUD_GROUP_EXPIRY_DAYS } from "@/lib/api/fraud/constants";
+import {
+  FRAUD_GROUP_EXPIRY_DAYS,
+  NON_EXPIRING_FRAUD_RULE_TYPES,
+} from "@/lib/api/fraud/constants";
 import { queueReleaseHoldCommissions } from "@/lib/api/fraud/release-hold-commissions";
 import { withCron } from "@/lib/cron/with-cron";
 import { prisma } from "@/lib/prisma";
@@ -9,7 +12,8 @@ export const dynamic = "force-dynamic";
 
 const BATCH_SIZE = 250;
 
-// This route is used to expire fraud event groups after 30 days
+// This route is used to expire fraud event groups after 30 days,
+// except for types in NON_EXPIRING_FRAUD_RULE_TYPES.
 // Runs once every day at 02:30:00 AM UTC (30 2 * * *)
 // POST /api/cron/cleanup/expired-fraud-groups
 export const POST = withCron(async () => {
@@ -18,6 +22,9 @@ export const POST = withCron(async () => {
     const groupsToExpire = await prisma.fraudEventGroup.findMany({
       where: {
         status: "pending",
+        type: {
+          notIn: NON_EXPIRING_FRAUD_RULE_TYPES,
+        },
         lastEventAt: {
           lt: subDays(new Date(), FRAUD_GROUP_EXPIRY_DAYS),
         },

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/risks/risk-events-table.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/risks/risk-events-table.tsx
@@ -3,6 +3,7 @@
 import {
   FRAUD_GROUP_EXPIRY_DAYS,
   FRAUD_RULES_BY_TYPE,
+  NON_EXPIRING_FRAUD_RULE_TYPES,
 } from "@/lib/api/fraud/constants";
 import { mutatePrefix } from "@/lib/swr/mutate";
 import { useFraudGroups } from "@/lib/swr/use-fraud-groups";
@@ -188,7 +189,10 @@ export function RiskEventsTable() {
             "The date and time of the most recent occurrence of this risk event.",
         },
         cell: ({ row }) => (
-          <LastDetectedCell lastEventAt={row.original.lastEventAt} />
+          <LastDetectedCell
+            lastEventAt={row.original.lastEventAt}
+            type={row.original.type}
+          />
         ),
       },
       {
@@ -370,7 +374,26 @@ export function RiskEventsTable() {
   );
 }
 
-function LastDetectedCell({ lastEventAt }: { lastEventAt: Date | string }) {
+function LastDetectedCell({
+  lastEventAt,
+  type,
+}: {
+  lastEventAt: Date | string;
+  type: FraudGroupProps["type"];
+}) {
+  if (NON_EXPIRING_FRAUD_RULE_TYPES.includes(type)) {
+    return (
+      <TimestampTooltip
+        timestamp={lastEventAt}
+        side="right"
+        rows={["local", "utc", "unix"]}
+        delayDuration={150}
+      >
+        {formatDateTimeSmart(lastEventAt)}
+      </TimestampTooltip>
+    );
+  }
+
   const daysUntilExpiry = differenceInDays(
     addDays(new Date(lastEventAt), FRAUD_GROUP_EXPIRY_DAYS),
     new Date(),

--- a/apps/web/lib/api/fraud/constants.ts
+++ b/apps/web/lib/api/fraud/constants.ts
@@ -101,6 +101,10 @@ export const FRAUD_RULES_BY_TYPE = Object.fromEntries(
 
 export const FRAUD_GROUP_EXPIRY_DAYS = 30;
 
+export const NON_EXPIRING_FRAUD_RULE_TYPES: FraudRuleType[] = [
+  FraudRuleType.partnerCrossProgramBan,
+];
+
 export const CONFIGURABLE_FRAUD_RULES = FRAUD_RULES.filter(
   (rule) => rule.configurable,
 );

--- a/apps/web/lib/api/fraud/constants.ts
+++ b/apps/web/lib/api/fraud/constants.ts
@@ -41,7 +41,7 @@ export const FRAUD_RULES: FraudRuleInfo[] = [
   // Partner rules
   {
     type: "partnerCrossProgramBan",
-    name: "Cross-program ban",
+    name: "Network-level ban",
     description:
       "This partner was banned from another program on Dub. Our team reviewed this decision and confirmed the fraudulent behavior or terms of service violation.",
     scope: "partner",

--- a/apps/web/ui/partners/fraud-risks/risk-disclaimer-banner.tsx
+++ b/apps/web/ui/partners/fraud-risks/risk-disclaimer-banner.tsx
@@ -12,7 +12,7 @@ export function RiskDisclaimerBanner({ className }: { className?: string }) {
       <TriangleWarning className="mt-0.5 size-4 shrink-0 text-amber-600" />
       <p className="flex-1 text-sm text-amber-900">
         We recommend reviewing the risk events thoroughly before taking action.
-        Unresolved events expire after 30 days, except confirmed cross-program
+        Unresolved events expire after 30 days, except confirmed network-level
         bans.{" "}
         <a
           href="https://dub.co/help/article/risk-monitoring"

--- a/apps/web/ui/partners/fraud-risks/risk-disclaimer-banner.tsx
+++ b/apps/web/ui/partners/fraud-risks/risk-disclaimer-banner.tsx
@@ -12,7 +12,8 @@ export function RiskDisclaimerBanner({ className }: { className?: string }) {
       <TriangleWarning className="mt-0.5 size-4 shrink-0 text-amber-600" />
       <p className="flex-1 text-sm text-amber-900">
         We recommend reviewing the risk events thoroughly before taking action.
-        Unresolved events expire after 30 days.{" "}
+        Unresolved events expire after 30 days, except confirmed cross-program
+        bans.{" "}
         <a
           href="https://dub.co/help/article/risk-monitoring"
           target="_blank"

--- a/packages/email/src/templates/unresolved-risk-events-summary.tsx
+++ b/packages/email/src/templates/unresolved-risk-events-summary.tsx
@@ -94,7 +94,7 @@ export default function UnresolvedRiskEventsSummary({
               <strong>{todayDate}</strong> for the{" "}
               <strong>{program.name}</strong> program. These risk events will
               automatically expire in 30 days if not resolved, except confirmed
-              cross-program bans.
+              network-level bans.
             </Text>
 
             <Section className="my-6 rounded-xl border border-solid border-neutral-200 bg-white p-0">

--- a/packages/email/src/templates/unresolved-risk-events-summary.tsx
+++ b/packages/email/src/templates/unresolved-risk-events-summary.tsx
@@ -93,7 +93,8 @@ export default function UnresolvedRiskEventsSummary({
               Here are your detected risk events reported for{" "}
               <strong>{todayDate}</strong> for the{" "}
               <strong>{program.name}</strong> program. These risk events will
-              automatically expire in 30 days if not resolved.
+              automatically expire in 30 days if not resolved, except confirmed
+              cross-program bans.
             </Text>
 
             <Section className="my-6 rounded-xl border border-solid border-neutral-200 bg-white p-0">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Confirmed network-level bans no longer expire automatically during risk-event cleanup.
  - Risk-event displays now show accurate timing information for non-expiring rules.

- **User Experience**
  - Updated risk disclaimers and email notifications to clarify that unresolved events expire after 30 days, except confirmed network-level bans.
  - Improved timestamp tooltips for non-expiring risk events.
  - Renamed “Cross-program ban” to “Network-level ban” for clearer terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->