### PR TITLE
Fix partner onboarding company name locking on validation error

### DIFF
--- a/apps/web/app/(ee)/partners.dub.co/(onboarding)/onboarding/onboarding-form.tsx
+++ b/apps/web/app/(ee)/partners.dub.co/(onboarding)/onboarding/onboarding-form.tsx
@@ -256,7 +256,7 @@ export function OnboardingForm({
                       ? "border-red-300 pr-10 text-red-900 placeholder-red-300 focus:border-red-500 focus:ring-red-500"
                       : "border-neutral-300 text-neutral-900 placeholder-neutral-400 focus:border-neutral-500 focus:ring-neutral-500",
                   )}
-                  readOnly={!!partner?.companyName || !!errors.companyName}
+                  readOnly={!!partner?.companyName}
                   {...register("companyName", {
                     required: profileType === "company",
                   })}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Fixes #4234: the **Legal company name** field in partner onboarding became `readOnly` whenever `errors.companyName` was set.
- Submitting with Profile Type = Company and an empty company name permanently locked the input (grey read-only styling + no typing), so the validation error could never be cleared without a page reload.
- `readOnly` now only applies when `partner?.companyName` already exists.

## Test plan

- [ ] Open partners onboarding ("Create your partner profile")
- [ ] Set Profile Type to Company
- [ ] Leave Legal company name empty and click Continue
- [ ] Confirm the field shows the error state but remains editable
- [ ] Enter a company name and confirm Continue succeeds
- [ ] Confirm an existing partner with `companyName` still sees the field as read-only

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://dub.slack.com/archives/C07H0T3SX97/p1788505476584989?thread_ts=1788505476.584989&cid=C07H0T3SX97)

<div><a href="https://cursor.com/agents/bc-d993fb01-551a-5ed1-ae3e-80ea8e22c75d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d993fb01-551a-5ed1-ae3e-80ea8e22c75d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

