### PR TITLE
Fix customer stats overflow on mobile

### DIFF
--- a/apps/web/ui/customers/customer-stats.tsx
+++ b/apps/web/ui/customers/customer-stats.tsx
@@ -63,9 +63,11 @@ export function CustomerStats({
       {
         label: "Lifetime value",
         value: customer ? (
-          <div className="flex items-center gap-1">
-            {currencyFormatter(customer.saleAmount ?? 0)}
-            <span className="text-xs text-neutral-500">
+          <div className="flex min-w-0 flex-wrap items-baseline gap-x-1 gap-y-0.5">
+            <span className="truncate">
+              {currencyFormatter(customer.saleAmount ?? 0)}
+            </span>
+            <span className="text-xs font-normal text-neutral-500">
               ({nFormatter(customer.sales ?? 0, { full: true })}{" "}
               {pluralize("sale", customer.sales ?? 0)})
             </span>
@@ -97,7 +99,8 @@ export function CustomerStats({
     <div className="@container/stats">
       <div
         className={cn(
-          "@xs/stats:grid-cols-[repeat(var(--cols),1fr)] grid grid-cols-1 ring-4 ring-black/5",
+          // 2x2 on narrow viewports; 4-up only when each cell has room for labels
+          "@[560px]/stats:grid-cols-[repeat(var(--cols),minmax(0,1fr))] grid grid-cols-2 ring-4 ring-black/5",
           "gap-px overflow-hidden rounded-xl border border-neutral-200 bg-neutral-200",
         )}
         style={
@@ -114,18 +117,20 @@ export function CustomerStats({
               href={href ?? "#"}
               target="_blank"
               className={cn(
-                "group relative flex flex-col bg-white p-3",
-                href && "transition-colors duration-150 hover:bg-neutral-50",
+                "group relative flex min-w-0 flex-col gap-0.5 bg-white p-3",
+                href && "pr-8 transition-colors duration-150 hover:bg-neutral-50",
               )}
             >
               {href && (
                 <ArrowUpRight2 className="text-content-subtle absolute right-3 top-3 size-3.5 opacity-50 transition-opacity duration-150 group-hover:opacity-100" />
               )}
-              <span className="text-xs text-neutral-500">{label}</span>
+              <span className="text-xs leading-tight text-neutral-500">
+                {label}
+              </span>
               {value === undefined ? (
                 <div className="h-5 w-16 animate-pulse rounded-md bg-neutral-200" />
               ) : (
-                <span className="text-content-emphasis text-sm font-medium">
+                <span className="text-content-emphasis min-w-0 text-sm font-medium leading-snug">
                   {value}
                 </span>
               )}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Customer stats switched to four columns at `@xs` (~320px), which squeezed cells on phones and caused label/value overlap (especially Lifetime value).
- Use a 2×2 grid below 560px and four columns only when there is enough room.
- Allow Lifetime value to wrap cleanly, add `min-w-0` on cells, and reserve space for the external-link icon.

## Test plan
- [ ] Open a customer detail page on a phone-width viewport (~375px)
- [ ] Confirm stats render as a 2×2 grid without overlapping text
- [ ] Confirm Lifetime value (`$0.00 (0 sales)`) wraps without covering the label
- [ ] Widen past ~560px and confirm four columns in a single row
- [ ] Click Lifetime value link and confirm hover/icon still work
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://dub.slack.com/archives/C072M31K2CU/p1787120195219879?thread_ts=1787120195.219879&cid=C072M31K2CU)

<div><a href="https://cursor.com/agents/bc-be866226-3ff4-5bf5-91f5-27c770d11973?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be866226-3ff4-5bf5-91f5-27c770d11973&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the customer statistics layout across screen sizes.
  * Statistics now use a two-column layout on narrow screens and expand to four columns when space allows.
  * Long lifetime values truncate cleanly, while labels and values have improved spacing and readability.
  * Added padding to linked statistics to prevent overlap with navigation icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->