### PR TITLE
Fix squashed browser icons in Events table

### DIFF
--- a/apps/web/ui/analytics/device-icon.tsx
+++ b/apps/web/ui/analytics/device-icon.tsx
@@ -12,6 +12,7 @@ import {
   Watch,
   Window,
 } from "@dub/ui/icons";
+import { cn } from "@dub/utils";
 import { TRIGGER_DISPLAY } from "./trigger-display";
 
 export function DeviceIcon({
@@ -57,7 +58,7 @@ export function DeviceIcon({
             width={20}
             height={20}
             // Non-square sources (e.g. Facebook/Instagram at 3:2) squash without this
-            className={`${className} object-cover`}
+            className={cn(className, "object-cover")}
           />
         );
     }

--- a/apps/web/ui/analytics/device-icon.tsx
+++ b/apps/web/ui/analytics/device-icon.tsx
@@ -56,7 +56,8 @@ export function DeviceIcon({
             alt={display}
             width={20}
             height={20}
-            className={className}
+            // Non-square sources (e.g. Facebook/Instagram at 3:2) squash without this
+            className={`${className} object-cover`}
           />
         );
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Browser icons for Facebook/Instagram (and any other non-square ua-parser assets) were stretched in the Events table Browser column because 3:2 PNGs were forced into a square `size-4` box.
- Adds `object-cover` on the default browser `BlurImage` in `DeviceIcon` so circular icons keep their aspect ratio.

## Test plan
- [ ] Open Analytics → Events and enable the Browser column
- [ ] Confirm Facebook/Instagram icons are circular (not vertically stretched)
- [ ] Confirm square icons (Chrome/Firefox/Safari) still look correct
- [ ] Spot-check browser icons in analytics filters / device section
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://dub.slack.com/archives/C072M31K2CU/p1788410338377729?thread_ts=1788410338.377729&cid=C072M31K2CU)

<div><a href="https://cursor.com/agents/bc-8be17971-ff8f-537c-98d5-e764185c0577?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8be17971-ff8f-537c-98d5-e764185c0577&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

