### PR TITLE
Feature/partner-search: weekly reconciliation sweep

### DIFF
--- a/apps/web/app/(ee)/api/cron/partners/search-sweep/route.ts
+++ b/apps/web/app/(ee)/api/cron/partners/search-sweep/route.ts
@@ -1,0 +1,26 @@
+import { getPartnerSearchProvider } from "@/lib/api/partners/search";
+import { withCron } from "@/lib/cron/with-cron";
+import { partnerSearchSweepJob } from "@/lib/jobs/handlers/partner-search-sweep-job";
+import { logAndRespond } from "../../utils";
+
+export const dynamic = "force-dynamic";
+
+// Kicks off a full re-index, which the job carries to completion by
+// re-dispatching itself with a cursor. The backstop for call-site drift, so the
+// pass interval is the worst-case staleness of any document.
+//
+// Runs weekly at 03:00 UTC on Sunday (0 3 * * 0)
+// GET /api/cron/partners/search-sweep
+export const GET = withCron(async () => {
+  if (!getPartnerSearchProvider()) {
+    return logAndRespond(
+      "Partner search provider is not configured, skipping sweep.",
+    );
+  }
+
+  // No cursor: every run starts a fresh pass rather than resuming an
+  // interrupted one, so a stalled pass cannot wedge the schedule.
+  await partnerSearchSweepJob.dispatch({});
+
+  return logAndRespond("Partner search sweep started.");
+});

--- a/apps/web/app/(ee)/api/cron/partners/search-sweep/route.ts
+++ b/apps/web/app/(ee)/api/cron/partners/search-sweep/route.ts
@@ -1,6 +1,9 @@
 import { getPartnerSearchProvider } from "@/lib/api/partners/search";
 import { withCron } from "@/lib/cron/with-cron";
-import { partnerSearchSweepJob } from "@/lib/jobs/handlers/partner-search-sweep-job";
+import {
+  partnerSearchSweepDeduplicationId,
+  partnerSearchSweepJob,
+} from "@/lib/jobs/handlers/partner-search-sweep-job";
 import { logAndRespond } from "../../utils";
 
 export const dynamic = "force-dynamic";
@@ -15,7 +18,10 @@ export const GET = withCron(async () => {
   }
 
   // A fresh pass each run, so a stalled one cannot wedge the schedule
-  await partnerSearchSweepJob.dispatch({});
+  await partnerSearchSweepJob.dispatch(
+    {},
+    { deduplicationId: partnerSearchSweepDeduplicationId() },
+  );
 
   return logAndRespond("Partner search sweep started.");
 });

--- a/apps/web/app/(ee)/api/cron/partners/search-sweep/route.ts
+++ b/apps/web/app/(ee)/api/cron/partners/search-sweep/route.ts
@@ -5,10 +5,6 @@ import { logAndRespond } from "../../utils";
 
 export const dynamic = "force-dynamic";
 
