### PR TITLE
Fix public page cache not busting after publish

### DIFF
--- a/apps/web/app/(ee)/api/bounties/[bountyId]/route.ts
+++ b/apps/web/app/(ee)/api/bounties/[bountyId]/route.ts
@@ -361,6 +361,8 @@ export const PATCH = withWorkspace(
       archivedAt: data.archivedAt,
     });
 
+    revalidateProgramPublicPages(programId);
+
     waitUntil(
       Promise.allSettled([
         recordAuditLog({
@@ -394,8 +396,6 @@ export const PATCH = withWorkspace(
               notBefore: Math.floor(data.startsAt.getTime() / 1000),
             }),
           }),
-
-        revalidateProgramPublicPages(programId),
       ]),
     );
 
@@ -453,6 +453,8 @@ export const DELETE = withWorkspace(
 
     const deletedBounty = BountySchema.parse(transformBounty(bounty));
 
+    revalidateProgramPublicPages(programId);
+
     waitUntil(
       Promise.allSettled([
         recordAuditLog({
@@ -469,8 +471,6 @@ export const DELETE = withWorkspace(
             },
           ],
         }),
-
-        revalidateProgramPublicPages(programId),
       ]),
     );
 

--- a/apps/web/app/(ee)/api/bounties/route.ts
+++ b/apps/web/app/(ee)/api/bounties/route.ts
@@ -4,8 +4,8 @@ import { DubApiError } from "@/lib/api/errors";
 import { throwIfInvalidGroupIds } from "@/lib/api/groups/throw-if-invalid-group-ids";
 import { throwIfInvalidPartnerTagIds } from "@/lib/api/partner-tags/throw-if-invalid-partner-tag-ids";
 import { getDefaultProgramIdOrThrow } from "@/lib/api/programs/get-default-program-id-or-throw";
-import { revalidateProgramPublicPages } from "@/lib/api/programs/revalidate-program-public-pages";
 import { getProgramEnrollmentOrThrow } from "@/lib/api/programs/get-program-enrollment-or-throw";
+import { revalidateProgramPublicPages } from "@/lib/api/programs/revalidate-program-public-pages";
 import { parseRequestBody } from "@/lib/api/utils";
 import { WorkflowAction } from "@/lib/api/workflows/types";
 import { validateWorkflowConditions } from "@/lib/api/workflows/validate-workflow-conditions";
@@ -329,6 +329,8 @@ export const POST = withWorkspace(
       canSendEmailCampaigns &&
       bounty.startMode !== BountyStartMode.relative;
 
+    revalidateProgramPublicPages(programId);
+
     waitUntil(
       Promise.allSettled([
         recordAuditLog({
@@ -373,8 +375,6 @@ export const POST = withWorkspace(
               notBefore: Math.floor(bounty.startsAt.getTime() / 1000),
             }),
           }),
-
-        revalidateProgramPublicPages(programId),
       ]),
     );
 

--- a/apps/web/app/(ee)/api/groups/[groupIdOrSlug]/default/route.ts
+++ b/apps/web/app/(ee)/api/groups/[groupIdOrSlug]/default/route.ts
@@ -7,7 +7,6 @@ import { DEFAULT_PARTNER_GROUP, GroupSchema } from "@/lib/zod/schemas/groups";
 import { RESOURCE_COLORS } from "@/ui/colors";
 import { nanoid, randomValue } from "@dub/utils";
 import slugify from "@sindresorhus/slugify";
-import { waitUntil } from "@vercel/functions";
 import { NextResponse } from "next/server";
 
 // POST /api/groups/[groupIdOrSlug]/default – set a group as default
@@ -85,7 +84,7 @@ export const POST = withWorkspace(
       });
     });
 
-    waitUntil(revalidateProgramPublicPages(programId));
+    revalidateProgramPublicPages(programId);
 
     return NextResponse.json(GroupSchema.parse(updatedGroup));
   },

--- a/apps/web/lib/actions/partners/update-discount.ts
+++ b/apps/web/lib/actions/partners/update-discount.ts
@@ -47,11 +47,15 @@ export const updateDiscountAction = authActionClient
       },
     });
 
+    const shouldExpireCache =
+      discount.couponTestId !== updatedDiscount.couponTestId;
+
+    if (shouldExpireCache) {
+      revalidateProgramPublicPages(programId);
+    }
+
     waitUntil(
       (async () => {
-        const shouldExpireCache =
-          discount.couponTestId !== updatedDiscount.couponTestId;
-
         await Promise.allSettled([
           ...(shouldExpireCache
             ? [
@@ -61,8 +65,6 @@ export const updateDiscountAction = authActionClient
                     groupId: partnerGroup?.id,
                   },
                 }),
-
-                revalidateProgramPublicPages(programId),
               ]
             : []),
 

--- a/apps/web/lib/actions/partners/update-group-branding.ts
+++ b/apps/web/lib/actions/partners/update-group-branding.ts
@@ -112,18 +112,13 @@ export const updateGroupBrandingAction = authActionClient
       },
     });
 
