### PR TITLE
Fix mobile horizontal overflow for long URLs in messages

### DIFF
--- a/apps/web/ui/messages/message-markdown.tsx
+++ b/apps/web/ui/messages/message-markdown.tsx
@@ -17,7 +17,7 @@ export function MessageMarkdown({
   return (
     <ReactMarkdown
       className={cn(
-        "prose prose-sm prose-neutral max-w-none transition-all",
+        "prose prose-sm prose-neutral max-w-none break-words transition-all [overflow-wrap:anywhere]",
         "prose-headings:font-semibold prose-headings:border-b prose-headings:pb-2",
         "prose-h1:text-2xl prose-h1:font-bold prose-h1:mt-8 prose-h1:mb-4",
         "prose-h2:text-xl prose-h2:font-semibold prose-h2:mt-6 prose-h2:mb-3",

--- a/apps/web/ui/messages/messages-panel.tsx
+++ b/apps/web/ui/messages/messages-panel.tsx
@@ -250,7 +250,7 @@ export function MessagesPanel({
                           {message.text && (
                             <div
                               className={cn(
-                                "max-w-[min(100%,512px)] rounded-xl px-4 py-2.5 text-sm",
+                                "min-w-0 max-w-[min(100%,512px)] rounded-xl px-4 py-2.5 text-sm",
                                 isMySide
                                   ? "rounded-br bg-neutral-700"
                                   : "rounded-bl bg-neutral-100",
@@ -493,7 +493,7 @@ function CampaignMessage({
 
         <div
           className={cn(
-            "max-w-[min(100%,512px)] rounded-xl text-sm",
+            "min-w-0 max-w-[min(100%,512px)] rounded-xl text-sm",
             isMySide
               ? "text-content-inverted rounded-br bg-neutral-700"
               : "text-content-default rounded-bl bg-neutral-100",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Long unbroken URLs in partner/program message bubbles were expanding past the viewport on mobile because `MessageMarkdown` had no word-break styles.

## Changes
- Add `break-words` and `overflow-wrap: anywhere` on `MessageMarkdown` prose so long URLs wrap inside the bubble
- Add `min-w-0` on message bubbles (including campaign email bubbles) so flex layout can shrink correctly

## Test plan
- [ ] Open messages on a narrow/mobile viewport
- [ ] Send or view a message containing a long Google Docs (or similar) URL with no spaces
- [ ] Confirm the URL wraps inside the bubble and the page does not scroll horizontally
- [ ] Spot-check normal short messages and campaign email expand/collapse still look correct

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://dub.slack.com/archives/C072M31K2CU/p1787846168583829?thread_ts=1787846168.583829&cid=C072M31K2CU)

<div><a href="https://cursor.com/agents/bc-f295c82a-cfde-575f-92b7-19195589b8d9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f295c82a-cfde-575f-92b7-19195589b8d9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message display so long words and unbroken text wrap correctly.
  * Prevented message bubbles from expanding beyond the available panel width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->