### PR TITLE
Partner interest empty state

### DIFF
--- a/apps/web/app/(ee)/partners.dub.co/(dashboard)/profile/about-you-form.tsx
+++ b/apps/web/app/(ee)/partners.dub.co/(dashboard)/profile/about-you-form.tsx
@@ -156,6 +156,7 @@ export function AboutYouForm({ partner }: { partner?: PartnerProps }) {
                           key={idx}
                           type="button"
                           disabled={disabled}
+                          aria-label="Add industry interest"
                           onClick={() => setShowIndustryInterestsModal(true)}
                           className={cn(
                             "relative flex h-11 w-32 items-center justify-center rounded-full bg-white",

--- a/apps/web/app/(ee)/partners.dub.co/(dashboard)/profile/about-you-form.tsx
+++ b/apps/web/app/(ee)/partners.dub.co/(dashboard)/profile/about-you-form.tsx
@@ -9,6 +9,7 @@ import { PartnerProps } from "@/lib/types";
 import { MAX_PARTNER_DESCRIPTION_LENGTH } from "@/lib/zod/schemas/partners";
 import { MaxCharactersCounter } from "@/ui/shared/max-characters-counter";
 import { Button, RadioGroup, RadioGroupItem, useEnterSubmit } from "@dub/ui";
+import { Plus } from "@dub/ui/icons";
 import { cn } from "@dub/utils";
 import { IndustryInterest, MonthlyTraffic } from "@prisma/client";
 import { useAction } from "next-safe-action/hooks";
@@ -151,12 +152,39 @@ export function AboutYouForm({ partner }: { partner?: PartnerProps }) {
                           </div>
                         ))
                     : [...Array(3)].map((_, idx) => (
-                        <div
+                        <button
                           key={idx}
+                          type="button"
+                          disabled={disabled}
+                          onClick={() => setShowIndustryInterestsModal(true)}
                           className={cn(
-                            "border-border-subtle h-11 w-32 rounded-full border border-dashed bg-white",
+                            "relative flex h-11 w-32 items-center justify-center rounded-full bg-white",
+                            !disabled &&
+                              "transition-colors hover:bg-neutral-50/60",
+                            disabled && "cursor-not-allowed",
                           )}
-                        />
+                        >
+                          <svg
+                            className="pointer-events-none absolute inset-0 size-full text-neutral-300"
+                            aria-hidden="true"
+                          >
+                            <rect
+                              x="0.5"
+                              y="0.5"
+                              width="100%"
+                              height="100%"
+                              rx="21.5"
+                              fill="none"
+                              stroke="currentColor"
+                              strokeDasharray="5 5"
+                              style={{
+                                width: "calc(100% - 1px)",
+                                height: "calc(100% - 1px)",
+                              }}
+                            />
+                          </svg>
+                          <Plus className="size-4 text-neutral-700" />
+                        </button>
                       ))}
                 </div>
                 <Button


### PR DESCRIPTION
- Changed to svg shape to control the dash length and to match the designs
- Now clickable and opens the interest selection modal
- Has subtle hover state

https://github.com/user-attachments/assets/ec7c4530-3040-4d51-84f6-d6f7e9f1f169



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added interactive controls for selecting industry interests.
  - Added a plus icon and visual hover states to available interest options.
  - Disabled options remain visibly inactive.
  - Added accessible labels for industry interest controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->