### PR TITLE
Add `queueGoogleAdsConversionUpload` coverage to more call sites

### DIFF
--- a/apps/web/app/(ee)/api/stripe/integration/webhook/checkout-session-completed.ts
+++ b/apps/web/app/(ee)/api/stripe/integration/webhook/checkout-session-completed.ts
@@ -5,6 +5,7 @@ import { getOrCreateCustomer } from "@/lib/api/customers/get-or-create-customer"
 import { includeTags } from "@/lib/api/links/include-tags";
 import { syncPartnerLinksStats } from "@/lib/api/partners/sync-partner-links-stats";
 import { executeWorkflows } from "@/lib/api/workflows/execute-workflows";
+import { queueGoogleAdsConversionUpload } from "@/lib/integrations/google-ads/upload-conversion";
 import { queuePartnerCommissionCreation } from "@/lib/partners/queue-partner-commission-creation";
 import { sendPartnerPostback } from "@/lib/postback/send-partner-postback";
 import { prisma } from "@/lib/prisma";
@@ -19,7 +20,7 @@ import { redis } from "@/lib/upstash";
 import { sendWorkspaceWebhook } from "@/lib/webhook/publish";
 import { transformSaleEventData } from "@/lib/webhook/transform";
 import { nanoid } from "@dub/utils";
-import { Customer } from "@prisma/client";
+import { Customer, EventType } from "@prisma/client";
 import { waitUntil } from "@vercel/functions";
 import type Stripe from "stripe";
 import { WebhookHandlerInput, WebhookHandlerResponse } from "./types";
@@ -571,6 +572,20 @@ export async function checkoutSessionCompleted({
           partner: result?.webhookPartner,
           metadata: null,
         }),
