### PR TITLE
Marketplace url clipping and mismatch of icons

### DIFF
--- a/apps/web/ui/program-marketplace/featured-program-card.tsx
+++ b/apps/web/ui/program-marketplace/featured-program-card.tsx
@@ -10,7 +10,7 @@ import {
   getMarketplaceProgramHref,
 } from "@/ui/program-marketplace/utils/urls";
 import { Tooltip } from "@dub/ui";
-import { ArrowUpRight, Link4 } from "@dub/ui/icons";
+import { ArrowUpRight, Globe } from "@dub/ui/icons";
 import { OG_AVATAR_URL, getDomainWithoutWWW } from "@dub/utils";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -172,7 +172,7 @@ export function FeaturedProgramCard({
                   }}
                   className="mt-2 flex max-w-[220px] items-center gap-1 text-sm font-medium text-neutral-900 transition-colors hover:text-neutral-600"
                 >
-                  <Link4 className="size-4 shrink-0" />
+                  <Globe className="size-4 shrink-0" />
                   <span className="truncate">
                     {getDomainWithoutWWW(program.url)}
                   </span>

--- a/apps/web/ui/program-marketplace/marketplace-program-hero.tsx
+++ b/apps/web/ui/program-marketplace/marketplace-program-hero.tsx
@@ -4,7 +4,7 @@ import { NetworkProgramExtendedProps } from "@/lib/types";
 import { marketplaceProgramDetailsColumnClassName } from "@/ui/program-marketplace/marketplace-program-details-layout";
 import { ProgramCategory } from "@/ui/program-marketplace/program-category";
 import { getMarketplaceCategoryHref } from "@/ui/program-marketplace/utils/urls";
-import { Globe } from "@dub/ui/icons";
+import { ArrowUpRight, Globe } from "@dub/ui/icons";
 import { OG_AVATAR_URL, cn, getDomainWithoutWWW } from "@dub/utils";
 import Link from "next/link";
 import { ReactNode } from "react";
@@ -106,12 +106,13 @@ export function MarketplaceProgramHero({
                 href={program.url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-content-default hover:text-content-emphasis flex h-7 max-w-[220px] items-center gap-1.5 text-sm font-medium leading-none"
+                className="flex h-7 max-w-[220px] items-center gap-1 text-sm font-medium text-neutral-900 transition-colors hover:text-neutral-600"
               >
                 <Globe className="size-4 shrink-0" />
                 <span className="truncate">
-                  {getDomainWithoutWWW(program.url)} ↗
+                  {getDomainWithoutWWW(program.url)}
                 </span>
+                <ArrowUpRight className="size-3.5 shrink-0" />
               </Link>
             </div>
           )}


### PR DESCRIPTION
Fixes the URL clipping, and ensures the globe icon used on the feature block and single page are the same. Was 2 different icons.

### After
<img width="497" height="218" alt="CleanShot 2026-08-17 at 21 15 02@2x" src="https://github.com/user-attachments/assets/21c1c872-aa48-4c87-a190-81d922d0dc21" />

### Before
<img width="535" height="244" alt="CleanShot 2026-08-17 at 21 21 03@2x" src="https://github.com/user-attachments/assets/e72f218e-96d4-479c-9a16-5379f2cc940e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated program marketplace website links with clearer globe and external-link icons.
  * Improved visual consistency for external-link indicators across featured program cards and marketplace hero links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->