### PR TITLE
Fix Qstash bypass implementation

### DIFF
--- a/apps/web/lib/cron/index.ts
+++ b/apps/web/lib/cron/index.ts
@@ -11,6 +11,11 @@ export const qstash = new Client({
   }),
 });
 
+export const qstashWithoutBypass = new Client({
+  baseUrl: process.env.QSTASH_URL || "https://qstash-us-east-1.upstash.io",
+  token: process.env.QSTASH_TOKEN || "",
+});
+
 // Default batch size for cron jobs that process records in batches
 export const CRON_BATCH_SIZE = 100;
 

--- a/apps/web/lib/cron/index.ts
+++ b/apps/web/lib/cron/index.ts
@@ -3,10 +3,12 @@ import { Client } from "@upstash/qstash";
 export const qstash = new Client({
   baseUrl: process.env.QSTASH_URL || "https://qstash-us-east-1.upstash.io",
   token: process.env.QSTASH_TOKEN || "",
-  headers: {
-    "x-vercel-protection-bypass":
-      process.env.VERCEL_AUTOMATION_BYPASS_SECRET || "",
-  },
+  ...(process.env.VERCEL_ENV === "preview" && {
+    headers: {
+      "x-vercel-protection-bypass":
+        process.env.VERCEL_AUTOMATION_BYPASS_SECRET || "",
+    },
+  }),
 });
 
 // Default batch size for cron jobs that process records in batches

--- a/apps/web/lib/cron/qstash-workflow.ts
+++ b/apps/web/lib/cron/qstash-workflow.ts
@@ -6,10 +6,12 @@ import { Client } from "@upstash/workflow";
 const client = new Client({
   baseUrl: process.env.QSTASH_URL || "https://qstash-us-east-1.upstash.io",
   token: process.env.QSTASH_TOKEN || "",
-  headers: {
-    "x-vercel-protection-bypass":
-      process.env.VERCEL_AUTOMATION_BYPASS_SECRET || "",
-  },
+  ...(process.env.VERCEL_ENV === "preview" && {
+    headers: {
+      "x-vercel-protection-bypass":
+        process.env.VERCEL_AUTOMATION_BYPASS_SECRET || "",
+    },
+  }),
 });
 
 type WorkflowType = "partner-approved" | "create-partner-commission";

--- a/apps/web/lib/webhook/qstash.ts
+++ b/apps/web/lib/webhook/qstash.ts
@@ -99,6 +99,13 @@ const publishWebhookEventToQStash = async ({
       "Dub-Signature": signature,
       "Upstash-Hide-Headers": "true",
 
+      ...(process.env.VERCEL_ENV === "preview" && {
+        "Upstash-Callback-Forward-x-vercel-protection-bypass":
+          process.env.VERCEL_AUTOMATION_BYPASS_SECRET || "",
+        "Upstash-Failure-Callback-Forward-x-vercel-protection-bypass":
+          process.env.VERCEL_AUTOMATION_BYPASS_SECRET || "",
+      }),
+
       // Integration specific headers
       ...(receiver === "segment" && {
         "Upstash-Forward-Authorization": createSegmentBasicAuthHeader(
@@ -108,6 +115,8 @@ const publishWebhookEventToQStash = async ({
     },
     callback: callbackUrl.href,
     failureCallback: failureCallbackUrl.href,
+
+    // for E2E tests, add a 5s delay
     ...(process.env.NODE_ENV === "test" && { delay: 5 }),
   });
 

--- a/apps/web/lib/webhook/qstash.ts
+++ b/apps/web/lib/webhook/qstash.ts
@@ -1,4 +1,4 @@
-import { qstash } from "@/lib/cron";
+import { qstashWithoutBypass } from "@/lib/cron";
 import { webhookPayloadSchema } from "@/lib/webhook/schemas";
 import { APP_DOMAIN_WITH_NGROK } from "@dub/utils";
 import { Webhook, WebhookReceiver } from "@prisma/client";
@@ -92,13 +92,18 @@ const publishWebhookEventToQStash = async ({
   // TODO:
   // Add deduplicationId to the webhook
 
-  const response = await qstash.publishJSON({
+  // here, we use qstashWithoutBypass to avoid passing the
+  // Vercel automation bypass secret to arbitrary third party webhook receivers
+  const response = await qstashWithoutBypass.publishJSON({
     url: webhook.url,
     body: finalPayload,
     headers: {
       "Dub-Signature": signature,
       "Upstash-Hide-Headers": "true",
 
+      // for Vercel preview (e2e tests), we need to pass the
+      // Vercel automation bypass secret to the callback URL
+      // see: https://upstash.com/docs/qstash/features/callbacks#configuring-callbacks
       ...(process.env.VERCEL_ENV === "preview" && {
         "Upstash-Callback-Forward-x-vercel-protection-bypass":
           process.env.VERCEL_AUTOMATION_BYPASS_SECRET || "",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved QStash integration for preview deployments by forwarding Vercel protection-bypass credentials only where needed.
  * Prevented automation credentials from being passed to third-party webhook receivers.
  * Ensured webhook callbacks and failure callbacks work correctly behind Vercel preview protection.
  * Added a protected- and unprotected-environment configuration for more reliable event delivery.
* **Tests**
  * Clarified the purpose of the test-only webhook delay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->