### PR TITLE
Skip additionalLinks URL validation for workspace partner

### DIFF
--- a/apps/web/app/(ee)/api/partners/links/route.ts
+++ b/apps/web/app/(ee)/api/partners/links/route.ts
@@ -1,6 +1,5 @@
 import { DubApiError, ErrorCodes } from "@/lib/api/errors";
 import { createLink, processLink } from "@/lib/api/links";
-import { validatePartnerLinkUrl } from "@/lib/api/links/validate-partner-link-url";
 import { getDefaultProgramIdOrThrow } from "@/lib/api/programs/get-default-program-id-or-throw";
 import { getProgramOrThrow } from "@/lib/api/programs/get-program-or-throw";
 import { parseRequestBody } from "@/lib/api/utils";
@@ -125,8 +124,6 @@ export const POST = withWorkspace(
         message: "This partner is not part of a partner group.",
       });
     }
-
-    validatePartnerLinkUrl({ group: partnerGroup, url });
 
     const linkUrl = url || partnerGroup.partnerGroupDefaultLinks[0].url;
 

--- a/apps/web/app/(ee)/api/partners/links/upsert/route.ts
+++ b/apps/web/app/(ee)/api/partners/links/upsert/route.ts
@@ -6,7 +6,6 @@ import {
   updateLink,
 } from "@/lib/api/links";
 import { includeTags } from "@/lib/api/links/include-tags";
-import { validatePartnerLinkUrl } from "@/lib/api/links/validate-partner-link-url";
 import { getDefaultProgramIdOrThrow } from "@/lib/api/programs/get-default-program-id-or-throw";
 import { getProgramOrThrow } from "@/lib/api/programs/get-program-or-throw";
 import { parseRequestBody } from "@/lib/api/utils";
@@ -80,11 +79,6 @@ export const PUT = withWorkspace(
         message: "This partner is not part of a partner group.",
       });
     }
