### PR TITLE
Show an error when magic-link login fails instead of a success toast

### DIFF
--- a/apps/web/ui/auth/login/email-sign-in.tsx
+++ b/apps/web/ui/auth/login/email-sign-in.tsx
@@ -100,7 +100,7 @@ export const EmailSignIn = ({ next }: { next?: string }) => {
             return;
           }
 
-          if (!response.ok && response.error) {
+          if (response.error) {
             if (errorCodes[response.error]) {
               toast.error(errorCodes[response.error]);
             } else {


### PR DESCRIPTION
## Summary
- Fixes #4272: NextAuth email failures (rate limit, AccessDenied, locked account) return HTTP 200 with `error` set, so the login form treated them as success and showed "Email sent - check your inbox!"
- Treat `response.error` as a failure regardless of `response.ok`, so the existing `EmailSignin` copy (and other mapped errors) actually renders.

## Test plan
- [ ] On a preview/production deploy (rate limits are skipped in local/CI), request a magic link 3 times within 60 seconds for an account with no password
- [ ] Confirm the third attempt shows "Failed to send login email. Please try again in a minute or contact support." instead of a success toast
- [ ] Confirm a successful first magic-link send still shows "Email sent - check your inbox!"
- [ ] Confirm credentials login still works (success has `error: null`; invalid credentials still show the error toast)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-in error handling so any reported error is surfaced correctly, even when the response status indicates success.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->