### PR TITLE
Persist country on customer PATCH

### DIFF
--- a/apps/web/app/(ee)/api/customers/[id]/route.ts
+++ b/apps/web/app/(ee)/api/customers/[id]/route.ts
@@ -50,7 +50,7 @@ export const PATCH = withWorkspace(
     const { includeExpandedFields } =
       getCustomersQuerySchema.parse(searchParams);
 
-    const { name, email, avatar, externalId, stripeCustomerId } =
+    const { name, email, avatar, externalId, stripeCustomerId, country } =
       updateCustomerBodySchema.parse(await parseRequestBody(req));
 
     const customer = await getCustomerOrThrow(
@@ -84,6 +84,7 @@ export const PATCH = withWorkspace(
           avatar: finalCustomerAvatar,
           externalId,
           stripeCustomerId,
+          country,
         },
       });
 

--- a/apps/web/playwright/api/customers/customers.spec.ts
+++ b/apps/web/playwright/api/customers/customers.spec.ts
@@ -102,6 +102,7 @@ test("PATCH /customers/{id}", async ({ api }) => {
     const toUpdate = {
       name: "Updated",
       avatar: "https://api.dub.co/og/avatar/1234567890",
+      country: "US",
     };
 
     const { status, data } = await api.patch<Customer>(

--- a/apps/web/playwright/api/customers/customers.spec.ts
+++ b/apps/web/playwright/api/customers/customers.spec.ts
@@ -102,7 +102,7 @@ test("PATCH /customers/{id}", async ({ api }) => {
     const toUpdate = {
       name: "Updated",
       avatar: "https://api.dub.co/og/avatar/1234567890",
-      country: "US",
+      country: "BR",
     };
 
     const { status, data } = await api.patch<Customer>(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Customer profiles can now be updated with a country value through the customer API, allowing location information to be maintained alongside other customer details.

* **Bug Fixes**
  * Updated customer records now correctly retain the submitted country information, ensuring changes are reflected after the update is completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->