### PR TITLE
Update `redir_url` implementation to comply with Google click tracking guidelines

### DIFF
--- a/apps/web/lib/middleware/link.ts
+++ b/apps/web/lib/middleware/link.ts
@@ -5,7 +5,10 @@ import {
   DUB_HEADERS,
   LEGAL_WORKSPACE_ID,
   LOCALHOST_GEO_DATA,
+  REDIRECTION_QUERY_PARAM,
+  getUrlFromStringIfValid,
   isDubDomain,
+  isGoogleClickTrackerDomain,
   isUnsupportedKey,
   nanoid,
   punyEncode,
@@ -38,7 +41,7 @@ import { parse } from "./utils/parse";
 import { resolveABTestURL } from "./utils/resolve-ab-test-url";
 
 export async function LinkMiddleware(req: NextRequest, ev: NextFetchEvent) {
-  let { domain, fullKey: originalKey, fullPath } = parse(req);
+  let { domain, fullKey: originalKey, fullPath, searchParamsObj } = parse(req);
 
   if (!domain) {
     return NextResponse.next();
@@ -174,6 +177,70 @@ export async function LinkMiddleware(req: NextRequest, ev: NextFetchEvent) {
   // everything else is not indexed by default, unless the user has explicitly set it to be indexed
   const shouldIndex = isDubDomain(domain) || doIndex === true;
 
+  const dubIdCookieName = `dub_id_${domain}_${key}`;
+
+  const cookieStore = await cookies();
+  let clickId = cookieStore.get(dubIdCookieName)?.value;
+  if (!clickId) {
+    // if we need to pass the clickId, check if clickId is cached in Redis
+    if (shouldCacheClickId) {
+      const identityHash = await getIdentityHash(req);
+      clickId =
+        (await recordClickCache
+          .get({ domain, key, identityHash })
+          .catch(() => undefined)) || undefined;
+    }
+
+    // if there's still no clickId, generate a new one
+    if (!clickId) {
+      clickId = nanoid(16);
+    }
+  }
+
+  const cookieData = {
+    path: `/${encodeURI(originalKey)}`,
+    dubIdCookieName,
+    dubIdCookieValue: clickId,
+    dubTestUrlValue: testUrl,
+  };
+
+  // for Google click tracker domains (dub.sh, dub.link):
+  // if there is a redirection url set, then use it instead of the target
+  if (isGoogleClickTrackerDomain(domain)) {
+    const redirectionUrl = getUrlFromStringIfValid(
+      searchParamsObj[REDIRECTION_QUERY_PARAM] ?? "",
+    );
+
+    // if redirectionUrl is present, return it immediately
+    if (redirectionUrl) {
+      ev.waitUntil(
+        recordClick({
+          req,
+          clickId,
+          workspaceId,
+          linkId,
+          domain,
+          key,
+          url: redirectionUrl,
+          programId: cachedLink.programId,
+          partnerId: cachedLink.partnerId,
+          shouldCacheClickId,
+        }),
+      );
+
+      return createResponseWithCookies(
+        NextResponse.redirect(redirectionUrl, {
+          headers: {
+            ...DUB_HEADERS,
+            ...(!shouldIndex && { "X-Robots-Tag": "googlebot: noindex" }),
+          },
+          status: key === "_root" ? 301 : 302,
+        }),
+        cookieData,
+      );
+    }
+  }
+
   // only show inspect modal if the link is not password protected
   if (inspectMode && !password) {
     return NextResponse.rewrite(
@@ -253,33 +320,6 @@ export async function LinkMiddleware(req: NextRequest, ev: NextFetchEvent) {
       });
     }
   }
-
-  const dubIdCookieName = `dub_id_${domain}_${key}`;
-
-  const cookieStore = await cookies();
-  let clickId = cookieStore.get(dubIdCookieName)?.value;
-  if (!clickId) {
-    // if we need to pass the clickId, check if clickId is cached in Redis
-    if (shouldCacheClickId) {
-      const identityHash = await getIdentityHash(req);
-      clickId =
-        (await recordClickCache
-          .get({ domain, key, identityHash })
-          .catch(() => undefined)) || undefined;
-    }
-
-    // if there's still no clickId, generate a new one
-    if (!clickId) {
-      clickId = nanoid(16);
-    }
-  }
-
-  const cookieData = {
-    path: `/${encodeURI(originalKey)}`,
-    dubIdCookieName,
-    dubIdCookieValue: clickId,
-    dubTestUrlValue: testUrl,
-  };
 
   // for root domain links, if there's no destination URL, rewrite to placeholder page
   if (!url) {

--- a/apps/web/lib/middleware/link.ts
+++ b/apps/web/lib/middleware/link.ts
@@ -6,11 +6,10 @@ import {
   LEGAL_WORKSPACE_ID,
   LOCALHOST_GEO_DATA,
   REDIRECTION_QUERY_PARAM,
-  getUrlFromStringIfValid,
   isDubDomain,
   isGoogleClickTrackerDomain,
-  isSafeLinkHref,
   isUnsupportedKey,
+  isValidUrl,
   nanoid,
   punyEncode,
 } from "@dub/utils";
@@ -288,12 +287,14 @@ export async function LinkMiddleware(req: NextRequest, ev: NextFetchEvent) {
   // for Google click tracker domains (dub.sh, dub.link):
   // if there is a redirection url set, then use it instead of the target
   if (isGoogleClickTrackerDomain(domain)) {
-    const redirectionUrl = getUrlFromStringIfValid(
-      searchParamsObj[REDIRECTION_QUERY_PARAM] ?? "",
-    );
+    const redirectionUrl = searchParamsObj[REDIRECTION_QUERY_PARAM];
 
-    // if redirectionUrl is present, return it immediately
-    if (redirectionUrl && isSafeLinkHref(redirectionUrl)) {
+    // if a valid redirection url is present, return it immediately
+    if (
+      redirectionUrl &&
+      isValidUrl(redirectionUrl) &&
+      redirectionUrl.startsWith("https://")
+    ) {
       ev.waitUntil(
         recordClick({
           req,

--- a/apps/web/lib/middleware/link.ts
+++ b/apps/web/lib/middleware/link.ts
@@ -9,6 +9,7 @@ import {
   getUrlFromStringIfValid,
   isDubDomain,
   isGoogleClickTrackerDomain,
+  isSafeLinkHref,
   isUnsupportedKey,
   nanoid,
   punyEncode,
@@ -204,43 +205,6 @@ export async function LinkMiddleware(req: NextRequest, ev: NextFetchEvent) {
     dubTestUrlValue: testUrl,
   };
 
-  // for Google click tracker domains (dub.sh, dub.link):
-  // if there is a redirection url set, then use it instead of the target
-  if (isGoogleClickTrackerDomain(domain)) {
-    const redirectionUrl = getUrlFromStringIfValid(
-      searchParamsObj[REDIRECTION_QUERY_PARAM] ?? "",
-    );
-
-    // if redirectionUrl is present, return it immediately
-    if (redirectionUrl) {
-      ev.waitUntil(
-        recordClick({
-          req,
-          clickId,
-          workspaceId,
-          linkId,
-          domain,
-          key,
-          url: redirectionUrl,
-          programId: cachedLink.programId,
-          partnerId: cachedLink.partnerId,
-          shouldCacheClickId,
-        }),
-      );
-
-      return createResponseWithCookies(
-        NextResponse.redirect(redirectionUrl, {
-          headers: {
-            ...DUB_HEADERS,
-            ...(!shouldIndex && { "X-Robots-Tag": "googlebot: noindex" }),
-          },
-          status: key === "_root" ? 301 : 302,
-        }),
-        cookieData,
-      );
-    }
-  }
-
   // only show inspect modal if the link is not password protected
   if (inspectMode && !password) {
     return NextResponse.rewrite(
@@ -318,6 +282,43 @@ export async function LinkMiddleware(req: NextRequest, ev: NextFetchEvent) {
           ...(!shouldIndex && { "X-Robots-Tag": "googlebot: noindex" }),
         },
       });
+    }
+  }
+
+  // for Google click tracker domains (dub.sh, dub.link):
+  // if there is a redirection url set, then use it instead of the target
+  if (isGoogleClickTrackerDomain(domain)) {
+    const redirectionUrl = getUrlFromStringIfValid(
+      searchParamsObj[REDIRECTION_QUERY_PARAM] ?? "",
+    );
+
+    // if redirectionUrl is present, return it immediately
+    if (redirectionUrl && isSafeLinkHref(redirectionUrl)) {
+      ev.waitUntil(
+        recordClick({
+          req,
+          clickId,
+          workspaceId,
+          linkId,
+          domain,
+          key,
+          url: redirectionUrl,
+          programId: cachedLink.programId,
+          partnerId: cachedLink.partnerId,
+          shouldCacheClickId,
+        }),
+      );
+
+      return createResponseWithCookies(
+        NextResponse.redirect(redirectionUrl, {
+          headers: {
+            ...DUB_HEADERS,
+            ...(!shouldIndex && { "X-Robots-Tag": "googlebot: noindex" }),
+          },
+          status: key === "_root" ? 301 : 302,
+        }),
+        cookieData,
+      );
     }
   }
 

--- a/apps/web/lib/middleware/utils/get-final-url.ts
+++ b/apps/web/lib/middleware/utils/get-final-url.ts
@@ -25,13 +25,20 @@ export const getFinalUrl = (
   // query is the query string (e.g. d.to/github?utm_source=twitter -> ?utm_source=twitter)
   const searchParams = req.nextUrl.searchParams;
 
-  // if there is a redirection url set, then use it instead of the target url
-  const redirectionUrl = getUrlFromStringIfValid(
-    searchParams.get(REDIRECTION_QUERY_PARAM) ?? "",
-  );
+  // for Google-certified click tracker domains (dub.sh, dub.link):
+  // if there is a redirection url set, then use it instead of the target
+  if (["dub.sh", "dub.link"].includes(parse(req).domain)) {
+    const redirectionUrl = getUrlFromStringIfValid(
+      searchParams.get(REDIRECTION_QUERY_PARAM) ?? "",
+    );
 
-  // get the query params of the target url
-  const urlObj = redirectionUrl ? new URL(redirectionUrl) : new URL(url);
+    // if redirectionUrl is present, return it immediately
+    if (redirectionUrl) {
+      return redirectionUrl;
+    }
+  }
+
+  const urlObj = new URL(url);
 
   if (via) {
     urlObj.searchParams.set("via", via);
@@ -58,9 +65,6 @@ export const getFinalUrl = (
 
   // for AppsFlyer tracking links
   if (isAppsFlyerTrackingUrl(url)) {
-    const { ua } = userAgent(req);
-    const ip = process.env.VERCEL === "1" ? ipAddress(req) : LOCALHOST_IP;
-
     // set hardcoded query params
     urlObj.searchParams.set("pid", "dubinc_int");
 

--- a/apps/web/lib/middleware/utils/get-final-url.ts
+++ b/apps/web/lib/middleware/utils/get-final-url.ts
@@ -2,7 +2,6 @@ import {
   LOCALHOST_IP,
   REDIRECTION_QUERY_PARAM,
 } from "@dub/utils/src/constants";
-import { getUrlFromStringIfValid } from "@dub/utils/src/functions";
 import { ipAddress } from "@vercel/functions";
 import { NextRequest, userAgent } from "next/server";
 import { isAppsFlyerTrackingUrl } from "./is-appsflyer-tracking-url";
@@ -24,19 +23,6 @@ export const getFinalUrl = (
 ) => {
   // query is the query string (e.g. d.to/github?utm_source=twitter -> ?utm_source=twitter)
   const searchParams = req.nextUrl.searchParams;
-
-  // for Google-certified click tracker domains (dub.sh, dub.link):
-  // if there is a redirection url set, then use it instead of the target
-  if (["dub.sh", "dub.link"].includes(parse(req).domain)) {
-    const redirectionUrl = getUrlFromStringIfValid(
-      searchParams.get(REDIRECTION_QUERY_PARAM) ?? "",
-    );
-
-    // if redirectionUrl is present, return it immediately
-    if (redirectionUrl) {
-      return redirectionUrl;
-    }
-  }
 
   const urlObj = new URL(url);
 

--- a/packages/utils/src/functions/domains.ts
+++ b/packages/utils/src/functions/domains.ts
@@ -85,3 +85,10 @@ export const getDomainWithoutWWW = (url: string) => {
 export const isDubDomain = (domain: string) => {
   return DUB_DOMAINS.some((d) => d.slug === domain);
 };
+
+export const isGoogleClickTrackerDomain = (domain: string) => {
+  // accepts both the full domain and the subdomain
+  return ["dub.sh", "dub.link"].some(
+    (d) => d === domain || domain.endsWith(`.${d}`),
+  );
+};


### PR DESCRIPTION
See: https://support.google.com/google-ads/answer/13707399

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved redirect handling for Google click tracker links on `dub.sh`, `dub.link`, and their subdomains.
  * Click tracking now records clicks correctly before redirecting through these links.
  * Redirects now consistently use the supplied target URL instead of an alternate redirect parameter.
  * AppsFlyer links no longer include request user-agent or IP address parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->