### PR TITLE
Feature/partner-search: strip the program domain from pasted links

### DIFF
--- a/apps/web/lib/api/partners/get-partners-count.ts
+++ b/apps/web/lib/api/partners/get-partners-count.ts
@@ -10,10 +10,10 @@ import {
   mergePartnerCountryAndSearchWhere,
 } from "./program-enrollment-query";
 import {
-  buildPartnerSearchCandidateQuery,
   findPartnerSearchCandidates,
   getPartnerSearchReadProvider,
   PartnerSearchProvider,
+  resolvePartnerSearchCandidateQuery,
 } from "./search";
 
 type PartnersCountFilters = z.infer<typeof partnersCountQuerySchema> & {
@@ -35,7 +35,10 @@ export async function getPartnersCount<T>(
 ): Promise<T> {
   const { groupBy, programId, ...enrollmentFilters } = filters;
   const candidateQuery = searchProvider
-    ? buildPartnerSearchCandidateQuery({ ...enrollmentFilters, programId })
+    ? await resolvePartnerSearchCandidateQuery({
+        ...enrollmentFilters,
+        programId,
+      })
     : null;
   const candidateResult =
     searchProvider && candidateQuery

--- a/apps/web/lib/api/partners/get-partners.ts
+++ b/apps/web/lib/api/partners/get-partners.ts
@@ -3,12 +3,12 @@ import { toCentsNumber } from "@dub/utils";
 import { Prisma } from "@prisma/client";
 import { buildProgramEnrollmentWhereForList } from "./program-enrollment-query";
 import {
-  buildPartnerSearchCandidateQuery,
   findPartnerSearchCandidates,
   getPartnerSearchReadProvider,
   orderByPartnerSearchHits,
   PartnerSearchProvider,
   PartnerSearchQueryInput,
+  resolvePartnerSearchCandidateQuery,
 } from "./search";
 
 type PartnerFilters = PartnerSearchQueryInput & {
@@ -39,7 +39,7 @@ export async function getPartners(
   } = filters;
 
   const candidateQuery = searchProvider
-    ? buildPartnerSearchCandidateQuery(filters)
+    ? await resolvePartnerSearchCandidateQuery(filters)
     : null;
   const candidateResult =
     searchProvider && candidateQuery

--- a/apps/web/lib/api/partners/search/build-search-query.ts
+++ b/apps/web/lib/api/partners/search/build-search-query.ts
@@ -81,3 +81,47 @@ export function buildPartnerSearchCandidateQuery({
     },
   };
 }
+
+/**
+ * A dotted host with an optional protocol, `www.`, and URL suffix. Plain words
+ * and email addresses do not match. This limits the program lookup to
+ * link-shaped search values.
+ */
+const LINK_SHAPED_QUERY =
+  /^(?:https?:\/\/)?(?:www\.)?([a-z0-9-]+(?:\.[a-z0-9-]+)+)([/?#]\S*)?$/i;
+
+export function isLinkShapedQuery(query: string): boolean {
+  return LINK_SHAPED_QUERY.test(query.trim());
+}
+
+/**
+ * Removes the program domain from a matching short link. The search index
+ * stores link keys, but it does not store link domains. Removing the domain
+ * prevents unrelated domain tokens from adding matches or changing result
+ * order. Other domains and bare domains are returned unchanged.
+ */
+export function stripProgramDomain(
+  query: string,
+  programDomain: string | null | undefined,
+): string {
+  const match = query.trim().match(LINK_SHAPED_QUERY);
+
+  if (!match || !programDomain) {
+    return query;
+  }
+
+  const [, host, rest = ""] = match;
+  const normalizedDomain = programDomain.toLowerCase().replace(/^www\./, "");
+
+  if (host.toLowerCase() !== normalizedDomain) {
+    return query;
+  }
+
+  // Query strings and fragments are never part of a key
+  const key = rest
+    .split(/[?#]/)[0]
+    .replace(/^\/+|\/+$/g, "")
+    .trim();
+
+  return key || query;
+}

--- a/apps/web/lib/api/partners/search/index.ts
+++ b/apps/web/lib/api/partners/search/index.ts
@@ -4,6 +4,7 @@ export * from "./find-candidates";
 export * from "./index-enrollments";
 export * from "./order-search-results";
 export * from "./provider";
+export * from "./resolve-candidate-query";
 export * from "./searchable-values";
 export * from "./serialize-document";
 export * from "./sync";

--- a/apps/web/lib/api/partners/search/resolve-candidate-query.ts
+++ b/apps/web/lib/api/partners/search/resolve-candidate-query.ts
@@ -1,0 +1,32 @@
+import { prisma } from "@/lib/prisma";
+import {
+  buildPartnerSearchCandidateQuery,
+  isLinkShapedQuery,
+  stripProgramDomain,
+} from "./build-search-query";
+import type { PartnerSearchCandidateQuery } from "./types";
+
+/**
+ * Builds the candidate query and removes the program domain from a matching
+ * short link. Shared by the list and the count so both send the provider the
+ * same query.
+ */
+export async function resolvePartnerSearchCandidateQuery(
+  input: Parameters<typeof buildPartnerSearchCandidateQuery>[0],
+): Promise<PartnerSearchCandidateQuery | null> {
+  const candidateQuery = buildPartnerSearchCandidateQuery(input);
+
+  if (!candidateQuery || !isLinkShapedQuery(candidateQuery.query)) {
+    return candidateQuery;
+  }
+
+  const program = await prisma.program.findUnique({
+    where: { id: candidateQuery.programId },
+    select: { domain: true },
+  });
+
+  return {
+    ...candidateQuery,
+    query: stripProgramDomain(candidateQuery.query, program?.domain),
+  };
+}

--- a/apps/web/tests/partners/get-partners-count-search.test.ts
+++ b/apps/web/tests/partners/get-partners-count-search.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   partnerGroupBy: vi.fn(),
   partnerTagGroupBy: vi.fn(),
   applicationEventGroupBy: vi.fn(),
+  programFindUnique: vi.fn(),
 }));
 
 vi.mock("@/lib/prisma", () => ({
@@ -23,6 +24,7 @@ vi.mock("@/lib/prisma", () => ({
     partner: { groupBy: mocks.partnerGroupBy, findUnique: vi.fn() },
     programPartnerTag: { groupBy: mocks.partnerTagGroupBy },
     programApplicationEvent: { groupBy: mocks.applicationEventGroupBy },
+    program: { findUnique: mocks.programFindUnique },
   },
 }));
 
@@ -42,6 +44,28 @@ describe("getPartnersCount search", () => {
     for (const mock of Object.values(mocks)) {
       mock.mockReset();
     }
+  });
+
+  it("counts a pasted program short link by its key", async () => {
+    const searchProvider = createSearchProvider(1);
+    mocks.programFindUnique.mockResolvedValue({ domain: "go.acme.com" });
+
+    const count = await getPartnersCount<number>(
+      {
+        programId: "prog_test",
+        search: "https://go.acme.com/partner",
+        status: "approved",
+      },
+      { searchProvider },
+    );
+
+    expect(count).toBe(1);
+    expect(searchProvider.searchCandidates).toHaveBeenCalledWith(
+      expect.objectContaining({ query: "partner" }),
+    );
+    expect(searchProvider.countCandidates).toHaveBeenCalledWith(
+      expect.objectContaining({ query: "partner" }),
+    );
   });
 
   it("reports the truncated candidate count when the total exceeds the candidate ceiling", async () => {

--- a/apps/web/tests/partners/get-partners-search.test.ts
+++ b/apps/web/tests/partners/get-partners-search.test.ts
@@ -7,6 +7,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   findMany: vi.fn(),
+  programFindUnique: vi.fn(),
 }));
 
 vi.mock("@/lib/prisma", () => ({
@@ -15,6 +16,7 @@ vi.mock("@/lib/prisma", () => ({
     programEnrollment: {
       findMany: mocks.findMany,
     },
+    program: { findUnique: mocks.programFindUnique },
   },
 }));
 
@@ -49,6 +51,29 @@ function createSearchProvider(
 describe("getPartners search", () => {
   beforeEach(() => {
     mocks.findMany.mockReset();
+    mocks.programFindUnique.mockReset();
+  });
+
+  it("searches a pasted program short link by its key", async () => {
+    mocks.findMany.mockResolvedValue([enrollment("pge_1", "pn_1")]);
+    mocks.programFindUnique.mockResolvedValue({ domain: "go.acme.com" });
+    const searchProvider = createSearchProvider([{ id: "pge_1" }]);
+
+    await getPartners(
+      {
+        programId: "prog_test",
+        search: "https://go.acme.com/partner",
+        page: 1,
+        pageSize: 25,
+        sortBy: "totalSaleAmount",
+        sortOrder: "desc",
+      },
+      { searchProvider },
+    );
+
+    expect(searchProvider.searchCandidates).toHaveBeenCalledWith(
+      expect.objectContaining({ query: "partner" }),
+    );
   });
 
   it("keeps a tenant filter on the database search path", async () => {

--- a/apps/web/tests/partners/partner-search-query.test.ts
+++ b/apps/web/tests/partners/partner-search-query.test.ts
@@ -1,6 +1,8 @@
 import {
   buildPartnerSearchCandidateQuery,
+  isLinkShapedQuery,
   PARTNER_SEARCH_CANDIDATE_LIMIT,
+  stripProgramDomain,
 } from "@/lib/api/partners/search";
 import { describe, expect, it } from "vitest";
 
@@ -82,5 +84,69 @@ describe("buildPartnerSearchCandidateQuery", () => {
         buildPartnerSearchCandidateQuery({ programId: "prog_1", search }),
       ).toMatchObject({ query: search });
     });
+  });
+});
+
+describe("isLinkShapedQuery", () => {
+  it.each([
+    "go.acme.com/partner",
+    "https://go.acme.com/partner",
+    "www.go.acme.com/partner",
+    "go.acme.com",
+    "  go.acme.com/partner  ",
+  ])("recognizes %s", (query) => {
+    expect(isLinkShapedQuery(query)).toBe(true);
+  });
+
+  it.each(["steven", "steven tey", "steven@dub.co", "pn_123", "acme/partner"])(
+    "does not recognize %s",
+    (query) => {
+      expect(isLinkShapedQuery(query)).toBe(false);
+    },
+  );
+});
+
+describe("stripProgramDomain", () => {
+  const domain = "go.acme.com";
+
+  it.each([
+    ["go.acme.com/partner", "partner"],
+    ["go.acme.com/partner/", "partner"],
+    ["https://go.acme.com/partner", "partner"],
+    ["https://go.acme.com/partner/", "partner"],
+    ["http://www.go.acme.com/partner", "partner"],
+    ["GO.ACME.COM/Partner", "Partner"],
+    ["go.acme.com/partner?utm_source=x", "partner"],
+    ["go.acme.com/partner/?utm_source=x", "partner"],
+    ["go.acme.com/partner#top", "partner"],
+    ["go.acme.com/partner/#top", "partner"],
+    ["go.acme.com/nested/partner", "nested/partner"],
+    ["go.acme.com/nested/partner/", "nested/partner"],
+    ["  go.acme.com/partner  ", "partner"],
+  ])("reduces %s to its key", (query, key) => {
+    expect(stripProgramDomain(query, domain)).toBe(key);
+  });
+
+  it("matches a program domain stored with www.", () => {
+    expect(stripProgramDomain("go.acme.com/partner", "www.go.acme.com")).toBe(
+      "partner",
+    );
+  });
+
+  it.each([
+    ["another domain", "dub.sh/partner"],
+    ["a longer host", "app.go.acme.com/partner"],
+    ["the bare domain", "go.acme.com"],
+    ["the bare domain with a slash", "go.acme.com/"],
+    ["a plain word", "partner"],
+    ["an email", "steven@go.acme.com"],
+  ])("leaves %s unchanged", (_label, query) => {
+    expect(stripProgramDomain(query, domain)).toBe(query);
+  });
+
+  it("leaves the query unchanged when the program has no domain", () => {
+    expect(stripProgramDomain("go.acme.com/partner", null)).toBe(
+      "go.acme.com/partner",
+    );
   });
 });

--- a/apps/web/tests/partners/partner-search-resolve-query.test.ts
+++ b/apps/web/tests/partners/partner-search-resolve-query.test.ts
@@ -1,0 +1,61 @@
+import { resolvePartnerSearchCandidateQuery } from "@/lib/api/partners/search";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ findUnique: vi.fn() }));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: { program: { findUnique: mocks.findUnique } },
+}));
+
+const input = (search: string) => ({
+  programId: "prog_test",
+  search,
+  page: 1,
+  pageSize: 25,
+  sortBy: "totalSaleAmount" as const,
+  sortOrder: "desc" as const,
+});
+
+describe("resolvePartnerSearchCandidateQuery", () => {
+  beforeEach(() => {
+    mocks.findUnique.mockReset();
+  });
+
+  it("reduces a link on the program domain to its key", async () => {
+    mocks.findUnique.mockResolvedValue({ domain: "go.acme.com" });
+
+    const query = await resolvePartnerSearchCandidateQuery(
+      input("https://go.acme.com/partner"),
+    );
+
+    expect(query?.query).toBe("partner");
+    expect(mocks.findUnique).toHaveBeenCalledWith({
+      where: { id: "prog_test" },
+      select: { domain: true },
+    });
+  });
+
+  it("keeps a link on another domain", async () => {
+    mocks.findUnique.mockResolvedValue({ domain: "go.acme.com" });
+
+    const query = await resolvePartnerSearchCandidateQuery(
+      input("dub.sh/partner"),
+    );
+
+    expect(query?.query).toBe("dub.sh/partner");
+  });
+
+  it("does not look the program up for a plain query", async () => {
+    const query = await resolvePartnerSearchCandidateQuery(input("steven"));
+
+    expect(query?.query).toBe("steven");
+    expect(mocks.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("returns null when there is no candidate query", async () => {
+    await expect(resolvePartnerSearchCandidateQuery(input(""))).resolves.toBe(
+      null,
+    );
+    expect(mocks.findUnique).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/tests/partners/partner-search-resolve-query.test.ts
+++ b/apps/web/tests/partners/partner-search-resolve-query.test.ts
@@ -45,6 +45,16 @@ describe("resolvePartnerSearchCandidateQuery", () => {
     expect(query?.query).toBe("dub.sh/partner");
   });
 
+  it("keeps the link when the program is not found", async () => {
+    mocks.findUnique.mockResolvedValue(null);
+
+    const query = await resolvePartnerSearchCandidateQuery(
+      input("go.acme.com/partner"),
+    );
+
+    expect(query?.query).toBe("go.acme.com/partner");
+  });
+
   it("does not look the program up for a plain query", async () => {
     const query = await resolvePartnerSearchCandidateQuery(input("steven"));
 


### PR DESCRIPTION
## Summary

When a user pastes a short link such as `go.acme.com/partner`, partner search sends both the domain and key as search tokens. The domain tokens can add unrelated matches and change the result order.

This change removes the program domain from matching short links and searches with the link key only. It does not require a search re-index.

## Changes

- Detect link-shaped search values.
- Remove the exact program domain from matching short links.
- Support protocols, `www.`, trailing slashes, query strings, fragments, and nested paths.
- Keep other domains, bare domains, plain text, emails, and partner IDs unchanged.
- Use the same resolved query for partner lists and counts.

## Test plan

- Added tests for link detection and domain removal.
- Added tests for program-domain lookup and unchanged queries.
- Confirmed that the existing partner list and count search tests pass.
- Added tests that the partner list and count send the stripped query to the provider.

## Validation against the production index

Ran `stripProgramDomain` on each paste with the Acme program domain, then sent the raw and the stripped query to the production Turbopuffer namespace.

| Paste | Query sent | Candidates | Top hit |
|---|---|---|---|
| `getacme.link/text-pplx` | `text-pplx` | 49 to 1 | stale e2e doc to Steven Elegance |
| `https://getacme.link/text-pplx` | `text-pplx` | 56 to 1 | same |
| `https://getacme.link/text-pplx/` | `text-pplx` | 56 to 1 | same |
| `getacme.link/e2-e-test-partner-goal-3cpw` | `e2-e-test-partner-goal-3cpw` | 729 to 729 | owner, both ways |
| `dub.sh/text-pplx` | unchanged | 741 to 741 | unchanged |

The single hit for `text-pplx` is the enrollment whose document carries that key. The e2e row shows the owner still ranks first, but the count stays at 729 with or without the domain. The last row is another domain, left untouched by design.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Partner search now recognizes program links and searches using the relevant link key.
  * Links with protocols, `www` prefixes, paths, query parameters, or fragments are handled consistently.
  * Search results and partner counts now apply the same link-processing behavior.

* **Bug Fixes**
  * Links hosted on other domains, plain text queries, emails, and partner IDs continue to search unchanged.
  * Improved handling of empty or invalid search input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
