### PR TITLE
Add reward variables to campaign emails

### DIFF
--- a/apps/web/app/(ee)/api/campaigns/[campaignId]/preview/route.ts
+++ b/apps/web/app/(ee)/api/campaigns/[campaignId]/preview/route.ts
@@ -106,6 +106,11 @@ export const POST = withWorkspace(
                 PartnerName: "Partner",
                 PartnerEmail: "partner@acme.com",
                 PartnerLink: "https://acme.com/partner",
+                SaleReward: "30% per sale for 6 months",
+                LeadReward: "$10 per lead",
+                ClickReward: "$0.50 per click",
+                ReferralReward:
+                  "10% per referred partner's commission for 1 year",
               },
             }),
           },

--- a/apps/web/app/(ee)/api/cron/campaigns/broadcast/route.ts
+++ b/apps/web/app/(ee)/api/cron/campaigns/broadcast/route.ts
@@ -1,3 +1,4 @@
+import { resolveCampaignEmailVariables } from "@/lib/api/campaigns/interpolate-email-template";
 import { renderCampaignEmailHTML } from "@/lib/api/campaigns/render-campaign-email-html";
 import { validateCampaignFromAddress } from "@/lib/api/campaigns/validate-campaign";
 import { createId } from "@/lib/api/create-id";
@@ -5,7 +6,6 @@ import { handleAndReturnErrorResponse } from "@/lib/api/errors";
 import { qstash } from "@/lib/cron";
 import { verifyQstashSignature } from "@/lib/cron/verify-qstash";
 import { resolveCampaignFromAddress } from "@/lib/email/parse-campaign-from-address";
-import { constructPartnerLink } from "@/lib/partners/construct-partner-link";
 import { prisma } from "@/lib/prisma";
 import { TiptapNode } from "@/lib/types";
 import { ACTIVE_ENROLLMENT_STATUSES } from "@/lib/zod/schemas/partners";
@@ -172,6 +172,10 @@ export async function POST(req: Request) {
             id: "asc",
           },
         },
+        clickReward: true,
+        leadReward: true,
+        saleReward: true,
+        referralReward: true,
         partner: {
           select: {
             id: true,
@@ -272,15 +276,10 @@ export async function POST(req: Request) {
                 preview: campaign.preview,
                 body: renderCampaignEmailHTML({
                   content: campaign.bodyJson as unknown as TiptapNode,
-                  variables: {
-                    PartnerName: partnerUser.partner.name,
-                    PartnerEmail: partnerUser.partner.email,
-                    PartnerLink:
-                      constructPartnerLink({
-                        group: partnerUser.enrollment.partnerGroup,
-                        link: partnerUser.enrollment.links?.[0],
-                      }) || null,
-                  },
+                  variables: resolveCampaignEmailVariables({
+                    partner: partnerUser.partner,
+                    enrollment: partnerUser.enrollment,
+                  }),
                 }),
               },
             }),

