### PR TITLE
Return 400 instead of 500 when partner analytics times out

### DIFF
--- a/apps/web/app/(ee)/api/partner-profile/programs/[programId]/analytics/route.ts
+++ b/apps/web/app/(ee)/api/partner-profile/programs/[programId]/analytics/route.ts
@@ -9,7 +9,7 @@ import {
   MAX_PARTNER_LINKS_FOR_LOCAL_FILTERING,
 } from "@/lib/constants/partner-profile";
 import { partnerProfileAnalyticsQuerySchema } from "@/lib/zod/schemas/partner-profile";
-import { parseFilterValue, toCentsNumber } from "@dub/utils";
+import { parseFilterValue, serializeError, toCentsNumber } from "@dub/utils";
 import { NextResponse } from "next/server";
 
 // GET /api/partner-profile/programs/[programId]/analytics – get analytics for a program enrollment link
@@ -81,21 +81,34 @@ export const GET = withPartnerProfile(
       };
     }
 
-    const response = await getAnalytics({
-      ...(LARGE_PROGRAM_IDS.includes(program.id) &&
-      toCentsNumber(totalCommissions) <
-        LARGE_PROGRAM_MIN_TOTAL_COMMISSIONS_CENTS
-        ? { event: parsedParams.event, groupBy: "count", interval: "all" }
-        : parsedParams),
-      workspaceId: program.workspaceId,
-      ...(parsedParams.linkId
-        ? { linkId: parsedParams.linkId }
-        : links.length > MAX_PARTNER_LINKS_FOR_LOCAL_FILTERING
-          ? { partnerId: partner.id }
-          : { linkId: parseFilterValue(links.map((link) => link.id)) }),
-      dataAvailableFrom: program.startedAt ?? program.createdAt,
-    });
+    try {
+      const response = await getAnalytics({
+        ...(LARGE_PROGRAM_IDS.includes(program.id) &&
+        toCentsNumber(totalCommissions) <
+          LARGE_PROGRAM_MIN_TOTAL_COMMISSIONS_CENTS
+          ? { event: parsedParams.event, groupBy: "count", interval: "all" }
+          : parsedParams),
+        workspaceId: program.workspaceId,
+        ...(parsedParams.linkId
+          ? { linkId: parsedParams.linkId }
+          : links.length > MAX_PARTNER_LINKS_FOR_LOCAL_FILTERING
+            ? { partnerId: partner.id }
+            : { linkId: parseFilterValue(links.map((link) => link.id)) }),
+        dataAvailableFrom: program.startedAt ?? program.createdAt,
+      });
 
-    return NextResponse.json(response);
+      return NextResponse.json(response);
+    } catch (error) {
+      // Tinybird times out after 30s on heavy partner queries; return a 400
+      // instead of 500 so the UI can show a retry hint.
+      if (serializeError(error).includes("Timeout exceeded")) {
+        throw new DubApiError({
+          code: "bad_request",
+          message: "Failed to fetch analytics. Refresh the page and try again.",
+        });
+      }
+
+      throw error;
+    }
   },
 );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved analytics error handling.
  * Displays a clear retry message when an analytics request times out.
  * Preserves appropriate handling for other errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->