### PR TITLE
Handle `redisFailOver`

### DIFF
--- a/apps/web/lib/api/links/cache.ts
+++ b/apps/web/lib/api/links/cache.ts
@@ -68,7 +68,10 @@ class LinkCache {
     ]);
   }
 
-  async get({ domain, key }: Pick<LinkProps, "domain" | "key">) {
+  async get({ domain, key }: Pick<LinkProps, "domain" | "key">): Promise<{
+    cachedLink: RedisLinkProps | null;
+    redisFailOver: boolean;
+  }> {
     // here we use linkcache:${domain}:${key} instead of this._createKey({ domain, key })
     // because the key can either be cached as case-sensitive or case-insensitive depending on the domain
     // so we should get the original key from the cache
@@ -80,7 +83,7 @@ class LinkCache {
     if (cachedLink) {
       console.log(`[LRU Cache HIT] ${cacheKey}`);
       linkLRUCache.set(cacheKey, cachedLink); // refresh the LRU cache
-      return cachedLink;
+      return { cachedLink, redisFailOver: false };
     }
 
     console.log(`[LRU Cache MISS] ${cacheKey} - Checking redisGlobal...`);
@@ -92,12 +95,12 @@ class LinkCache {
       if (cachedLink) {
         console.log(`[Redis Cache HIT] ${cacheKey} - Populating LRU Cache...`);
         linkLRUCache.set(cacheKey, cachedLink); // persist to LRU cache
-        return cachedLink;
+        return { cachedLink, redisFailOver: false };
       } else {
         console.log(
           `[Redis Cache MISS] ${cacheKey} - Not found in LRU or Redis, falling back to MySQL...`,
         );
-        return null;
+        return { cachedLink: null, redisFailOver: false };
       }
     } catch (error) {
       console.error(`[Redis Cache Error] ${cacheKey} - ${error}`);
@@ -106,7 +109,7 @@ class LinkCache {
       if (cachedLink) {
         console.log(`[Vercel Cache HIT] ${cacheKey}`);
         linkLRUCache.set(cacheKey, cachedLink);
-        return cachedLink;
+        return { cachedLink, redisFailOver: true };
       }
 
       console.log(`[Vercel Cache MISS] ${cacheKey} - Falling back to MySQL...`);
@@ -128,7 +131,7 @@ class LinkCache {
           ttl: VERCEL_CACHE_EXPIRATION,
         }),
       );
-      return cachedLink;
+      return { cachedLink, redisFailOver: true };
     }
   }
 

--- a/apps/web/lib/middleware/link.ts
+++ b/apps/web/lib/middleware/link.ts
@@ -189,9 +189,10 @@ export async function LinkMiddleware(req: NextRequest, ev: NextFetchEvent) {
 
   const cookieStore = await cookies();
   let clickId = cookieStore.get(dubIdCookieName)?.value;
-  if (!clickId) {
-    // if we need to cache the clickId, check if clickId is cached in Redis (assuming no redisFailOver)
-    if (shouldCacheClickId && !redisFailOver) {
+  // only mint a new clickId if not in Redis failover mode
+  if (!clickId && !redisFailOver) {
+    // if we need to cache the clickId, check if clickId is cached in Redis
+    if (shouldCacheClickId) {
       const identityHash = await getIdentityHash(req);
       clickId =
         (await recordClickCache
@@ -484,18 +485,20 @@ export async function LinkMiddleware(req: NextRequest, ev: NextFetchEvent) {
       isIosAppStoreUrl(ios) &&
       !req.nextUrl.searchParams.get("skip_deeplink_preview")
     ) {
-      ev.waitUntil(
-        cacheDeepLinkClickData({
-          req,
-          clickId,
-          link: {
-            id: linkId,
-            domain,
-            key,
-            url, // pass the main destination URL to the cache (for deferred deep linking)
-          },
-        }),
-      );
+      if (clickId) {
+        ev.waitUntil(
+          cacheDeepLinkClickData({
+            req,
+            clickId,
+            link: {
+              id: linkId,
+              domain,
+              key,
+              url, // pass the main destination URL to the cache (for deferred deep linking)
+            },
+          }),
+        );
+      }
 
       // redirect to the deeplink interstitial splash page "DeepLinkPreviewPage"
       // we're doing this because the interstitial page needs to be on a different domain than the actual deep link domain
@@ -552,18 +555,20 @@ export async function LinkMiddleware(req: NextRequest, ev: NextFetchEvent) {
       isGooglePlayStoreUrl(android) &&
       !req.nextUrl.searchParams.get("skip_deeplink_preview")
     ) {
-      ev.waitUntil(
-        cacheDeepLinkClickData({
-          req,
-          clickId,
-          link: {
-            id: linkId,
-            domain,
-            key,
-            url, // pass the main destination URL to the cache (for deferred deep linking)
-          },
-        }),
-      );
+      if (clickId) {
+        ev.waitUntil(
+          cacheDeepLinkClickData({
+            req,
+            clickId,
+            link: {
+              id: linkId,
+              domain,
+              key,
+              url, // pass the main destination URL to the cache (for deferred deep linking)
+            },
+          }),
+        );
+      }
 
       // redirect to the deeplink interstitial splash page "DeepLinkPreviewPage"
       return createResponseWithCookies(

--- a/apps/web/lib/middleware/link.ts
+++ b/apps/web/lib/middleware/link.ts
@@ -187,22 +187,25 @@ export async function LinkMiddleware(req: NextRequest, ev: NextFetchEvent) {
 
   const dubIdCookieName = `dub_id_${domain}_${key}`;
 
-  const cookieStore = await cookies();
-  let clickId = cookieStore.get(dubIdCookieName)?.value;
-  // only mint a new clickId if not in Redis failover mode
-  if (!clickId && !redisFailOver) {
-    // if we need to cache the clickId, check if clickId is cached in Redis
-    if (shouldCacheClickId) {
-      const identityHash = await getIdentityHash(req);
-      clickId =
-        (await recordClickCache
-          .get({ domain, key, identityHash })
-          .catch(() => undefined)) || undefined;
-    }
-
-    // if there's still no clickId, generate a new one
+  let clickId: string | undefined;
+  // only lookup/mint a new clickId if not in Redis failover mode
+  if (!redisFailOver) {
+    const cookieStore = await cookies();
+    clickId = cookieStore.get(dubIdCookieName)?.value;
     if (!clickId) {
-      clickId = nanoid(16);
+      // if we need to cache the clickId, check if clickId is cached in Redis
+      if (shouldCacheClickId) {
+        const identityHash = await getIdentityHash(req);
+        clickId =
+          (await recordClickCache
+            .get({ domain, key, identityHash })
+            .catch(() => undefined)) || undefined;
+      }
+
+      // if there's still no clickId, generate a new one
+      if (!clickId) {
+        clickId = nanoid(16);
+      }
     }
   }
 

--- a/apps/web/lib/middleware/link.ts
+++ b/apps/web/lib/middleware/link.ts
@@ -1,4 +1,4 @@
-import { recordClick } from "@/lib/tinybird";
+import { recordClick as recordClickJob } from "@/lib/tinybird";
 import { formatRedisLink } from "@/lib/upstash";
 import {
   APP_DOMAIN,
@@ -86,8 +86,16 @@ export async function LinkMiddleware(req: NextRequest, ev: NextFetchEvent) {
     });
   }
 
-  let cachedLink = await linkCache.get({ domain, key });
+  let { cachedLink, redisFailOver } = await linkCache.get({ domain, key });
   let isPartnerLink = Boolean(cachedLink?.programId && cachedLink?.partnerId);
+
+  // skip click tracking during Redis failover to avoid timeouts
+  const recordClick = redisFailOver
+    ? async () => {
+        console.log("Redis failover detected, skipping click tracking...");
+        return;
+      }
+    : recordClickJob;
 
   if (!cachedLink) {
     let linkData = await getLinkViaEdge({
@@ -182,8 +190,8 @@ export async function LinkMiddleware(req: NextRequest, ev: NextFetchEvent) {
   const cookieStore = await cookies();
   let clickId = cookieStore.get(dubIdCookieName)?.value;
   if (!clickId) {
-    // if we need to pass the clickId, check if clickId is cached in Redis
-    if (shouldCacheClickId) {
+    // if we need to cache the clickId, check if clickId is cached in Redis (assuming no redisFailOver)
+    if (shouldCacheClickId && !redisFailOver) {
       const identityHash = await getIdentityHash(req);
       clickId =
         (await recordClickCache

--- a/apps/web/lib/middleware/utils/create-response-with-cookies.ts
+++ b/apps/web/lib/middleware/utils/create-response-with-cookies.ts
@@ -10,16 +10,18 @@ export function createResponseWithCookies(
   }: {
     path: string;
     dubIdCookieName: string;
-    dubIdCookieValue: string;
+    dubIdCookieValue?: string;
     dubTestUrlValue?: string | null;
   },
 ): NextResponse {
   // set dub_id_<domain>_<key> cookie
   // this caches dub_id for 1 hour (for deduplication)
-  response.cookies.set(dubIdCookieName, dubIdCookieValue, {
-    path,
-    maxAge: 60 * 60, // 1 hour
-  });
+  if (dubIdCookieValue) {
+    response.cookies.set(dubIdCookieName, dubIdCookieValue, {
+      path,
+      maxAge: 60 * 60, // 1 hour
+    });
+  }
 
   // set dub_test_url if this link has testVariants
   // caches for 1 week (for consistent user experience)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved link handling when the primary caching service is unavailable.
  * Ensured links remain accessible during cache failover without generating invalid click identifiers.
  * Prevented click-tracking errors during service interruptions.
  * Avoided storing incomplete deep-link click data when tracking services are unavailable.
  * Prevented unnecessary tracking cookies from being set when no identifier is available.
  * Preserved normal click tracking when all services are operating as expected.
  * Improved reliability of redirects and click tracking during temporary caching outages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->