### PR TITLE
Revalidate public partner pages

### DIFF
--- a/apps/web/app/(ee)/api/bounties/[bountyId]/route.ts
+++ b/apps/web/app/(ee)/api/bounties/[bountyId]/route.ts
@@ -3,6 +3,7 @@ import { DubApiError } from "@/lib/api/errors";
 import { throwIfInvalidGroupIds } from "@/lib/api/groups/throw-if-invalid-group-ids";
 import { throwIfInvalidPartnerTagIds } from "@/lib/api/partner-tags/throw-if-invalid-partner-tag-ids";
 import { getDefaultProgramIdOrThrow } from "@/lib/api/programs/get-default-program-id-or-throw";
+import { revalidateProgramPublicPages } from "@/lib/api/programs/revalidate-program-public-pages";
 import { parseRequestBody } from "@/lib/api/utils";
 import { WorkflowCondition } from "@/lib/api/workflows/types";
 import { validateWorkflowConditions } from "@/lib/api/workflows/validate-workflow-conditions";
@@ -393,6 +394,8 @@ export const PATCH = withWorkspace(
               notBefore: Math.floor(data.startsAt.getTime() / 1000),
             }),
           }),
+
+        revalidateProgramPublicPages(programId),
       ]),
     );
 
@@ -451,20 +454,24 @@ export const DELETE = withWorkspace(
     const deletedBounty = BountySchema.parse(transformBounty(bounty));
 
     waitUntil(
-      recordAuditLog({
-        workspaceId: workspace.id,
-        programId,
-        action: "bounty.deleted",
-        description: `Bounty ${bountyId} deleted`,
-        actor: session?.user,
-        targets: [
-          {
-            type: "bounty",
-            id: bountyId,
-            metadata: deletedBounty,
-          },
-        ],
-      }),
+      Promise.allSettled([
+        recordAuditLog({
+          workspaceId: workspace.id,
+          programId,
+          action: "bounty.deleted",
+          description: `Bounty ${bountyId} deleted`,
+          actor: session?.user,
+          targets: [
+            {
+              type: "bounty",
+              id: bountyId,
+              metadata: deletedBounty,
+            },
+          ],
+        }),
+
+        revalidateProgramPublicPages(programId),
+      ]),
     );
 
     return NextResponse.json({ id: bountyId });

--- a/apps/web/app/(ee)/api/bounties/route.ts
+++ b/apps/web/app/(ee)/api/bounties/route.ts
@@ -4,6 +4,7 @@ import { DubApiError } from "@/lib/api/errors";
 import { throwIfInvalidGroupIds } from "@/lib/api/groups/throw-if-invalid-group-ids";
 import { throwIfInvalidPartnerTagIds } from "@/lib/api/partner-tags/throw-if-invalid-partner-tag-ids";
 import { getDefaultProgramIdOrThrow } from "@/lib/api/programs/get-default-program-id-or-throw";
+import { revalidateProgramPublicPages } from "@/lib/api/programs/revalidate-program-public-pages";
 import { getProgramEnrollmentOrThrow } from "@/lib/api/programs/get-program-enrollment-or-throw";
 import { parseRequestBody } from "@/lib/api/utils";
 import { WorkflowAction } from "@/lib/api/workflows/types";
@@ -372,6 +373,8 @@ export const POST = withWorkspace(
               notBefore: Math.floor(bounty.startsAt.getTime() / 1000),
             }),
           }),
+
+        revalidateProgramPublicPages(programId),
       ]),
     );
 

--- a/apps/web/app/(ee)/api/groups/[groupIdOrSlug]/default/route.ts
+++ b/apps/web/app/(ee)/api/groups/[groupIdOrSlug]/default/route.ts
@@ -1,5 +1,6 @@
 import { getGroupOrThrow } from "@/lib/api/groups/get-group-or-throw";
 import { getDefaultProgramIdOrThrow } from "@/lib/api/programs/get-default-program-id-or-throw";
+import { revalidateProgramPublicPages } from "@/lib/api/programs/revalidate-program-public-pages";
 import { withWorkspace } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { DEFAULT_PARTNER_GROUP, GroupSchema } from "@/lib/zod/schemas/groups";
