### PR TITLE
Feature/partner-search: CodeRabbit follow-ups

### DIFF
--- a/apps/web/lib/actions/partners/accept-program-invite.ts
+++ b/apps/web/lib/actions/partners/accept-program-invite.ts
@@ -46,6 +46,9 @@ export const acceptProgramInviteAction = authPartnerActionClient
       },
     });
 
+    // Queue an index update because the enrollment status moved to approved.
+    waitUntil(queuePartnerSearchSync({ enrollmentIds: [enrollment.id] }));
+
     waitUntil(
       (async () => {
         const workspace = await prisma.project.findUnique({
@@ -97,10 +100,6 @@ export const acceptProgramInviteAction = authPartnerActionClient
               programId,
               partnerId: enrolledPartner.id,
             },
-          }),
-          // Queue an index update because the enrollment status moved to approved
-          queuePartnerSearchSync({
-            enrollmentIds: [enrollment.id],
           }),
         ]);
       })(),

--- a/apps/web/lib/actions/partners/update-partner-profile.ts
+++ b/apps/web/lib/actions/partners/update-partner-profile.ts
@@ -187,6 +187,10 @@ export const updatePartnerProfileAction = authPartnerActionClient
         },
       });
 
+      // Queue an index update because the partner profile changed. Not scoped
+      // by program, since a profile is shared across them.
+      waitUntil(queuePartnerSearchSync({ partnerIds: [partner.id] }));
+
       // If the email is being changed, we need to verify the new email address
       if (emailChanged) {
         if (syncIdentity) {
@@ -256,10 +260,6 @@ export const updatePartnerProfileAction = authPartnerActionClient
 
       waitUntil(
         Promise.allSettled([
-          // Queue an index update because the partner profile changed. Not
-          // scoped by program, since a profile is shared across them.
-          queuePartnerSearchSync({ partnerIds: [partner.id] }),
-
           (async () => {
             const shouldExpireCache = !deepEqual(
               {

--- a/apps/web/lib/api/groups/move-partners-to-group.ts
+++ b/apps/web/lib/api/groups/move-partners-to-group.ts
@@ -96,6 +96,9 @@ export async function movePartnersToGroup({
     return 0;
   }
 
+  // Queue an index update because the enrollments moved group (filterable field)
+  waitUntil(queuePartnerSearchSync({ partnerIds, programId }));
+
   waitUntil(
     (async () => {
       const partnerLinks = await prisma.link.findMany({
@@ -189,11 +192,6 @@ export async function movePartnersToGroup({
         }),
 
         recordLink(partnerLinks),
-
-        // Queue an index update because the enrollments moved group (filterable field)
-        queuePartnerSearchSync({
-          enrollmentIds: updatedProgramEnrollments.map(({ id }) => id),
-        }),
 
         notifyPartnerGroupChange({
           programId,

--- a/apps/web/lib/api/partners/create-and-enroll-partner.ts
+++ b/apps/web/lib/api/partners/create-and-enroll-partner.ts
@@ -180,6 +180,9 @@ export const createAndEnrollPartner = async ({
     });
   }
 
+  // Queue an index update because a new enrollment was created.
+  waitUntil(queuePartnerSearchSync({ enrollmentIds: [programEnrollment.id] }));
+
   // Create the partner links based on group defaults
   const links = await createPartnerDefaultLinks({
     workspace: {
@@ -253,9 +256,6 @@ export const createAndEnrollPartner = async ({
           trigger: "partner.enrolled",
           data: enrolledPartner,
         }),
-
-      // Queue an index update because a new enrollment was created.
-      queuePartnerSearchSync({ enrollmentIds: [programEnrollment.id] }),
     ]),
   );
 

--- a/apps/web/lib/api/partners/queue-partner-search-sync.ts
+++ b/apps/web/lib/api/partners/queue-partner-search-sync.ts
@@ -41,8 +41,9 @@ function unique(values: string[] | undefined): string[] {
 /**
  * Queues an index sync for whatever the caller just changed.
  *
- * Never throws, so a queue error cannot fail the source mutation. The sweep
- * repairs a missed upsert, but not a missed delete.
+ * Never throws, so a queue error cannot fail the source mutation. A failed
+ * QStash publish falls back to the jobs outbox, so this catch only fires when
+ * even that persist fails, and the sync is lost.
  */
 export async function queuePartnerSearchSync({
   enrollmentIds,
@@ -79,7 +80,7 @@ export async function queuePartnerSearchSync({
     await partnerSearchSyncJob.dispatchBatch(payloads, () => ({ delay }));
   } catch (error) {
     console.error(
-      "[Partner Search] Failed to queue an index sync. The sweep repairs a missed upsert, but not a missed delete.",
+      "[Partner Search] Failed to queue an index sync and the outbox could not persist it. The affected documents stay stale until their next sync.",
       error,
     );
   }

--- a/apps/web/lib/firstpromoter/import-partners.ts
+++ b/apps/web/lib/firstpromoter/import-partners.ts
@@ -230,9 +230,18 @@ async function createPartnerAndLinks({
       idx === 0 ? group.partnerGroupDefaultLinks[0]?.id ?? null : null,
   }));
 
-  await bulkCreateLinks({
-    links,
-  });
+  try {
+    await bulkCreateLinks({
+      links,
+    });
+  } catch (error) {
+    // The enrollment is already committed, so its ID must still reach the
+    // page-level search sync even when link creation fails.
+    console.error(
+      `Failed to create links for imported affiliate ${affiliate.id}`,
+      error,
+    );
+  }
 
   return programEnrollment.id;
 }

--- a/apps/web/lib/partnerstack/import-partners.ts
+++ b/apps/web/lib/partnerstack/import-partners.ts
@@ -206,9 +206,15 @@ async function createPartner({
   // PS doesn't return the partner email address in the customers response
   // so we need to keep a map of partner_key (PS) -> partner_id (Dub)
   // and use it to identify the partner in the customers response
-  await redis.hset(`${PARTNER_IDS_KEY_PREFIX}:${program.id}`, {
-    [partner.key]: partnerId,
-  });
+  try {
+    await redis.hset(`${PARTNER_IDS_KEY_PREFIX}:${program.id}`, {
+      [partner.key]: partnerId,
+    });
+  } catch (error) {
+    // The enrollment is already committed, so its ID must still reach the
+    // page-level search sync even when the mapping write fails.
+    console.error("Failed to map imported partner key", error, partner.key);
+  }
 
   return partnerId;
 }

--- a/apps/web/scripts/dev/seed-100k-partners.ts
+++ b/apps/web/scripts/dev/seed-100k-partners.ts
@@ -625,25 +625,9 @@ async function main() {
   // Tags and groups are created once per run and reused, so filters have a
   // small stable set of values to select on rather than one value per partner.
   const tagIds = TAG_NAMES.map((_, index) => createId({ prefix: "ptag_" }));
-  await prisma.partnerTag.createMany({
-    data: TAG_NAMES.map((name, index) => ({
-      id: tagIds[index],
-      programId: program.id,
-      name: `${name} ${seed}`,
-    })),
-  });
-
   const seededGroupIds = SEEDED_GROUP_NAMES.map(() =>
     createId({ prefix: "grp_" }),
   );
-  await prisma.partnerGroup.createMany({
-    data: SEEDED_GROUP_NAMES.map((name, index) => ({
-      id: seededGroupIds[index],
-      programId: program.id,
-      name: `${name} ${seed}`,
-      slug: `${name.toLowerCase()}-${seedFingerprint.slice(0, 6)}`,
-    })),
-  });
 
   // The program's own default group, the seeded ones, and null, so "no group"
   // is represented too, which is what a negated filter has to include.
@@ -652,6 +636,41 @@ async function main() {
     ...seededGroupIds,
     null,
   ];
+
+  // The duplicate-seed check runs before anything is written; running it
+  // after the tag and group writes would leave their rows behind on a rerun.
+  await assertSeedNotAlreadyApplied(
+    generatePartnerChunk({
+      start: 0,
+      end: Math.min(CHUNK_SIZE, totalCount),
+      seedFingerprint,
+      passwordHash,
+      runStartedAt,
+      programId: program.id,
+      programDomain: program.domain,
+      workspaceId: workspace.id,
+      groupIds,
+      tagIds,
+    }),
+    seed,
+  );
+
+  await prisma.partnerTag.createMany({
+    data: TAG_NAMES.map((name, index) => ({
+      id: tagIds[index],
+      programId: program.id,
+      name: `${name} ${seed}`,
+    })),
+  });
+
+  await prisma.partnerGroup.createMany({
+    data: SEEDED_GROUP_NAMES.map((name, index) => ({
+      id: seededGroupIds[index],
+      programId: program.id,
+      name: `${name} ${seed}`,
+      slug: `${name.toLowerCase()}-${seedFingerprint.slice(0, 6)}`,
+    })),
+  });
 
   console.log(
     `Created ${tagIds.length} tags and ${seededGroupIds.length} groups for filtering\n`,
@@ -676,10 +695,6 @@ async function main() {
       groupIds,
       tagIds,
     });
-
-    if (chunk === 0) {
-      await assertSeedNotAlreadyApplied(partnerChunk, seed);
-    }
 
     const insertedInChunk = await insertPartnerChunk(partnerChunk);
     insertedPartners += insertedInChunk;


### PR DESCRIPTION
# Partner search follow-ups

The pagination cap is no longer needed. This PR contains the remaining valid CodeRabbit fixes from #4316 and #4343.

## Changes

- Queue partner search sync immediately after partner and enrollment database writes.
- Keep committed enrollments in the page-level sync when FirstPromoter link creation or PartnerStack key mapping fails.
- Check for a repeated seed before the script creates tags or groups.
- Update the queue error message to describe the jobs outbox from #4419.
- Log only the FirstPromoter affiliate ID when link creation fails.

## Scope

This PR does not add automatic repair for failed importer link creation or Redis mapping. These import paths already continued after a failure. A later import run can safely create the missing links or mapping. This change makes sure that the committed enrollment still reaches partner search sync.