### PR TITLE
Support passing `metadata` in `POST /commissions`

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/commissions/create-commission-sheet.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/commissions/create-commission-sheet.tsx
@@ -282,7 +282,7 @@ function CreateCommissionSheetContent({
               saleAmount: null,
               saleEventDate: null,
               invoiceId: null,
-              productId: null,
+              metadata: null,
             }
           : {
               saleAmount: data.saleAmount
@@ -292,7 +292,9 @@ function CreateCommissionSheetContent({
                 ? data.saleEventDate.toISOString()
                 : null,
               invoiceId: data.invoiceId || null,
-              productId: data.productId || null,
+              metadata: data.productId
+                ? { productId: data.productId }
+                : null,
             }),
       };
     }

--- a/apps/web/lib/api/commissions/create-manual-commissions.ts
+++ b/apps/web/lib/api/commissions/create-manual-commissions.ts
@@ -119,6 +119,7 @@ export async function createManualCommissions(args: CreateCommissionsArgs) {
       saleEventDate,
       invoiceId,
       productId,
+      metadata,
     } = args;
 
     if (!importStripeInvoices && !saleAmount) {
@@ -129,14 +130,14 @@ export async function createManualCommissions(args: CreateCommissionsArgs) {
     }
 
     const hasManualSaleFields =
-      saleAmount || saleEventDate || invoiceId || productId;
+      saleAmount || saleEventDate || invoiceId || metadata || productId;
 
     if (importStripeInvoices) {
       if (hasManualSaleFields) {
         throw new DubApiError({
           code: "bad_request",
           message:
-            "saleAmount, saleEventDate, invoiceId, and productId cannot be provided when importStripeInvoices is enabled.",
+            "You cannot pass any manual sale fields when `importStripeInvoices` is enabled.",
         });
       }
 
@@ -203,6 +204,9 @@ export async function createManualCommissions(args: CreateCommissionsArgs) {
         customer: {
           country: targetCustomer.country,
         },
+        lead: {
+          ...(args.metadata != null && { metadata: args.metadata }),
+        },
       },
     });
   }
@@ -235,6 +239,7 @@ export async function createManualCommissions(args: CreateCommissionsArgs) {
           sale: {
             productId: saleEvent.productId,
             amount: saleEvent.amount,
+            ...(saleEvent.metadata != null && { metadata: saleEvent.metadata }),
           },
         },
         isFirstConversion,
@@ -477,6 +482,8 @@ async function recordEvents(args: RecordEventsArgs) {
     event_name: leadEventName ?? "Sign up",
     customer_id: targetCustomer.id,
     timestamp: finalLeadEventDate.toISOString(),
+    metadata:
+      type === "lead" && args.metadata ? JSON.stringify(args.metadata) : "",
   });
 
   // Record sale events
@@ -486,6 +493,7 @@ async function recordEvents(args: RecordEventsArgs) {
       saleAmount,
       saleEventDate,
       productId,
+      metadata,
       importStripeInvoices,
     } = args;
 
@@ -505,6 +513,13 @@ async function recordEvents(args: RecordEventsArgs) {
         }),
       );
     } else if (saleAmount) {
+      // Merge deprecated `productId` into metadata for backwards compatibility.
+      // `metadata.productId` takes precedence when both are provided.
+      const saleMetadata = {
+        ...(productId ? { productId } : {}),
+        ...metadata,
+      };
+
       saleEvents = [
         saleEventSchemaTBWithTimestamp.parse({
           ...clickEvent,
@@ -516,7 +531,10 @@ async function recordEvents(args: RecordEventsArgs) {
           payment_processor: "custom",
           currency: "usd",
           timestamp: new Date(saleEventDate ?? Date.now()).toISOString(),
-          metadata: productId ? JSON.stringify({ productId }) : undefined,
+          metadata:
+            Object.keys(saleMetadata).length > 0
+              ? JSON.stringify(saleMetadata)
+              : "",
         }),
       ];
     }
@@ -553,6 +571,7 @@ async function recordEvents(args: RecordEventsArgs) {
         currency: saleEvent.currency,
         invoiceId: saleEvent.invoice_id,
         productId: metadata?.productId,
+        metadata,
         ...(stripeInvoice?.refunded && {
           status: "refunded" as const,
         }),

--- a/apps/web/lib/zod/schemas/commissions.ts
+++ b/apps/web/lib/zod/schemas/commissions.ts
@@ -515,6 +515,16 @@ export const createManualCommissionBodySchema = z
         .describe(
           "The name of the lead event. If not provided, defaults to 'Sign up'.",
         ),
+      metadata: z
+        .record(z.string(), z.any())
+        .nullish()
+        .refine((val) => !val || JSON.stringify(val).length <= 10000, {
+          message:
+            "Metadata must be less than 10,000 characters when stringified",
+        })
+        .describe(
+          "Additional metadata to be stored with the lead event – will also impact commission earnings calculation. Max 10,000 characters when stringified.",
+        ),
     }),
 
     // Sale commission
@@ -564,12 +574,23 @@ export const createManualCommissionBodySchema = z
         .describe(
           "Only used when `importStripeInvoices` is `false`. An optional invoice ID to attach to the generated sale event and commission entry for deduplication.",
         ),
+      metadata: z
+        .record(z.string(), z.any())
+        .nullish()
+        .refine((val) => !val || JSON.stringify(val).length <= 10000, {
+          message:
+            "Metadata must be less than 10,000 characters when stringified",
+        })
+        .describe(
+          "Only used when `importStripeInvoices` is `false`. Additional metadata to be stored with the sale event – will also impact commission earnings calculation. Max 10,000 characters when stringified.",
+        ),
       productId: z
         .string()
         .nullish()
         .describe(
-          "Only used when `importStripeInvoices` is `false`. An optional product ID stored on the sale event metadata – will also impact commission earnings calculation (if a `Sale` `Product ID` modifier is set).",
-        ),
+          "Deprecated: Use `metadata['productId']` instead. An optional product ID stored on the sale event metadata – will also impact commission earnings calculation (if a `Sale` `Product ID` modifier is set).",
+        )
+        .meta({ deprecated: true }),
     }),
   ])
   .superRefine((data, ctx) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for storing custom metadata with manually created leads and sales.
  * Sale metadata is now available in commission and sale event details.
  * Existing product information remains supported through sale metadata.

* **Bug Fixes**
  * Improved commission creation handling for Stripe-imported and manually created sales.
  * Added validation to prevent oversized metadata entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->