### PR TITLE
Fix `determinePartnerRewards` logic

### DIFF
--- a/apps/web/lib/partners/determine-partner-reward.ts
+++ b/apps/web/lib/partners/determine-partner-reward.ts
@@ -150,11 +150,13 @@ export const determinePartnerRewards = ({
       });
 
       if (reward) {
+        // product.amount is the Stripe line total (unit × quantity). Flat
+        // rewards are per sale/line, so do not multiply by line.quantity.
         rewards.push({
           reward,
           sale: {
             amount: product.amount,
-            quantity: product.quantity,
+            quantity: 1,
           },
         });
       }

--- a/apps/web/tests/rewards/determine-partner-rewards.test.ts
+++ b/apps/web/tests/rewards/determine-partner-rewards.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, test, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
-const ADDON_PRODUCT_ID = "prod_R1uuEScGJsUARB";
+const ADDON_PRODUCT_ID = "prod_abc";
 
 function saleReward(overrides: Partial<Reward> = {}): Reward {
   return {
@@ -50,7 +50,7 @@ describe("determinePartnerRewards", () => {
               operator: "AND",
               conditions: [
                 {
-                  value: [ADDON_PRODUCT_ID, "prod_SzAJMZg7bsc5Cf"],
+                  value: [ADDON_PRODUCT_ID, "prod_xyz"],
                   entity: "sale",
                   operator: "in",
                   attribute: "productId",

--- a/apps/web/tests/rewards/determine-partner-rewards.test.ts
+++ b/apps/web/tests/rewards/determine-partner-rewards.test.ts
@@ -1,0 +1,183 @@
+import { calculateSaleEarnings } from "@/lib/api/sales/calculate-sale-earnings";
+import { determinePartnerRewards } from "@/lib/partners/determine-partner-reward";
+import { Prisma, Reward } from "@prisma/client";
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const ADDON_PRODUCT_ID = "prod_R1uuEScGJsUARB";
+
+function saleReward(overrides: Partial<Reward> = {}): Reward {
+  return {
+    id: "rw_test",
+    programId: "prog_test",
+    description: null,
+    tooltipDescription: null,
+    event: "sale",
+    type: "percentage",
+    amountInCents: null,
+    amountInPercentage: new Prisma.Decimal(30),
+    maxDuration: 12,
+    modifiers: null,
+    config: null,
+    spendLimitAmount: null,
+    spendLimitInterval: null,
+    createdAt: new Date("2026-01-01"),
+    updatedAt: new Date("2026-01-01"),
+    ...overrides,
+  };
+}
+
+function enrollment(saleRewardValue: Reward) {
+  return {
+    partner: { country: null },
+    links: null,
+    totalCommissions: 0,
+    saleReward: saleRewardValue,
+  };
+}
+
+describe("determinePartnerRewards", () => {
+  test("does not multiply a flat reward by Stripe line quantity", () => {
+    const rewards = determinePartnerRewards({
+      event: "sale",
+      programEnrollment: enrollment(
+        saleReward({
+          modifiers: [
+            {
+              id: "product-zero-percent",
+              type: "percentage",
+              operator: "AND",
+              conditions: [
+                {
+                  value: [ADDON_PRODUCT_ID, "prod_SzAJMZg7bsc5Cf"],
+                  entity: "sale",
+                  operator: "in",
+                  attribute: "productId",
+                },
+              ],
+              maxDuration: 12,
+              amountInPercentage: 0,
+            },
+            {
+              id: "amount-gte-200",
+              type: "flat",
+              operator: "AND",
+              conditions: [
+                {
+                  value: 20000,
+                  entity: "sale",
+                  operator: "greater_than_or_equal",
+                  attribute: "amount",
+                },
+              ],
+              maxDuration: 0,
+              amountInCents: 6000,
+            },
+          ],
+        }),
+      ),
+      context: {
+        sale: {
+          amount: 20000,
+          products: [
+            {
+              id: ADDON_PRODUCT_ID,
+              amount: 20000,
+              quantity: 200,
+            },
+          ],
+        },
+      },
+      amount: 20000,
+      quantity: 1,
+    });
+
+    expect(rewards).toHaveLength(1);
+    expect(rewards[0].sale).toEqual({ amount: 20000, quantity: 1 });
+    expect(rewards[0].reward.type).toBe("flat");
+    expect(rewards[0].reward.amountInCents).toBe(6000);
+    expect(
+      calculateSaleEarnings({
+        reward: rewards[0].reward,
+        sale: rewards[0].sale,
+      }),
+    ).toBe(6000);
+  });
+
+  test("applies percentage rewards to the line total, ignoring line quantity", () => {
+    const rewards = determinePartnerRewards({
+      event: "sale",
+      programEnrollment: enrollment(
+        saleReward({
+          modifiers: [
+            {
+              type: "percentage",
+              operator: "AND",
+              amountInPercentage: 10,
+              conditions: [
+                {
+                  entity: "sale",
+                  attribute: "productId",
+                  operator: "equals_to",
+                  value: ADDON_PRODUCT_ID,
+                },
+              ],
+            },
+          ],
+        }),
+      ),
+      context: {
+        sale: {
+          products: [
+            {
+              id: ADDON_PRODUCT_ID,
+              amount: 20000,
+              quantity: 200,
+            },
+          ],
+        },
+      },
+      amount: 20000,
+      quantity: 1,
+    });
+
+    expect(rewards).toHaveLength(1);
+    expect(rewards[0].sale.quantity).toBe(1);
+    expect(
+      calculateSaleEarnings({
+        reward: rewards[0].reward,
+        sale: rewards[0].sale,
+      }),
+    ).toBe(2000);
+  });
+
+  test("uses the sale quantity when there is no productId modifier", () => {
+    const rewards = determinePartnerRewards({
+      event: "sale",
+      programEnrollment: enrollment(
+        saleReward({
+          type: "flat",
+          amountInCents: 500,
+          amountInPercentage: null,
+        }),
+      ),
+      context: {
+        sale: {
+          products: [
+            {
+              id: ADDON_PRODUCT_ID,
+              amount: 20000,
+              quantity: 200,
+            },
+          ],
+        },
+      },
+      amount: 20000,
+      quantity: 1,
+    });
+
+    expect(rewards).toHaveLength(1);
+    expect(rewards[0].sale).toEqual({ amount: 20000, quantity: 1 });
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected flat partner reward calculations for Stripe purchases so rewards are not multiplied by product quantity.
  * Ensured percentage-based rewards continue to use the full line-item total.
  * Preserved sale quantity handling when no product-specific reward modifier applies.
  * Improved reward accuracy across different product and pricing configurations.

* **Tests**
  * Added coverage for flat rewards, percentage rewards, and fallback sale-quantity behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->