### PR TITLE
Fix SAML/SCIM three-dots menu misalignment on mobile

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/security/saml.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/security/saml.tsx
@@ -63,7 +63,7 @@ export function SAML() {
           <img
             src={currentProvider.logo}
             alt={currentProvider.name}
-            className="h-8 w-8"
+            className="h-8 w-8 shrink-0"
           />
         ),
         title: `${currentProvider.name} SAML`,
@@ -73,7 +73,7 @@ export function SAML() {
       return {
         status: "unconfigured",
         logo: (
-          <div className="rounded-full border border-neutral-200 p-2">
+          <div className="shrink-0 rounded-full border border-neutral-200 p-2">
             <Lock className="h-4 w-4 text-neutral-600" />
           </div>
         ),
@@ -130,12 +130,12 @@ export function SAML() {
           </div>
 
           <div className="rounded-xl border border-neutral-200 bg-white">
-            <div className="flex flex-col items-start justify-between space-y-4 px-4 py-4 sm:flex-row sm:items-center sm:justify-between sm:space-y-0">
-              <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center">
+            <div className="flex items-center justify-between gap-4 px-4 py-4">
+              <div className="flex min-w-0 items-center gap-4">
                 {data.logo || (
-                  <div className="h-8 w-8 animate-pulse rounded-full bg-neutral-100" />
+                  <div className="h-8 w-8 shrink-0 animate-pulse rounded-full bg-neutral-100" />
                 )}
-                <div className="flex flex-col">
+                <div className="flex min-w-0 flex-col">
                   {data.title ? (
                     <h3 className="font-medium">{data.title}</h3>
                   ) : (
@@ -150,7 +150,7 @@ export function SAML() {
                   )}
                 </div>
               </div>
-              <div>
+              <div className="shrink-0">
                 {loading ? (
                   <div className="h-9 w-24 animate-pulse rounded-md bg-neutral-100" />
                 ) : configured ? (

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/security/scim.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/security/scim.tsx
@@ -37,7 +37,7 @@ export function SCIM() {
           <img
             src={SAML_PROVIDERS.find((p) => p.scim === provider)!.logo}
             alt={`${provider} logo`}
-            className="h-8 w-8"
+            className="h-8 w-8 shrink-0"
           />
         ),
         title: `${SAML_PROVIDERS.find((p) => p.scim === provider)!.name} SCIM`,
@@ -46,7 +46,7 @@ export function SCIM() {
     } else
       return {
         logo: (
-          <div className="rounded-full border border-neutral-200 p-2">
+          <div className="shrink-0 rounded-full border border-neutral-200 p-2">
             <FolderSync className="h-4 w-4 text-neutral-600" />
           </div>
         ),
@@ -74,12 +74,12 @@ export function SCIM() {
           </div>
 
           <div className="rounded-xl border border-neutral-200 bg-white">
-            <div className="flex flex-col items-start justify-between space-y-4 px-4 py-4 sm:flex-row sm:items-center sm:justify-between sm:space-y-0">
-              <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center">
+            <div className="flex items-center justify-between gap-4 px-4 py-4">
+              <div className="flex min-w-0 items-center gap-4">
                 {data.logo || (
-                  <div className="h-8 w-8 animate-pulse rounded-full bg-neutral-100" />
+                  <div className="h-8 w-8 shrink-0 animate-pulse rounded-full bg-neutral-100" />
                 )}
-                <div className="flex flex-col">
+                <div className="flex min-w-0 flex-col">
                   {data.title ? (
                     <h3 className="font-medium">{data.title}</h3>
                   ) : (
@@ -94,7 +94,7 @@ export function SCIM() {
                   )}
                 </div>
               </div>
-              <div>
+              <div className="shrink-0">
                 {loading ? (
                   <div className="h-9 w-24 animate-pulse rounded-md bg-neutral-100" />
                 ) : configured ? (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- The SAML (and SCIM) provider row used `flex-col` on mobile, which pushed the three-dots menu onto its own line under the status text.
- Keep the provider info and action menu in a single horizontal row on all breakpoints so the kebab stays aligned on the right.

## Test plan
- [ ] Open workspace Settings → Security on a narrow/mobile viewport with SAML configured
- [ ] Confirm the three-dots menu sits on the same line as the provider header (right-aligned)
- [ ] Confirm Configure button layout still looks correct when SAML is not configured
- [ ] Spot-check Directory Sync (SCIM) for the same alignment
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://dub.slack.com/archives/C072M31K2CU/p1787120081765139?thread_ts=1787120081.765139&cid=C072M31K2CU)

<div><a href="https://cursor.com/agents/bc-ef765011-072c-536b-846c-23670b69da88?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef765011-072c-536b-846c-23670b69da88&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

