### PR TITLE
Queue partner cleanup when Stripe Connect is missing

### DIFF
--- a/apps/web/lib/tapfiliate/update-stripe-customers.ts
+++ b/apps/web/lib/tapfiliate/update-stripe-customers.ts
@@ -34,8 +34,13 @@ export async function updateStripeCustomers(payload: TapfiliateImportPayload) {
 
   if (!workspace.stripeConnectId) {
     console.error(
-      `Workspace ${workspace.id} has no stripeConnectId. Skipping...`,
+      `Workspace ${workspace.id} has no stripeConnectId. Skipping Stripe customer matching...`,
     );
+
+    await tapfiliateImporter.queue({
+      ...payload,
+      action: "cleanup-partners",
+    });
     return;
   }
 

--- a/apps/web/lib/tolt/update-stripe-customers.ts
+++ b/apps/web/lib/tolt/update-stripe-customers.ts
@@ -34,8 +34,13 @@ export async function updateStripeCustomers(payload: ToltImportPayload) {
 
   if (!workspace.stripeConnectId) {
     console.error(
-      `Workspace ${workspace.id} has no stripeConnectId. Skipping...`,
+      `Workspace ${workspace.id} has no stripeConnectId. Skipping Stripe customer matching...`,
     );
+
+    await toltImporter.queue({
+      ...payload,
+      action: "cleanup-partners",
+    });
     return;
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved partner cleanup when a workspace is missing its Stripe connection.
  * Automatically queues cleanup actions for affected partner records in supported integrations.
  * Enhanced diagnostic messaging to make missing Stripe connection issues clearer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->