@@ -7,7 +8,6 @@ import { RESOURCE_COLORS } from "@/ui/colors";
 import { nanoid, randomValue } from "@dub/utils";
 import slugify from "@sindresorhus/slugify";
 import { waitUntil } from "@vercel/functions";
-import { revalidatePath } from "next/cache";
 import { NextResponse } from "next/server";
 
 // POST /api/groups/[groupIdOrSlug]/default – set a group as default
@@ -25,13 +25,6 @@ export const POST = withWorkspace(
           programId_slug: {
             programId,
             slug: DEFAULT_PARTNER_GROUP.slug,
-          },
-        },
-        include: {
-          program: {
-            select: {
-              slug: true,
-            },
           },
         },
       }),
@@ -92,16 +85,7 @@ export const POST = withWorkspace(
       });
     });
 
-    const programSlug = currentDefaultGroup.program.slug;
-
-    // need to revalidate the program's cached public pages
-    waitUntil(
-      Promise.allSettled([
-        revalidatePath(`/partners.dub.co/${programSlug}`),
-        revalidatePath(`/partners.dub.co/${programSlug}/apply`),
-        revalidatePath(`/partners.dub.co/${programSlug}/apply/success`),
-      ]),
-    );
+    waitUntil(revalidateProgramPublicPages(programId));
 
     return NextResponse.json(GroupSchema.parse(updatedGroup));
   },

--- a/apps/web/lib/actions/partners/update-discount.ts
+++ b/apps/web/lib/actions/partners/update-discount.ts
@@ -3,13 +3,12 @@
 import { recordAuditLog } from "@/lib/api/audit-logs/record-audit-log";
 import { getDiscountOrThrow } from "@/lib/api/partners/get-discount-or-throw";
 import { getDefaultProgramIdOrThrow } from "@/lib/api/programs/get-default-program-id-or-throw";
+import { revalidateProgramPublicPages } from "@/lib/api/programs/revalidate-program-public-pages";
 import { qstash } from "@/lib/cron";
 import { prisma } from "@/lib/prisma";
 import { updateDiscountSchema } from "@/lib/zod/schemas/discount";
-import { DEFAULT_PARTNER_GROUP } from "@/lib/zod/schemas/groups";
 import { APP_DOMAIN_WITH_NGROK } from "@dub/utils";
 import { waitUntil } from "@vercel/functions";
-import { revalidatePath } from "next/cache";
 import { authActionClient } from "../safe-action";
 import { throwIfNoPermission } from "../throw-if-no-permission";
 
@@ -31,24 +30,22 @@ export const updateDiscountAction = authActionClient
       discountId,
     });
 
-    const { program, partnerGroup, ...updatedDiscount } =
-      await prisma.discount.update({
-        where: {
-          id: discountId,
-        },
-        data: {
-          couponTestId: couponTestId || null,
-          ...(autoProvision !== undefined && {
-            autoProvisionEnabledAt: autoProvision
-              ? discount.autoProvisionEnabledAt ?? new Date()
-              : null,
-          }),
-        },
-        include: {
-          program: true,
-          partnerGroup: true,
-        },
-      });
+    const { partnerGroup, ...updatedDiscount } = await prisma.discount.update({
+      where: {
+        id: discountId,
+      },
+      data: {
+        couponTestId: couponTestId || null,
+        ...(autoProvision !== undefined && {
+          autoProvisionEnabledAt: autoProvision
+            ? discount.autoProvisionEnabledAt ?? new Date()
+            : null,
+        }),
+      },
+      include: {
+        partnerGroup: true,
+      },
+    });
 
     waitUntil(
       (async () => {
@@ -65,17 +62,7 @@ export const updateDiscountAction = authActionClient
                   },
                 }),
 
-                // we only cache default group pages for now so we need to invalidate them
-                ...(partnerGroup?.slug === DEFAULT_PARTNER_GROUP.slug
-                  ? [
-                      revalidatePath(`/partners.dub.co/${program.slug}`),
-                      revalidatePath(`/partners.dub.co/${program.slug}/apply`),
-                      program.addedToMarketplaceAt &&
-                        revalidatePath(
-                          `/partners.dub.co/marketplace/${program.slug}`,
-                        ),
-                    ]
-                  : []),
+                revalidateProgramPublicPages(programId),
               ]
             : []),
 

