### PR TITLE
Make `charge.dispute.created` webhook idempotent for legal user

### DIFF
--- a/apps/web/app/(ee)/api/stripe/webhook/charge-dispute-created.ts
+++ b/apps/web/app/(ee)/api/stripe/webhook/charge-dispute-created.ts
@@ -33,9 +33,13 @@ export async function chargeDisputeCreated(
 
   await disableWorkspaceLinks(workspace.id);
 
+  // Update all users to viewer role except for LEGAL_USER_ID
   const updatedUsers = await prisma.projectUsers.updateMany({
     where: {
       projectId: workspace.id,
+      userId: {
+        not: LEGAL_USER_ID,
+      },
     },
     data: {
       role: "viewer",
@@ -44,13 +48,24 @@ export async function chargeDisputeCreated(
 
   console.log(`Updated ${updatedUsers.count} users to viewer role`);
 
-  await prisma.projectUsers.create({
-    data: {
+  // Add LEGAL_USER_ID as owner
+  await prisma.projectUsers.upsert({
+    where: {
+      userId_projectId: {
+        projectId: workspace.id,
+        userId: LEGAL_USER_ID,
+      },
+    },
+    update: {
+      role: "owner",
+    },
+    create: {
       projectId: workspace.id,
       userId: LEGAL_USER_ID,
       role: "owner",
     },
   });
+
   console.log(
     `Added legal user ${LEGAL_USER_ID} as owner to workspace ${workspace.id}`,
   );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of payment disputes by consistently preserving the designated legal owner’s workspace ownership.
  * Corrected cases where the legal owner’s workspace membership already existed, ensuring ownership is updated reliably.
  * Other dispute protections remain unchanged, including disabling workspace links, cancelling the subscription, and applying fraud safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->