### PR TITLE
Render markdown tables on partner landing pages

### DIFF
--- a/apps/web/lib/ai/generate-lander.ts
+++ b/apps/web/lib/ai/generate-lander.ts
@@ -118,7 +118,8 @@ export const generateLanderAction = authActionClient
         `Do not add any file blocks. ` +
         `For image blocks, make sure the image URL is an absolute URL, not a relative URL (append the website URL to the image URL if it's a relative URL). ` +
         `If you have product pricing information, ${landerData ? "you could" : "you should"} include an earnings calculator block, using the highest non-enterprise tier for the product price. ` +
-        `Markdown is supported in "text" blocks, but use it sparingly. ` +
+        `Markdown is supported in "text" and "accordion" blocks, but use it sparingly. ` +
+        `GFM tables are supported in those blocks (pipe tables with one row per line) and should be used for structured data. ` +
         `Avoid using links. Relevant CTA links are already on the landing page. ` +
         // Additional instructions
         (prompt

--- a/apps/web/ui/partners/groups/design/lander/modals/text-block-modal.tsx
+++ b/apps/web/ui/partners/groups/design/lander/modals/text-block-modal.tsx
@@ -107,7 +107,7 @@ function TextBlockModalInner({
               />
             </div>
             <a
-              href="https://www.markdownguide.org/basic-syntax/"
+              href="https://www.markdownguide.org/extended-syntax/#tables"
               target="_blank"
               rel="noopener noreferrer"
               className="text-content-subtle mt-1 flex items-center gap-1 text-xs"

--- a/apps/web/ui/partners/lander/blocks/block-markdown.tsx
+++ b/apps/web/ui/partners/lander/blocks/block-markdown.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@dub/utils";
 import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 
 export function BlockMarkdown({
   className,
@@ -15,14 +16,27 @@ export function BlockMarkdown({
         "prose-headings:leading-tight prose-bullet:text-red-500",
         "prose-a:font-medium prose-a:text-neutral-500 hover:prose-a:text-neutral-600",
         "marker:prose-ul:text-neutral-700 prose-ul:pl-[1.5em] [&_ul>li]:pl-0",
+        "prose-table:my-0 prose-table:w-full prose-table:text-sm prose-table:leading-6",
+        "prose-thead:border-border-subtle prose-tr:border-border-subtle",
+        "prose-th:px-4 prose-th:py-2.5 prose-th:font-medium prose-th:text-content-emphasis",
+        "prose-td:px-4 prose-td:py-2.5 prose-td:text-content-default",
+        "[&_td]:whitespace-nowrap [&_th]:whitespace-nowrap",
+        "[&_td:first-child]:pl-0 [&_th:first-child]:pl-0",
+        "[&_td:last-child]:pr-0 [&_th:last-child]:pr-0",
         className,
       )}
       dir="auto"
     >
       <Markdown
+        remarkPlugins={[remarkGfm]}
         components={{
           a: ({ node, ...props }) => (
             <a {...props} target="_blank" rel="noopener noreferrer" />
+          ),
+          table: ({ node, ...props }) => (
+            <div className="overflow-x-auto">
+              <table {...props} />
+            </div>
           ),
         }}
       >

--- a/apps/web/ui/partners/lander/blocks/block-markdown.tsx
+++ b/apps/web/ui/partners/lander/blocks/block-markdown.tsx
@@ -16,13 +16,6 @@ export function BlockMarkdown({
         "prose-headings:leading-tight prose-bullet:text-red-500",
         "prose-a:font-medium prose-a:text-neutral-500 hover:prose-a:text-neutral-600",
         "marker:prose-ul:text-neutral-700 prose-ul:pl-[1.5em] [&_ul>li]:pl-0",
-        "prose-table:my-0 prose-table:w-full prose-table:text-sm prose-table:leading-6",
-        "prose-thead:border-border-subtle prose-tr:border-border-subtle",
-        "prose-th:px-4 prose-th:py-2.5 prose-th:font-medium prose-th:text-content-emphasis",
-        "prose-td:px-4 prose-td:py-2.5 prose-td:text-content-default",
-        "[&_td]:whitespace-nowrap [&_th]:whitespace-nowrap",
-        "[&_td:first-child]:pl-0 [&_th:first-child]:pl-0",
-        "[&_td:last-child]:pr-0 [&_th:last-child]:pr-0",
         className,
       )}
       dir="auto"
@@ -33,9 +26,19 @@ export function BlockMarkdown({
           a: ({ node, ...props }) => (
             <a {...props} target="_blank" rel="noopener noreferrer" />
           ),
-          table: ({ node, ...props }) => (
-            <div className="overflow-x-auto">
-              <table {...props} />
+          table: ({ node, className, ...props }) => (
+            <div className="my-6 max-w-full overflow-x-auto rounded-xl border border-neutral-200">
+              <table
+                className={cn(
+                  "my-0 w-full border-separate border-spacing-0 text-left text-[0.95rem]",
+                  "[&_th]:border-b [&_th]:border-r [&_th]:border-neutral-200 [&_th]:bg-neutral-50 [&_th]:!px-4 [&_th]:py-3 [&_th]:align-top [&_th]:font-semibold [&_th]:text-neutral-900",
+                  "[&_td]:border-b [&_td]:border-r [&_td]:border-neutral-200 [&_td]:!px-4 [&_td]:py-3 [&_td]:align-top [&_td]:text-neutral-600",
+                  "[&_td:last-child]:border-r-0 [&_th:last-child]:border-r-0",
+                  "[&>:last-child>tr:last-child>*]:border-b-0",
+                  className,
+                )}
+                {...props}
+              />
             </div>
           ),
         }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Landing pages now support GitHub Flavored Markdown, including pipe-formatted tables, in text and accordion blocks.
  * Tables include improved styling and horizontal scrolling for better readability on smaller screens.

* **Documentation**
  * Updated the Markdown help link to include guidance for extended syntax and tables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->