-
-    validatePartnerLinkUrl({
-      group: partnerGroup,
-      url,
-    });
 
     const link = await prisma.link.findFirst({
       where: {

--- a/apps/web/lib/zod/schemas/partners.ts
+++ b/apps/web/lib/zod/schemas/partners.ts
@@ -843,7 +843,7 @@ export const createPartnerLinkSchema = partnerIdTenantIdSchema
   .extend({
     url: parseUrlSchema
       .describe(
-        "The URL to shorten (if not provided, the program's default URL will be used). Will throw an error if the domain doesn't match the program's default URL domain.",
+        "The URL to shorten (if not provided, the program's default URL will be used).",
       )
       .nullish(),
     key: z
@@ -862,9 +862,7 @@ export const createPartnerLinkSchema = partnerIdTenantIdSchema
   );
 
 export const upsertPartnerLinkSchema = createPartnerLinkSchema.extend({
-  url: parseUrlSchema.describe(
-    "The URL to upsert for. Will throw an error if the domain doesn't match the program's default URL domain.",
-  ),
+  url: parseUrlSchema.describe("The URL to upsert for."),
 });
 
 // For /api/partners/analytics

--- a/apps/web/playwright/api/embed/referrals-links.spec.ts
+++ b/apps/web/playwright/api/embed/referrals-links.spec.ts
@@ -1,0 +1,245 @@
+import { prisma } from "@/lib/prisma";
+import { nanoid } from "@dub/utils";
+import { expect } from "@playwright/test";
+import { apiError } from "../../utils";
+import { createBearerApiClient, test } from "../fixtures";
+import {
+  createGroupWithAdditionalLinks,
+  createPartner,
+  deletePartner,
+} from "../partners/helpers";
+import { TEST_WORKSPACE } from "../setup-test-workspace";
+
+type EmbedLink = {
+  id: string;
+  domain: string;
+  key: string;
+  url: string;
+};
+
+test.describe.configure({ mode: "serial" });
+
+test("GET /embed/referrals/links", async ({ api, playwright }) => {
+  let partnerId: string | undefined;
+
+  try {
+    const { data: partner } = await createPartner(api);
+    partnerId = partner.id;
+
+    const { status: tokenStatus, data: token } = await api.post<{
+      publicToken: string;
+    }>("/api/tokens/embed/referrals", { partnerId: partner.id });
+    expect(tokenStatus).toEqual(201);
+
+    const { api: embedApi, dispose } = await createBearerApiClient({
+      playwright,
+      token: token.publicToken,
+    });
+
+    try {
+      const { status, data } = await embedApi.get<EmbedLink[]>(
+        "/api/embed/referrals/links",
+      );
+
+      expect(status).toEqual(200);
+      expect(data).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: partner.links![0].id,
+            domain: TEST_WORKSPACE.program.domain,
+          }),
+        ]),
+      );
+    } finally {
+      await dispose();
+    }
+  } finally {
+    await deletePartner(partnerId);
+  }
+});
+
+test("POST /embed/referrals/links - default URL", async ({
+  api,
+  playwright,
+}) => {
+  let partnerId: string | undefined;
+
+  try {
+    const { data: partner } = await createPartner(api);
+    partnerId = partner.id;
+
+    const { data: token } = await api.post<{ publicToken: string }>(
+      "/api/tokens/embed/referrals",
+      { partnerId: partner.id },
+    );
+    const { api: embedApi, dispose } = await createBearerApiClient({
+      playwright,
+      token: token.publicToken,
+    });
+    const key = nanoid(8);
+
+    try {
+      const { status, data } = await embedApi.post<EmbedLink>(
+        "/api/embed/referrals/links",
+        { key },
+      );
+
+      expect(status).toEqual(201);
+      expect(data).toMatchObject({
+        id: expect.any(String),
+        domain: TEST_WORKSPACE.program.domain,
+        key,
+        shortLink: `https://${TEST_WORKSPACE.program.domain}/${key}`,
+      });
+    } finally {
+      await dispose();
+    }
+  } finally {
+    await deletePartner(partnerId);
+  }
+});
+
+test("POST /embed/referrals/links - URL outside additionalLinks", async ({
+  api,
+  playwright,
+}) => {
+  let partnerId: string | undefined;
+
+  try {
+    const { data: partner } = await createPartner(api);
+    partnerId = partner.id;
+
+    const { data: token } = await api.post<{ publicToken: string }>(
+      "/api/tokens/embed/referrals",
+      { partnerId: partner.id },
+    );
+    const { api: embedApi, dispose } = await createBearerApiClient({
+      playwright,
+      token: token.publicToken,
+    });
+
+    try {
+      expect(
+        await embedApi.post("/api/embed/referrals/links", {
+          key: nanoid(8),
+          url: `https://github.com/dubinc/${nanoid()}`,
+        }),
+      ).toEqual(
+        apiError({
+          code: "bad_request",
+          message: "You cannot create additional links for this program.",
+        }),
+      );
+    } finally {
+      await dispose();
+    }
+  } finally {
+    await deletePartner(partnerId);
+  }
+});
+
+test("POST /embed/referrals/links - allowed additionalLinks domain", async ({
+  api,
+  program,
+  playwright,
+}) => {
+  let partnerId: string | undefined;
+  let groupId: string | undefined;
+
+  try {
+    const group = await createGroupWithAdditionalLinks(program.id);
+    groupId = group.id;
+
+    const { data: partner } = await createPartner(api, { groupId });
+    partnerId = partner.id;
+
+    const { data: token } = await api.post<{ publicToken: string }>(
+      "/api/tokens/embed/referrals",
+      { partnerId: partner.id },
+    );
+    const { api: embedApi, dispose } = await createBearerApiClient({
+      playwright,
+      token: token.publicToken,
+    });
+    const url = `https://example.com/${nanoid()}`;
+
+    try {
+      const { status, data } = await embedApi.post<EmbedLink>(
+        "/api/embed/referrals/links",
+        { key: nanoid(8), url },
+      );
+
+      expect(status).toEqual(201);
+      expect(data.url).toEqual(url);
+    } finally {
+      await dispose();
+    }
+  } finally {
+    await deletePartner(partnerId);
+    if (groupId) await prisma.partnerGroup.delete({ where: { id: groupId } });
+  }
+});
+
+test("POST /embed/referrals/links - mismatched additionalLinks domain", async ({
+  api,
+  program,
+  playwright,
+}) => {
+  let partnerId: string | undefined;
+  let groupId: string | undefined;
+
+  try {
+    const group = await createGroupWithAdditionalLinks(program.id);
+    groupId = group.id;
+
+    const { data: partner } = await createPartner(api, { groupId });
+    partnerId = partner.id;
+
+    const { data: token } = await api.post<{ publicToken: string }>(
+      "/api/tokens/embed/referrals",
+      { partnerId: partner.id },
+    );
+    const { api: embedApi, dispose } = await createBearerApiClient({
+      playwright,
+      token: token.publicToken,
+    });
+
+    try {
+      expect(
+        await embedApi.post("/api/embed/referrals/links", {
+          key: nanoid(8),
+          url: `https://github.com/dubinc/${nanoid()}`,
+        }),
+      ).toEqual(
+        apiError({
+          code: "bad_request",
+          message:
+            "The provided URL's domain (github.com) does not match the program's link domains.",
+        }),
+      );
+    } finally {
+      await dispose();
+    }
+  } finally {
+    await deletePartner(partnerId);
+    if (groupId) await prisma.partnerGroup.delete({ where: { id: groupId } });
+  }
+});
+
+test("GET /embed/referrals/links - invalid token", async ({ playwright }) => {
+  const { api: embedApi, dispose } = await createBearerApiClient({
+    playwright,
+    token: "dub_embed_invalid",
+  });
+
+  try {
+    expect(await embedApi.get("/api/embed/referrals/links")).toEqual(
+      apiError({
+        code: "unauthorized",
+        message: "Invalid embed public token.",
+      }),
+    );
+  } finally {
+    await dispose();
+  }
+});

