### PR TITLE
Remove redundant `queuePartnerSearchSync`

### DIFF
--- a/apps/web/app/(ee)/api/cron/domains/update/route.ts
+++ b/apps/web/app/(ee)/api/cron/domains/update/route.ts
@@ -6,7 +6,6 @@ import { handleAndReturnErrorResponse } from "@/lib/api/errors";
 import { linkCache } from "@/lib/api/links/cache";
 import { includeProgramEnrollment } from "@/lib/api/links/include-program-enrollment";
 import { includeTags } from "@/lib/api/links/include-tags";
-import { queuePartnerSearchSyncForLinks } from "@/lib/api/partners/queue-partner-search-sync";
 import { verifyQstashSignature } from "@/lib/cron/verify-qstash";
 import { prisma } from "@/lib/prisma";
 import { recordLink } from "@/lib/tinybird";
@@ -101,10 +100,6 @@ export async function POST(req: Request) {
       // expire the redis cache for the old links
       linkCache.expireMany(linksToUpdate),
     ]);
-
-    // Queue an index update because the domain change rewrote each link's
-    // shortLink. Queued after updateShortLinks above, which performs the rewrite
-    await queuePartnerSearchSyncForLinks(updatedLinks);
 
     const response = await queueDomainUpdate({
       ...payload,

--- a/apps/web/app/(ee)/api/cron/groups/sync-utm/route.ts
+++ b/apps/web/app/(ee)/api/cron/groups/sync-utm/route.ts
@@ -1,6 +1,5 @@
 import { handleAndReturnErrorResponse } from "@/lib/api/errors";
 import { linkCache } from "@/lib/api/links/cache";
-import { queuePartnerSearchSync } from "@/lib/api/partners/queue-partner-search-sync";
 import { extractUtmParams } from "@/lib/api/utm/extract-utm-params";
 import { qstash } from "@/lib/cron";
 import { verifyQstashSignature } from "@/lib/cron/verify-qstash";
@@ -126,12 +125,6 @@ export async function POST(req: Request) {
 
     const redisRes = await linkCache.expireMany(linksToUpdate);
     console.log(`Updated Redis cache: ${JSON.stringify(redisRes, null, 2)}`);
-
-    // Queue an index update because the UTM template rewrote each link's
-    // destination URL.
-    await queuePartnerSearchSync({
-      enrollmentIds: programEnrollments.map(({ id }) => id),
-    });
 
     if (programEnrollments.length === PAGE_SIZE) {
       await qstash.publishJSON({

--- a/apps/web/app/(ee)/api/cron/groups/update-default-links/route.ts
+++ b/apps/web/app/(ee)/api/cron/groups/update-default-links/route.ts
@@ -1,6 +1,5 @@
 import { handleAndReturnErrorResponse } from "@/lib/api/errors";
 import { linkCache } from "@/lib/api/links/cache";
-import { queuePartnerSearchSyncForLinks } from "@/lib/api/partners/queue-partner-search-sync";
 import { extractUtmParams } from "@/lib/api/utm/extract-utm-params";
 import { qstash } from "@/lib/cron";
 import { verifyQstashSignature } from "@/lib/cron/verify-qstash";
@@ -197,12 +196,6 @@ export async function POST(req: Request) {
               data: link,
             }),
           ),
-        );
-
-        // Queue an index update because the default link change rewrote
-        // destination URLs.
-        await queuePartnerSearchSyncForLinks(
-          linksToUpdate.map(({ owner }) => owner),
         );
       }
 

--- a/apps/web/lib/api/links/bulk-create-links.ts
+++ b/apps/web/lib/api/links/bulk-create-links.ts
@@ -236,9 +236,7 @@ export async function bulkCreateLinks({
         linksCount: links.length,
         timestamp: new Date().toISOString(),
       }),
-      // Queue an index update because the new links carry searchable
-      // shortLinks. Default delay, since a new short link is how people find
-      // that partner.
+      // Queue an index update because the new links carry searchable link keys
       queuePartnerSearchSyncForLinks(createdLinksData),
     ]),
   );

