### PR TITLE
AB testing fixes and updates

### DIFF
--- a/apps/web/lib/api/links/complete-ab-tests.ts
+++ b/apps/web/lib/api/links/complete-ab-tests.ts
@@ -9,6 +9,17 @@ import { linkCache } from "./cache";
 import { includeProgramEnrollment } from "./include-program-enrollment";
 import { includeTags } from "./include-tags";
 
+// Analytics groups by base URL with a trailing slash (e.g. "https://dub.co/"),
+// while test variants store the URL without one
+const normalizeUrl = (url: string) => url.replace(/\/$/, "");
+
+type VariantStats = {
+  url: string;
+  clicks: number;
+  leads: number;
+  sales: number;
+};
+
 export async function completeABTests(link: Link) {
   if (!link.testVariants || !link.testCompletedAt || !link.projectId) {
     return;
@@ -16,8 +27,14 @@ export async function completeABTests(link: Link) {
 
   const testVariants = ABTestVariantsSchema.parse(link.testVariants);
 
-  const analytics: { url: string; leads: number }[] = await getAnalytics({
-    event: "leads",
+  const analytics: {
+    url: string;
+    clicks: number;
+    leads: number;
+    sales: number;
+    saleAmount: number;
+  }[] = await getAnalytics({
+    event: "composite",
     groupBy: "top_base_urls",
     linkId: link.id,
     workspaceId: link.projectId,
@@ -25,34 +42,52 @@ export async function completeABTests(link: Link) {
     end: link.testCompletedAt,
   });
 
-  const max = Math.max(
-    ...testVariants.map(
-      (test) => analytics.find(({ url }) => url === test.url)?.leads || 0,
-    ),
-  );
+  const stats: VariantStats[] = testVariants.map((test) => {
+    const variantAnalytics = analytics.find(
+      ({ url }) => normalizeUrl(url) === normalizeUrl(test.url),
+    );
 
-  // There are no leads generated for any test variant, do nothing
-  if (max === 0) {
+    return {
+      url: test.url,
+      clicks: variantAnalytics?.clicks ?? 0,
+      leads: variantAnalytics?.leads ?? 0,
+      sales: variantAnalytics?.sales ?? 0,
+    };
+  });
+
+  // No data recorded for any variant, do nothing
+  if (stats.every(({ clicks, leads, sales }) => !clicks && !leads && !sales)) {
     console.log(
       `AB Test completed but all results are zero for ${link.id}, doing nothing.`,
     );
     return;
   }
 
-  const winners = testVariants.filter(
-    (test) =>
-      (analytics.find(({ url }) => url === test.url)?.leads || 0) === max,
-  );
+  // If any conversions were recorded, pick by conversions, then conversion
+  // rate, then clicks. Otherwise pick by leads, then lead rate, then clicks.
+  const criteria: ((stats: VariantStats) => number)[] = stats.some(
+    ({ sales }) => sales > 0,
+  )
+    ? [
+        ({ sales }) => sales,
+        ({ sales, clicks }) => (clicks > 0 ? sales / clicks : 0),
+        ({ clicks }) => clicks,
+      ]
+    : [
+        ({ leads }) => leads,
+        ({ leads, clicks }) => (clicks > 0 ? leads / clicks : 0),
+        ({ clicks }) => clicks,
+      ];
 
-  // this should NEVER happen, but just in case
-  if (winners.length === 0) {
-    console.log(
-      `AB Test completed but failed to find winners based on max leads for link ${link.id}, doing nothing.`,
-    );
-    return;
+  let candidates = stats;
+  for (const criterion of criteria) {
+    const max = Math.max(...candidates.map(criterion));
+    candidates = candidates.filter((stats) => criterion(stats) === max);
+    if (candidates.length === 1) break;
   }
 
-  const winner = winners[Math.floor(Math.random() * winners.length)];
+  // Fully tied on all criteria – pick randomly among the tied variants
+  const winner = candidates[Math.floor(Math.random() * candidates.length)];
 
   if (winner.url === link.url) {
     return;

--- a/apps/web/ui/links/link-builder/link-builder-provider.tsx
+++ b/apps/web/ui/links/link-builder/link-builder-provider.tsx
@@ -68,8 +68,9 @@ export function LinkBuilderProvider({
         const firstVariant = testVariants[0];
         if (!firstVariant) return;
 
-        // Don't rewrite the variants of a completed test
-        if (testCompletedAt && new Date(testCompletedAt) < new Date()) return;
+        // Don't rewrite the variants of a completed test (<= so a test ended
+        // in this same tick already counts as completed)
+        if (testCompletedAt && new Date(testCompletedAt) <= new Date()) return;
 
         if (firstVariant.url !== url)
           form.setValue(

--- a/apps/web/ui/links/link-builder/link-builder-provider.tsx
+++ b/apps/web/ui/links/link-builder/link-builder-provider.tsx
@@ -7,6 +7,7 @@ import {
   PropsWithChildren,
   SetStateAction,
   useContext,
+  useEffect,
   useState,
 } from "react";
 import { FormProvider, useForm } from "react-hook-form";
@@ -56,6 +57,34 @@ export function LinkBuilderProvider({
           false,
       },
   });
+
+  // Keep the first A/B test variant in sync with the destination URL – they
+  // represent the same URL (the modal writes testVariants[0].url back to url)
+  useEffect(() => {
+    const { unsubscribe } = form.watch(
+      ({ url, testVariants, testCompletedAt }, { name }) => {
+        if (name !== "url" || !Array.isArray(testVariants)) return;
+
+        const firstVariant = testVariants[0];
+        if (!firstVariant) return;
+
+        // Don't rewrite the variants of a completed test
+        if (testCompletedAt && new Date(testCompletedAt) < new Date()) return;
+
+        if (firstVariant.url !== url)
+          form.setValue(
+            "testVariants",
+            [
+              { ...firstVariant, url: url ?? "" },
+              ...testVariants.slice(1),
+            ] as LinkFormData["testVariants"],
+            { shouldDirty: true },
+          );
+      },
+    );
+
+    return () => unsubscribe();
+  }, [form]);
 
   return (
     <LinkBuilderContext.Provider

--- a/apps/web/ui/links/link-tests.tsx
+++ b/apps/web/ui/links/link-tests.tsx
@@ -1,12 +1,16 @@
 import useWorkspace from "@/lib/swr/use-workspace";
 import { ABTestVariantsSchema } from "@/lib/zod/schemas/links";
-import { fetcher, getPrettyUrl } from "@dub/utils";
+import { fetcher } from "@dub/utils";
 import { motion } from "motion/react";
 import { memo, useMemo } from "react";
 import useSWR from "swr";
 import { LinkAnalyticsBadge } from "./link-analytics-badge";
 import { useLinkCardContext } from "./link-card";
 import { ResponseLink } from "./links-container";
+
+// Analytics groups by base URL with a trailing slash (e.g. "https://dub.co/"),
+// while test variants store the URL without one
+const normalizeUrl = (url: string) => url.replace(/\/$/, "");
 
 export const LinkTests = memo(({ link }: { link: ResponseLink }) => {
   const { id: workspaceId } = useWorkspace();
@@ -65,7 +69,9 @@ export const LinkTests = memo(({ link }: { link: ResponseLink }) => {
     >
       <ul className="flex flex-col gap-2.5 border-t border-neutral-200 bg-neutral-100 p-3">
         {testVariants.map((test, idx) => {
-          const analytics = data?.find(({ url }) => url === test.url);
+          const analytics = data?.find(
+            ({ url }) => normalizeUrl(url) === normalizeUrl(test.url),
+          );
 
           return (
             <li
@@ -82,18 +88,11 @@ export const LinkTests = memo(({ link }: { link: ResponseLink }) => {
 
                 {/* Test name */}
                 <span className="truncate text-sm font-medium text-neutral-800">
-                  {getPrettyUrl(test.url)}
+                  {test.url}
                 </span>
               </div>
 
-              <div className="flex items-center gap-5">
-                {/* Test percentage */}
-                <div className="h-7 shrink-0 select-none rounded-[6px] border border-neutral-200/50 p-px">
-                  <div className="flex size-full items-center justify-center rounded-[5px] bg-gradient-to-t from-neutral-950/5 px-1.5 text-xs font-semibold tabular-nums text-neutral-800">
-                    {Math.round(test.percentage)}%
-                  </div>
-                </div>
-
+              <div className="flex items-center gap-2">
                 {/* Analytics badge */}
                 <div className="flex justify-end sm:min-w-48">
                   {isLoading ? (
@@ -110,6 +109,13 @@ export const LinkTests = memo(({ link }: { link: ResponseLink }) => {
                       sharingEnabled={false}
                     />
                   )}
+                </div>
+
+                {/* Test percentage */}
+                <div className="h-7 shrink-0 select-none rounded-[6px] border border-neutral-200/50 p-px">
+                  <div className="flex size-full items-center justify-center rounded-[5px] bg-gradient-to-t from-neutral-950/5 px-1.5 text-xs font-semibold tabular-nums text-neutral-800">
+                    {Math.round(test.percentage)}%
+                  </div>
                 </div>
               </div>
             </li>

--- a/apps/web/ui/links/tests-badge.tsx
+++ b/apps/web/ui/links/tests-badge.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Flask } from "@dub/ui/icons";
-import { cn } from "@dub/utils";
+import { cn, formatDateTime } from "@dub/utils";
 import * as HoverCard from "@radix-ui/react-hover-card";
 import { useLinkCardContext } from "./link-card";
 import { ResponseLink } from "./links-container";
@@ -20,9 +20,21 @@ export function TestsBadge({
           <HoverCard.Content
             side="bottom"
             sideOffset={8}
-            className="animate-slide-up-fade z-[99] items-center overflow-hidden rounded-xl border border-neutral-200 bg-white p-2 text-sm text-neutral-700 shadow-sm"
+            className="animate-slide-up-fade z-[99] items-center overflow-hidden rounded-xl border border-neutral-200 bg-white p-3 text-sm text-neutral-700 shadow-sm"
           >
-            A/B tests
+            <div className="flex flex-col gap-1 text-center">
+              <span className="font-semibold text-neutral-900">
+                A/B test is running
+              </span>
+              {link.testCompletedAt && (
+                <span>
+                  Scheduled completion date is{" "}
+                  <span className="font-semibold text-neutral-900">
+                    {formatDateTime(new Date(link.testCompletedAt))}
+                  </span>
+                </span>
+              )}
+            </div>
           </HoverCard.Content>
         </HoverCard.Portal>
         <HoverCard.Trigger>

--- a/apps/web/ui/modals/link-builder/ab-testing-modal.tsx
+++ b/apps/web/ui/modals/link-builder/ab-testing-modal.tsx
@@ -3,7 +3,10 @@ import {
   MAX_TEST_COUNT,
   MIN_TEST_PERCENTAGE,
 } from "@/lib/zod/schemas/links";
-import { LinkFormData } from "@/ui/links/link-builder/link-builder-provider";
+import {
+  LinkFormData,
+  useLinkBuilderContext,
+} from "@/ui/links/link-builder/link-builder-provider";
 import { useLinkBuilderKeyboardShortcut } from "@/ui/links/link-builder/use-link-builder-keyboard-shortcut";
 import { useAvailableDomains } from "@/ui/links/use-available-domains";
 import { useEndABTestingModal } from "@/ui/modals/link-builder/ab-testing/end-ab-testing-modal";
@@ -22,6 +25,7 @@ import {
   cn,
   formatDateTime,
   getDateTimeLocal,
+  getUrlFromString,
   isValidUrl,
   parseDateTime,
 } from "@dub/utils";
@@ -54,6 +58,8 @@ function ABTestingModal({
 }) {
   const id = useId();
   const inputRef = useRef<HTMLInputElement>(null);
+
+  const { props: savedLink } = useLinkBuilderContext();
 
   const {
     watch: watchParent,
@@ -97,6 +103,13 @@ function ABTestingModal({
   const testVariants = watch("testVariants") || [];
   const testCompletedAt = watch("testCompletedAt");
   const [idParent, testVariantsParent] = watchParent(["id", "testVariants"]);
+
+  // Restrict completion date from -1 days to 6 weeks
+  const completionDateOutOfRange = Boolean(
+    testCompletedAt &&
+      (differenceInDays(testCompletedAt, new Date()) > 6 * 7 ||
+        differenceInDays(testCompletedAt, new Date()) < -1),
+  );
 
   const addTestUrl = () => {
     if (!testVariants.length || testVariants.length >= MAX_TEST_COUNT) return;
@@ -303,6 +316,17 @@ function ABTestingModal({
                               testVariants.length <= MAX_TEST_COUNT
                             );
                           },
+                          onBlur: (e) => {
+                            const url = getUrlFromString(e.target.value);
+                            if (url) {
+                              // remove trailing slash and set the https:// prefix
+                              setValue(
+                                `testVariants.${index}.url`,
+                                url.replace(/\/$/, ""),
+                                { shouldDirty: true, shouldValidate: true },
+                              );
+                            }
+                          },
                         })}
                       />
                       {index > 0 && (
@@ -417,10 +441,17 @@ function ABTestingModal({
               className="w-[40px] border-none bg-transparent text-neutral-500 focus:outline-none focus:ring-0 sm:text-sm"
             />
           </div>
-          <p className="mt-1 text-xs text-neutral-500">6 weeks maximum</p>
+          <p
+            className={cn(
+              "mt-1 text-xs text-neutral-500",
+              completionDateOutOfRange && "text-red-600",
+            )}
+          >
+            6 weeks maximum
+          </p>
         </div>
 
-        {testVariantsParent && (
+        {Boolean(savedLink?.testVariants) && (
           <Callout variant="warn" size={2} className="mt-6">
             Changing the original A/B test settings will impact your future
             analytics and event tracking.
@@ -469,16 +500,7 @@ function ABTestingModal({
                   : "Start testing"
               }
               className="h-9 w-fit"
-              disabled={
-                !isDirty ||
-                !isValid ||
-                Boolean(
-                  testCompletedAt &&
-                    // Restrict competion date from -1 days to 6 weeks
-                    (differenceInDays(testCompletedAt, new Date()) > 6 * 7 ||
-                      differenceInDays(testCompletedAt, new Date()) < -1),
-                )
-              }
+              disabled={!isDirty || !isValid || completionDateOutOfRange}
             />
           </div>
         </div>
@@ -636,11 +658,17 @@ function TrafficSplitSlider({
             style={{ width: `${test.percentage}%` }}
           >
             {i > 0 && <div className="w-1.5" />}
-            <div className="flex h-full grow items-center justify-center gap-2 rounded-md border border-neutral-300 text-xs">
+            <div className="flex h-full grow items-center justify-center rounded-md border border-neutral-300 text-xs">
               <span className="text-xs font-semibold text-neutral-900">
                 {i + 1}
               </span>
-              <span className="@[64px]:block hidden font-medium text-neutral-600">
+              <span
+                className={cn(
+                  "overflow-hidden font-medium text-neutral-600",
+                  "max-w-0 opacity-0 transition-[max-width,opacity,margin-left] duration-200 ease-out",
+                  "@[64px]:ml-2 @[64px]:max-w-12 @[64px]:opacity-100",
+                )}
+              >
                 {test.percentage}%
               </span>
             </div>

--- a/apps/web/ui/modals/link-builder/ab-testing/ab-testing-modal.tsx
+++ b/apps/web/ui/modals/link-builder/ab-testing/ab-testing-modal.tsx
@@ -23,6 +23,7 @@ import {
   cn,
   formatDateTime,
   getDateTimeLocal,
+  getUrlFromString,
   isValidUrl,
   parseDateTime,
 } from "@dub/utils";
@@ -345,6 +346,17 @@ function ABTestingEdit({
                               testVariants.length > 1 &&
                               testVariants.length <= MAX_TEST_COUNT
                             );
+                          },
+                          onBlur: (e) => {
+                            const url = getUrlFromString(e.target.value);
+                            if (url) {
+                              // remove trailing slash and set the https:// prefix
+                              setValue(
+                                `testVariants.${index}.url`,
+                                url.replace(/\/$/, ""),
+                                { shouldDirty: true, shouldValidate: true },
+                              );
+                            }
                           },
                         })}
                       />

--- a/apps/web/ui/modals/link-builder/ab-testing/end-ab-testing-modal.tsx
+++ b/apps/web/ui/modals/link-builder/ab-testing/end-ab-testing-modal.tsx
@@ -1,13 +1,155 @@
+import useWorkspace from "@/lib/swr/use-workspace";
 import { LinkFormData } from "@/ui/links/link-builder/link-builder-provider";
-import { Button, Modal } from "@dub/ui";
+import {
+  Button,
+  CursorRays,
+  InvoiceDollar,
+  Modal,
+  Tooltip,
+  UserCheck,
+} from "@dub/ui";
+import { cn, currencyFormatter, fetcher, nFormatter } from "@dub/utils";
 import {
   Dispatch,
   SetStateAction,
   useCallback,
+  useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { useFormContext } from "react-hook-form";
+import useSWR from "swr";
+
+// Analytics groups by base URL with a trailing slash (e.g. "https://dub.co/"),
+// while test variants store the URL without one
+const normalizeUrl = (url: string) => url.replace(/\/$/, "");
+
+function useIsTruncated<T extends HTMLElement>() {
+  const ref = useRef<T>(null);
+  const [truncated, setTruncated] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const check = () => setTruncated(el.scrollWidth > el.clientWidth);
+    check();
+
+    const resizeObserver = new ResizeObserver(check);
+    resizeObserver.observe(el);
+    return () => resizeObserver.disconnect();
+  }, []);
+
+  return { ref, truncated };
+}
+
+function VariantStats({
+  clicks,
+  leads,
+  saleAmount,
+}: {
+  clicks: number;
+  leads: number;
+  saleAmount: number;
+}) {
+  const stats = [
+    {
+      id: "clicks",
+      icon: CursorRays,
+      value: clicks,
+      iconClassName: "data-[active=true]:text-blue-500",
+    },
+    {
+      id: "leads",
+      icon: UserCheck,
+      value: leads,
+      iconClassName: "data-[active=true]:text-purple-500",
+    },
+    {
+      id: "sales",
+      icon: InvoiceDollar,
+      value: saleAmount,
+      iconClassName: "data-[active=true]:text-teal-500",
+    },
+  ];
+
+  return (
+    <div className="flex shrink-0 items-center gap-0.5 rounded-md border border-neutral-200 bg-neutral-50 p-0.5 text-sm text-neutral-600">
+      {stats.map(({ id, icon: Icon, value, iconClassName }) => (
+        <div
+          key={id}
+          className="flex items-center gap-1 whitespace-nowrap rounded-md px-1 py-px"
+        >
+          <Icon
+            data-active={value > 0}
+            className={cn("h-4 w-4 shrink-0", iconClassName)}
+          />
+          <span>
+            {id === "sales"
+              ? currencyFormatter(value, {
+                  // @ts-ignore – trailingZeroDisplay is a valid option but TS is outdated
+                  trailingZeroDisplay: "stripIfInteger",
+                })
+              : nFormatter(value)}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function VariantOption({
+  test,
+  selected,
+  onSelect,
+  analytics,
+  isLoading,
+}: {
+  test: { url: string; percentage: number };
+  selected: boolean;
+  onSelect: () => void;
+  analytics?: { clicks: number; leads: number; saleAmount: number };
+  isLoading: boolean;
+}) {
+  const { ref, truncated } = useIsTruncated<HTMLSpanElement>();
+
+  return (
+    <button
+      onClick={onSelect}
+      className={`relative flex w-full items-center gap-3 rounded-md border bg-white p-2.5 text-left ring-0 ring-black transition-all duration-100 hover:bg-neutral-50 ${
+        selected ? "border-black ring-1" : "border-neutral-300"
+      }`}
+    >
+      <div
+        className={`size-4 shrink-0 rounded-full border transition-all ${
+          selected ? "border-4 border-black" : "border-neutral-400"
+        }`}
+      />
+      <Tooltip
+        disabled={!truncated}
+        content={
+          <div className="max-w-xs break-all px-3 py-2 text-sm text-neutral-700">
+            {test.url}
+          </div>
+        }
+      >
+        <span ref={ref} className="min-w-0 grow truncate text-sm font-medium">
+          {test.url}
+        </span>
+      </Tooltip>
+      {isLoading ? (
+        <div className="h-6 w-32 shrink-0 animate-pulse rounded-md bg-neutral-100" />
+      ) : (
+        <VariantStats
+          clicks={analytics?.clicks ?? 0}
+          leads={analytics?.leads ?? 0}
+          saleAmount={analytics?.saleAmount ?? 0}
+        />
+      )}
+    </button>
+  );
+}
 
 function EndABTestingModal({
   showEndABTestingModal,
@@ -18,6 +160,7 @@ function EndABTestingModal({
   setShowEndABTestingModal: Dispatch<SetStateAction<boolean>>;
   onEndTest?: () => void;
 }) {
+  const { id: workspaceId } = useWorkspace();
   const { watch: watchParent, setValue: setValueParent } =
     useFormContext<LinkFormData>();
 
@@ -25,8 +168,34 @@ function EndABTestingModal({
     url: string;
     percentage: number;
   }> | null;
+  const [linkId, testStartedAt] = watchParent(["id", "testStartedAt"]);
 
   const [selectedUrl, setSelectedUrl] = useState<string | null>(null);
+
+  const { data: analyticsData, isLoading } = useSWR<
+    {
+      url: string;
+      clicks: number;
+      leads: number;
+      saleAmount: number;
+      sales: number;
+    }[]
+  >(
+    Boolean(showEndABTestingModal && linkId && workspaceId) &&
+      `/api/analytics?${new URLSearchParams({
+        event: "composite",
+        groupBy: "top_base_urls",
+        linkId: linkId as string,
+        workspaceId: workspaceId!,
+        ...(testStartedAt && {
+          start: new Date(testStartedAt).toISOString(),
+        }),
+      }).toString()}`,
+    fetcher,
+    {
+      revalidateOnFocus: false,
+    },
+  );
 
   return (
     <Modal
@@ -39,39 +208,21 @@ function EndABTestingModal({
 
         <div className="mt-4">
           <p className="text-sm text-neutral-600">
-            Select which destination URL to use as the current destination URL,
-            and end the test. Save your changes on the link editor to confirm
-            the change.
+            Select the new destination URL to end the test. Save your changes on
+            the link editor to confirm the change.
           </p>
           <div className="mt-4 flex flex-col gap-2">
             {testVariants?.map((test, index) => (
-              <button
+              <VariantOption
                 key={index}
-                onClick={() => setSelectedUrl(test.url)}
-                className={`relative flex w-full items-center rounded-md border bg-white p-0 text-left ring-0 ring-black transition-all duration-100 hover:bg-neutral-50 ${
-                  selectedUrl === test.url
-                    ? "border-black ring-1"
-                    : "border-neutral-300"
-                }`}
-              >
-                <div className="flex grow items-center space-x-3 overflow-hidden">
-                  <span className="flex h-9 w-8 shrink-0 items-center justify-center border-r border-neutral-300 text-center text-sm font-medium text-neutral-800">
-                    {index + 1}
-                  </span>
-                  <span className="min-w-0 truncate text-sm font-medium">
-                    {test.url}
-                  </span>
-                </div>
-                <div className="flex size-9 shrink-0 items-center justify-center">
-                  <div
-                    className={`size-4 rounded-full border transition-all ${
-                      selectedUrl === test.url
-                        ? "border-4 border-black"
-                        : "border-neutral-400"
-                    }`}
-                  />
-                </div>
-              </button>
+                test={test}
+                selected={selectedUrl === test.url}
+                onSelect={() => setSelectedUrl(test.url)}
+                analytics={analyticsData?.find(
+                  ({ url }) => normalizeUrl(url) === normalizeUrl(test.url),
+                )}
+                isLoading={isLoading}
+              />
             ))}
           </div>
         </div>

--- a/apps/web/ui/modals/link-builder/ab-testing/end-ab-testing-modal.tsx
+++ b/apps/web/ui/modals/link-builder/ab-testing/end-ab-testing-modal.tsx
@@ -244,10 +244,13 @@ function EndABTestingModal({
             disabled={!selectedUrl}
             onClick={() => {
               if (selectedUrl) {
-                setValueParent("url", selectedUrl, { shouldDirty: true });
+                // Set testCompletedAt before url so the destination URL <->
+                // first variant sync sees the test as completed and doesn't
+                // overwrite testVariants[0].url with the selected winner
                 setValueParent("testCompletedAt", new Date(), {
                   shouldDirty: true,
                 });
+                setValueParent("url", selectedUrl, { shouldDirty: true });
                 setShowEndABTestingModal(false);
                 onEndTest?.();
               }

--- a/apps/web/ui/modals/link-builder/ab-testing/traffic-split-slider.tsx
+++ b/apps/web/ui/modals/link-builder/ab-testing/traffic-split-slider.tsx
@@ -78,11 +78,17 @@ export function TrafficSplitSlider({
             style={{ width: `${test.percentage}%` }}
           >
             {i > 0 && <div className="w-1.5" />}
-            <div className="flex h-full grow items-center justify-center gap-2 rounded-md border border-neutral-300 text-xs">
+            <div className="flex h-full grow items-center justify-center rounded-md border border-neutral-300 text-xs">
               <span className="text-xs font-semibold text-neutral-900">
                 {i + 1}
               </span>
-              <span className="@[64px]:block hidden font-medium text-neutral-600">
+              <span
+                className={cn(
+                  "overflow-hidden font-medium text-neutral-600",
+                  "max-w-0 opacity-0 transition-[max-width,opacity,margin-left] duration-200 ease-out",
+                  "@[64px]:ml-2 @[64px]:max-w-12 @[64px]:opacity-100",
+                )}
+              >
                 {test.percentage}%
               </span>
             </div>


### PR DESCRIPTION
### Assorted updates
Updated running AB test view
<img width="1294" height="239" alt="CleanShot 2026-08-24 at 16 17 21@2x" src="https://github.com/user-attachments/assets/01ae2faf-4b88-4fcc-a955-f457ed84002c" />

Updated hover state when running to show when it completes
<img width="463" height="140" alt="CleanShot 2026-08-24 at 16 17 50@2x" src="https://github.com/user-attachments/assets/76100910-6487-4091-87a3-bf5540a87b40" />

Appends https:// to urls if the user doesn't include it
<img width="446" height="205" alt="CleanShot 2026-08-24 at 16 18 23@2x" src="https://github.com/user-attachments/assets/9776efb8-b540-48c4-ad3f-e6cbc439d6bb" />

Added transition when the number appears/disappears
<img width="800" height="161" alt="CleanShot 2026-08-24 at 16 20 21" src="https://github.com/user-attachments/assets/94c481dc-e3d5-4dd2-b872-6cfd7ec7f4ff" />

Adds the stats when ending the test manually
<img width="496" height="269" alt="CleanShot 2026-08-24 at 16 21 24@2x" src="https://github.com/user-attachments/assets/1fd1aee4-1c10-43bf-85e0-191d31ce1ecc" />

Adds hover tooltip if the url is clipping
<img width="499" height="208" alt="CleanShot 2026-08-24 at 16 21 29@2x" src="https://github.com/user-attachments/assets/605acb14-c821-47fe-b33b-4bfe192b4b40" />

### AB logic updated
- Select the link with the highest amount of conversions
- If conversions are tied, select the link with the highest conversion rate (conversions ÷ clicks)
- If still tied, select the link with the highest clicks
`OR - If no conversions are recorded or tracked`
- Select the link with the highest number of leads
- If leads are tied, select the link with the highest lead rate (leads ÷ clicks)
- If still tied, select the link with the highest clicks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - View clicks, leads, and sales for each A/B test variant when ending a test.
  - Winner selection now considers sales, conversion rates, clicks, and leads.
  - A/B test badges show active status and scheduled completion dates.
  - Traffic split percentages appear responsively with smooth transitions.

- **Bug Fixes**
  - Improved URL normalization for more reliable analytics matching.
  - The first variant URL stays synchronized with the destination URL.
  - Added clearer validation and feedback for test URLs and completion dates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->