### PR TITLE
Allow mapping event names for Google Ads settings

### DIFF
--- a/apps/web/lib/api/conversions/track-lead.ts
+++ b/apps/web/lib/api/conversions/track-lead.ts
@@ -357,6 +357,7 @@ export const trackLead = async ({
               workspaceId: workspace.id,
               eventType: EventType.lead,
               eventId: leadEventId,
+              eventName,
               conversionDateTime: new Date().toISOString(),
               conversionCount: eventQuantity ?? undefined,
               click: {

--- a/apps/web/lib/api/conversions/track-sale.ts
+++ b/apps/web/lib/api/conversions/track-sale.ts
@@ -645,6 +645,7 @@ const _trackSale = async ({
         queueGoogleAdsConversionUpload({
           workspaceId: workspace.id,
           eventType: EventType.sale,
+          eventName,
           conversionDateTime: new Date().toISOString(),
           eventId: saleData.event_id,
           conversionValue: amount / 100, // Data Manager expects major currency units

--- a/apps/web/lib/integrations/google-ads/constants.ts
+++ b/apps/web/lib/integrations/google-ads/constants.ts
@@ -5,8 +5,8 @@ export const GOOGLE_ADS_DEFAULT_SETTINGS = {
   customerId: null,
   loginCustomerId: null,
   customerName: null,
-  leadConversionAction: null,
-  saleConversionAction: null,
+  leadMappings: [],
+  saleMappings: [],
 } as const;
 
 export const GOOGLE_ADS_OAUTH_SCOPE = [

--- a/apps/web/lib/integrations/google-ads/schema.ts
+++ b/apps/web/lib/integrations/google-ads/schema.ts
@@ -18,13 +18,19 @@ export const googleAdsCustomerSchema = z.object({
   loginCustomerId: z.string().nullish(),
 });
 
+export const googleAdsEventMappingSchema = z.object({
+  conversionAction: z.string().min(1),
+  // Empty means this mapping matches all event names of that type
+  eventNames: z.array(z.string().trim().min(1).max(255)).max(50).default([]),
+});
+
 export const googleAdsSettingsSchema = z.object({
   customers: z.array(googleAdsCustomerSchema).default([]),
   customerId: z.string().nullish(),
   loginCustomerId: z.string().nullish(),
   customerName: z.string().nullish(),
-  leadConversionAction: z.string().nullish(),
-  saleConversionAction: z.string().nullish(),
+  leadMappings: z.array(googleAdsEventMappingSchema).max(50).default([]),
+  saleMappings: z.array(googleAdsEventMappingSchema).max(50).default([]),
 });
 
 export const googleAdsConversionActionSchema = z.object({
@@ -42,6 +48,7 @@ export const googleAdsConversionUploadSchema = z.object({
   }),
   conversionDateTime: z.string(),
   eventId: z.string(),
+  eventName: z.string().optional(),
   conversionValue: z.number().optional(),
   currencyCode: z.string().optional(),
   conversionCount: z.number().positive().optional(),

--- a/apps/web/lib/integrations/google-ads/ui/settings.tsx
+++ b/apps/web/lib/integrations/google-ads/ui/settings.tsx
@@ -3,10 +3,11 @@
 import useWorkspace from "@/lib/swr/use-workspace";
 import { InstalledIntegrationInfoProps } from "@/lib/types";
 import { Button, Combobox, ComboboxOption } from "@dub/ui";
-import { fetcher } from "@dub/utils";
+import { fetcher, nFormatter } from "@dub/utils";
 import { ChevronDown } from "lucide-react";
 import { useAction } from "next-safe-action/hooks";
 import { useEffect, useMemo } from "react";
+import type { Control } from "react-hook-form";
 import { Controller, useForm } from "react-hook-form";
 import { toast } from "sonner";
 import useSWR from "swr";
@@ -14,6 +15,7 @@ import * as z from "zod/v4";
 import { GOOGLE_ADS_DEFAULT_SETTINGS } from "../constants";
 import {
   googleAdsConversionActionSchema,
+  googleAdsEventMappingSchema,
   googleAdsSettingsSchema,
 } from "../schema";
 import { updateGoogleAdsSettingsAction } from "../update-google-ads-settings";
@@ -23,16 +25,43 @@ type GoogleAdsCustomerOption = ComboboxOption<{
   manager: boolean;
 }>;
 
+type EventNameOption = ComboboxOption<{
+  count?: number;
+}>;
+
+type EventMapping = z.infer<typeof googleAdsEventMappingSchema>;
+
 type FormData = {
-  [K in keyof Omit<
-    z.infer<typeof googleAdsSettingsSchema>,
-    "customers"
-  >]: string;
+  customerId: string;
+  loginCustomerId: string;
+  customerName: string;
+  leadMappings: EventMapping[];
+  saleMappings: EventMapping[];
 };
 
 type ConversionActionsResponse = {
   conversionActions: z.infer<typeof googleAdsConversionActionSchema>[];
   loginCustomerId: string | null;
+};
+
+type EventNameRow = {
+  eventName: string;
+  leads: number;
+  sales: number;
+};
+
+const createEmptyMapping = (): EventMapping => ({
+  conversionAction: "",
+  eventNames: [],
+});
+
+const comboboxCaret = (
+  <ChevronDown className="text-content-muted size-3.5 shrink-0 transition-transform duration-75 group-data-[state=open]:rotate-180" />
+);
+
+const comboboxButtonProps = {
+  className:
+    "h-9 w-full max-w-none justify-between gap-1.5 px-3 py-0 text-sm font-normal shadow-none",
 };
 
 export const GoogleAdsSettings = ({
@@ -51,14 +80,18 @@ export const GoogleAdsSettings = ({
       customerId: googleAdsSettings.customerId ?? "",
       loginCustomerId: googleAdsSettings.loginCustomerId ?? "",
       customerName: googleAdsSettings.customerName ?? "",
-      leadConversionAction: googleAdsSettings.leadConversionAction ?? "",
-      saleConversionAction: googleAdsSettings.saleConversionAction ?? "",
+      leadMappings: toFormMappings(googleAdsSettings.leadMappings),
+      saleMappings: toFormMappings(googleAdsSettings.saleMappings),
     },
   });
 
   const customerId = watch("customerId");
-  const leadConversionAction = watch("leadConversionAction");
-  const saleConversionAction = watch("saleConversionAction");
+  const leadMappings = watch("leadMappings");
+  const saleMappings = watch("saleMappings");
+  const leadConversionAction = leadMappings[0]?.conversionAction ?? "";
+  const saleConversionAction = saleMappings[0]?.conversionAction ?? "";
+  const leadEventNames = leadMappings[0]?.eventNames ?? [];
+  const saleEventNames = saleMappings[0]?.eventNames ?? [];
 
   const customerOptions = useMemo<GoogleAdsCustomerOption[]>(
     () =>
@@ -84,6 +117,28 @@ export const GoogleAdsSettings = ({
     fetcher,
   );
 
+  const {
+    data: leadEventNamesData,
+    isLoading: isLoadingLeadEventNames,
+    error: leadEventNamesError,
+  } = useSWR<EventNameRow[]>(
+    workspaceId && installed && leadConversionAction
+      ? `/api/analytics?event=leads&groupBy=event_names&interval=90d&workspaceId=${workspaceId}`
+      : null,
+    fetcher,
+  );
+
+  const {
+    data: saleEventNamesData,
+    isLoading: isLoadingSaleEventNames,
+    error: saleEventNamesError,
+  } = useSWR<EventNameRow[]>(
+    workspaceId && installed && saleConversionAction
+      ? `/api/analytics?event=sales&groupBy=event_names&interval=90d&workspaceId=${workspaceId}`
+      : null,
+    fetcher,
+  );
+
   useEffect(() => {
     if (conversionActionsError) {
       toast.error(
@@ -92,6 +147,22 @@ export const GoogleAdsSettings = ({
       );
     }
   }, [conversionActionsError]);
+
+  useEffect(() => {
+    if (leadEventNamesError) {
+      toast.error(
+        leadEventNamesError.message || "Failed to load lead event names.",
+      );
+    }
+  }, [leadEventNamesError]);
+
+  useEffect(() => {
+    if (saleEventNamesError) {
+      toast.error(
+        saleEventNamesError.message || "Failed to load sale event names.",
+      );
+    }
+  }, [saleEventNamesError]);
 
   useEffect(() => {
     if (!conversionActionsData) {
@@ -108,6 +179,26 @@ export const GoogleAdsSettings = ({
         label: action.name,
       })),
     [conversionActionsData?.conversionActions],
+  );
+
+  const leadEventNameOptions = useMemo(
+    () =>
+      buildEventNameOptions({
+        rows: leadEventNamesData,
+        selected: leadEventNames,
+        countKey: "leads",
+      }),
+    [leadEventNamesData, leadEventNames],
+  );
+
+  const saleEventNameOptions = useMemo(
+    () =>
+      buildEventNameOptions({
+        rows: saleEventNamesData,
+        selected: saleEventNames,
+        countKey: "sales",
+      }),
+    [saleEventNamesData, saleEventNames],
   );
 
   const { executeAsync: saveSettings, isPending: isSaving } = useAction(
@@ -155,8 +246,8 @@ export const GoogleAdsSettings = ({
       customerId: data.customerId || null,
       loginCustomerId: data.loginCustomerId || null,
       customerName: data.customerName || null,
-      leadConversionAction: data.leadConversionAction || null,
-      saleConversionAction: data.saleConversionAction || null,
+      leadMappings: sanitizeMappings(data.leadMappings),
+      saleMappings: sanitizeMappings(data.saleMappings),
     });
   };
 
@@ -197,18 +288,13 @@ export const GoogleAdsSettings = ({
                     setValue("customerId", option.value);
                     setValue("customerName", option.label);
                     setValue("loginCustomerId", "");
-                    setValue("leadConversionAction", "");
-                    setValue("saleConversionAction", "");
+                    setValue("leadMappings", [createEmptyMapping()]);
+                    setValue("saleMappings", [createEmptyMapping()]);
                   }}
                   placeholder="Select account"
                   matchTriggerWidth
-                  caret={
-                    <ChevronDown className="text-content-muted size-3.5 shrink-0 transition-transform duration-75 group-data-[state=open]:rotate-180" />
-                  }
-                  buttonProps={{
-                    className:
-                      "h-9 w-full max-w-none justify-between gap-1.5 px-3 py-0 text-sm font-normal shadow-none",
-                  }}
+                  caret={comboboxCaret}
+                  buttonProps={comboboxButtonProps}
                 />
               )}
             />
@@ -229,7 +315,7 @@ export const GoogleAdsSettings = ({
                   action.
                 </p>
                 <Controller
-                  name="leadConversionAction"
+                  name="leadMappings.0.conversionAction"
                   control={control}
                   render={({ field }) => (
                     <Combobox
@@ -246,16 +332,24 @@ export const GoogleAdsSettings = ({
                           : "Select lead conversion action"
                       }
                       matchTriggerWidth
-                      caret={
-                        <ChevronDown className="text-content-muted size-3.5 shrink-0 transition-transform duration-75 group-data-[state=open]:rotate-180" />
-                      }
-                      buttonProps={{
-                        className:
-                          "h-9 w-full max-w-none justify-between gap-1.5 px-3 py-0 text-sm font-normal shadow-none",
-                      }}
+                      caret={comboboxCaret}
+                      buttonProps={comboboxButtonProps}
                     />
                   )}
                 />
+
+                {leadConversionAction && (
+                  <EventNamesField
+                    name="leadMappings.0.eventNames"
+                    control={control}
+                    options={leadEventNameOptions}
+                    isLoading={isLoadingLeadEventNames}
+                    label="Lead event names"
+                    description="Choose which Dub lead event names to upload as this conversion. If none are selected, all lead events will be sent. Options are based on your top lead events from the last 90 days."
+                    placeholder="All lead events"
+                    emptyState="No lead events in the last 90 days. Type a name to add one."
+                  />
+                )}
               </div>
 
               <div>
@@ -267,7 +361,7 @@ export const GoogleAdsSettings = ({
                   action.
                 </p>
                 <Controller
-                  name="saleConversionAction"
+                  name="saleMappings.0.conversionAction"
                   control={control}
                   render={({ field }) => (
                     <Combobox
@@ -284,16 +378,24 @@ export const GoogleAdsSettings = ({
                           : "Select sale conversion action"
                       }
                       matchTriggerWidth
-                      caret={
-                        <ChevronDown className="text-content-muted size-3.5 shrink-0 transition-transform duration-75 group-data-[state=open]:rotate-180" />
-                      }
-                      buttonProps={{
-                        className:
-                          "h-9 w-full max-w-none justify-between gap-1.5 px-3 py-0 text-sm font-normal shadow-none",
-                      }}
+                      caret={comboboxCaret}
+                      buttonProps={comboboxButtonProps}
                     />
                   )}
                 />
+
+                {saleConversionAction && (
+                  <EventNamesField
+                    name="saleMappings.0.eventNames"
+                    control={control}
+                    options={saleEventNameOptions}
+                    isLoading={isLoadingSaleEventNames}
+                    label="Sale event names"
+                    description="Choose which Dub sale event names to upload as this conversion. If none are selected, all sale events will be sent. Options are based on your top sale events from the last 90 days."
+                    placeholder="All sale events"
+                    emptyState="No sale events in the last 90 days. Type a name to add one."
+                  />
+                )}
               </div>
             </>
           )}
@@ -309,3 +411,124 @@ export const GoogleAdsSettings = ({
     </form>
   );
 };
+
+function toFormMappings(mappings: EventMapping[]): EventMapping[] {
+  if (mappings.length === 0) {
+    return [createEmptyMapping()];
+  }
+
+  return mappings.map((mapping) => ({
+    conversionAction: mapping.conversionAction,
+    eventNames: [...mapping.eventNames],
+  }));
+}
+
+function sanitizeMappings(mappings: EventMapping[]) {
+  return mappings
+    .filter((mapping) => mapping.conversionAction)
+    .map((mapping) => ({
+      conversionAction: mapping.conversionAction,
+      eventNames: [...new Set(mapping.eventNames)],
+    }));
+}
+
+function buildEventNameOptions({
+  rows,
+  selected,
+  countKey,
+}: {
+  rows: EventNameRow[] | undefined;
+  selected: string[];
+  countKey: "leads" | "sales";
+}): EventNameOption[] {
+  const fromAnalytics = (rows ?? [])
+    .filter((row) => row.eventName)
+    .map((row) => ({
+      value: row.eventName,
+      label: row.eventName,
+      meta: { count: row[countKey] },
+    }));
+  const fromAnalyticsSet = new Set(fromAnalytics.map((option) => option.value));
+  const extras = selected
+    .filter((name) => !fromAnalyticsSet.has(name))
+    .map((name) => ({
+      value: name,
+      label: name,
+    }));
+
+  return [...extras, ...fromAnalytics];
+}
+
+function EventNamesField({
+  name,
+  control,
+  options,
+  isLoading,
+  label,
+  description,
+  placeholder,
+  emptyState,
+}: {
+  name: "leadMappings.0.eventNames" | "saleMappings.0.eventNames";
+  control: Control<FormData>;
+  options: EventNameOption[];
+  isLoading: boolean;
+  label: string;
+  description: string;
+  placeholder: string;
+  emptyState: string;
+}) {
+  return (
+    <div className="mt-6">
+      <p className="mb-2 text-sm font-medium text-neutral-700">{label}</p>
+      <p className="mb-4 text-sm leading-normal text-neutral-600">
+        {description}
+      </p>
+      <Controller
+        name={name}
+        control={control}
+        render={({ field }) => (
+          <Combobox
+            multiple
+            options={isLoading ? undefined : options}
+            selected={(field.value ?? []).map(
+              (eventName) =>
+                options.find((option) => option.value === eventName) ?? {
+                  value: eventName,
+                  label: eventName,
+                },
+            )}
+            setSelected={(selected) => {
+              field.onChange(selected.map((option) => option.value));
+            }}
+            onCreate={async (search) => {
+              const eventName = search.trim();
+              if (!eventName) {
+                return false;
+              }
+              const current = field.value ?? [];
+              if (!current.includes(eventName)) {
+                field.onChange([...current, eventName]);
+              }
+              return true;
+            }}
+            createLabel={(search) => `Add "${search.trim()}"`}
+            placeholder={isLoading ? "Loading event names..." : placeholder}
+            searchPlaceholder="Search or add event names..."
+            emptyState={emptyState}
+            optionRight={(option) =>
+              option.meta?.count != null ? (
+                <span className="text-xs text-neutral-500">
+                  {nFormatter(option.meta.count, { full: true })}
+                </span>
+              ) : undefined
+            }
+            matchTriggerWidth
+            caret={comboboxCaret}
+            buttonProps={comboboxButtonProps}
+          />
+        )}
+      />
+    </div>
+  );
+}

--- a/apps/web/lib/integrations/google-ads/update-google-ads-settings.ts
+++ b/apps/web/lib/integrations/google-ads/update-google-ads-settings.ts
@@ -14,6 +14,14 @@ const schema = googleAdsSettingsSchema.omit({ customers: true }).extend({
   workspaceId: z.string(),
 });
 
+const uniqueMappingEventNames = (
+  mappings: z.infer<typeof googleAdsSettingsSchema>["leadMappings"],
+) =>
+  mappings.map((mapping) => ({
+    ...mapping,
+    eventNames: [...new Set(mapping.eventNames)],
+  }));
+
 export const updateGoogleAdsSettingsAction = authActionClient
   .inputSchema(schema)
   .action(async ({ parsedInput, ctx }) => {
@@ -22,8 +30,8 @@ export const updateGoogleAdsSettingsAction = authActionClient
       customerId,
       customerName,
       loginCustomerId: submittedLoginCustomerId,
-      leadConversionAction,
-      saleConversionAction,
+      leadMappings,
+      saleMappings,
     } = parsedInput;
 
     throwIfNoPermission({
@@ -75,7 +83,7 @@ export const updateGoogleAdsSettingsAction = authActionClient
         })
       : null;
 
-    if (!customerId && (leadConversionAction || saleConversionAction)) {
+    if (!customerId && (leadMappings.length || saleMappings.length)) {
       throw new Error(
         "A Google Ads account is required to configure conversion actions.",
       );
@@ -86,15 +94,17 @@ export const updateGoogleAdsSettingsAction = authActionClient
       const expectedPrefix = `customers/${normalizedCustomerId}/conversionActions/`;
 
       if (
-        leadConversionAction &&
-        !leadConversionAction.startsWith(expectedPrefix)
+        leadMappings.some(
+          (mapping) => !mapping.conversionAction.startsWith(expectedPrefix),
+        )
       ) {
         throw new Error("Invalid lead conversion action.");
       }
 
       if (
-        saleConversionAction &&
-        !saleConversionAction.startsWith(expectedPrefix)
+        saleMappings.some(
+          (mapping) => !mapping.conversionAction.startsWith(expectedPrefix),
+        )
       ) {
         throw new Error("Invalid sale conversion action.");
       }
@@ -110,8 +120,8 @@ export const updateGoogleAdsSettingsAction = authActionClient
           customerId,
           loginCustomerId: resolvedLoginCustomerId,
           customerName,
-          leadConversionAction,
-          saleConversionAction,
+          leadMappings: uniqueMappingEventNames(leadMappings),
+          saleMappings: uniqueMappingEventNames(saleMappings),
         },
       },
     });

--- a/apps/web/lib/integrations/google-ads/upload-conversion.ts
+++ b/apps/web/lib/integrations/google-ads/upload-conversion.ts
@@ -14,6 +14,7 @@ import {
   googleAdsConversionUploadSchema,
   googleAdsSettingsSchema,
 } from "./schema";
+import { resolveGoogleAdsConversionMapping } from "./utils";
 
 const extractGoogleAdsClickId = (url: string): GoogleAdsClickId | null => {
   try {
@@ -98,6 +99,7 @@ export const uploadGoogleAdsConversion = async (
     click,
     conversionDateTime,
     eventId,
+    eventName,
     conversionValue,
     currencyCode,
     conversionCount,
@@ -127,17 +129,30 @@ export const uploadGoogleAdsConversion = async (
       installedIntegration.settings ?? {},
     );
 
-    const conversionAction =
-      eventType === "lead"
-        ? settings.leadConversionAction
-        : settings.saleConversionAction;
+    const mappings =
+      eventType === "lead" ? settings.leadMappings : settings.saleMappings;
+    const mapping = resolveGoogleAdsConversionMapping({
+      mappings,
+      eventName,
+    });
 
-    if (!settings.customerId || !conversionAction) {
+    if (!settings.customerId) {
       return {
-        message: `Missing ${!settings.customerId ? "customerId" : `${eventType}ConversionAction`}. Skipping...`,
+        message: `Missing customerId. Skipping...`,
         status: "skipped",
       };
     }
+
+    if (!mapping) {
+      return {
+        message: mappings.length
+          ? `No ${eventType} conversion mapping matched event name "${eventName ?? ""}". Skipping...`
+          : `Missing ${eventType} conversion mapping. Skipping...`,
+        status: "skipped",
+      };
+    }
+
+    const conversionAction = mapping.conversionAction;
 
     const googleClickId = extractGoogleAdsClickId(click.url);
 

--- a/apps/web/lib/integrations/google-ads/utils.ts
+++ b/apps/web/lib/integrations/google-ads/utils.ts
@@ -3,3 +3,34 @@ import { GOOGLE_ADS_ALLOWED_WORKSPACE_IDS } from "./constants";
 
 export const isGoogleAdsAllowedWorkspace = (workspaceId: string) =>
   GOOGLE_ADS_ALLOWED_WORKSPACE_IDS.has(normalizeWorkspaceId(workspaceId));
+
+type GoogleAdsEventMapping = {
+  conversionAction: string;
+  eventNames: string[];
+};
+
+// Prefer a mapping whose eventNames includes the event, then a catch-all
+// mapping with an empty eventNames list. Returns null when nothing matches.
+export const resolveGoogleAdsConversionMapping = ({
+  mappings,
+  eventName,
+}: {
+  mappings: GoogleAdsEventMapping[];
+  eventName?: string | null;
+}): GoogleAdsEventMapping | null => {
+  if (!mappings.length) {
+    return null;
+  }
+
+  if (eventName) {
+    const specific = mappings.find((mapping) =>
+      mapping.eventNames.includes(eventName),
+    );
+
+    if (specific) {
+      return specific;
+    }
+  }
+
+  return mappings.find((mapping) => mapping.eventNames.length === 0) ?? null;
+};

--- a/apps/web/tests/misc/google-ads-lead-event-filter.test.ts
+++ b/apps/web/tests/misc/google-ads-lead-event-filter.test.ts
@@ -1,0 +1,81 @@
+import { resolveGoogleAdsConversionMapping } from "@/lib/integrations/google-ads/utils";
+import { describe, expect, it } from "vitest";
+
+const signUpAction = "customers/1/conversionActions/signup";
+const trialAction = "customers/1/conversionActions/trial";
+const purchaseAction = "customers/1/conversionActions/purchase";
+
+describe("resolveGoogleAdsConversionMapping", () => {
+  it("returns null when no mappings are configured", () => {
+    expect(
+      resolveGoogleAdsConversionMapping({
+        mappings: [],
+        eventName: "Sign Up",
+      }),
+    ).toBeNull();
+  });
+
+  it("matches a catch-all mapping with empty event names", () => {
+    expect(
+      resolveGoogleAdsConversionMapping({
+        mappings: [{ conversionAction: signUpAction, eventNames: [] }],
+        eventName: "Sign Up",
+      }),
+    ).toEqual({ conversionAction: signUpAction, eventNames: [] });
+  });
+
+  it("matches a mapping by event name", () => {
+    expect(
+      resolveGoogleAdsConversionMapping({
+        mappings: [
+          { conversionAction: signUpAction, eventNames: ["Sign Up"] },
+          { conversionAction: trialAction, eventNames: ["Started Trial"] },
+        ],
+        eventName: "Started Trial",
+      }),
+    ).toEqual({
+      conversionAction: trialAction,
+      eventNames: ["Started Trial"],
+    });
+  });
+
+  it("prefers a specific event-name mapping over a catch-all", () => {
+    expect(
+      resolveGoogleAdsConversionMapping({
+        mappings: [
+          { conversionAction: purchaseAction, eventNames: [] },
+          { conversionAction: signUpAction, eventNames: ["Sign Up"] },
+        ],
+        eventName: "Sign Up",
+      }),
+    ).toEqual({
+      conversionAction: signUpAction,
+      eventNames: ["Sign Up"],
+    });
+  });
+
+  it("returns null when no mapping matches the event name", () => {
+    expect(
+      resolveGoogleAdsConversionMapping({
+        mappings: [{ conversionAction: signUpAction, eventNames: ["Sign Up"] }],
+        eventName: "Demo Booked",
+      }),
+    ).toBeNull();
+  });
+
+  it("skips unnamed events unless a catch-all mapping exists", () => {
+    expect(
+      resolveGoogleAdsConversionMapping({
+        mappings: [{ conversionAction: signUpAction, eventNames: ["Sign Up"] }],
+        eventName: undefined,
+      }),
+    ).toBeNull();
+
+    expect(
+      resolveGoogleAdsConversionMapping({
+        mappings: [{ conversionAction: signUpAction, eventNames: [] }],
+        eventName: undefined,
+      }),
+    ).toEqual({ conversionAction: signUpAction, eventNames: [] });
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Google Ads conversions can now be mapped to specific lead and sale event names.
  * Added support for multiple conversion mappings, including catch-all mappings.
  * Google Ads settings include event-name selection with suggested analytics events.

* **Bug Fixes**
  * Conversion uploads now retain event names, ensuring the correct conversion action is selected.
  * Improved validation and handling for missing or unmatched conversion mappings.

* **Tests**
  * Added coverage for event-specific, catch-all, unmatched, and unnamed event scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->