### PR TITLE
Feature/partner-search: strip the program domain from pasted links

### DIFF
--- a/apps/web/lib/api/partners/get-partners-count.ts
+++ b/apps/web/lib/api/partners/get-partners-count.ts
@@ -10,10 +10,10 @@ import {
   mergePartnerCountryAndSearchWhere,
 } from "./program-enrollment-query";
 import {
-  buildPartnerSearchCandidateQuery,
   findPartnerSearchCandidates,
   getPartnerSearchReadProvider,
   PartnerSearchProvider,
+  resolvePartnerSearchCandidateQuery,
 } from "./search";
 
 type PartnersCountFilters = z.infer<typeof partnersCountQuerySchema> & {
@@ -35,7 +35,10 @@ export async function getPartnersCount<T>(
 ): Promise<T> {
   const { groupBy, programId, ...enrollmentFilters } = filters;
   const candidateQuery = searchProvider
-    ? buildPartnerSearchCandidateQuery({ ...enrollmentFilters, programId })
+    ? await resolvePartnerSearchCandidateQuery({
+        ...enrollmentFilters,
+        programId,
+      })
     : null;
   const candidateResult =
     searchProvider && candidateQuery

--- a/apps/web/lib/api/partners/get-partners.ts
+++ b/apps/web/lib/api/partners/get-partners.ts
@@ -3,12 +3,12 @@ import { toCentsNumber } from "@dub/utils";
 import { Prisma } from "@prisma/client";
 import { buildProgramEnrollmentWhereForList } from "./program-enrollment-query";
 import {
-  buildPartnerSearchCandidateQuery,
   findPartnerSearchCandidates,
   getPartnerSearchReadProvider,
   orderByPartnerSearchHits,
   PartnerSearchProvider,
   PartnerSearchQueryInput,
+  resolvePartnerSearchCandidateQuery,
 } from "./search";
 
 type PartnerFilters = PartnerSearchQueryInput & {
@@ -39,7 +39,7 @@ export async function getPartners(
   } = filters;
 
   const candidateQuery = searchProvider
-    ? buildPartnerSearchCandidateQuery(filters)
+    ? await resolvePartnerSearchCandidateQuery(filters)
     : null;
   const candidateResult =
     searchProvider && candidateQuery

--- a/apps/web/lib/api/partners/search/build-search-query.ts
+++ b/apps/web/lib/api/partners/search/build-search-query.ts
@@ -81,3 +81,47 @@ export function buildPartnerSearchCandidateQuery({
     },
   };
 }
+
+/**
+ * A dotted host with an optional protocol, `www.`, and URL suffix. Plain words
+ * and email addresses do not match. This limits the program lookup to
+ * link-shaped search values.
+ */
+const LINK_SHAPED_QUERY =
+  /^(?:https?:\/\/)?(?:www\.)?([a-z0-9-]+(?:\.[a-z0-9-]+)+)([/?#]\S*)?$/i;
+
+export function isLinkShapedQuery(query: string): boolean {
+  return LINK_SHAPED_QUERY.test(query.trim());
+}
+
+/**
+ * Removes the program domain from a matching short link. The search index
+ * stores link keys, but it does not store link domains. Removing the domain
+ * prevents unrelated domain tokens from adding matches or changing result
+ * order. Other domains and bare domains are returned unchanged.
+ */
+export function stripProgramDomain(
+  query: string,
+  programDomain: string | null | undefined,
+): string {
+  const match = query.trim().match(LINK_SHAPED_QUERY);
+
+  if (!match || !programDomain) {
+    return query;
+  }
+
+  const [, host, rest = ""] = match;
+  const normalizedDomain = programDomain.toLowerCase().replace(/^www\./, "");
+
+  if (host.toLowerCase() !== normalizedDomain) {
+    return query;
+  }
+
+  // Query strings and fragments are never part of a key
+  const key = rest
+    .split(/[?#]/)[0]
+    .replace(/^\/+|\/+$/g, "")
+    .trim();
+
+  return key || query;
+}

--- a/apps/web/lib/api/partners/search/index.ts
+++ b/apps/web/lib/api/partners/search/index.ts
@@ -4,6 +4,7 @@ export * from "./find-candidates";
 export * from "./index-enrollments";
 export * from "./order-search-results";
 export * from "./provider";
+export * from "./resolve-candidate-query";
 export * from "./searchable-values";
 export * from "./serialize-document";
 export * from "./sync";

--- a/apps/web/lib/api/partners/search/resolve-candidate-query.ts
+++ b/apps/web/lib/api/partners/search/resolve-candidate-query.ts
@@ -1,0 +1,32 @@
+import { prisma } from "@/lib/prisma";
+import {
+  buildPartnerSearchCandidateQuery,
+  isLinkShapedQuery,
+  stripProgramDomain,
+} from "./build-search-query";
+import type { PartnerSearchCandidateQuery } from "./types";
+
+/**
+ * Builds the candidate query and removes the program domain from a matching
+ * short link. Shared by the list and the count so both send the provider the
+ * same query.
+ */
+export async function resolvePartnerSearchCandidateQuery(
+  input: Parameters<typeof buildPartnerSearchCandidateQuery>[0],
+): Promise<PartnerSearchCandidateQuery | null> {
+  const candidateQuery = buildPartnerSearchCandidateQuery(input);
+
+  if (!candidateQuery || !isLinkShapedQuery(candidateQuery.query)) {
+    return candidateQuery;
+  }
+
+  const program = await prisma.program.findUnique({
+    where: { id: candidateQuery.programId },
+    select: { domain: true },
+  });
+
+  return {
+    ...candidateQuery,
+    query: stripProgramDomain(candidateQuery.query, program?.domain),
+  };
+}

--- a/apps/web/tests/partners/partner-search-query.test.ts
+++ b/apps/web/tests/partners/partner-search-query.test.ts
@@ -1,6 +1,8 @@
 import {
   buildPartnerSearchCandidateQuery,
+  isLinkShapedQuery,
   PARTNER_SEARCH_CANDIDATE_LIMIT,
+  stripProgramDomain,
 } from "@/lib/api/partners/search";
 import { describe, expect, it } from "vitest";
 
@@ -82,5 +84,69 @@ describe("buildPartnerSearchCandidateQuery", () => {
         buildPartnerSearchCandidateQuery({ programId: "prog_1", search }),
       ).toMatchObject({ query: search });
     });
+  });
+});
+
+describe("isLinkShapedQuery", () => {
+  it.each([
+    "go.acme.com/partner",
+    "https://go.acme.com/partner",
+    "www.go.acme.com/partner",
+    "go.acme.com",
+    "  go.acme.com/partner  ",
+  ])("recognizes %s", (query) => {
+    expect(isLinkShapedQuery(query)).toBe(true);
+  });
+
+  it.each(["steven", "steven tey", "steven@dub.co", "pn_123", "acme/partner"])(
+    "does not recognize %s",
+    (query) => {
+      expect(isLinkShapedQuery(query)).toBe(false);
+    },
+  );
+});
+
+describe("stripProgramDomain", () => {
+  const domain = "go.acme.com";
+
+  it.each([
+    ["go.acme.com/partner", "partner"],
+    ["go.acme.com/partner/", "partner"],
+    ["https://go.acme.com/partner", "partner"],
+    ["https://go.acme.com/partner/", "partner"],
+    ["http://www.go.acme.com/partner", "partner"],
+    ["GO.ACME.COM/Partner", "Partner"],
+    ["go.acme.com/partner?utm_source=x", "partner"],
+    ["go.acme.com/partner/?utm_source=x", "partner"],
+    ["go.acme.com/partner#top", "partner"],
+    ["go.acme.com/partner/#top", "partner"],
+    ["go.acme.com/nested/partner", "nested/partner"],
+    ["go.acme.com/nested/partner/", "nested/partner"],
+    ["  go.acme.com/partner  ", "partner"],
+  ])("reduces %s to its key", (query, key) => {
+    expect(stripProgramDomain(query, domain)).toBe(key);
+  });
+
+  it("matches a program domain stored with www.", () => {
+    expect(stripProgramDomain("go.acme.com/partner", "www.go.acme.com")).toBe(
+      "partner",
+    );
+  });
+
+  it.each([
+    ["another domain", "dub.sh/partner"],
+    ["a longer host", "app.go.acme.com/partner"],
+    ["the bare domain", "go.acme.com"],
+    ["the bare domain with a slash", "go.acme.com/"],
+    ["a plain word", "partner"],
+    ["an email", "steven@go.acme.com"],
+  ])("leaves %s unchanged", (_label, query) => {
+    expect(stripProgramDomain(query, domain)).toBe(query);
+  });
+
+  it("leaves the query unchanged when the program has no domain", () => {
+    expect(stripProgramDomain("go.acme.com/partner", null)).toBe(
+      "go.acme.com/partner",
+    );
   });
 });

--- a/apps/web/tests/partners/partner-search-resolve-query.test.ts
+++ b/apps/web/tests/partners/partner-search-resolve-query.test.ts
@@ -1,0 +1,61 @@
+import { resolvePartnerSearchCandidateQuery } from "@/lib/api/partners/search";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ findUnique: vi.fn() }));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: { program: { findUnique: mocks.findUnique } },
+}));
+
+const input = (search: string) => ({
+  programId: "prog_test",
+  search,
+  page: 1,
+  pageSize: 25,
+  sortBy: "totalSaleAmount" as const,
+  sortOrder: "desc" as const,
+});
+
+describe("resolvePartnerSearchCandidateQuery", () => {
+  beforeEach(() => {
+    mocks.findUnique.mockReset();
+  });
+
+  it("reduces a link on the program domain to its key", async () => {
+    mocks.findUnique.mockResolvedValue({ domain: "go.acme.com" });
+
+    const query = await resolvePartnerSearchCandidateQuery(
+      input("https://go.acme.com/partner"),
+    );
+
+    expect(query?.query).toBe("partner");
+    expect(mocks.findUnique).toHaveBeenCalledWith({
+      where: { id: "prog_test" },
+      select: { domain: true },
+    });
+  });
+
+  it("keeps a link on another domain", async () => {
+    mocks.findUnique.mockResolvedValue({ domain: "go.acme.com" });
+
+    const query = await resolvePartnerSearchCandidateQuery(
+      input("dub.sh/partner"),
+    );
+
+    expect(query?.query).toBe("dub.sh/partner");
+  });
+
+  it("does not look the program up for a plain query", async () => {
+    const query = await resolvePartnerSearchCandidateQuery(input("steven"));
+
+    expect(query?.query).toBe("steven");
+    expect(mocks.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("returns null when there is no candidate query", async () => {
+    await expect(resolvePartnerSearchCandidateQuery(input(""))).resolves.toBe(
+      null,
+    );
+    expect(mocks.findUnique).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Strip the program domain from a pasted short link before the query reaches Turbopuffer.

A paste like `go.acme.com/partner` sends the tokens `go`, `acme`, `com` and `partner`. The index stores link keys, not domains, but the domain tokens still match partner company names, websites and descriptions in the identity branch. Those matches widen the result set and can outrank the true owner of the key. This holds after the keys-only backfill too, so it is a separate fix from the re-index.

## Changes

- `stripProgramDomain`: reduces a link on the program's own domain to its key. Matches with or without protocol, `www.` and trailing slash, case-insensitive. Drops query strings and fragments. Links on other domains, the bare domain and plain queries are unchanged.
- `isLinkShapedQuery`: gates the program lookup so it only runs for link-shaped queries. Plain words and emails never trigger it.
- `resolvePartnerSearchCandidateQuery`: builds the candidate query and applies the strip. `getPartners` and `getPartnersCount` both use it, so the list and the count send the same query.

## Test plan

- [x] `partner-search-query.test.ts`: strip and shape cases (protocol, `www.`, case, trailing slash, query string, fragment, nested path, other domain, bare domain, email, no program domain).
- [x] `partner-search-resolve-query.test.ts`: program lookup only for link-shaped queries, strip applied, other domains untouched, null passthrough.
- [x] Existing `getPartners` and `getPartnersCount` search tests unchanged and passing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved partner search for link-shaped queries, including URLs with protocols, paths, query parameters, and fragments.
  * Matching program domains are removed so searches use the relevant link path or key.
  * Partner lists and result counts now apply consistent search behavior.

* **Bug Fixes**
  * Links from other domains, invalid inputs, emails, and plain-text queries remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->