--- a/apps/web/lib/api/links/bulk-create-links.ts
+++ b/apps/web/lib/api/links/bulk-create-links.ts
@@ -236,8 +236,11 @@ export async function bulkCreateLinks({
         linksCount: links.length,
         timestamp: new Date().toISOString(),
       }),
-      // Queue an index update because the new links carry searchable link keys
-      queuePartnerSearchSyncForLinks(createdLinksData),
+      // Queue an index update if any of the new links are associated with a partner
+      createdLinksData.some((link) => link.partnerId) &&
+        queuePartnerSearchSyncForLinks(
+          createdLinksData.filter((link) => link.partnerId),
+        ),
     ]),
   );
 

--- a/apps/web/lib/api/links/bulk-delete-links.ts
+++ b/apps/web/lib/api/links/bulk-delete-links.ts
@@ -64,8 +64,7 @@ export async function bulkDeleteLinks(
 
         // Queue an index update because the links were deleted. The enrollment
         // outlives them, so the document is re-serialized without them.
-        queuePartnerSearchSyncForLinks(links, {
-        }),
+        queuePartnerSearchSyncForLinks(links),
       ]),
     );
   }

--- a/apps/web/lib/api/links/bulk-delete-links.ts
+++ b/apps/web/lib/api/links/bulk-delete-links.ts
@@ -62,9 +62,12 @@ export async function bulkDeleteLinks(
             storage.delete({ key: link.image!.replace(`${R2_URL}/`, "") }),
           ),
 
-        // Queue an index update because the links were deleted. The enrollment
-        // outlives them, so the document is re-serialized without them.
-        queuePartnerSearchSyncForLinks(links),
+        // Queue an index update if any of the deleted links are associated with a partner
+        // The program enrollments outlives them, so the document is re-serialized without them.
+        links.some((link) => link.partnerId) &&
+          queuePartnerSearchSyncForLinks(
+            links.filter((link) => link.partnerId),
+          ),
       ]),
     );
   }

