### PR TITLE
Import PartnerStack customers without email when external ID exists

### DIFF
--- a/apps/web/lib/partnerstack/import-customers.ts
+++ b/apps/web/lib/partnerstack/import-customers.ts
@@ -219,25 +219,28 @@ async function createCustomer({
     await logImportError({
       ...commonImportLogInputs,
       code: "LINK_NOT_FOUND",
-      message: `Link not found for customer ${customer.customer_key}.`,
+      message: `Link not found for customer ${commonImportLogInputs.entity_id}.`,
     });
 
     return;
   }
 
-  if (!customer.email) {
+  const externalId = customer.customer_key || customer.email;
+
+  if (!externalId) {
     await logImportError({
       ...commonImportLogInputs,
       code: "CUSTOMER_EMAIL_NOT_FOUND",
-      message: `Email not found for customer ${customer.customer_key}.`,
+      message: `No external ID or email found for customer ${customer.key}.`,
     });
 
     return;
   }
 
-  // Find the customer by email address
   const customerFound = existingCustomers.find(
-    (c) => c.email === customer.email || c.externalId === customer.customer_key,
+    (c) =>
+      (customer.email != null && c.email === customer.email) ||
+      (customer.customer_key != null && c.externalId === customer.customer_key),
   );
 
   if (customerFound) {
@@ -281,9 +284,9 @@ async function createCustomer({
       data: {
         id: customerId,
         name:
-          // if name is null/undefined or starts with cus_, use email as name
+          // if name is null/undefined or starts with cus_, use email or external ID
           !customer.name || customer.name.startsWith("cus_")
-            ? customer.email
+            ? customer.email || customer.customer_key
             : customer.name,
         email: customer.email,
         projectId: workspace.id,
@@ -295,7 +298,10 @@ async function createCustomer({
         country: clickEvent.country,
         clickedAt: new Date(customer.created_at),
         createdAt: new Date(customer.created_at),
-        externalId: customer.customer_key || customer.email,
+        externalId,
+        ...(customer.provider_key?.startsWith("cus_") && {
+          stripeCustomerId: customer.provider_key,
+        }),
       },
     });
 

--- a/apps/web/lib/partnerstack/update-stripe-customers.ts
+++ b/apps/web/lib/partnerstack/update-stripe-customers.ts
@@ -53,6 +53,9 @@ export async function updateStripeCustomers(
       where: {
         projectId: workspace.id,
         stripeCustomerId: null,
+        email: {
+          not: null,
+        },
       },
       select: {
         id: true,
@@ -147,6 +150,10 @@ async function searchStripeAndUpdateCustomer({
     entity: "customer",
     entity_id: customer.id,
   } as const;
+
+  if (!customer.email) {
+    return null;
+  }
 
   try {
     const stripeCustomers = await stripe.customers.search(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Customer imports can now identify customers using either an email address or customer key.
  * Stripe customer IDs are recognized from supported provider identifiers.
  * Imported customer names fall back to available identifying information.

* **Bug Fixes**
  * Improved duplicate detection using email addresses or external IDs.
  * Customers without email addresses are excluded from Stripe lookups and updates.
  * Import validation now clearly reports missing customer identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->