+      }),
+
+      queueGoogleAdsConversionUpload({
+        workspaceId: workspace.id,
+        eventType: EventType.sale,
+        eventName: saleData.event_name,
+        conversionDateTime: new Date().toISOString(),
+        eventId: saleData.event_id,
+        conversionValue: saleData.amount / 100, // Data Manager expects major currency units
+        currencyCode: saleData.currency,
+        click: {
+          id: saleData.click_id,
+          url: saleData.url,
+        },
       }),
 
       ...(link?.partnerId

--- a/apps/web/app/(ee)/api/stripe/integration/webhook/invoice-paid.ts
+++ b/apps/web/app/(ee)/api/stripe/integration/webhook/invoice-paid.ts
@@ -3,6 +3,7 @@ import { isFirstConversion } from "@/lib/analytics/is-first-conversion";
 import { includeTags } from "@/lib/api/links/include-tags";
 import { syncPartnerLinksStats } from "@/lib/api/partners/sync-partner-links-stats";
 import { executeWorkflows } from "@/lib/api/workflows/execute-workflows";
+import { queueGoogleAdsConversionUpload } from "@/lib/integrations/google-ads/upload-conversion";
 import { queuePartnerCommissionCreation } from "@/lib/partners/queue-partner-commission-creation";
 import { sendPartnerPostback } from "@/lib/postback/send-partner-postback";
 import { prisma } from "@/lib/prisma";
@@ -13,6 +14,7 @@ import { redis } from "@/lib/upstash";
 import { sendWorkspaceWebhook } from "@/lib/webhook/publish";
 import { transformSaleEventData } from "@/lib/webhook/transform";
 import { nanoid } from "@dub/utils";
+import { EventType } from "@prisma/client";
 import { waitUntil } from "@vercel/functions";
 import type Stripe from "stripe";
 import { WebhookHandlerInput, WebhookHandlerResponse } from "./types";
@@ -404,6 +406,20 @@ export async function invoicePaid({
           partner: result?.webhookPartner,
           metadata: null,
         }),
+      }),
+
+      queueGoogleAdsConversionUpload({
+        workspaceId: workspace.id,
+        eventType: EventType.sale,
+        eventName: saleData.event_name,
+        conversionDateTime: new Date().toISOString(),
+        eventId: saleData.event_id,
+        conversionValue: saleData.amount / 100, // Data Manager expects major currency units
+        currencyCode: saleData.currency,
+        click: {
+          id: saleData.click_id,
+          url: saleData.url,
+        },
       }),
 
       ...(link?.partnerId

--- a/apps/web/app/(ee)/api/stripe/integration/webhook/utils/attribute-via-promotion-code-id.ts
+++ b/apps/web/app/(ee)/api/stripe/integration/webhook/utils/attribute-via-promotion-code-id.ts
@@ -2,6 +2,7 @@ import { createId } from "@/lib/api/create-id";
 import { getOrCreateCustomer } from "@/lib/api/customers/get-or-create-customer";
 import { syncPartnerLinksStats } from "@/lib/api/partners/sync-partner-links-stats";
 import { executeWorkflows } from "@/lib/api/workflows/execute-workflows";
+import { queueGoogleAdsConversionUpload } from "@/lib/integrations/google-ads/upload-conversion";
 import { generateRandomName } from "@/lib/names";
 import { queuePartnerCommissionCreation } from "@/lib/partners/queue-partner-commission-creation";
 import { sendPartnerPostback } from "@/lib/postback/send-partner-postback";
@@ -13,7 +14,7 @@ import { redis } from "@/lib/upstash";
 import { sendWorkspaceWebhook } from "@/lib/webhook/publish";
 import { transformLeadEventData } from "@/lib/webhook/transform";
 import { COUNTRIES_TO_CONTINENTS, nanoid } from "@dub/utils";
-import { Project } from "@prisma/client";
+import { EventType, Project } from "@prisma/client";
 import { waitUntil } from "@vercel/functions";
 import type Stripe from "stripe";
 import { getPromotionCode } from "./get-promotion-code";
@@ -252,6 +253,19 @@ export async function attributeViaPromotionCodeId({
             partner: result?.webhookPartner,
             metadata: null,
           }),
+        }),
+
+        queueGoogleAdsConversionUpload({
+          workspaceId: workspace.id,
+          eventType: EventType.lead,
+          eventId: leadEvent.event_id,
+          eventName: leadEvent.event_name,
+          conversionDateTime: new Date().toISOString(),
+          conversionCount: 1,
+          click: {
+            id: leadEvent.click_id,
+            url: leadEvent.url,
+          },
         }),
 
         ...(link.partnerId

--- a/apps/web/app/(ee)/api/stripe/integration/webhook/utils/sync-customer.ts
+++ b/apps/web/app/(ee)/api/stripe/integration/webhook/utils/sync-customer.ts
@@ -3,6 +3,7 @@ import { getOrCreateCustomer } from "@/lib/api/customers/get-or-create-customer"
 import { includeTags } from "@/lib/api/links/include-tags";
 import { syncPartnerLinksStats } from "@/lib/api/partners/sync-partner-links-stats";
 import { executeWorkflows } from "@/lib/api/workflows/execute-workflows";
+import { queueGoogleAdsConversionUpload } from "@/lib/integrations/google-ads/upload-conversion";
 import { generateRandomName } from "@/lib/names";
 import { constructWebhookPartner } from "@/lib/partners/constuct-webhook-partner";
 import { sendPartnerPostback } from "@/lib/postback/send-partner-postback";
@@ -12,7 +13,7 @@ import { redis } from "@/lib/upstash";
 import { sendWorkspaceWebhook } from "@/lib/webhook/publish";
 import { transformLeadEventData } from "@/lib/webhook/transform";
 import { nanoid, pick } from "@dub/utils";
-import { Prisma } from "@prisma/client";
+import { EventType, Prisma } from "@prisma/client";
 import { waitUntil } from "@vercel/functions";
 import type Stripe from "stripe";
 import { WebhookHandlerInput, WebhookHandlerResponse } from "../types";
@@ -267,18 +268,32 @@ export async function syncCustomer({
         ]);
       }
 
-      await sendWorkspaceWebhook({
-        trigger: "lead.created",
-        workspace,
-        data: transformLeadEventData({
-          ...clickData,
-          eventName,
-          link: linkUpdated,
-          customer,
-          partner: webhookPartner,
-          metadata: null,
+      await Promise.allSettled([
+        sendWorkspaceWebhook({
+          trigger: "lead.created",
+          workspace,
+          data: transformLeadEventData({
+            ...clickData,
+            eventName,
+            link: linkUpdated,
+            customer,
+            partner: webhookPartner,
+            metadata: null,
+          }),
         }),
-      });
+        queueGoogleAdsConversionUpload({
+          workspaceId: workspace.id,
+          eventType: EventType.lead,
+          eventId: leadData.event_id,
+          eventName: leadData.event_name,
+          conversionDateTime: new Date().toISOString(),
+          conversionCount: 1,
+          click: {
+            id: clickData.click_id,
+            url: clickData.url,
+          },
+        }),
+      ]);
     })(),
   );
 

