### PR TITLE
Campaign editor fixes

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/campaigns/[campaignId]/campaign-editor.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/campaigns/[campaignId]/campaign-editor.tsx
@@ -181,7 +181,7 @@ function CampaignFromField({
       <input
         type="text"
         placeholder={displayNamePlaceholder}
-        className="text-content-default placeholder:text-content-muted min-w-0 flex-1 border-0 bg-transparent p-0 focus:outline-none focus:ring-0 sm:text-sm"
+        className="text-content-default placeholder:text-content-muted min-w-0 flex-1 cursor-pointer border-0 bg-transparent p-0 focus:outline-none focus:ring-0 disabled:cursor-not-allowed sm:text-sm"
         disabled={disabled}
         value={displayName}
         onChange={(e) => {
@@ -216,7 +216,7 @@ function CampaignFromField({
           type="text"
           placeholder="address"
           style={{ width: Math.max(localPartWidth, 1) }}
-          className="text-content-default placeholder:text-content-muted m-0 max-w-[12rem] border-0 bg-transparent p-0 text-sm leading-none focus:outline-none focus:ring-0"
+          className="text-content-default placeholder:text-content-muted m-0 max-w-[12rem] cursor-pointer border-0 bg-transparent p-0 text-sm leading-none focus:outline-none focus:ring-0 disabled:cursor-not-allowed"
           disabled={disabled}
           value={localPart}
           onChange={(e) => {
@@ -417,6 +417,14 @@ export function CampaignEditor({ campaign }: { campaign: Campaign }) {
   const statusBadge = CAMPAIGN_STATUS_BADGES[campaign.status];
 
   const editorRef = useRef<{ setContent: (content: any) => void }>(null);
+  const subjectInputProps = register("subject");
+
+  // Whether the subject text is clipped by the input's edge (shows a fade when it is)
+  const [subjectOverflows, setSubjectOverflows] = useState(false);
+  const subjectResizeObserverRef = useRef<ResizeObserver | null>(null);
+  const measureSubjectOverflow = (input: HTMLInputElement) =>
+    setSubjectOverflows(input.scrollWidth > input.clientWidth);
+
   const previewInputProps = register("preview", {
     onBlur: (e) => {
       if (!e.target.value) setShowPreviewText(false);
@@ -588,7 +596,16 @@ export function CampaignEditor({ campaign }: { campaign: Campaign }) {
                         value={field.value}
                         onChange={field.onChange}
                         placeholder='E.g. "tomorrow at 5pm" or "in 2 hours"'
-                        className="hover:border-border-subtle mt-0 h-8 min-h-8 border-transparent shadow-none focus-within:border-black/75 focus-within:ring-black/75 hover:cursor-pointer hover:bg-neutral-100"
+                        className={cn(
+                          "hover:border-border-subtle mt-0 h-8 min-h-8 border-transparent shadow-none focus-within:border-black/75 focus-within:ring-black/75 hover:cursor-pointer hover:bg-neutral-100",
+                          // Like the text inputs: only colors animate, so the focus ring appears at once
+                          "transition-colors",
+                          // Keep the focused look (like the text inputs) even while hovered: the hover state
+                          // sticks while the native picker is open, since the page stops getting mouse events
+                          "hover:focus-within:border-black/75 hover:focus-within:bg-white",
+                          // Match the padding and cursor of the other inputs (the forms plugin gives inputs px-3 by default)
+                          "[&_button]:px-1.5 [&_input]:cursor-pointer [&_input]:px-1.5 [&_input]:py-0",
+                        )}
                       />
                     </DisabledInputWrapper>
                   )}
@@ -608,11 +625,40 @@ export function CampaignEditor({ campaign }: { campaign: Campaign }) {
                   placeholder="Enter a subject..."
                   className={cn(
                     inputClassName,
+                    "peer",
                     !isLocked && !showPreviewText && "pr-24",
                   )}
                   disabled={isLocked}
-                  {...register("subject")}
+                  {...subjectInputProps}
+                  ref={(input) => {
+                    subjectInputProps.ref(input);
+
+                    // Re-measure the overflow whenever the input is resized
+                    subjectResizeObserverRef.current?.disconnect();
+                    if (!input) return;
+                    subjectResizeObserverRef.current = new ResizeObserver(() =>
+                      measureSubjectOverflow(input),
+                    );
+                    subjectResizeObserverRef.current.observe(input);
+                  }}
+                  onChange={(e) => {
+                    subjectInputProps.onChange(e);
+                    measureSubjectOverflow(e.currentTarget);
+                  }}
                 />
+                {/* Fades out subject text that is clipped by the input's edge (hidden while editing).
+                    The gradient ends in currentColor so it can transition along with the input's hover background. */}
+                {subjectOverflows && (
+                  <div
+                    aria-hidden
+                    className={cn(
+                      "pointer-events-none absolute inset-y-0 w-12 bg-gradient-to-r from-transparent to-current text-white transition-[color,opacity] duration-150",
+                      "peer-hover:text-neutral-100 peer-focus:opacity-0",
+                      "group-hover/locked:text-neutral-100",
+                      !isLocked && !showPreviewText ? "right-24" : "right-1.5",
+                    )}
+                  />
+                )}
                 {!isLocked && (
                   <div className="absolute right-0 top-1/2 -translate-y-1/2">
                     <button

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/campaigns/[campaignId]/campaign-recipients-selector.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/campaigns/[campaignId]/campaign-recipients-selector.tsx
@@ -20,14 +20,31 @@ export function CampaignGroupsSelector({
   setSelectedGroupIds: (groupIds: string[] | null) => void;
 }) {
   const hasGroupFilter = Boolean(selectedGroupIds?.length);
-  const { groups: selectedGroups, loading: groupsLoading } = useGroups({
-    query: { groupIds: selectedGroupIds ?? undefined },
-    enabled: hasGroupFilter,
-  });
   const [openPopover, setOpenPopover] = useState(false);
 
-  const isLoading = groupsLoading && hasGroupFilter;
-  const plusCount = Math.max(0, (selectedGroups?.length ?? 0) - MAX_DISPLAYED);
+  // The popover's list is cached under this same key, so groups picked there resolve
+  // instantly instead of being re-fetched by id on every selection
+  const { groups: allGroups, loading: allGroupsLoading } = useGroups({
+    enabled: hasGroupFilter,
+  });
+
+  // Only fetch by id what the list doesn't include (groups beyond its first page)
+  const missingGroupIds = getMissingIds(selectedGroupIds, allGroups);
+  const { groups: missingGroups, loading: missingGroupsLoading } = useGroups({
+    query: { groupIds: missingGroupIds },
+    enabled: missingGroupIds.length > 0,
+  });
+
+  const selectedGroups = resolveSelected(
+    selectedGroupIds,
+    allGroups,
+    missingGroups,
+  );
+  const isLoading =
+    hasGroupFilter &&
+    selectedGroups.length === 0 &&
+    (allGroupsLoading || missingGroupsLoading);
+  const plusCount = Math.max(0, selectedGroups.length - MAX_DISPLAYED);
 
   return (
     <CampaignRecipientPopover
@@ -51,7 +68,7 @@ export function CampaignGroupsSelector({
         </RecipientChip>
       ) : (
         <div className="flex min-w-0 flex-1 items-center gap-2">
-          {selectedGroups?.slice(0, MAX_DISPLAYED).map((group) => (
+          {selectedGroups.slice(0, MAX_DISPLAYED).map((group) => (
             <RecipientChip key={group.id} openPopover={openPopover}>
               <GroupColorCircle group={group} />
               <span className="text-content-default min-w-0 truncate text-sm font-medium">
@@ -77,14 +94,30 @@ export function CampaignTagsSelector({
   setSelectedPartnerTagIds: (tagIds: string[] | null) => void;
 }) {
   const hasTagFilter = Boolean(selectedPartnerTagIds?.length);
-  const { partnerTags: selectedTags, isLoading: tagsLoading } = usePartnerTags({
-    query: { ids: selectedPartnerTagIds ?? undefined },
-    enabled: hasTagFilter,
-  });
   const [openPopover, setOpenPopover] = useState(false);
 
-  const isLoading = tagsLoading && hasTagFilter;
-  const plusCount = Math.max(0, (selectedTags?.length ?? 0) - MAX_DISPLAYED);
+  // Same approach as the groups above: resolve from the popover's cached list first
+  const { partnerTags: allTags, isLoading: allTagsLoading } = usePartnerTags({
+    enabled: hasTagFilter,
+  });
+
+  const missingTagIds = getMissingIds(selectedPartnerTagIds, allTags);
+  const { partnerTags: missingTags, isLoading: missingTagsLoading } =
+    usePartnerTags({
+      query: { ids: missingTagIds },
+      enabled: missingTagIds.length > 0,
+    });
+
+  const selectedTags = resolveSelected(
+    selectedPartnerTagIds,
+    allTags,
+    missingTags,
+  );
+  const isLoading =
+    hasTagFilter &&
+    selectedTags.length === 0 &&
+    (allTagsLoading || missingTagsLoading);
+  const plusCount = Math.max(0, selectedTags.length - MAX_DISPLAYED);
 
   return (
     <CampaignRecipientPopover
@@ -108,7 +141,7 @@ export function CampaignTagsSelector({
         </RecipientChip>
       ) : (
         <div className="flex min-w-0 flex-1 items-center gap-2">
-          {selectedTags?.slice(0, MAX_DISPLAYED).map((tag) => (
+          {selectedTags.slice(0, MAX_DISPLAYED).map((tag) => (
             <RecipientChip key={tag.id} openPopover={openPopover}>
               <TagIcon className="size-3.5 shrink-0" />
               <span className="text-content-default min-w-0 truncate text-sm font-medium">
@@ -211,4 +244,38 @@ function PlusCountBadge({
       +{count}
     </span>
   );
+}
+
+// Selected ids that the loaded list doesn't contain. Derived from the list only, so the
+// fallback fetch's key stays stable once its own results arrive.
+function getMissingIds(
+  selectedIds: string[] | null,
+  list: { id: string }[] | undefined,
+) {
+  if (!selectedIds?.length || !list) return [];
+
+  return selectedIds.filter((id) => !list.some((item) => item.id === id));
+}
+
+// Resolves the selected ids against each source in turn, keeping the sources' own order
+function resolveSelected<T extends { id: string }>(
+  selectedIds: string[] | null,
+  ...sources: (T[] | undefined)[]
+) {
+  if (!selectedIds?.length) return [];
+
+  const resolved: T[] = [];
+
+  for (const source of sources) {
+    for (const item of source ?? []) {
+      if (
+        selectedIds.includes(item.id) &&
+        !resolved.some((r) => r.id === item.id)
+      ) {
+        resolved.push(item);
+      }
+    }
+  }
+
+  return resolved;
 }

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/campaigns/[campaignId]/campaign-recipients-selector.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/campaigns/[campaignId]/campaign-recipients-selector.tsx
@@ -24,12 +24,20 @@ export function CampaignGroupsSelector({
 
   // The popover's list is cached under this same key, so groups picked there resolve
   // instantly instead of being re-fetched by id on every selection
-  const { groups: allGroups, loading: allGroupsLoading } = useGroups({
+  const {
+    groups: allGroups,
+    loading: allGroupsLoading,
+    error: allGroupsError,
+  } = useGroups({
     enabled: hasGroupFilter,
   });
 
   // Only fetch by id what the list doesn't include (groups beyond its first page)
-  const missingGroupIds = getMissingIds(selectedGroupIds, allGroups);
+  const missingGroupIds = getMissingIds(
+    selectedGroupIds,
+    allGroups,
+    Boolean(allGroupsError),
+  );
   const { groups: missingGroups, loading: missingGroupsLoading } = useGroups({
     query: { groupIds: missingGroupIds },
     enabled: missingGroupIds.length > 0,
@@ -97,11 +105,19 @@ export function CampaignTagsSelector({
   const [openPopover, setOpenPopover] = useState(false);
 
   // Same approach as the groups above: resolve from the popover's cached list first
-  const { partnerTags: allTags, isLoading: allTagsLoading } = usePartnerTags({
+  const {
+    partnerTags: allTags,
+    isLoading: allTagsLoading,
+    error: allTagsError,
+  } = usePartnerTags({
     enabled: hasTagFilter,
   });
 
-  const missingTagIds = getMissingIds(selectedPartnerTagIds, allTags);
+  const missingTagIds = getMissingIds(
+    selectedPartnerTagIds,
+    allTags,
+    Boolean(allTagsError),
+  );
   const { partnerTags: missingTags, isLoading: missingTagsLoading } =
     usePartnerTags({
       query: { ids: missingTagIds },
@@ -251,8 +267,12 @@ function PlusCountBadge({
 function getMissingIds(
   selectedIds: string[] | null,
   list: { id: string }[] | undefined,
+  listFailed: boolean,
 ) {
-  if (!selectedIds?.length || !list) return [];
+  if (!selectedIds?.length) return [];
+
+  // No list yet: wait for it, unless its request failed, then fetch everything by id
+  if (!list) return listFailed ? selectedIds : [];
 
   return selectedIds.filter((id) => !list.some((item) => item.id === id));
 }

--- a/apps/web/lib/api/campaigns/render-campaign-email-html.ts
+++ b/apps/web/lib/api/campaigns/render-campaign-email-html.ts
@@ -1,11 +1,15 @@
 import { configureCampaignEmailImage } from "@/lib/tiptap/campaign-email-image";
 import { EmailTemplateVariables, TiptapNode } from "@/lib/types";
 import { EMAIL_TEMPLATE_VARIABLES } from "@/lib/zod/schemas/campaigns";
+import { CAMPAIGN_EMAIL_TEXT_COLOR } from "@dub/email/templates/campaign-email";
 import Mention from "@tiptap/extension-mention";
 import { generateHTML } from "@tiptap/html/server";
 import StarterKit from "@tiptap/starter-kit";
 import sanitizeHtml from "sanitize-html";
 import { interpolateEmailTemplate } from "./interpolate-email-template";
+
+// neutral-500, matching the editor's list markers
+const LIST_MARKER_COLOR = "#737373";
 
 export function renderCampaignEmailHTML({
   content,
@@ -72,9 +76,17 @@ export function renderCampaignEmailHTML({
       /<ol([^>]*)>/g,
       '<ol$1 style="padding-left: 30px; margin-left: 0;">',
     )
+    // The bullet/number takes its color from the <li>, so color the <li> and
+    // restore the body text color on the paragraph inside it (below).
     .replace(
       /<li([^>]*)>/g,
-      '<li$1 style="margin-left: 0; padding-left: 4px; margin-top: 0px; margin-bottom: 0px;">',
+      `<li$1 style="margin-left: 0; padding-left: 4px; margin-top: 0px; margin-bottom: 4px; color: ${LIST_MARKER_COLOR};">`,
+    )
+    // Tiptap wraps each list item's content in a <p>, and email clients give it
+    // a default 1em margin. Zero it so the 4px <li> margin is the only gap.
+    .replace(
+      /(<li[^>]*>)<p>/g,
+      `$1<p style="margin: 0; color: ${CAMPAIGN_EMAIL_TEXT_COLOR};">`,
     );
 
   return interpolateEmailTemplate({
@@ -105,6 +117,7 @@ const sanitizeHtmlBody = (body: string) => {
       ul: ["style"],
       ol: ["style"],
       li: ["style"],
+      p: ["style"],
       "*": ["class"],
     },
     allowedSchemes: ["http", "https", "mailto"],

--- a/packages/email/src/templates/campaign-email.tsx
+++ b/packages/email/src/templates/campaign-email.tsx
@@ -13,6 +13,10 @@ import {
   Text,
 } from "@react-email/components";
 
+// Body text color. renderCampaignEmailHTML applies it inline to list item text
+// as well, since list items are colored for their bullets/numbers.
+export const CAMPAIGN_EMAIL_TEXT_COLOR = "#000000";
+
 export default function CampaignEmail({
   program = {
     name: "Acme",
@@ -76,7 +80,11 @@ export default function CampaignEmail({
 
             <Section>
               <div
-                style={{ fontSize: "14px", lineHeight: 1.7142857 }}
+                style={{
+                  fontSize: "14px",
+                  lineHeight: 1.7142857,
+                  color: CAMPAIGN_EMAIL_TEXT_COLOR,
+                }}
                 dangerouslySetInnerHTML={{ __html: styledHtml }}
               />
             </Section>

--- a/packages/ui/src/icons/nucleo/calendar.tsx
+++ b/packages/ui/src/icons/nucleo/calendar.tsx
@@ -9,53 +9,17 @@ export function CalendarIcon(props: SVGProps<SVGSVGElement>) {
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >
-      <g fill="currentColor">
-        <line
-          fill="none"
-          stroke="currentColor"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth="1.5"
-          x1="5.75"
-          x2="5.75"
-          y1="2.75"
-          y2=".75"
-        />
-        <line
-          fill="none"
-          stroke="currentColor"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth="1.5"
-          x1="12.25"
-          x2="12.25"
-          y1="2.75"
-          y2=".75"
-        />
-        <line
-          fill="none"
-          stroke="currentColor"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth="1.5"
-          x1="2.25"
-          x2="15.75"
-          y1="6.25"
-          y2="6.25"
-        />
-        <rect
-          height="12.5"
-          width="13.5"
-          fill="none"
-          rx="2"
-          ry="2"
-          stroke="currentColor"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth="1.5"
-          x="2.25"
-          y="2.75"
-        />
+      <g
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.5"
+      >
+        <line x1="5.75" y1="3.25" x2="5.75" y2="1.25" />
+        <line x1="12.25" y1="3.25" x2="12.25" y2="1.25" />
+        <rect x="2.25" y="3.25" width="13.5" height="12.5" rx="2" ry="2" />
+        <line x1="2.25" y1="6.75" x2="15.75" y2="6.75" />
       </g>
     </svg>
   );

--- a/packages/ui/src/rich-text-area/rich-text-provider.tsx
+++ b/packages/ui/src/rich-text-area/rich-text-provider.tsx
@@ -306,6 +306,10 @@ export const RichTextProvider = forwardRef<
           class: cn(
             "max-w-none focus:outline-none",
             "prose prose-sm prose-neutral",
+            // Tiptap wraps each list item's content in a <p>, which Typography treats as a
+            // "loose" list and gives paragraph spacing. Zero it so items sit 4px apart (the
+            // <li> margins), and match the bullet color to the ordered list counters.
+            "[&_li>p]:my-0 marker:prose-ul:text-neutral-500",
             PROSE_STYLES[style],
             "[&_.ProseMirror-selectednode]:outline [&_.ProseMirror-selectednode]:outline-2 [&_.ProseMirror-selectednode]:outline-blue-500 [&_.ProseMirror-selectednode]:outline-offset-2",
             "[&_.ProseMirror-selectednode:has(img)]:outline-none",

--- a/packages/ui/src/smart-datetime-picker.tsx
+++ b/packages/ui/src/smart-datetime-picker.tsx
@@ -5,6 +5,7 @@ import {
   parseDateTime,
 } from "@dub/utils";
 import { useEffect, useId, useRef } from "react";
+import { CalendarIcon } from "./icons";
 
 interface SmartDateTimePickerProps {
   value: Date | null | undefined;
@@ -27,6 +28,23 @@ export function SmartDateTimePicker({
 }: SmartDateTimePickerProps) {
   const id = useId();
   const inputRef = useRef<HTMLInputElement>(null);
+  const nativeInputRef = useRef<HTMLInputElement>(null);
+
+  // Opens the browser's own date/time popover for the (visually hidden) native input
+  const openNativePicker = () => {
+    const input = nativeInputRef.current;
+    if (!input) return;
+
+    // Safari only dismisses the picker when its input loses focus, so the input
+    // has to be focused first or the picker can't be closed
+    input.focus();
+
+    try {
+      input.showPicker();
+    } catch {
+      // Browsers without showPicker support: the focused input still takes keyboard entry
+    }
+  };
 
   // Hacky fix to focus the input automatically, not sure why autoFocus doesn't work here
   useEffect(() => {
@@ -80,22 +98,36 @@ export function SmartDateTimePicker({
               }
             }
           }}
-          className="flex-1 border-none bg-transparent text-neutral-900 placeholder-neutral-400 focus:outline-none focus:ring-0 sm:text-sm"
+          className="min-w-0 flex-1 border-none bg-transparent text-neutral-900 placeholder-neutral-400 focus:outline-none focus:ring-0 sm:text-sm"
         />
-        <input
-          type="datetime-local"
-          id={`${id}-datetime-local`}
-          required={required}
-          value={value ? getDateTimeLocal(value) : ""}
-          onChange={(e) => {
-            const date = new Date(e.target.value);
-            onChange(date);
-            if (inputRef.current) {
-              inputRef.current.value = formatDateTime(date);
-            }
-          }}
-          className="w-[40px] border-none bg-transparent text-neutral-500 focus:outline-none focus:ring-0 sm:text-sm"
-        />
+        <div className="relative shrink-0 self-stretch">
+          <button
+            type="button"
+            onClick={openNativePicker}
+            aria-label="Open date picker"
+            className="flex h-full items-center px-3 text-neutral-500 transition-colors hover:text-neutral-700 focus:outline-none"
+          >
+            <CalendarIcon className="size-4 flex-none" aria-hidden />
+          </button>
+          {/* Kept in the layout (but invisible) so the native popover anchors to the icon */}
+          <input
+            ref={nativeInputRef}
+            type="datetime-local"
+            id={`${id}-datetime-local`}
+            required={required}
+            tabIndex={-1}
+            aria-label="Date and time"
+            value={value ? getDateTimeLocal(value) : ""}
+            onChange={(e) => {
+              const date = new Date(e.target.value);
+              onChange(date);
+              if (inputRef.current) {
+                inputRef.current.value = formatDateTime(date);
+              }
+            }}
+            className="pointer-events-none absolute inset-0 size-full opacity-0"
+          />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
- List item spacing was too large in the editor and the emails.
- Groups and tags transition when adding is flashing with each selection
- Subject line gradient added to end when overlfowing
- Updating the calendar icon to finally not be the system version
- Other adjustments like: indent on date selection now consistent, all inputs use the same cursor style, fixing the date picker not being able to close in safari, and consistent focus states.

### After
<img width="817" height="683" alt="CleanShot 2026-09-04 at 7 56 22 PM@2x" src="https://github.com/user-attachments/assets/a653af55-7553-4a81-9715-accac6d4c444" />

### Before
<img width="805" height="553" alt="CleanShot 2026-09-04 at 7 57 14 PM@2x" src="https://github.com/user-attachments/assets/bcf97999-fe5b-443d-b45a-ad2f4ea9a341" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a calendar button for opening native date and time selection.
  - Campaign subject fields now indicate when text is clipped.

- **Bug Fixes**
  - Improved recipient selection when cached group or tag lists fail to load.
  - Improved campaign email text colors, list spacing, and list-marker styling.
  - Improved rich-text list formatting by removing extra paragraph spacing and aligning marker colors.
  - Refined calendar icon rendering and campaign editor input interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->