### PR TITLE
Feature/partner-search: exports skip the search field

### DIFF
--- a/apps/web/lib/zod/schemas/partners.ts
+++ b/apps/web/lib/zod/schemas/partners.ts
@@ -322,8 +322,9 @@ export const getPartnersRouteQuerySchema = getPartnersQuerySchemaExtended
   );
 
 export const partnersExportQuerySchema = getPartnersQuerySchemaExtended
-  .omit({ page: true, pageSize: true })
+  .omit({ page: true, pageSize: true, search: true })
   .extend({
+    sortBy: getPartnersQuerySchema.shape.sortBy,
     columns: z
       .string()
       .default(exportPartnersColumnsDefault.join(","))

--- a/apps/web/tests/partners/get-partners-route-query.test.ts
+++ b/apps/web/tests/partners/get-partners-route-query.test.ts
@@ -1,4 +1,7 @@
-import { getPartnersRouteQuerySchema } from "@/lib/zod/schemas/partners";
+import {
+  getPartnersRouteQuerySchema,
+  partnersExportQuerySchema,
+} from "@/lib/zod/schemas/partners";
 import { describe, expect, it } from "vitest";
 
 const accepts = (params: Record<string, unknown>) =>
@@ -62,5 +65,27 @@ describe("getPartnersRouteQuerySchema", () => {
     expect(result.error?.issues[0].message).toContain(
       "sortBy=relevance requires a non-empty search",
     );
+  });
+});
+
+describe("partnersExportQuerySchema", () => {
+  // Exports do not apply the search field: its provider results are capped at
+  // the candidate ceiling, so exporting them would silently truncate the file.
+  it("strips the search field", () => {
+    const result = partnersExportQuerySchema.safeParse({
+      sortBy: "totalSaleAmount",
+      search: "examp",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data).not.toHaveProperty("search");
+  });
+
+  it("rejects relevance, which cannot exist without a search", () => {
+    expect(
+      partnersExportQuerySchema.safeParse({
+        sortBy: "relevance",
+      }).success,
+    ).toBe(false);
   });
 });

--- a/apps/web/ui/modals/export-partners-modal.tsx
+++ b/apps/web/ui/modals/export-partners-modal.tsx
@@ -71,7 +71,13 @@ function ExportPartnersModal({
       };
 
       const searchParams = data.useFilters
-        ? getQueryString(params, { exclude: ["search"] })
+        ? getQueryString(params, {
+            exclude: [
+              "search",
+              // Relevance only exists for searches, which exports skip
+              ...(searchParamsObj.sortBy === "relevance" ? ["sortBy"] : []),
+            ],
+          })
         : "?" + new URLSearchParams(params);
 
       const response = await fetch(`/api/partners/export${searchParams}`, {

--- a/apps/web/ui/modals/export-partners-modal.tsx
+++ b/apps/web/ui/modals/export-partners-modal.tsx
@@ -8,7 +8,6 @@ import {
 import {
   Button,
   Checkbox,
-  InfoTooltip,
   Modal,
   Switch,
   useRouterStuff,
@@ -72,7 +71,7 @@ function ExportPartnersModal({
       };
 
       const searchParams = data.useFilters
-        ? getQueryString(params)
+        ? getQueryString(params, { exclude: ["search"] })
         : "?" + new URLSearchParams(params);
 
       const response = await fetch(`/api/partners/export${searchParams}`, {
@@ -167,11 +166,16 @@ function ExportPartnersModal({
             name="useFilters"
             control={control}
             render={({ field }) => (
-              <div className="flex items-center justify-between gap-2">
-                <span className="flex select-none items-center gap-2 text-sm font-medium text-neutral-600 group-hover:text-neutral-800">
-                  Apply current filters
-                  <InfoTooltip content="Filter exported partners by your currently selected filters" />
-                </span>
+              <div className="flex items-start justify-between gap-2">
+                <div className="flex select-none flex-col gap-1">
+                  <span className="text-sm font-medium text-neutral-600 group-hover:text-neutral-800">
+                    Apply current filters
+                  </span>
+                  <span className="text-xs text-neutral-500">
+                    Filter exported partners by your currently selected
+                    filters. The search field is not included.
+                  </span>
+                </div>
                 <Switch checked={field.value} fn={field.onChange} />
               </div>
             )}


### PR DESCRIPTION
# Partner search: exports skip the search field

Instead of running exports through the database search path, exports simply do not apply the search field. Search results are capped at the provider's candidate ceiling, so applying search to an export would silently truncate the file. Every other filter still applies.

## What changed

- `partnersExportQuerySchema` omits `search`, so the field is stripped from parsed params on both export paths (inline and background batch). `sortBy=relevance` is rejected since nothing remains to rank.
- The export modal excludes `search` from the request and says so in plain text under the "Apply current filters" toggle (moved out of the info tooltip): "Filter exported partners by your currently selected filters. The search field is not included."

## Testing

Schema tests: `search` stripped from parsed export params, `relevance` rejected.

## UI/Demo

<img width="438" height="84" alt="Screenshot 2026-08-31 at 4 13 43 PM" src="https://github.com/user-attachments/assets/aeef5666-7d8e-47b3-bca2-38701f3390a9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Partner exports now reject unsupported relevance sorting instead of silently changing the sort order.
- Search terms are excluded when exporting partners with current filters applied.
- Supported database-backed sorting options remain available for exports.

## UI Improvements
- Updated the export filter description to clarify that search terms aren’t included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->