### PR TITLE
Referral reward quality

### DIFF
--- a/apps/web/ui/partners/rewards/reward-quality.tsx
+++ b/apps/web/ui/partners/rewards/reward-quality.tsx
@@ -38,6 +38,32 @@ export const getRewardQuality = ({
     return "strong";
   }
 
+  if (event === "referral") {
+    if (type === "flat") {
+      if (amountInCents == null || Number.isNaN(amountInCents)) {
+        return null;
+      }
+
+      return "limited";
+    }
+
+    if (type !== "percentage") {
+      return null;
+    }
+
+    if (amountInPercentage == null || Number.isNaN(amountInPercentage)) {
+      return null;
+    }
+
+    if (maxDuration === 1) {
+      return "limited";
+    }
+
+    if (amountInPercentage < 3) return "low";
+    if (amountInPercentage <= 5) return "good";
+    return "strong";
+  }
+
   if (event !== "sale" || !type) {
     return null;
   }
@@ -234,7 +260,7 @@ function getRewardQualityTooltipCopy({
     return {
       title: "Reward quality",
       description:
-        event === "click" || event === "lead"
+        event === "click" || event === "lead" || event === "referral"
           ? "Set amount to evaluate this reward"
           : "Set amount and duration to evaluate this reward",
     };


### PR DESCRIPTION
Was missing from this reward type

<img width="567" height="394" alt="CleanShot 2026-08-25 at 09 29 54@2x" src="https://github.com/user-attachments/assets/c7b5a533-aeb3-413a-8bad-59a33399dc16" />

**Logic:**
- Low ->	below 3%
- Good -> 3% up to and including 5%
- Strong -> above 5%
- Limited -> Flat selected, or with percentage the user enters 1 month.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reward quality evaluation for referral-based rewards.
  * Referral rewards are now categorized as limited, low, good, or strong based on their configuration and percentage thresholds.

* **Bug Fixes**
  * Updated missing-quality guidance for referral rewards to clearly indicate when an amount is required for evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->