### PR TITLE
Add `description` to commission CSV export

### DIFF
--- a/apps/web/lib/zod/schemas/commissions.ts
+++ b/apps/web/lib/zod/schemas/commissions.ts
@@ -326,6 +326,7 @@ export const COMMISSION_EXPORT_COLUMNS = [
   { id: "currency", label: "Currency", type: "string", default: true },
   { id: "status", label: "Status", type: "string", default: true },
   { id: "invoiceId", label: "Invoice ID", type: "string", default: true },
+  { id: "description", label: "Description", type: "string", default: false },
   { id: "quantity", label: "Quantity", type: "number", default: true },
   { id: "createdAt", label: "Created at", type: "date", default: true },
   { id: "paidAt", label: "Paid at", type: "date", default: false },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional **Description** column to commission exports.
  * The column is available for selection but excluded from default exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->