--- a/apps/web/playwright/api/fixtures.ts
+++ b/apps/web/playwright/api/fixtures.ts
@@ -1,6 +1,11 @@
-import { test as base, type APIRequestContext } from "@playwright/test";
+import {
+  test as base,
+  type APIRequest,
+  type APIRequestContext,
+} from "@playwright/test";
 import { readFileSync } from "fs";
 import path from "path";
+import { PLAYWRIGHT_API_BASE } from "./constants";
 
 const authFile = path.join(__dirname, "../.auth/api.json");
 
@@ -50,6 +55,29 @@ function createApiClient(request: APIRequestContext): ApiClient {
     patch: <T>(url: string, data?: unknown) =>
       parse<T>(request.patch(url, { data })),
     delete: <T>(url: string) => parse<T>(request.delete(url)),
+  };
+}
+
+export async function createBearerApiClient({
+  playwright,
+  token,
+  baseURL = PLAYWRIGHT_API_BASE,
+}: {
+  playwright: { request: APIRequest };
+  token: string;
+  baseURL?: string;
+}) {
+  const context = await playwright.request.newContext({
+    baseURL,
+    extraHTTPHeaders: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+  });
+
+  return {
+    api: createApiClient(context),
+    dispose: () => context.dispose(),
   };
 }
 

