### PR TITLE
Skip Intercom webhook API logs when no partner is found.

### DIFF
--- a/apps/web/app/(ee)/api/intercom/webhook/process/conversation-admin-replied.ts
+++ b/apps/web/app/(ee)/api/intercom/webhook/process/conversation-admin-replied.ts
@@ -38,7 +38,7 @@ export async function handleConversationAdminReplied({
   data: z.infer<typeof intercomConversationRepliedSchema>;
   program: Pick<Program, "id" | "workspaceId">;
   installation: Pick<InstalledIntegration, "credentials" | "userId">;
-}): Promise<string> {
+}): Promise<{ message: string; partnersFound: boolean }> {
   const credentials = intercomCredentialsSchema.parse(installation.credentials);
 
   const partners = await identifyPartnersFromContacts({
@@ -48,7 +48,10 @@ export async function handleConversationAdminReplied({
   });
 
   if (partners.length === 0) {
-    return `No partners found for ${pluralize("contact", data.item.contacts.contacts.length)} ${data.item.contacts.contacts.map((contact) => contact.id).join(", ")}. Skipping message forwarding.`;
+    return {
+      message: `No partners found for ${pluralize("contact", data.item.contacts.contacts.length)} ${data.item.contacts.contacts.map((contact) => contact.id).join(", ")}. Skipping message forwarding.`,
+      partnersFound: false,
+    };
   }
 
   const { conversation_parts: conversations } = data.item.conversation_parts;
@@ -154,7 +157,10 @@ export async function handleConversationAdminReplied({
     ),
   );
 
-  return `Message forwarded to ${pluralize("partner", partners.length)}.`;
+  return {
+    message: `Message forwarded to ${pluralize("partner", partners.length)}.`,
+    partnersFound: true,
+  };
 }
 
 async function resolveWorkspaceUser({

--- a/apps/web/app/(ee)/api/intercom/webhook/process/route.ts
+++ b/apps/web/app/(ee)/api/intercom/webhook/process/route.ts
@@ -80,29 +80,32 @@ export const POST = withAxiom(async (req) => {
       return logAndRespond(`[Intercom] Program ${program.id} is deactivated.`);
     }
 
-    let response: Awaited<ReturnType<typeof handleConversationAdminReplied>> =
-      "";
+    let result:
+      | Awaited<ReturnType<typeof handleConversationAdminReplied>>
+      | undefined;
 
     if (topic === "conversation.admin.replied") {
-      response = await handleConversationAdminReplied({
+      result = await handleConversationAdminReplied({
         data,
         program,
         installation,
       });
     }
 
-    await captureWebhookLog({
-      workspaceId,
-      method: "POST",
-      path: "/intercom/webhook",
-      statusCode: 200,
-      duration: Date.now() - startTime,
-      requestBody: body,
-      responseBody: response,
-      userAgent: req.headers.get("user-agent"),
-    });
+    if (result?.partnersFound) {
+      await captureWebhookLog({
+        workspaceId,
+        method: "POST",
+        path: "/intercom/webhook",
+        statusCode: 200,
+        duration: Date.now() - startTime,
+        requestBody: body,
+        responseBody: result.message,
+        userAgent: req.headers.get("user-agent"),
+      });
+    }
 
-    return logAndRespond(response);
+    return logAndRespond(result?.message ?? "Webhook processed successfully.");
   } catch (error) {
     const response = handleAndReturnErrorResponse(error);
 

--- a/apps/web/lib/api-logs/constants.ts
+++ b/apps/web/lib/api-logs/constants.ts
@@ -221,7 +221,7 @@ export const WEBHOOK_REQUEST_ACTORS_BY_PATH = {
     id: INTERCOM_INTEGRATION_ID,
     name: "Intercom",
     image:
-      "https://dubassets.com/integrations/int_ffw3qgrFAahY6qs1hXaH3wHS_JPoCPOh",
+      "https://dubassets.com/integrations/int_1KV6R1E61E0044C0VFQKV2Q6K_PfbSFTk",
   },
 } as const;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Intercom webhook handling when no partner records are identified.
  - Webhook responses now provide the relevant processing message or a clear default success message.
  - Successful webhook activity is recorded only when partner forwarding occurs.

- **Style**
  - Updated the Intercom webhook activity icon displayed in API logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->