### PR TITLE
Group move rule bug fix

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/groups/[groupSlug]/settings/group-move-rules.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/groups/[groupSlug]/settings/group-move-rules.tsx
@@ -112,8 +112,13 @@ export function GroupMoveRules() {
     [metricRuleIndexes],
   );
 
+  const hasIncompleteMetricRule = metricRuleIndexes.some(
+    ({ rule }) => !rule.attribute,
+  );
+
   const canAddMetricRule =
-    usedMetricAttributes.length < GROUP_MOVE_METRIC_ATTRIBUTE_KEYS.length;
+    !hasIncompleteMetricRule &&
+    metricRuleIndexes.length < GROUP_MOVE_METRIC_ATTRIBUTE_KEYS.length;
 
   // Source group is only an additional condition after a complete metric rule
   const canAddPartnerGroupCondition =
@@ -220,7 +225,9 @@ export function GroupMoveRules() {
           disabled={!canAddMetricRule && ruleFields.length > 0}
           disabledTooltip={
             !canAddMetricRule && ruleFields.length > 0
-              ? "All rules are in use. Delete existing rules."
+              ? hasIncompleteMetricRule
+                ? "Select an activity before adding another rule"
+                : "All available rules have been added"
               : undefined
           }
         />


### PR DESCRIPTION
## Current
If the user doesn't select an activity, they can keep clicking `add` forever. 

<img width="1208" height="762" alt="CleanShot 2026-08-28 at 09 22 54@2x" src="https://github.com/user-attachments/assets/b3d17727-7f59-45a3-88bd-9a7e08da0776" />

## Updated
This blocks the user adding another rule before selecting the activity. Tooltip content updated.
<img width="1332" height="336" alt="CleanShot 2026-08-28 at 09 23 13@2x" src="https://github.com/user-attachments/assets/60c87e50-93a5-400e-be08-770a49cc7c77" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metric-rule validation to prevent adding rules when existing rules are incomplete.
  * Updated guidance messages to distinguish incomplete rules from cases where all available attributes are already used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->