--- a/apps/web/lib/actions/partners/update-group-branding.ts
+++ b/apps/web/lib/actions/partners/update-group-branding.ts
@@ -3,6 +3,7 @@
 import { recordAuditLog } from "@/lib/api/audit-logs/record-audit-log";
 import { getGroupOrThrow } from "@/lib/api/groups/get-group-or-throw";
 import { getDefaultProgramIdOrThrow } from "@/lib/api/programs/get-default-program-id-or-throw";
+import { revalidateProgramPublicPages } from "@/lib/api/programs/revalidate-program-public-pages";
 import { prisma } from "@/lib/prisma";
 import { isStored, storage } from "@/lib/storage";
 import { ProgramLanderData } from "@/lib/types";
@@ -14,7 +15,6 @@ import {
 } from "@/lib/zod/schemas/program-lander";
 import { isFulfilled, isRejected, nanoid, R2_URL } from "@dub/utils";
 import { waitUntil } from "@vercel/functions";
-import { revalidatePath } from "next/cache";
 import * as z from "zod/v4";
 import { authActionClient } from "../safe-action";
 import { throwIfNoPermission } from "../throw-if-no-permission";
@@ -121,17 +121,7 @@ export const updateGroupBrandingAction = authActionClient
          - application form data
         */
           ...(landerDataInput || applicationFormDataInput || unpublish
-            ? [
-                revalidatePath(`/partners.dub.co/${program.slug}`),
-                revalidatePath(`/partners.dub.co/${program.slug}/apply`),
-                revalidatePath(
-                  `/partners.dub.co/${program.slug}/apply/success`,
-                ),
-                program.addedToMarketplaceAt &&
-                  revalidatePath(
-                    `/partners.dub.co/marketplace/${program.slug}`,
-                  ),
-              ]
+            ? [revalidateProgramPublicPages(programId)]
             : []),
 
           recordAuditLog({

--- a/apps/web/lib/actions/partners/update-program.ts
+++ b/apps/web/lib/actions/partners/update-program.ts
@@ -2,6 +2,7 @@
 
 import { recordAuditLog } from "@/lib/api/audit-logs/record-audit-log";
 import { getDefaultProgramIdOrThrow } from "@/lib/api/programs/get-default-program-id-or-throw";
+import { revalidateProgramPublicPages } from "@/lib/api/programs/revalidate-program-public-pages";
 import {
   ALLOWED_MIN_PAYOUT_AMOUNTS,
   getAllowedMinPayoutAmounts,
@@ -10,7 +11,6 @@ import { getPlanCapabilities } from "@/lib/plan-capabilities";
 import { prisma } from "@/lib/prisma";
 import { submittedLeadFormSchema } from "@/lib/zod/schemas/submitted-lead-form";
 import { waitUntil } from "@vercel/functions";
-import { revalidatePath } from "next/cache";
 import * as z from "zod/v4";
 import { getProgramOrThrow } from "../../api/programs/get-program-or-throw";
 import { ProgramSchema, updateProgramSchema } from "../../zod/schemas/programs";
@@ -75,25 +75,25 @@ export const updateProgramAction = authActionClient
       },
     });
 