-// Kicks off a full re-index, which the job carries to completion by
-// re-dispatching itself with a cursor. The backstop for call-site drift, so the
-// pass interval is the worst-case staleness of any document.
-//
 // Runs weekly at 03:00 UTC on Sunday (0 3 * * 0)
 // GET /api/cron/partners/search-sweep
 export const GET = withCron(async () => {
@@ -18,8 +14,7 @@ export const GET = withCron(async () => {
     );
   }
 
-  // No cursor: every run starts a fresh pass rather than resuming an
-  // interrupted one, so a stalled pass cannot wedge the schedule.
+  // A fresh pass each run, so a stalled one cannot wedge the schedule
   await partnerSearchSweepJob.dispatch({});
 
   return logAndRespond("Partner search sweep started.");

--- a/apps/web/lib/api/partners/search/index.ts
+++ b/apps/web/lib/api/partners/search/index.ts
@@ -6,5 +6,6 @@ export * from "./order-search-results";
 export * from "./provider";
 export * from "./searchable-values";
 export * from "./serialize-document";
+export * from "./sweep";
 export * from "./sync";
 export * from "./types";

--- a/apps/web/lib/api/partners/search/sweep.ts
+++ b/apps/web/lib/api/partners/search/sweep.ts
@@ -5,10 +5,10 @@ import type { PartnerSearchProvider } from "./types";
 export const PARTNER_SEARCH_SWEEP_BATCH_SIZE = 500;
 
 /**
- * How long one hop indexes before handing off. The job route allows 600s, and
- * the margin covers the batch in flight when the budget expires, since the
- * check happens between batches. Errs generous: overrunning kills the hop and
- * QStash retries the same cursor, stalling the pass silently.
+ * How long one hop indexes before handing off. The job route allows 600s. The
+ * budget is checked between batches, so the batch in flight runs past it.
+ * Overrunning kills the hop, QStash retries the same cursor, and the pass
+ * stalls silently.
  */
 export const PARTNER_SEARCH_SWEEP_TIME_BUDGET_MS = 240_000;
 
@@ -21,15 +21,10 @@ interface SweepPartnerSearchOptions {
 }
 
 /**
- * Re-indexes a slice of the corpus, resuming from `after`. The backstop for
- * call-site drift: a mutation path that never queued a sync is corrected by the
- * next pass.
- *
- * Re-indexes everything rather than filtering by timestamp, because a watermark
- * misses a tag change (ProgramPartnerTag has no timestamps) and a link edit
- * (which moves neither the enrollment's timestamp nor the partner's).
- *
- * Upserts only: a pass re-indexes the rows it reads.
+ * Re-indexes a slice of the corpus, resuming from `after`. Everything, not a
+ * timestamp filter, because a watermark misses a tag change (ProgramPartnerTag
+ * has no timestamps) and a link edit (which moves neither the enrollment's
+ * timestamp nor the partner's).
  */
 export async function sweepPartnerSearch({
   after,

--- a/apps/web/lib/api/partners/search/sweep.ts
+++ b/apps/web/lib/api/partners/search/sweep.ts
@@ -1,0 +1,60 @@
+import { indexPartnerSearchEnrollments } from "./index-enrollments";
+import { getPartnerSearchProvider } from "./provider";
+import type { PartnerSearchProvider } from "./types";
+
+export const PARTNER_SEARCH_SWEEP_BATCH_SIZE = 500;
+
+/**
+ * How long one hop indexes before handing off. The job route allows 600s, and
+ * the margin covers the batch in flight when the budget expires, since the
+ * check happens between batches. Errs generous: overrunning kills the hop and
+ * QStash retries the same cursor, stalling the pass silently.
+ */
+export const PARTNER_SEARCH_SWEEP_TIME_BUDGET_MS = 240_000;
+
+interface SweepPartnerSearchOptions {
+  after?: string;
+  batchSize?: number;
+  timeBudgetMs?: number;
+  now?: () => number;
+  searchProvider?: PartnerSearchProvider | null;
+}
+
+/**
+ * Re-indexes a slice of the corpus, resuming from `after`. The backstop for
+ * call-site drift: a mutation path that never queued a sync is corrected by the
+ * next pass.
+ *
+ * Re-indexes everything rather than filtering by timestamp, because a watermark
+ * misses a tag change (ProgramPartnerTag has no timestamps) and a link edit
+ * (which moves neither the enrollment's timestamp nor the partner's).
+ *
+ * Upserts only: a pass re-indexes the rows it reads.
+ */
+export async function sweepPartnerSearch({
+  after,
+  batchSize = PARTNER_SEARCH_SWEEP_BATCH_SIZE,
+  timeBudgetMs = PARTNER_SEARCH_SWEEP_TIME_BUDGET_MS,
+  now,
+  searchProvider = getPartnerSearchProvider(),
+}: SweepPartnerSearchOptions = {}) {
+  if (!searchProvider) {
+    throw new Error("Partner search provider is not configured.");
+  }
+
+  if (!Number.isSafeInteger(batchSize) || batchSize <= 0) {
+    throw new Error("Batch size must be a positive integer.");
+  }
+
+  if (!Number.isSafeInteger(timeBudgetMs) || timeBudgetMs <= 0) {
+    throw new Error("Time budget must be a positive integer.");
+  }
+
+  return await indexPartnerSearchEnrollments({
+    searchProvider,
+    after,
+    batchSize,
+    timeBudgetMs,
+    ...(now && { now }),
+  });
+}

--- a/apps/web/lib/jobs/handlers/partner-search-sweep-job.ts
+++ b/apps/web/lib/jobs/handlers/partner-search-sweep-job.ts
@@ -1,0 +1,69 @@
+import {
+  getPartnerSearchProvider,
+  sweepPartnerSearch,
+} from "@/lib/api/partners/search";
+import * as z from "zod/v4";
+import { defineJob } from "../index";
+
+const inputSchema = z.object({
+  /** Keyset cursor, carried across hops. Absent starts a fresh pass. */
+  after: z.string().optional(),
+  /**
+   * Documents indexed so far in this pass, for logging continuity. Defaulted in
+   * the handler rather than by the schema, because defineJob types the dispatch
+   * payload from the schema's output and a zod default would make this required
+   * at every call site.
+   */
+  processed: z.number().int().nonnegative().optional(),
+});
+
+export const partnerSearchSweepJob = defineJob({
+  name: "partner-search-sweep-job",
+  schema: inputSchema,
+  defaults: {
+    retries: 3,
+    flowControl: {
+      // A pass is inherently sequential, and holding it to one in flight keeps
+      // a long sweep from competing with interactive syncs for write capacity.
+      key: "partner-search-sweep",
+      parallelism: 1,
+    },
+  },
+  async handle({ after, processed: alreadyProcessed = 0 }) {
+    if (!getPartnerSearchProvider()) {
+      console.log(
+        "[partnerSearchSweepJob] No search provider configured. Skipping...",
+      );
+      return;
+    }
+
+    const { processed, lastDocumentId, done } = await sweepPartnerSearch({
+      after,
+    });
+
+    const totalProcessed = alreadyProcessed + processed;
+
+    if (done) {
+      console.log(
+        `[partnerSearchSweepJob] Pass complete. Re-indexed ${totalProcessed} documents.`,
+      );
+      return;
+    }
+
+    console.log(
+      `[partnerSearchSweepJob] Re-indexed ${totalProcessed} documents so far, continuing after ${lastDocumentId}.`,
+    );
+
+    // Cursor lives in the payload rather than in storage, so a pass needs no
+    // state of its own and an interrupted one simply restarts on the next cron.
+    await partnerSearchSweepJob.dispatch(
+      {
+        ...(lastDocumentId && { after: lastDocumentId }),
+        processed: totalProcessed,
+      },
+      {
+        delay: 1,
+      },
+    );
+  },
+});

--- a/apps/web/lib/jobs/handlers/partner-search-sweep-job.ts
+++ b/apps/web/lib/jobs/handlers/partner-search-sweep-job.ts
@@ -5,6 +5,14 @@ import {
 import * as z from "zod/v4";
 import { defineJob } from "../index";
 
+/**
+ * One hop per cursor. QStash can deliver a hop twice, and each copy would
+ * re-index the rest of the pass and dispatch its own continuation.
+ */
+export function partnerSearchSweepDeduplicationId(after?: string | null) {
+  return `partner-search-sweep-${after ?? "start"}`;
+}
+
 const inputSchema = z.object({
   /** Keyset cursor, carried across hops. Absent starts a fresh pass. */
   after: z.string().optional(),
@@ -43,12 +51,14 @@ export const partnerSearchSweepJob = defineJob({
     if (done) {
       console.log(
         `[partnerSearchSweepJob] Pass complete. Re-indexed ${totalProcessed} documents.`,
+        { totalProcessed },
       );
       return;
     }
 
     console.log(
       `[partnerSearchSweepJob] Re-indexed ${totalProcessed} documents so far, continuing after ${lastDocumentId}.`,
+      { after: lastDocumentId, processedInHop: processed, totalProcessed },
     );
 
     await partnerSearchSweepJob.dispatch(
@@ -58,6 +68,7 @@ export const partnerSearchSweepJob = defineJob({
       },
       {
         delay: 1,
+        deduplicationId: partnerSearchSweepDeduplicationId(lastDocumentId),
       },
     );
   },

--- a/apps/web/lib/jobs/handlers/partner-search-sweep-job.ts
+++ b/apps/web/lib/jobs/handlers/partner-search-sweep-job.ts
@@ -9,10 +9,8 @@ const inputSchema = z.object({
   /** Keyset cursor, carried across hops. Absent starts a fresh pass. */
   after: z.string().optional(),
   /**
-   * Documents indexed so far in this pass, for logging continuity. Defaulted in
-   * the handler rather than by the schema, because defineJob types the dispatch
-   * payload from the schema's output and a zod default would make this required
-   * at every call site.
+   * Documents indexed so far in this pass, for logging. Defaulted in the
+   * handler. A zod default would make it required in the dispatch payload type.
    */
   processed: z.number().int().nonnegative().optional(),
 });
@@ -23,8 +21,7 @@ export const partnerSearchSweepJob = defineJob({
   defaults: {
     retries: 3,
     flowControl: {
-      // A pass is inherently sequential, and holding it to one in flight keeps
-      // a long sweep from competing with interactive syncs for write capacity.
+      // Hops are sequential. One in flight bounds the sweep's write load.
       key: "partner-search-sweep",
       parallelism: 1,
     },
@@ -54,8 +51,6 @@ export const partnerSearchSweepJob = defineJob({
       `[partnerSearchSweepJob] Re-indexed ${totalProcessed} documents so far, continuing after ${lastDocumentId}.`,
     );
 
-    // Cursor lives in the payload rather than in storage, so a pass needs no
-    // state of its own and an interrupted one simply restarts on the next cron.
     await partnerSearchSweepJob.dispatch(
       {
         ...(lastDocumentId && { after: lastDocumentId }),

--- a/apps/web/lib/jobs/registry.ts
+++ b/apps/web/lib/jobs/registry.ts
@@ -35,6 +35,11 @@ const jobLoaders = {
       (m) => m.partnerSearchSyncJob,
     ),
 
+  "partner-search-sweep-job": () =>
+    import("./handlers/partner-search-sweep-job").then(
+      (m) => m.partnerSearchSweepJob,
+    ),
+
   "welcome-user-job": () =>
     import("./handlers/welcome-user-job").then((m) => m.welcomeUserJob),
 

--- a/apps/web/tests/partners/partner-search-sweep-job.test.ts
+++ b/apps/web/tests/partners/partner-search-sweep-job.test.ts
@@ -1,4 +1,7 @@
-import { partnerSearchSweepJob } from "@/lib/jobs/handlers/partner-search-sweep-job";
+import {
+  partnerSearchSweepDeduplicationId,
+  partnerSearchSweepJob,
+} from "@/lib/jobs/handlers/partner-search-sweep-job";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -64,7 +67,7 @@ describe("partnerSearchSweepJob", () => {
     expect(mocks.sweepPartnerSearch).toHaveBeenCalledWith({ after: undefined });
     expect(dispatch).toHaveBeenCalledWith(
       { after: "pge_20", processed: 20 },
-      { delay: 1 },
+      { delay: 1, deduplicationId: "partner-search-sweep-pge_20" },
     );
   });
 
@@ -84,7 +87,16 @@ describe("partnerSearchSweepJob", () => {
     expect(mocks.sweepPartnerSearch).toHaveBeenCalledWith({ after: "pge_10" });
     expect(dispatch).toHaveBeenCalledWith(
       { after: "pge_20", processed: 50 },
-      { delay: 1 },
+      { delay: 1, deduplicationId: "partner-search-sweep-pge_20" },
+    );
+  });
+
+  it("gives every hop of a pass a cursor-bound deduplication id", () => {
+    expect(partnerSearchSweepDeduplicationId()).toBe(
+      "partner-search-sweep-start",
+    );
+    expect(partnerSearchSweepDeduplicationId("pge_20")).toBe(
+      "partner-search-sweep-pge_20",
     );
   });
 });

--- a/apps/web/tests/partners/partner-search-sweep-job.test.ts
+++ b/apps/web/tests/partners/partner-search-sweep-job.test.ts
@@ -1,0 +1,70 @@
+import { partnerSearchSweepJob } from "@/lib/jobs/handlers/partner-search-sweep-job";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getPartnerSearchProvider: vi.fn(),
+  sweepPartnerSearch: vi.fn(),
+}));
+
+vi.mock("@/lib/api/partners/search", () => ({
+  getPartnerSearchProvider: mocks.getPartnerSearchProvider,
+  sweepPartnerSearch: mocks.sweepPartnerSearch,
+}));
+
+describe("partnerSearchSweepJob", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mocks.getPartnerSearchProvider
+      .mockReset()
+      .mockReturnValue({ name: "turbopuffer" });
+    mocks.sweepPartnerSearch.mockReset().mockResolvedValue({
+      processed: 0,
+      lastDocumentId: null,
+      done: true,
+    });
+  });
+
+  it("skips entirely when no provider is configured", async () => {
+    mocks.getPartnerSearchProvider.mockReturnValue(null);
+
+    await partnerSearchSweepJob.execute({});
+
+    expect(mocks.sweepPartnerSearch).not.toHaveBeenCalled();
+  });
+
+  it("stops when the pass is done", async () => {
+    const dispatch = vi
+      .spyOn(partnerSearchSweepJob, "dispatch")
+      .mockResolvedValue({ status: "published", messageId: "msg_1" });
+
+    mocks.sweepPartnerSearch.mockResolvedValue({
+      processed: 12,
+      lastDocumentId: "pge_12",
+      done: true,
+    });
+
+    await partnerSearchSweepJob.execute({});
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("carries the cursor and running total to the next hop", async () => {
+    const dispatch = vi
+      .spyOn(partnerSearchSweepJob, "dispatch")
+      .mockResolvedValue({ status: "published", messageId: "msg_1" });
+
+    mocks.sweepPartnerSearch.mockResolvedValue({
+      processed: 20,
+      lastDocumentId: "pge_20",
+      done: false,
+    });
+
+    await partnerSearchSweepJob.execute({ after: "pge_10", processed: 30 });
+
+    expect(mocks.sweepPartnerSearch).toHaveBeenCalledWith({ after: "pge_10" });
+    expect(dispatch).toHaveBeenCalledWith(
+      { after: "pge_20", processed: 50 },
+      { delay: 1 },
+    );
+  });
+});

--- a/apps/web/tests/partners/partner-search-sweep-job.test.ts
+++ b/apps/web/tests/partners/partner-search-sweep-job.test.ts
@@ -48,6 +48,26 @@ describe("partnerSearchSweepJob", () => {
     expect(dispatch).not.toHaveBeenCalled();
   });
 
+  it("starts the running total from zero on the first hop", async () => {
+    const dispatch = vi
+      .spyOn(partnerSearchSweepJob, "dispatch")
+      .mockResolvedValue({ status: "published", messageId: "msg_1" });
+
+    mocks.sweepPartnerSearch.mockResolvedValue({
+      processed: 20,
+      lastDocumentId: "pge_20",
+      done: false,
+    });
+
+    await partnerSearchSweepJob.execute({});
+
+    expect(mocks.sweepPartnerSearch).toHaveBeenCalledWith({ after: undefined });
+    expect(dispatch).toHaveBeenCalledWith(
+      { after: "pge_20", processed: 20 },
+      { delay: 1 },
+    );
+  });
+
   it("carries the cursor and running total to the next hop", async () => {
     const dispatch = vi
       .spyOn(partnerSearchSweepJob, "dispatch")

--- a/apps/web/tests/partners/partner-search-sweep.test.ts
+++ b/apps/web/tests/partners/partner-search-sweep.test.ts
@@ -1,0 +1,197 @@
+import {
+  PARTNER_SEARCH_SWEEP_TIME_BUDGET_MS,
+  partnerSearchDocumentSelect,
+  sweepPartnerSearch,
+  type PartnerSearchDocumentSource,
+  type PartnerSearchProvider,
+} from "@/lib/api/partners/search";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  findMany: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    programEnrollment: {
+      findMany: mocks.findMany,
+    },
+  },
+}));
+
+function createSource(id: string): PartnerSearchDocumentSource {
+  return {
+    id,
+    programId: "prog_test",
+    partnerId: `pn_${id}`,
+    status: "approved" as const,
+    groupId: null,
+    partner: {
+      name: "Rafi Hasan",
+      email: "partner@example.com",
+      companyName: null,
+      description: null,
+      country: null,
+      programPartnerTags: [],
+      platforms: [],
+    },
+    links: [],
+  };
+}
+
+function createProvider(): PartnerSearchProvider {
+  return {
+    searchCandidates: vi.fn(),
+    countCandidates: vi.fn(),
+    upsert: vi.fn(),
+    delete: vi.fn(),
+  };
+}
+
+describe("sweepPartnerSearch", () => {
+  beforeEach(() => {
+    mocks.findMany.mockReset();
+  });
+
+  it("re-indexes the whole corpus rather than a filtered slice", async () => {
+    const searchProvider = createProvider();
+    mocks.findMany.mockResolvedValueOnce([createSource("pge_1")]);
+
+    await sweepPartnerSearch({ batchSize: 2, searchProvider });
+
+    expect(mocks.findMany).toHaveBeenCalledWith({
+      where: {},
+      select: partnerSearchDocumentSelect,
+      orderBy: { id: "asc" },
+      take: 2,
+    });
+  });
+
+  it("reports the pass as done when a page comes back short", async () => {
+    const searchProvider = createProvider();
+    mocks.findMany.mockResolvedValueOnce([createSource("pge_1")]);
+
+    const result = await sweepPartnerSearch({ batchSize: 2, searchProvider });
+
+    expect(result).toEqual({
+      processed: 1,
+      lastDocumentId: "pge_1",
+      done: true,
+    });
+  });
+
+  it("stops at the time budget and returns a resumable cursor", async () => {
+    const searchProvider = createProvider();
+    mocks.findMany
+      .mockResolvedValueOnce([createSource("pge_1"), createSource("pge_2")])
+      .mockResolvedValueOnce([createSource("pge_3"), createSource("pge_4")]);
+
+    // Each batch costs 40s against a 60s budget, so the second one crosses it.
+    let clock = 0;
+    const now = () => (clock += 40_000);
+
+    const result = await sweepPartnerSearch({
+      batchSize: 2,
+      timeBudgetMs: 60_000,
+      now,
+      searchProvider,
+    });
+
+    expect(result).toEqual({
+      processed: 4,
+      lastDocumentId: "pge_4",
+      done: false,
+    });
+    expect(mocks.findMany).toHaveBeenCalledTimes(2);
+  });
+
+  // Otherwise a hop that starts with no time left makes no progress, and the
+  // pass retries the same cursor forever without advancing.
+  it("always indexes at least one batch, however tight the budget", async () => {
+    const searchProvider = createProvider();
+    mocks.findMany.mockResolvedValueOnce([
+      createSource("pge_1"),
+      createSource("pge_2"),
+    ]);
+
+    // Budget already blown by the time the first batch finishes.
+    let reads = 0;
+    const now = () => (reads++ === 0 ? 0 : 10_000);
+
+    const result = await sweepPartnerSearch({
+      batchSize: 2,
+      timeBudgetMs: 1,
+      now,
+      searchProvider,
+    });
+
+    expect(result.processed).toBe(2);
+    expect(result.lastDocumentId).toBe("pge_2");
+    expect(mocks.findMany).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports done rather than exhausted when the range runs out first", async () => {
+    const searchProvider = createProvider();
+    mocks.findMany.mockResolvedValueOnce([createSource("pge_1")]);
+
+    const result = await sweepPartnerSearch({
+      batchSize: 2,
+      timeBudgetMs: 60_000,
+      now: () => 0,
+      searchProvider,
+    });
+
+    expect(result.done).toBe(true);
+  });
+
+  it("resumes from the cursor it was given", async () => {
+    const searchProvider = createProvider();
+    mocks.findMany.mockResolvedValueOnce([]);
+
+    await sweepPartnerSearch({
+      after: "pge_100",
+      batchSize: 2,
+      searchProvider,
+    });
+
+    expect(mocks.findMany.mock.calls[0][0].where).toEqual({
+      id: { gt: "pge_100" },
+    });
+  });
+
+  it("never deletes, because an out-of-range id looks the same as a missing one", async () => {
+    const searchProvider = createProvider();
+    mocks.findMany.mockResolvedValueOnce([createSource("pge_1")]);
+
+    await sweepPartnerSearch({ batchSize: 2, searchProvider });
+
+    expect(searchProvider.delete).not.toHaveBeenCalled();
+    expect(searchProvider.upsert).toHaveBeenCalledTimes(1);
+  });
+
+  it("requires a configured provider", async () => {
+    await expect(sweepPartnerSearch({ searchProvider: null })).rejects.toThrow(
+      "Partner search provider is not configured.",
+    );
+
+    expect(mocks.findMany).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-positive time budget", async () => {
+    const searchProvider = createProvider();
+
+    await expect(
+      sweepPartnerSearch({ timeBudgetMs: 0, searchProvider }),
+    ).rejects.toThrow("Time budget must be a positive integer.");
+  });
+
+  // The hop budget is only meaningful if it finishes well inside the function
+  // limit, since the batch in flight when it expires cannot be interrupted.
+  it("leaves the job route room to finish the batch in flight", () => {
+    const JOB_ROUTE_MAX_DURATION_MS = 600_000;
+
+    expect(PARTNER_SEARCH_SWEEP_TIME_BUDGET_MS).toBeLessThanOrEqual(
+      JOB_ROUTE_MAX_DURATION_MS / 2,
+    );
+  });
+});

--- a/apps/web/tests/partners/partner-search-sweep.test.ts
+++ b/apps/web/tests/partners/partner-search-sweep.test.ts
@@ -177,6 +177,16 @@ describe("sweepPartnerSearch", () => {
     expect(mocks.findMany).not.toHaveBeenCalled();
   });
 
+  it("rejects a non-positive batch size", async () => {
+    const searchProvider = createProvider();
+
+    await expect(
+      sweepPartnerSearch({ batchSize: 0, searchProvider }),
+    ).rejects.toThrow("Batch size must be a positive integer.");
+
+    expect(mocks.findMany).not.toHaveBeenCalled();
+  });
+
   it("rejects a non-positive time budget", async () => {
     const searchProvider = createProvider();
 

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -95,6 +95,10 @@
     {
       "path": "/api/cron/campaigns/queue-scheduled",
       "schedule": "* * * * *"
+    },
+    {
+      "path": "/api/cron/partners/search-sweep",
+      "schedule": "0 3 * * 0"
     }
   ],
   "functions": {


### PR DESCRIPTION
# Partner search: weekly reconciliation sweep

Follows [#4343](https://github.com/dubinc/dub/pull/4343) and the jobs outbox in [#4419](https://github.com/dubinc/dub/pull/4419). The outbox covers one failure: a sync was queued and the publish failed. This covers drift that never reached the queue: a write path with no hook, a process that died between the database write and the queue call, a job that exhausted its retries, or another deployment writing old-format documents into the shared namespace. Any of those is corrected by the next pass.

Upserts only, so a missed delete still leaves a document behind. Deletes rest on the hooks in #4343.

## How it works

- Weekly cron (`0 3 * * 0`) kicks off `partner-search-sweep-job`, which re-indexes the whole corpus in self-dispatching hops under a 240s time budget (the job route allows 600s; the margin covers the batch in flight when the budget expires).
- The keyset cursor lives in the job payload rather than in storage, so a pass needs no state of its own and an interrupted one simply restarts on the next cron.
- Held to one hop in flight (`parallelism: 1`), so a long sweep never competes with interactive syncs for write capacity.
- It re-indexes everything rather than filtering by timestamp, because a watermark misses tag changes (`ProgramPartnerTag` has no timestamps) and link edits (which move neither the enrollment's timestamp nor the partner's).
- Upserts only: an ID absent from a range scan looks identical to one that was never in range, so deletions rest entirely on the sync hooks in #4343.

## Testing

13 unit tests: the sweep always makes progress however tight its budget, resumes from the cursor, and the job re-dispatches itself with the carried total until the pass completes.


## Known limitation: a slow sweep write can overwrite a newer sync write

The sweep reads a batch and writes that snapshot with no version check. A mutation can land after the read, its live sync can write the fresh document, and the slower sweep write then restores the stale one. The sweep and sync jobs use different QStash flow-control keys, so nothing orders them against each other.

The damage is bounded: stale status, group, country, or tag data in the index until the next sync for that enrollment or the next weekly pass, and the database re-applies every filter, so a stale document can hide a row from search results but never surface a wrong one. Left as a follow-up: either an ordered write path or a document version that stops an older snapshot from replacing a newer one.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated partner search re-indexing in resumable batches.
  - Added a weekly scheduled sweep to keep partner search results up to date.
  - Added progress tracking and sequential processing for reliable indexing.
  - Sweeps safely skip when partner search is not configured.
  - Re-indexing preserves existing search documents while processing large datasets incrementally.
  - Improved reliability by preventing duplicate sweep processing.

- **Tests**
  - Added coverage for completed, resumable, time-limited, and unconfigured search sweeps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->