### PR TITLE
Skip invalid Stripe payout amounts on balance.available

### DIFF
--- a/apps/web/app/(ee)/api/cron/payouts/balance-available/route.ts
+++ b/apps/web/app/(ee)/api/cron/payouts/balance-available/route.ts
@@ -60,8 +60,14 @@ export const POST = withCron(async ({ rawBody }) => {
 
     let { amount: availableBalance, currency } = balance.available[0];
 
-    // if available balance is 0, check if there's any pending balance
-    if (availableBalance === 0) {
+    if (["huf", "twd"].includes(currency)) {
+      // Stripe requires HUF/TWD payouts to be evenly divisible by 100
+      availableBalance = Math.floor(availableBalance / 100) * 100;
+    }
+
+    // Stripe requires payout amount >= 1; skip dust (e.g. HUF/TWD rounded down)
+    // and negatives (refunds/reversals). Requeue if funds are still pending.
+    if (availableBalance < 1) {
       const pendingBalance = balance.pending?.[0]?.amount ?? 0;
 
       // if there's a pending balance, schedule another check in 1 hour
@@ -83,7 +89,7 @@ export const POST = withCron(async ({ rawBody }) => {
       }
 
       return logAndRespond(
-        `Partner ${partner.email} (${stripeAccount})'s available balance is 0. Skipping...`,
+        `Partner ${partner.email} (${stripeAccount}) has no payoutable available balance (${currencyFormatter(availableBalance, { currency })}). Skipping...`,
       );
     }
 
@@ -123,12 +129,6 @@ export const POST = withCron(async ({ rawBody }) => {
       return logAndRespond(
         `Partner ${partner.email} (${stripeAccount}) has an errored bank account. Skipping...`,
       );
-    }
-
-    if (["huf", "twd"].includes(currency)) {
-      // For HUF and TWD, Stripe requires payout amounts to be evenly divisible by 100
-      // We need to round down to the nearest 100 units
-      availableBalance = Math.floor(availableBalance / 100) * 100;
     }
 
     const stripePayout = await stripe.payouts.create(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved payout handling for HUF and TWD balances by rounding down to the nearest 100 units before eligibility checks.
  * Prevented payouts for negative, zero, or negligible available balances, ensuring these amounts follow the pending-balance handling path.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->