-    if (updatedProgram.termsUrl !== program.termsUrl) {
-      revalidatePath(`/partners.dub.co/${program.slug}/apply`);
-    }
-
     waitUntil(
-      recordAuditLog({
-        workspaceId: workspace.id,
-        programId: program.id,
-        action: "program.updated",
-        description: `Program ${program.name} updated`,
-        actor: user,
-        targets: [
-          {
-            type: "program",
-            id: program.id,
-            metadata: updatedProgram,
-          },
-        ],
-      }),
+      Promise.allSettled([
+        updatedProgram.termsUrl !== program.termsUrl &&
+          revalidateProgramPublicPages(programId),
+        recordAuditLog({
+          workspaceId: workspace.id,
+          programId: program.id,
+          action: "program.updated",
+          description: `Program ${program.name} updated`,
+          actor: user,
+          targets: [
+            {
+              type: "program",
+              id: program.id,
+              metadata: updatedProgram,
+            },
+          ],
+        }),
+      ]),
     );
 
     return {

--- a/apps/web/lib/actions/partners/update-reward.ts
+++ b/apps/web/lib/actions/partners/update-reward.ts
@@ -5,6 +5,7 @@ import { recordAuditLog } from "@/lib/api/audit-logs/record-audit-log";
 import { getRewardOrThrow } from "@/lib/api/partners/get-reward-or-throw";
 import { serializeReward } from "@/lib/api/partners/serialize-reward";
 import { getDefaultProgramIdOrThrow } from "@/lib/api/programs/get-default-program-id-or-throw";
+import { revalidateProgramPublicPages } from "@/lib/api/programs/revalidate-program-public-pages";
 import { queueRewardProcessing } from "@/lib/api/rewards/queue-reward-processing";
 import { validateReward } from "@/lib/api/rewards/validate-reward";
 import { getPlanCapabilities } from "@/lib/plan-capabilities";
@@ -13,7 +14,6 @@ import { updateRewardSchema } from "@/lib/zod/schemas/rewards";
 import { formatRewardDescription } from "@/ui/partners/format-reward-description";
 import { Prisma } from "@prisma/client";
 import { waitUntil } from "@vercel/functions";
-import { revalidatePath } from "next/cache";
 import { authActionClient } from "../safe-action";
 import { throwIfNoPermission } from "../throw-if-no-permission";
 
@@ -101,7 +101,6 @@ export const updateRewardAction = authActionClient
             }),
       },
       include: {
-        program: true,
         clickPartnerGroup: true,
         leadPartnerGroup: true,
         salePartnerGroup: true,
@@ -110,20 +109,12 @@ export const updateRewardAction = authActionClient
     });
 
     const {
-      program,
       clickPartnerGroup,
       leadPartnerGroup,
       salePartnerGroup,
       referralPartnerGroup,
       ...rewardMetadata
     } = updatedReward;
-
-    const isDefaultGroup = [
-      clickPartnerGroup,
-      leadPartnerGroup,
-      salePartnerGroup,
-      referralPartnerGroup,
-    ].some((group) => group?.slug === "default");
 
     // Determine the groupId from the partner group relation
     const partnerGroup =
@@ -179,15 +170,7 @@ export const updateRewardAction = authActionClient
           description: activityDescription,
         }),
 
-        // we only cache default group pages for now so we need to invalidate them
-        ...(isDefaultGroup && program
-          ? [
-              revalidatePath(`/partners.dub.co/${program.slug}`),
-              revalidatePath(`/partners.dub.co/${program.slug}/apply`),
-              program.addedToMarketplaceAt &&
-                revalidatePath(`/partners.dub.co/marketplace/${program.slug}`),
-            ]
-          : []),
+        revalidateProgramPublicPages(programId),
       ]),
     );
   });

--- a/apps/web/lib/api/programs/revalidate-program-public-pages.ts
+++ b/apps/web/lib/api/programs/revalidate-program-public-pages.ts
@@ -1,0 +1,32 @@
+import { prisma } from "@/lib/prisma";
+import { DEFAULT_PARTNER_GROUP } from "@/lib/zod/schemas/groups";
+import { revalidatePath } from "next/cache";
+
+export async function revalidateProgramPublicPages(programId: string) {
+  const program = await prisma.program.findUniqueOrThrow({
+    where: { id: programId },
+    select: {
+      slug: true,
+      addedToMarketplaceAt: true,
+      groups: { select: { slug: true } },
+    },
+  });
+
+  const paths = [
+    `/partners.dub.co/${program.slug}`,
+    `/partners.dub.co/${program.slug}/apply`,
+    `/partners.dub.co/${program.slug}/apply/success`,
+    ...program.groups
+      .filter((group) => group.slug !== DEFAULT_PARTNER_GROUP.slug)
+      .flatMap((group) => [
+        `/partners.dub.co/${program.slug}/${group.slug}`,
+        `/partners.dub.co/${program.slug}/${group.slug}/apply`,
+        `/partners.dub.co/${program.slug}/${group.slug}/apply/success`,
+      ]),
+    ...(program.addedToMarketplaceAt
+      ? [`/partners.dub.co/marketplace/${program.slug}`]
+      : []),
+  ];
+
+  paths.forEach((path) => revalidatePath(path));
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Public program pages now refresh automatically when bounties are created, updated, or deleted, and when rewards, discounts, branding, groups, or program details change.
  * Related application, success, marketplace, and group pages are also kept up to date.
  * Public pages now refresh consistently for changes across all partner groups, not only default groups.
* **Improvements**
  * Improved consistency and coverage of public-page updates across program management actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->