--- a/apps/web/lib/api/conversions/track-sale.ts
+++ b/apps/web/lib/api/conversions/track-sale.ts
@@ -645,14 +645,14 @@ const _trackSale = async ({
         queueGoogleAdsConversionUpload({
           workspaceId: workspace.id,
           eventType: EventType.sale,
-          eventName,
+          eventName: saleData.event_name,
           conversionDateTime: new Date().toISOString(),
           eventId: saleData.event_id,
-          conversionValue: amount / 100, // Data Manager expects major currency units
-          currencyCode: currency,
+          conversionValue: saleData.amount / 100, // Data Manager expects major currency units
+          currencyCode: saleData.currency,
           click: {
-            id: leadEventData.click_id,
-            url: leadEventData.url,
+            id: saleData.click_id,
+            url: saleData.url,
           },
         }),
 

--- a/apps/web/lib/integrations/shopify/create-lead.ts
+++ b/apps/web/lib/integrations/shopify/create-lead.ts
@@ -10,7 +10,9 @@ import { sendWorkspaceWebhook } from "@/lib/webhook/publish";
 import { transformLeadEventData } from "@/lib/webhook/transform";
 import { leadEventSchemaTB } from "@/lib/zod/schemas/leads";
 import { nanoid } from "@dub/utils";
+import { EventType } from "@prisma/client";
 import { waitUntil } from "@vercel/functions";
+import { queueGoogleAdsConversionUpload } from "../google-ads/upload-conversion";
 import { orderSchema } from "./schema";
 
 export async function createShopifyLead({
@@ -136,6 +138,19 @@ export async function createShopifyLead({
           customer,
           metadata: null,
         }),
+      }),
+
+      queueGoogleAdsConversionUpload({
+        workspaceId: workspace.id,
+        eventType: EventType.lead,
+        eventId: leadData.event_id,
+        eventName: leadData.event_name,
+        conversionDateTime: new Date().toISOString(),
+        conversionCount: 1,
+        click: {
+          id: clickData.click_id,
+          url: clickData.url,
+        },
       }),
 
       ...(link.partnerId

--- a/apps/web/lib/integrations/shopify/process-order.ts
+++ b/apps/web/lib/integrations/shopify/process-order.ts
@@ -13,8 +13,9 @@ import { WorkspaceProps } from "@/lib/types";
 import { sendWorkspaceWebhook } from "@/lib/webhook/publish";
 import { transformLeadEventData } from "@/lib/webhook/transform";
 import { COUNTRIES_TO_CONTINENTS, nanoid } from "@dub/utils";
-import { Link } from "@prisma/client";
+import { EventType, Link } from "@prisma/client";
 import { waitUntil } from "@vercel/functions";
+import { queueGoogleAdsConversionUpload } from "../google-ads/upload-conversion";
 import { createShopifyLead } from "./create-lead";
 import { createShopifySale } from "./create-sale";
 import { orderSchema } from "./schema";
@@ -205,6 +206,19 @@ export async function attributeViaDiscountCode({
             partner: result?.webhookPartner,
             metadata: null,
           }),
+        }),
+
+        queueGoogleAdsConversionUpload({
+          workspaceId: workspace.id,
+          eventType: EventType.lead,
+          eventId: leadEvent.event_id,
+          eventName: leadEvent.event_name,
+          conversionDateTime: new Date().toISOString(),
+          conversionCount: 1,
+          click: {
+            id: leadEvent.click_id,
+            url: leadEvent.url,
+          },
         }),
 
         ...(link.partnerId


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Google Ads conversion tracking for Stripe purchases and invoices.
  * Added Google Ads conversion tracking for leads created through Stripe and Shopify integrations.
  * Conversion data now includes event details, value, currency, timestamp, and click attribution where available.

* **Refactor**
  * Standardized sale conversion data handling for more consistent tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->