--- a/apps/web/playwright/api/partner-profile/links.spec.ts
+++ b/apps/web/playwright/api/partner-profile/links.spec.ts
@@ -1,0 +1,242 @@
+import { createId } from "@/lib/api/create-id";
+import { hashToken } from "@/lib/auth/hash-token";
+import { prisma } from "@/lib/prisma";
+import { nanoid } from "@dub/utils";
+import { expect } from "@playwright/test";
+import { apiError } from "../../utils";
+import { createBearerApiClient, test } from "../fixtures";
+import {
+  createGroupWithAdditionalLinks,
+  createPartner,
+  deletePartner,
+} from "../partners/helpers";
+import { TEST_WORKSPACE } from "../setup-test-workspace";
+
+type PartnerProfileLink = {
+  id: string;
+  domain: string;
+  key: string;
+  url: string;
+  partnerGroupDefaultLinkId?: string | null;
+};
+
+async function createPartnerProfileAuth(partner: {
+  id: string;
+  email?: string | null;
+}) {
+  const token = `dub_pw_${nanoid(24)}`;
+  const user = await prisma.user.create({
+    data: {
+      id: createId({ prefix: "user_" }),
+      email: partner.email,
+      emailVerified: new Date(),
+      defaultPartnerId: partner.id,
+      partners: {
+        create: {
+          partnerId: partner.id,
+          role: "owner",
+        },
+      },
+      tokens: {
+        create: {
+          name: "Playwright partner profile",
+          hashedKey: await hashToken(token),
+          partialKey: `${token.slice(0, 3)}...${token.slice(-4)}`,
+        },
+      },
+    },
+  });
+
+  return { token, userId: user.id };
+}
+
+test("GET /partner-profile/programs/:id/links - workspace token is rejected", async ({
+  api,
+  program,
+}) => {
+  expect(
+    await api.get(`/api/partner-profile/programs/${program.id}/links`),
+  ).toEqual(
+    apiError({
+      code: "not_found",
+      message: "Partner profile not found.",
+    }),
+  );
+});
+
+test("POST /partner-profile/programs/:id/links - default URL", async ({
+  api,
+  program,
+  playwright,
+}) => {
+  let partnerId: string | undefined;
+  let userId: string | undefined;
+
+  try {
+    const { data: partner } = await createPartner(api);
+    partnerId = partner.id;
+    const auth = await createPartnerProfileAuth(partner);
+    userId = auth.userId;
+
+    const { api: partnerApi, dispose } = await createBearerApiClient({
+      playwright,
+      token: auth.token,
+    });
+
+    try {
+      const key = nanoid(8);
+      const { status, data } = await partnerApi.post<PartnerProfileLink>(
+        `/api/partner-profile/programs/${program.id}/links`,
+        { key },
+      );
+
+      expect(status).toEqual(201);
+      expect(data).toMatchObject({
+        id: expect.any(String),
+        domain: TEST_WORKSPACE.program.domain,
+        key,
+        shortLink: `https://${TEST_WORKSPACE.program.domain}/${key}`,
+      });
+    } finally {
+      await dispose();
+    }
+  } finally {
+    if (userId) await prisma.user.delete({ where: { id: userId } });
+    await deletePartner(partnerId);
+  }
+});
+
+test("POST /partner-profile/programs/:id/links - URL outside additionalLinks", async ({
+  api,
+  program,
+  playwright,
+}) => {
+  let partnerId: string | undefined;
+  let userId: string | undefined;
+
+  try {
+    const { data: partner } = await createPartner(api);
+    partnerId = partner.id;
+    const auth = await createPartnerProfileAuth(partner);
+    userId = auth.userId;
+
+    const { api: partnerApi, dispose } = await createBearerApiClient({
+      playwright,
+      token: auth.token,
+    });
+
+    try {
+      expect(
+        await partnerApi.post(
+          `/api/partner-profile/programs/${program.id}/links`,
+          {
+            key: nanoid(8),
+            url: `https://github.com/dubinc/${nanoid()}`,
+          },
+        ),
+      ).toEqual(
+        apiError({
+          code: "bad_request",
+          message: "You cannot create additional links for this program.",
+        }),
+      );
+    } finally {
+      await dispose();
+    }
+  } finally {
+    if (userId) await prisma.user.delete({ where: { id: userId } });
+    await deletePartner(partnerId);
+  }
+});
+
+test("POST /partner-profile/programs/:id/links - allowed additionalLinks domain", async ({
+  api,
+  program,
+  playwright,
+}) => {
+  let partnerId: string | undefined;
+  let userId: string | undefined;
+  let groupId: string | undefined;
+
+  try {
+    const group = await createGroupWithAdditionalLinks(program.id);
+    groupId = group.id;
+
+    const { data: partner } = await createPartner(api, { groupId });
+    partnerId = partner.id;
+    const auth = await createPartnerProfileAuth(partner);
+    userId = auth.userId;
+
+    const { api: partnerApi, dispose } = await createBearerApiClient({
+      playwright,
+      token: auth.token,
+    });
+    const url = `https://example.com/${nanoid()}`;
+
+    try {
+      const { status, data } = await partnerApi.post<PartnerProfileLink>(
+        `/api/partner-profile/programs/${program.id}/links`,
+        { key: nanoid(8), url },
+      );
+
+      expect(status).toEqual(201);
+      expect(data.url).toEqual(url);
+    } finally {
+      await dispose();
+    }
+  } finally {
+    if (userId) await prisma.user.delete({ where: { id: userId } });
+    await deletePartner(partnerId);
+    if (groupId) await prisma.partnerGroup.delete({ where: { id: groupId } });
+  }
+});
+
+test("PATCH /partner-profile/programs/:id/links/:linkId - cannot change default link URL", async ({
+  api,
+  program,
+  playwright,
+}) => {
+  let partnerId: string | undefined;
+  let userId: string | undefined;
+
+  try {
+    const { data: partner } = await createPartner(api);
+    partnerId = partner.id;
+    const auth = await createPartnerProfileAuth(partner);
+    userId = auth.userId;
+
+    const { api: partnerApi, dispose } = await createBearerApiClient({
+      playwright,
+      token: auth.token,
+    });
+
+    try {
+      const { data: links } = await partnerApi.get<PartnerProfileLink[]>(
+        `/api/partner-profile/programs/${program.id}/links`,
+      );
+      const defaultLink =
+        links.find((link) => link.partnerGroupDefaultLinkId) ?? links[0];
+
+      expect(
+        await partnerApi.patch(
+          `/api/partner-profile/programs/${program.id}/links/${defaultLink.id}`,
+          {
+            key: defaultLink.key,
+            url: `https://example.com/${nanoid()}`,
+          },
+        ),
+      ).toEqual(
+        apiError({
+          code: "forbidden",
+          message:
+            "You cannot update the destination URL of your default link.",
+        }),
+      );
+    } finally {
+      await dispose();
+    }
+  } finally {
+    if (userId) await prisma.user.delete({ where: { id: userId } });
+    await deletePartner(partnerId);
+  }
+});