+    if (landerDataInput || applicationFormDataInput || unpublish) {
+      revalidateProgramPublicPages(programId);
+    }
+
     waitUntil(
       (async () => {
         const res = await Promise.allSettled([
-          /*
-         Revalidate public pages if the following fields were updated:
-         - lander data
-         - application form data
-        */
-          ...(landerDataInput || applicationFormDataInput || unpublish
-            ? [revalidateProgramPublicPages(programId)]
-            : []),
-
           recordAuditLog({
             workspaceId: workspace.id,
             programId: program.id,

--- a/apps/web/lib/actions/partners/update-program.ts
+++ b/apps/web/lib/actions/partners/update-program.ts
@@ -75,10 +75,12 @@ export const updateProgramAction = authActionClient
       },
     });
 
+    if (updatedProgram.termsUrl !== program.termsUrl) {
+      revalidateProgramPublicPages(programId);
+    }
+
     waitUntil(
       Promise.allSettled([
-        updatedProgram.termsUrl !== program.termsUrl &&
-          revalidateProgramPublicPages(programId),
         recordAuditLog({
           workspaceId: workspace.id,
           programId: program.id,

--- a/apps/web/lib/actions/partners/update-reward.ts
+++ b/apps/web/lib/actions/partners/update-reward.ts
@@ -141,6 +141,8 @@ export const updateRewardAction = authActionClient
       },
     });
 
+    revalidateProgramPublicPages(programId);
+
     waitUntil(
       Promise.allSettled([
         recordAuditLog({
@@ -169,8 +171,6 @@ export const updateRewardAction = authActionClient
           new: updatedReward,
           description: activityDescription,
         }),
-
-        revalidateProgramPublicPages(programId),
       ]),
     );
   });

--- a/apps/web/lib/api/programs/revalidate-program-public-pages.ts
+++ b/apps/web/lib/api/programs/revalidate-program-public-pages.ts
@@ -1,32 +1,35 @@
 import { prisma } from "@/lib/prisma";
 import { DEFAULT_PARTNER_GROUP } from "@/lib/zod/schemas/groups";
 import { revalidatePath } from "next/cache";
+import { after } from "next/server";
 
-export async function revalidateProgramPublicPages(programId: string) {
-  const program = await prisma.program.findUniqueOrThrow({
-    where: { id: programId },
-    select: {
-      slug: true,
-      addedToMarketplaceAt: true,
-      groups: { select: { slug: true } },
-    },
+export function revalidateProgramPublicPages(programId: string) {
+  after(async () => {
+    const program = await prisma.program.findUniqueOrThrow({
+      where: { id: programId },
+      select: {
+        slug: true,
+        addedToMarketplaceAt: true,
+        groups: { select: { slug: true } },
+      },
+    });
+
+    const paths = [
+      `/partners.dub.co/${program.slug}`,
+      `/partners.dub.co/${program.slug}/apply`,
+      `/partners.dub.co/${program.slug}/apply/success`,
+      ...program.groups
+        .filter((group) => group.slug !== DEFAULT_PARTNER_GROUP.slug)
+        .flatMap((group) => [
+          `/partners.dub.co/${program.slug}/${group.slug}`,
+          `/partners.dub.co/${program.slug}/${group.slug}/apply`,
+          `/partners.dub.co/${program.slug}/${group.slug}/apply/success`,
+        ]),
+      ...(program.addedToMarketplaceAt
+        ? [`/partners.dub.co/marketplace/${program.slug}`]
+        : []),
+    ];
+
+    paths.forEach((path) => revalidatePath(path));
   });
-
-  const paths = [
-    `/partners.dub.co/${program.slug}`,
-    `/partners.dub.co/${program.slug}/apply`,
-    `/partners.dub.co/${program.slug}/apply/success`,
-    ...program.groups
-      .filter((group) => group.slug !== DEFAULT_PARTNER_GROUP.slug)
-      .flatMap((group) => [
-        `/partners.dub.co/${program.slug}/${group.slug}`,
-        `/partners.dub.co/${program.slug}/${group.slug}/apply`,
-        `/partners.dub.co/${program.slug}/${group.slug}/apply/success`,
-      ]),
-    ...(program.addedToMarketplaceAt
-      ? [`/partners.dub.co/marketplace/${program.slug}`]
-      : []),
-  ];
-
-  paths.forEach((path) => revalidatePath(path));
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Public program pages now begin revalidating immediately after related bounty, group, discount, program, or reward changes.
  * Updates to public-facing program content are reflected more reliably without waiting for background processing.
  * Background tasks continue handling audit logs, notifications, and other follow-up processing independently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->