### PR TITLE
Fix public page cache not busting after publish

### DIFF
--- a/apps/web/app/(ee)/api/bounties/[bountyId]/route.ts
+++ b/apps/web/app/(ee)/api/bounties/[bountyId]/route.ts
@@ -361,6 +361,8 @@ export const PATCH = withWorkspace(
       archivedAt: data.archivedAt,
     });
 
+    await revalidateProgramPublicPages(programId);
+
     waitUntil(
       Promise.allSettled([
         recordAuditLog({
@@ -394,8 +396,6 @@ export const PATCH = withWorkspace(
               notBefore: Math.floor(data.startsAt.getTime() / 1000),
             }),
           }),
-
-        revalidateProgramPublicPages(programId),
       ]),
     );
 
@@ -453,6 +453,8 @@ export const DELETE = withWorkspace(
 
     const deletedBounty = BountySchema.parse(transformBounty(bounty));
 
+    await revalidateProgramPublicPages(programId);
+
     waitUntil(
       Promise.allSettled([
         recordAuditLog({
@@ -469,8 +471,6 @@ export const DELETE = withWorkspace(
             },
           ],
         }),
-
-        revalidateProgramPublicPages(programId),
       ]),
     );
 

--- a/apps/web/app/(ee)/api/bounties/route.ts
+++ b/apps/web/app/(ee)/api/bounties/route.ts
@@ -4,8 +4,8 @@ import { DubApiError } from "@/lib/api/errors";
 import { throwIfInvalidGroupIds } from "@/lib/api/groups/throw-if-invalid-group-ids";
 import { throwIfInvalidPartnerTagIds } from "@/lib/api/partner-tags/throw-if-invalid-partner-tag-ids";
 import { getDefaultProgramIdOrThrow } from "@/lib/api/programs/get-default-program-id-or-throw";
-import { revalidateProgramPublicPages } from "@/lib/api/programs/revalidate-program-public-pages";
 import { getProgramEnrollmentOrThrow } from "@/lib/api/programs/get-program-enrollment-or-throw";
+import { revalidateProgramPublicPages } from "@/lib/api/programs/revalidate-program-public-pages";
 import { parseRequestBody } from "@/lib/api/utils";
 import { WorkflowAction } from "@/lib/api/workflows/types";
 import { validateWorkflowConditions } from "@/lib/api/workflows/validate-workflow-conditions";
@@ -329,6 +329,8 @@ export const POST = withWorkspace(
       canSendEmailCampaigns &&
       bounty.startMode !== BountyStartMode.relative;
 
+    await revalidateProgramPublicPages(programId);
+
     waitUntil(
       Promise.allSettled([
         recordAuditLog({
@@ -373,8 +375,6 @@ export const POST = withWorkspace(
               notBefore: Math.floor(bounty.startsAt.getTime() / 1000),
             }),
           }),
-
-        revalidateProgramPublicPages(programId),
       ]),
     );
 

--- a/apps/web/app/(ee)/api/groups/[groupIdOrSlug]/default/route.ts
+++ b/apps/web/app/(ee)/api/groups/[groupIdOrSlug]/default/route.ts
@@ -7,7 +7,6 @@ import { DEFAULT_PARTNER_GROUP, GroupSchema } from "@/lib/zod/schemas/groups";
 import { RESOURCE_COLORS } from "@/ui/colors";
 import { nanoid, randomValue } from "@dub/utils";
 import slugify from "@sindresorhus/slugify";
-import { waitUntil } from "@vercel/functions";
 import { NextResponse } from "next/server";
 
 // POST /api/groups/[groupIdOrSlug]/default – set a group as default
@@ -85,7 +84,7 @@ export const POST = withWorkspace(
       });
     });
 
-    waitUntil(revalidateProgramPublicPages(programId));
+    await revalidateProgramPublicPages(programId);
 
     return NextResponse.json(GroupSchema.parse(updatedGroup));
   },

--- a/apps/web/lib/actions/partners/update-discount.ts
+++ b/apps/web/lib/actions/partners/update-discount.ts
@@ -47,11 +47,15 @@ export const updateDiscountAction = authActionClient
       },
     });
 
+    const shouldExpireCache =
+      discount.couponTestId !== updatedDiscount.couponTestId;
+
+    if (shouldExpireCache) {
+      await revalidateProgramPublicPages(programId);
+    }
+
     waitUntil(
       (async () => {
-        const shouldExpireCache =
-          discount.couponTestId !== updatedDiscount.couponTestId;
-
         await Promise.allSettled([
           ...(shouldExpireCache
             ? [
@@ -61,8 +65,6 @@ export const updateDiscountAction = authActionClient
                     groupId: partnerGroup?.id,
                   },
                 }),
-
-                revalidateProgramPublicPages(programId),
               ]
             : []),
 

--- a/apps/web/lib/actions/partners/update-group-branding.ts
+++ b/apps/web/lib/actions/partners/update-group-branding.ts
@@ -112,18 +112,13 @@ export const updateGroupBrandingAction = authActionClient
       },
     });
 
+    if (landerDataInput || applicationFormDataInput || unpublish) {
+      await revalidateProgramPublicPages(programId);
+    }
+
     waitUntil(
       (async () => {
         const res = await Promise.allSettled([
-          /*
-         Revalidate public pages if the following fields were updated:
-         - lander data
-         - application form data
-        */
-          ...(landerDataInput || applicationFormDataInput || unpublish
-            ? [revalidateProgramPublicPages(programId)]
-            : []),
-
           recordAuditLog({
             workspaceId: workspace.id,
             programId: program.id,

--- a/apps/web/lib/actions/partners/update-program.ts
+++ b/apps/web/lib/actions/partners/update-program.ts
@@ -75,25 +75,25 @@ export const updateProgramAction = authActionClient
       },
     });
 
+    if (updatedProgram.termsUrl !== program.termsUrl) {
+      await revalidateProgramPublicPages(programId);
+    }
+
     waitUntil(
-      Promise.allSettled([
-        updatedProgram.termsUrl !== program.termsUrl &&
-          revalidateProgramPublicPages(programId),
-        recordAuditLog({
-          workspaceId: workspace.id,
-          programId: program.id,
-          action: "program.updated",
-          description: `Program ${program.name} updated`,
-          actor: user,
-          targets: [
-            {
-              type: "program",
-              id: program.id,
-              metadata: updatedProgram,
-            },
-          ],
-        }),
-      ]),
+      recordAuditLog({
+        workspaceId: workspace.id,
+        programId: program.id,
+        action: "program.updated",
+        description: `Program ${program.name} updated`,
+        actor: user,
+        targets: [
+          {
+            type: "program",
+            id: program.id,
+            metadata: updatedProgram,
+          },
+        ],
+      }),
     );
 
     return {

--- a/apps/web/lib/actions/partners/update-reward.ts
+++ b/apps/web/lib/actions/partners/update-reward.ts
@@ -127,6 +127,8 @@ export const updateRewardAction = authActionClient
       throw new Error("Partner group not found.");
     }
 
+    await revalidateProgramPublicPages(programId);
+
     await queueRewardProcessing({
       event: "reward-updated",
       groupId: partnerGroup.id,
@@ -169,8 +171,6 @@ export const updateRewardAction = authActionClient
           new: updatedReward,
           description: activityDescription,
         }),
-
-        revalidateProgramPublicPages(programId),
       ]),
     );
   });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Public program pages now refresh reliably after changes to bounties, rewards, branding, terms, discounts, and default groups.
  - Updates are reflected before related background processing begins, reducing stale information on public pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->