--- a/apps/web/playwright/api/partners/helpers.ts
+++ b/apps/web/playwright/api/partners/helpers.ts
@@ -1,8 +1,12 @@
+import { createId } from "@/lib/api/create-id";
 import { conn } from "@/lib/planetscale";
 import { prisma } from "@/lib/prisma";
 import type { EnrolledPartnerProps } from "@/lib/types";
+import { DEFAULT_ADDITIONAL_PARTNER_LINKS } from "@/lib/zod/schemas/groups";
+import { nanoid } from "@dub/utils";
 import { randomName, randomPartnerEmail } from "../../utils";
 import type { ApiClient } from "../fixtures";
+import { TEST_WORKSPACE } from "../setup-test-workspace";
 
 export async function createPartner(
   api: ApiClient,
@@ -12,6 +16,33 @@ export async function createPartner(
     name: randomName(),
     email: randomPartnerEmail(),
     ...overrides,
+  });
+}
+
+export async function createGroupWithAdditionalLinks(programId: string) {
+  return prisma.partnerGroup.create({
+    data: {
+      id: createId({ prefix: "grp_" }),
+      programId,
+      slug: `pw-links-${nanoid(8).toLowerCase()}`,
+      name: randomName("links-group"),
+      maxPartnerLinks: DEFAULT_ADDITIONAL_PARTNER_LINKS,
+      additionalLinks: [
+        {
+          domain: "example.com",
+          path: "",
+          validationMode: "domain",
+        },
+      ],
+      partnerGroupDefaultLinks: {
+        create: {
+          id: createId({ prefix: "pgdl_" }),
+          programId,
+          domain: TEST_WORKSPACE.program.domain,
+          url: TEST_WORKSPACE.program.url,
+        },
+      },
+    },
   });
 }
 

--- a/apps/web/tests/partners/create-partner-link.test.ts
+++ b/apps/web/tests/partners/create-partner-link.test.ts
@@ -1,3 +1,4 @@
+import { nanoid } from "@dub/utils";
 import { Link } from "@prisma/client";
 import { expect, onTestFinished, test } from "vitest";
 import { IntegrationHarness } from "../utils/integration";
@@ -23,4 +24,29 @@ test("POST /api/partners/links", async () => {
   expect(status).toEqual(201);
   expect(LinkSchema.strict().parse(link)).toBeTruthy();
   expect(link).toStrictEqual(partnerLink);
+});
+
+test("POST /api/partners/links with a URL outside additionalLinks", async () => {
+  const h = new IntegrationHarness();
+  const { http } = await h.init();
+  const url = `https://github.com/dubinc/${nanoid()}`;
+
+  onTestFinished(async () => {
+    await h.deleteLink(link.id);
+  });
+
+  const { status, data: link } = await http.post<Link>({
+    path: "/partners/links",
+    body: {
+      partnerId: E2E_PARTNER.id,
+      url,
+    },
+  });
+
+  expect(status).toEqual(201);
+  expect(LinkSchema.strict().parse(link)).toBeTruthy();
+  expect(link).toStrictEqual({
+    ...partnerLink,
+    url,
+  });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Partner link creation and updates now accept partner-provided destination URLs without enforcing partner-group domain restrictions.
  - Existing workflows continue applying group tracking settings and webhook notifications.
  - Embed referral links and partner-profile links continue enforcing their configured domain restrictions.

- **Tests**
  - Added coverage for partner link creation, updates, domain restrictions, authentication, and default-link protections.
  - Added validation for accepted external destination URLs and invalid access credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->