--- a/apps/web/lib/api/links/bulk-update-links.ts
+++ b/apps/web/lib/api/links/bulk-update-links.ts
@@ -40,10 +40,10 @@ export async function bulkUpdateLinks(
 
   const imageUrlNonce = nanoid(7);
 
-  // The bulk payload omits domain/key/externalId but not `partnerId`, so an
+  // The bulk payload omits link key but not `partnerId`, so an
   // update can move links between partners. The former owners are unrecoverable
   // after the write, so read them first, and only when the payload can move one.
-  const previousOwners =
+  const previousPartnersForLinks =
     rest.partnerId !== undefined || rest.programId !== undefined
       ? await prisma.link.findMany({
           where: { id: { in: linkIds } },
@@ -127,9 +127,12 @@ export async function bulkUpdateLinks(
       propagateBulkLinkChanges({
         links: updatedLinks,
       }),
-      // Queue an index update because a bulk edit can change the destination
-      // URL or the link owner.
-      queuePartnerSearchSyncForLinks([...previousOwners, ...updatedLinks]),
+      // Queue an index update if there are previous partners (meaning partnerId was bulk updated)
+      previousPartnersForLinks.length > 0 &&
+        queuePartnerSearchSyncForLinks([
+          ...previousPartnersForLinks,
+          ...updatedLinks,
+        ]),
       // if proxy is true and image is not stored in R2, upload image to R2
       proxy &&
         image &&

--- a/apps/web/lib/api/links/complete-ab-tests.ts
+++ b/apps/web/lib/api/links/complete-ab-tests.ts
@@ -1,5 +1,4 @@
 import { getAnalytics } from "@/lib/analytics/get-analytics";
-import { queuePartnerSearchSyncForLinks } from "@/lib/api/partners/queue-partner-search-sync";
 import { prisma } from "@/lib/prisma";
 import { recordLink } from "@/lib/tinybird";
 import { sendWorkspaceWebhook } from "@/lib/webhook/publish";
@@ -79,9 +78,6 @@ export async function completeABTests(link: Link) {
       linkCache.set(response),
       // record the link
       recordLink(response),
-      // Queue an index update because the winning variant replaced the
-      // destination URL.
-      queuePartnerSearchSyncForLinks([response]),
       // send a link.updated webhook to the workspace
       response.project &&
         sendWorkspaceWebhook({

--- a/apps/web/lib/api/links/update-link.ts
+++ b/apps/web/lib/api/links/update-link.ts
@@ -211,8 +211,7 @@ export async function updateLink({
         // Queue an index update because the edit can change the destination URL
         // or move the link. Both owners, so a former one is re-serialized
         // without it.
-        queuePartnerSearchSyncForLinks([oldLink, response], {
-        }),
+        queuePartnerSearchSyncForLinks([oldLink, response]),
 
         // If proxy is true and image is not stored in R2, upload image to R2
         proxy &&

--- a/apps/web/lib/api/links/update-link.ts
+++ b/apps/web/lib/api/links/update-link.ts
@@ -51,9 +51,11 @@ export async function updateLink({
     proxy,
     geo,
     publicStats,
+    partnerId,
   } = updatedLink;
   const changedKey = key.toLowerCase() !== oldLink.key.toLowerCase();
   const changedDomain = domain !== oldLink.domain;
+  const changedPartnerId = partnerId !== oldLink.partnerId;
 
   const { utm_source, utm_medium, utm_campaign, utm_term, utm_content } =
     getParamsFromURL(url);
@@ -208,10 +210,9 @@ export async function updateLink({
         // If key is changed: delete the old key in Redis
         (changedDomain || changedKey) && linkCache.delete(oldLink),
 
-        // Queue an index update because the edit can change the destination URL
-        // or move the link. Both owners, so a former one is re-serialized
-        // without it.
-        queuePartnerSearchSyncForLinks([oldLink, response]),
+        // Queue an index update if the link key or partner ID changed (indexed fields)
+        (changedKey || changedPartnerId) &&
+          queuePartnerSearchSyncForLinks([oldLink, response]),
 
         // If proxy is true and image is not stored in R2, upload image to R2
         proxy &&

--- a/apps/web/tests/partners/turbopuffer-partner-search-provider.test.ts
+++ b/apps/web/tests/partners/turbopuffer-partner-search-provider.test.ts
@@ -94,7 +94,12 @@ describe("Turbopuffer partner search provider", () => {
     );
     // Description, platforms, and links stay out, so a name cannot be
     // out-weighted by how much else a partner has.
-    for (const value of ["affiliate marketer", "youtube", "@rafi", "rafi-link"]) {
+    for (const value of [
+      "affiliate marketer",
+      "youtube",
+      "@rafi",
+      "rafi-link",
+    ]) {
       expect(row.identityText).not.toContain(value);
     }
     // ContainsAllTokens reads the BM25 index, so no text attribute needs a
@@ -128,8 +133,8 @@ describe("Turbopuffer partner search provider", () => {
 
   it("pins a tokenizer that splits URLs into their components", async () => {
     // The default tokenizer keeps a URL as one token, so "scottdigital" cannot
-    // match "https://www.scottdigital-42.techcorp.io", and websites, short
-    // links, and destination URLs are all searchable here.
+    // match "https://www.scottdigital-42.techcorp.io"
+    // and websites + partner links are all searchable here
     await createProvider().upsert([document]);
 
     const [{ schema }] = mocks.write.mock.calls[0];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved search index accuracy when links are created, updated, moved, or deleted.
  - Reduced unnecessary background processing during automated domain, group, and link updates.
  - Preserved existing caching, batching, pagination, tracking, and notification behavior.

- **Maintenance**
  - Refined synchronization so search updates occur only when relevant partner associations or ownership details change.
  - Updated test formatting without changing test behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->