--- a/apps/web/lib/api/campaigns/interpolate-email-template.ts
+++ b/apps/web/lib/api/campaigns/interpolate-email-template.ts
@@ -1,4 +1,58 @@
-import { EmailTemplateVariables } from "@/lib/types";
+import { constructPartnerLink } from "@/lib/partners/construct-partner-link";
+import { EmailTemplateVariables, GroupProps } from "@/lib/types";
+import { formatRewardDescription } from "@/ui/partners/format-reward-description";
+import type { Reward } from "@prisma/client";
+
+export function resolveCampaignEmailVariables({
+  partner,
+  enrollment,
+}: {
+  partner: {
+    name: string | null;
+    email: string | null;
+  };
+  enrollment: {
+    partnerGroup?: Pick<GroupProps, "linkStructure"> | null;
+    links?: Array<{
+      key: string;
+      url: string;
+      shortLink: string;
+    }>;
+    clickReward?: Reward | null;
+    leadReward?: Reward | null;
+    saleReward?: Reward | null;
+    referralReward?: Reward | null;
+  };
+}): EmailTemplateVariables {
+  return {
+    PartnerName: partner.name,
+    PartnerEmail: partner.email,
+    PartnerLink:
+      constructPartnerLink({
+        group: enrollment.partnerGroup,
+        link: enrollment.links?.[0],
+      }) || null,
+    SaleReward: formatEnrollmentReward(enrollment.saleReward),
+    LeadReward: formatEnrollmentReward(enrollment.leadReward),
+    ClickReward: formatEnrollmentReward(enrollment.clickReward),
+    ReferralReward: formatEnrollmentReward(enrollment.referralReward),
+  };
+}
+
+function formatEnrollmentReward(reward: Reward | null | undefined) {
+  if (!reward) return null;
+
+  return formatRewardDescription(
+    {
+      ...reward,
+      amountInPercentage:
+        reward.amountInPercentage != null
+          ? Number(reward.amountInPercentage)
+          : null,
+    },
+    { includeEarnPrefix: false },
+  );
+}
 
 /**
  * Escapes a string for safe insertion into HTML text nodes and double-quoted attributes.

--- a/apps/web/lib/api/campaigns/render-campaign-email-html.ts
+++ b/apps/web/lib/api/campaigns/render-campaign-email-html.ts
@@ -57,7 +57,7 @@ export function renderCampaignEmailHTML({
         items: ({ query }: { query: string }) => {
           return EMAIL_TEMPLATE_VARIABLES.filter((item) =>
             item.toLowerCase().startsWith(query.toLowerCase()),
-          ).slice(0, 5);
+          ).slice(0, 10);
         },
       },
     }),

--- a/apps/web/lib/api/campaigns/render-campaign-email-markdown.ts
+++ b/apps/web/lib/api/campaigns/render-campaign-email-markdown.ts
@@ -30,7 +30,7 @@ export function renderCampaignEmailMarkdown({
           items: ({ query }: { query: string }) => {
             return EMAIL_TEMPLATE_VARIABLES.filter((item) =>
               item.toLowerCase().startsWith(query.toLowerCase()),
-            ).slice(0, 5);
+            ).slice(0, 10);
           },
         },
       }),

--- a/apps/web/lib/api/workflows/send-campaign/execute.ts
+++ b/apps/web/lib/api/workflows/send-campaign/execute.ts
@@ -2,7 +2,6 @@ import { evaluateWorkflowConditions } from "@/lib/api/workflows/evaluate-workflo
 import { WorkflowCondition, WorkflowContext } from "@/lib/api/workflows/types";
 import { resolveCampaignFromAddress } from "@/lib/email/parse-campaign-from-address";
 import { aggregatePartnerLinksStats } from "@/lib/partners/aggregate-partner-links-stats";
-import { constructPartnerLink } from "@/lib/partners/construct-partner-link";
 import { prisma } from "@/lib/prisma";
 import { TiptapNode } from "@/lib/types";
 import { WORKFLOW_ACTION_TYPES } from "@/lib/zod/schemas/workflows";
@@ -11,6 +10,7 @@ import CampaignEmail from "@dub/email/templates/campaign-email";
 import { chunk } from "@dub/utils";
 import { NotificationEmailType, Prisma, Workflow } from "@prisma/client";
 import { addHours, differenceInDays, subDays } from "date-fns";
+import { resolveCampaignEmailVariables } from "../../campaigns/interpolate-email-template";
 import { renderCampaignEmailHTML } from "../../campaigns/render-campaign-email-html";
 import { validateCampaignFromAddress } from "../../campaigns/validate-campaign";
 import { createId } from "../../create-id";
@@ -177,15 +177,10 @@ export const executeSendCampaignWorkflow = async ({
             preview: campaign.preview,
             body: renderCampaignEmailHTML({
               content: campaign.bodyJson as unknown as TiptapNode,
-              variables: {
-                PartnerName: partnerUser.partner.name,
-                PartnerEmail: partnerUser.partner.email,
-                PartnerLink:
-                  constructPartnerLink({
-                    group: partnerUser.enrollment.partnerGroup,
-                    link: partnerUser.enrollment.links?.[0],
-                  }) || null,
-              },
+              variables: resolveCampaignEmailVariables({
+                partner: partnerUser.partner,
+                enrollment: partnerUser.enrollment,
+              }),
             }),
           },
         }),
@@ -245,6 +240,10 @@ const includePartnerUsers = {
       id: "asc" as const,
     },
   },
+  clickReward: true,
+  leadReward: true,
+  saleReward: true,
+  referralReward: true,
 } satisfies Prisma.ProgramEnrollmentInclude;
 
 async function getProgramEnrollments({

--- a/apps/web/lib/zod/schemas/campaigns.ts
+++ b/apps/web/lib/zod/schemas/campaigns.ts
@@ -14,6 +14,10 @@ export const EMAIL_TEMPLATE_VARIABLES = [
   "PartnerName",
   "PartnerEmail",
   "PartnerLink",
+  "SaleReward",
+  "LeadReward",
+  "ClickReward",
+  "ReferralReward",
 ] as const;
 
 export const CAMPAIGN_FROM_FORMAT_ERROR =

--- a/apps/web/tests/misc/interpolate-email-template.test.ts
+++ b/apps/web/tests/misc/interpolate-email-template.test.ts
@@ -66,4 +66,31 @@ describe("interpolateEmailTemplate", () => {
       }),
     ).toBe("Hi &lt;script&gt;alert(1)&lt;/script&gt;");
   });
+
+  it("replaces reward variables with their formatted values", () => {
+    expect(
+      interpolateEmailTemplate({
+        text: "Commission: {{SaleReward}}",
+        variables: { SaleReward: "30% per sale for 6 months" },
+      }),
+    ).toBe("Commission: 30% per sale for 6 months");
+  });
+
+  it("HTML-escapes reward variables to avoid injection", () => {
+    expect(
+      interpolateEmailTemplate({
+        text: "Reward: {{SaleReward}}",
+        variables: { SaleReward: "<b>30%</b>" },
+      }),
+    ).toBe("Reward: &lt;b&gt;30%&lt;/b&gt;");
+  });
+
+  it("uses fallback when a reward variable is missing", () => {
+    expect(
+      interpolateEmailTemplate({
+        text: "Reward: {{SaleReward | N/A}}",
+        variables: {},
+      }),
+    ).toBe("Reward: N/A");
+  });
 });

--- a/packages/ui/src/rich-text-area/variables.tsx
+++ b/packages/ui/src/rich-text-area/variables.tsx
@@ -36,7 +36,7 @@ const updatePosition = (editor: Editor, element: HTMLElement) => {
 export const suggestions = (variables: string[]) => ({
   items: ({ query }: { query: string }) => {
     const q = query.trim().toLowerCase();
-    if (!q) return variables.slice(0, 5);
+    if (!q) return variables.slice(0, 10);
     return variables
       .filter((item) => item.toLowerCase().includes(q))
       .sort((a, b) => {
@@ -47,7 +47,7 @@ export const suggestions = (variables: string[]) => ({
         if (aPrefix !== bPrefix) return aPrefix - bPrefix;
         return a.localeCompare(b);
       })
-      .slice(0, 5);
+      .slice(0, 10);
   },
 
   render: () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Campaign emails now support Sale, Lead, Click, and Referral reward variables.
  - Reward values are formatted automatically, including percentage-based rewards.
  - Variable suggestions now display up to 10 matching options.

- **Bug Fixes**
  - Improved campaign email rendering with safer handling of missing reward and partner details.

- **Tests**
  - Added coverage for reward interpolation, HTML escaping, and missing-value fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->