### PR TITLE
Fix provisioned domain banner wrapping on mobile

### DIFF
--- a/apps/web/ui/domains/domain-card.tsx
+++ b/apps/web/ui/domains/domain-card.tsx
@@ -135,9 +135,9 @@ export default function DomainCard({ props }: { props: DomainProps }) {
         onPointerLeave={() => setGroupHover(false)}
       >
         {isDubProvisioned && (
-          <div className="flex items-center justify-between gap-2 rounded-t-xl border-b border-neutral-100 bg-neutral-50 px-5 py-2 text-xs">
-            <div className="flex items-center gap-2">
-              <div className="flex items-center gap-1.5">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 rounded-t-xl border-b border-neutral-100 bg-neutral-50 px-4 py-2 text-xs sm:px-5">
+            <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-2 gap-y-1">
+              <div className="flex shrink-0 items-center gap-1.5">
                 <Wordmark className="h-4" />
                 <span className="font-medium text-neutral-900">
                   Provisioned by Dub
@@ -146,8 +146,9 @@ export default function DomainCard({ props }: { props: DomainProps }) {
 
               {expiresAt && (
                 <button
+                  type="button"
                   className={cn(
-                    "flex items-center gap-1 decoration-dotted underline-offset-2 hover:underline",
+                    "flex items-center gap-1 whitespace-nowrap decoration-dotted underline-offset-2 hover:underline",
                     isExpired
                       ? "text-red-600"
                       : autoRenew
@@ -159,9 +160,9 @@ export default function DomainCard({ props }: { props: DomainProps }) {
                   }}
                 >
                   {autoRenew ? (
-                    <Repeat className="size-3.5" />
+                    <Repeat className="size-3.5 shrink-0" />
                   ) : (
-                    <CircleHalfDottedClock className="size-3.5" />
+                    <CircleHalfDottedClock className="size-3.5 shrink-0" />
                   )}
                   <span className="text-xs font-medium">
                     {autoRenew
@@ -175,7 +176,7 @@ export default function DomainCard({ props }: { props: DomainProps }) {
             <a
               href="https://dub.co/help/article/free-dot-link-domain"
               target="_blank"
-              className="text-neutral-500 underline transition-colors hover:text-neutral-800"
+              className="ml-auto shrink-0 text-neutral-500 underline transition-colors hover:text-neutral-800"
             >
               Learn more
             </a>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fixes the cramped “Provisioned by Dub” header on domain cards at narrow widths
- Renewal date now wraps as a whole unit (no mid-date line break like `2026` alone)
- Slightly tighter mobile padding; “Learn more” stays right-aligned without colliding

## Change
In `domain-card.tsx`, the provisioned banner now uses `flex-wrap` with `whitespace-nowrap` on the renewal/expiry date button so content reflows cleanly on mobile instead of squeezing into one rigid row.

## Test plan
- [ ] Open workspace Domains settings on a phone-width viewport with a Dub-provisioned `.link` domain
- [ ] Confirm banner shows brand + date without awkward mid-date wrapping
- [ ] Confirm “Learn more” remains readable and tappable
- [ ] Confirm desktop layout is unchanged
- [ ] Toggle auto-renewal via the date control still works

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0189a-91b4-79d2-9be4-8a888bde67d0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0189a-91b4-79d2-9be4-8a888bde67d0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved provisioned-domain header layout for better wrapping and responsive spacing.
  * Right-aligned “Learn more” content for a cleaner presentation.
  * Prevented expiration controls and icons from wrapping or shrinking unexpectedly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->