### PR TITLE
Lay out bank requirements warning alert horizontally

### DIFF
--- a/apps/web/ui/partners/payouts/bank-account-requirements-modal.tsx
+++ b/apps/web/ui/partners/payouts/bank-account-requirements-modal.tsx
@@ -40,8 +40,8 @@ function BankAccountRequirementsModal({
       </div>
 
       <div className="flex flex-col gap-6 border-t border-neutral-200 bg-neutral-50 p-6">
-        <div className="flex flex-col gap-2.5 rounded-lg border border-amber-200 bg-amber-50 p-3">
-          <TriangleWarning className="size-3.5 text-amber-500" />
+        <div className="flex items-start gap-2.5 rounded-lg border border-amber-200 bg-amber-50 p-3">
+          <TriangleWarning className="mt-0.5 size-3.5 shrink-0 text-amber-500" />
           <p className="text-sm leading-5 text-amber-900">
             If your bank account does not meet these requirements, payouts may
             be delayed or rejected.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Updates the bank account requirements warning in the payouts modal so the icon sits beside the text (top-aligned) instead of stacked above it.
- Matches the compact horizontal alert layout (Frame 41351) and saves vertical space while keeping the existing amber warning styling.

## Test plan
- [ ] Open the bank account requirements modal from partner payouts connect flow
- [ ] Confirm the warning alert shows icon left of text, top-aligned with the first line
- [ ] Confirm amber warning colors/border are unchanged
- [ ] Confirm layout still looks good when the text wraps on narrower widths

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://dub.slack.com/archives/C072M31K2CU/p1787177770682799?thread_ts=1787177770.682799&cid=C072M31K2CU)

<div><a href="https://cursor.com/agents/bc-d7337188-74dd-582c-9763-d3f37059c55e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7337188-74dd-582c-9763-d3f37059c55e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the bank account requirements warning layout for clearer alignment and presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->