### PR TITLE
Pass crypto wallet payout method id

### DIFF
--- a/apps/web/lib/partners/create-stablecoin-payout.ts
+++ b/apps/web/lib/partners/create-stablecoin-payout.ts
@@ -26,6 +26,7 @@ import { markPayoutsAsProcessed } from "../payouts/mark-payouts-as-processed";
 import { createStripeOutboundPayment } from "../stripe/create-stripe-outbound-payment";
 import { fundFinancialAccount } from "../stripe/fund-financial-account";
 import { getStripeRecipientAccount } from "../stripe/get-stripe-recipient-account";
+import { getStripeRecipientPayoutMethod } from "../stripe/get-stripe-recipient-payout-method";
 
 interface CreateStablecoinPayoutParams {
   partnerId: string;
@@ -226,6 +227,32 @@ export const createStablecoinPayout = async ({
     }
   }
 
+  const stripePayoutMethod = await getStripeRecipientPayoutMethod(
+    partner.stripeRecipientId,
+  );
+
+  if (!stripePayoutMethod?.id) {
+    await prisma.partner.update({
+      where: {
+        id: partner.id,
+      },
+      data: {
+        payoutsEnabledAt: null,
+      },
+    });
+
+    await markPayoutsAsProcessed(currentInvoicePayouts);
+
+    const message = `Stripe recipient account for partner ${partner.email} does not have an active crypto wallet payout method.`;
+
+    if (forceWithdrawal) {
+      throw new Error(message);
+    } else {
+      console.warn(message);
+      return;
+    }
+  }
+
   const allPayoutsProgramNames = [
     ...new Set(allPayouts.map((p) => p.program.name)),
   ];
@@ -245,6 +272,7 @@ export const createStablecoinPayout = async ({
 
   const outboundPayment = await createStripeOutboundPayment({
     stripeRecipientId: partner.stripeRecipientId,
+    payoutMethodId: stripePayoutMethod.id,
     amount: totalTransferableAmount,
     description: `Dub Partners payout (${allPayoutsProgramNames.join(", ")})`,
     idempotencyKey,

--- a/apps/web/lib/stripe/create-stripe-outbound-payment.ts
+++ b/apps/web/lib/stripe/create-stripe-outbound-payment.ts
@@ -3,6 +3,7 @@ import { STRIPE_API_VERSION, stripeV2Fetch } from "./stripe-v2-client";
 
 export interface CreateStripeOutboundPaymentParams {
   stripeRecipientId: string;
+  payoutMethodId: string;
   amount: number;
   description: string;
   idempotencyKey: string;
@@ -10,6 +11,7 @@ export interface CreateStripeOutboundPaymentParams {
 
 export async function createStripeOutboundPayment({
   stripeRecipientId,
+  payoutMethodId,
   amount,
   description,
   idempotencyKey,
@@ -36,6 +38,7 @@ export async function createStripeOutboundPayment({
         to: {
           recipient: stripeRecipientId,
           currency: "usdc",
+          payout_method: payoutMethodId,
         },
         amount: {
           value: amount,

--- a/apps/web/lib/stripe/get-stripe-recipient-payout-method.ts
+++ b/apps/web/lib/stripe/get-stripe-recipient-payout-method.ts
@@ -21,5 +21,9 @@ export async function getStripeRecipientPayoutMethod(
     throw new Error(error.message);
   }
 
-  return data.data?.find((m) => m.type === "crypto_wallet") ?? null;
+  return (
+    data.data?.find(
+      (m) => m.type === "crypto_wallet" && !m.crypto_wallet?.archived,
+    ) ?? null
+  );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Stablecoin payouts now use the recipient’s active crypto wallet and exclude archived wallets.
  - Invalid payout attempts are prevented when no eligible wallet is available.
  - Outbound payments are directed to the selected payout method.
  - Forced withdrawals without a valid payout method now fail clearly, while regular payout processing avoids creating incomplete payments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->