### PR TITLE
Allow owners to uninstall integrations

### DIFF
--- a/apps/web/app/api/integrations/uninstall/route.ts
+++ b/apps/web/app/api/integrations/uninstall/route.ts
@@ -3,7 +3,11 @@ import { withWorkspace } from "@/lib/auth";
 import { googleAdsInstalledWorkspaces } from "@/lib/integrations/google-ads/installed-workspaces";
 import { slackOAuthProvider } from "@/lib/integrations/slack/oauth";
 import { prisma } from "@/lib/prisma";
-import { GOOGLE_ADS_INTEGRATION_ID, SLACK_INTEGRATION_ID } from "@dub/utils";
+import {
+  GOOGLE_ADS_INTEGRATION_ID,
+  RAYCAST_INTEGRATION_ID,
+  SLACK_INTEGRATION_ID,
+} from "@dub/utils/src/constants/integrations";
 import { waitUntil } from "@vercel/functions";
 import { NextResponse } from "next/server";
 
@@ -26,12 +30,17 @@ export const DELETE = withWorkspace(
       });
     }
 
+    const isInstaller = installation.userId === session.user.id;
     const isOwner = workspace.users[0].role === "owner";
-    if (installation.userId !== session.user.id && !isOwner) {
+    const isPersonalIntegration =
+      installation.integrationId === RAYCAST_INTEGRATION_ID;
+
+    if (!isInstaller && (!isOwner || isPersonalIntegration)) {
       throw new DubApiError({
         code: "unauthorized",
-        message:
-          "You are not authorized to uninstall this integration. Only the user who installed it or a workspace owner can uninstall it.",
+        message: isPersonalIntegration
+          ? "You are not authorized to uninstall this integration. Only the user who installed it can uninstall it."
+          : "You are not authorized to uninstall this integration. Only the user who installed it or a workspace owner can uninstall it.",
       });
     }
 

--- a/apps/web/app/api/integrations/uninstall/route.ts
+++ b/apps/web/app/api/integrations/uninstall/route.ts
@@ -26,11 +26,12 @@ export const DELETE = withWorkspace(
       });
     }
 
-    if (installation.userId !== session.user.id) {
+    const isOwner = workspace.users[0].role === "owner";
+    if (installation.userId !== session.user.id && !isOwner) {
       throw new DubApiError({
         code: "unauthorized",
         message:
-          "You are not authorized to uninstall this integration. Only the user who installed it can uninstall it.",
+          "You are not authorized to uninstall this integration. Only the user who installed it or a workspace owner can uninstall it.",
       });
     }
 

--- a/apps/web/app/api/workspaces/[idOrSlug]/users/route.ts
+++ b/apps/web/app/api/workspaces/[idOrSlug]/users/route.ts
@@ -152,7 +152,7 @@ export const DELETE = withWorkspace(
       });
     }
 
-    const activeRestrictedTokens = await prisma.restrictedToken.count({
+    const activeRestrictedTokens = await prisma.restrictedToken.findMany({
       where: {
         projectId: workspace.id,
         userId,
@@ -160,13 +160,59 @@ export const DELETE = withWorkspace(
           not: null,
         },
       },
+      select: {
+        installationId: true,
+        installedIntegration: {
+          select: {
+            integration: {
+              select: {
+                name: true,
+              },
+            },
+          },
+        },
+      },
     });
 
-    if (activeRestrictedTokens) {
-      const tokenTense = pluralize("token", activeRestrictedTokens);
+    if (activeRestrictedTokens.length > 0) {
+      const apiKeyCount = activeRestrictedTokens.filter(
+        (token) => token.installationId === null,
+      ).length;
+
+      const integrationNames = [
+        ...new Set(
+          activeRestrictedTokens.flatMap((token) =>
+            token.installedIntegration?.integration.name
+              ? [token.installedIntegration.integration.name]
+              : [],
+          ),
+        ),
+      ];
+
+      const parts: string[] = [];
+
+      if (apiKeyCount > 0) {
+        parts.push(
+          `${apiKeyCount} active API ${pluralize("key", apiKeyCount)}`,
+        );
+      }
+
+      if (integrationNames.length > 0) {
+        parts.push(
+          `${integrationNames.length} active ${pluralize("integration", integrationNames.length)} (${integrationNames.join(", ")})`,
+        );
+      }
+
+      const action =
+        apiKeyCount > 0 && integrationNames.length > 0
+          ? "Please remove them first"
+          : apiKeyCount > 0
+            ? `Please remove the API ${pluralize("key", apiKeyCount)} first`
+            : `Please uninstall ${integrationNames.length === 1 ? "it" : "them"} first`;
+
       throw new DubApiError({
         code: "bad_request",
-        message: `This user has ${activeRestrictedTokens} active restricted ${tokenTense}. Please remove the ${tokenTense} first before removing the user from the workspace.`,
+        message: `This user has ${parts.join(" and ")}. ${action} before removing the user from the workspace.`,
       });
     }
 

--- a/packages/utils/src/constants/integrations.ts
+++ b/packages/utils/src/constants/integrations.ts
@@ -1,6 +1,7 @@
 export const SLACK_INTEGRATION_ID = "clzu59rx9000110bm5fnlzwuj";
 export const STRIPE_INTEGRATION_ID = "clzra1ya60001wnj4a89zcg9h";
 export const SEGMENT_INTEGRATION_ID = "int_zGnSElTzimbz20OWnXerPoKv";
+export const RAYCAST_INTEGRATION_ID = "clzlmyzlx0005jeqy95pjrwbz";
 export const ZAPIER_INTEGRATION_ID = "clzlmz336000fjeqynwhfv8vo";
 export const SHOPIFY_INTEGRATION_ID = "int_iWOtrZgmcyU6XDwKr4AYYqLN";
 export const HUBSPOT_INTEGRATION_ID = "int_ffw3qgrFAahY6qs1hXaH3wHS";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace owners can uninstall eligible integrations installed by other workspace members.
  * Raycast integrations remain restricted to the person who installed them.
* **Bug Fixes**
  * Improved authorization messaging when an integration cannot be uninstalled.
  * Workspace member removal now identifies active API keys and integrations that must be removed first.
  * Error messages list affected integration names and provide tailored instructions for resolving the issue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->