### PR TITLE
Add more permission error text for non-member roels

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/bounties/[bountyId]/bounty-submission-details-sheet.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/bounties/[bountyId]/bounty-submission-details-sheet.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { BountySubmissionStatusBadges } from "@/lib/bounty/bounty-submission-status-badges";
+import { clientAccessCheck } from "@/lib/client-access-check";
 import { REJECT_BOUNTY_SUBMISSION_REASONS } from "@/lib/bounty/constants";
 import { calculateSocialMetricsRewardAmount } from "@/lib/bounty/rewards";
 import { resolveBountyDetails } from "@/lib/bounty/utils";
@@ -65,7 +66,13 @@ function BountySubmissionDetailsSheetContent({
   setIsOpen,
 }: BountySubmissionDetailsSheetProps) {
   const { bounty } = useBounty();
-  const { slug: workspaceSlug } = useWorkspace();
+  const { slug: workspaceSlug, role } = useWorkspace();
+
+  const permissionsError = clientAccessCheck({
+    action: "bounties.write",
+    role,
+    customPermissionDescription: "review bounty submissions",
+  }).error;
 
   const { setShowRejectModal, RejectBountySubmissionModal } =
     useRejectBountySubmissionModal(submission, onNext);
@@ -131,7 +138,7 @@ function BountySubmissionDetailsSheetContent({
         );
       }
     },
-    { sheet: true },
+    { sheet: true, enabled: !permissionsError },
   );
 
   useKeyboardShortcut(
@@ -141,7 +148,7 @@ function BountySubmissionDetailsSheetContent({
         setShowRejectModal(true);
       }
     },
-    { sheet: true },
+    { sheet: true, enabled: !permissionsError },
   );
 
   const isValidForm = useMemo(() => {
@@ -565,11 +572,13 @@ function BountySubmissionDetailsSheetContent({
                     text="Reject"
                     shortcut="R"
                     disabledTooltip={
-                      submission.status === "draft"
-                        ? "Bounty submission is in progress."
-                        : submission.status === "rejected"
-                          ? "Bounty submission already rejected."
-                          : undefined
+                      permissionsError
+                        ? permissionsError
+                        : submission.status === "draft"
+                          ? "Bounty submission is in progress."
+                          : submission.status === "rejected"
+                            ? "Bounty submission already rejected."
+                            : undefined
                     }
                     disabled={submission.status === "draft"}
                     onClick={() => setShowRejectModal(true)}
@@ -588,9 +597,11 @@ function BountySubmissionDetailsSheetContent({
                       )
                     }
                     disabledTooltip={
-                      submission.status === "draft"
-                        ? "Bounty submission is in progress."
-                        : undefined
+                      permissionsError
+                        ? permissionsError
+                        : submission.status === "draft"
+                          ? "Bounty submission is in progress."
+                          : undefined
                     }
                     disabled={!isValidForm || submission.status === "draft"}
                   />

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/bounties/bounty-action-button.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/bounties/bounty-action-button.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { clientAccessCheck } from "@/lib/client-access-check";
 import { mutatePrefix } from "@/lib/swr/mutate";
 import {
   SubmissionsCountByStatus,
@@ -28,7 +29,13 @@ export function BountyActionButton({
   buttonClassName,
 }: BountyActionButtonProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const { id: workspaceId } = useWorkspace();
+  const { id: workspaceId, role } = useWorkspace();
+
+  const permissionsError = clientAccessCheck({
+    action: "bounties.write",
+    role,
+    customPermissionDescription: "manage bounties",
+  }).error;
   const { setShowCreateBountySheet, BountySheet } = useBountySheet({ bounty });
 
   const { submissionsCount } = useBountySubmissionsCount<
@@ -81,6 +88,7 @@ export function BountyActionButton({
             className="h-9 w-fit rounded-lg"
             icon={<PenWriting className="size-4 shrink-0" />}
             onClick={() => setShowCreateBountySheet(true)}
+            disabledTooltip={permissionsError || undefined}
           />
 
           <Popover
@@ -98,9 +106,11 @@ export function BountyActionButton({
                       setShowDeleteModal(true);
                     }}
                     disabledTooltip={
-                      totalSubmissions > 0
-                        ? "Bounties with submissions cannot be deleted."
-                        : undefined
+                      permissionsError
+                        ? permissionsError
+                        : totalSubmissions > 0
+                          ? "Bounties with submissions cannot be deleted."
+                          : undefined
                     }
                   >
                     Delete bounty

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/bounties/create-bounty-button.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/bounties/create-bounty-button.tsx
@@ -1,15 +1,26 @@
 "use client";
 
+import { clientAccessCheck } from "@/lib/client-access-check";
+import useWorkspace from "@/lib/swr/use-workspace";
 import { Button, useKeyboardShortcut, useMediaQuery } from "@dub/ui";
 import { useBountySheet } from "./add-edit-bounty/add-edit-bounty-sheet";
 
 export function CreateBountyButton() {
   const { isMobile } = useMediaQuery();
+  const { role } = useWorkspace();
   const { BountySheet, setShowCreateBountySheet } = useBountySheet({
     nested: false,
   });
 
-  useKeyboardShortcut("c", () => setShowCreateBountySheet(true));
+  const permissionsError = clientAccessCheck({
+    action: "bounties.write",
+    role,
+    customPermissionDescription: "create bounties",
+  }).error;
+
+  useKeyboardShortcut("c", () => setShowCreateBountySheet(true), {
+    enabled: !permissionsError,
+  });
 
   return (
     <>
@@ -20,6 +31,7 @@ export function CreateBountyButton() {
         text={`Create${isMobile ? "" : " bounty"}`}
         shortcut="C"
         className="h-8 px-3 sm:h-9"
+        disabledTooltip={permissionsError || undefined}
       />
     </>
   );

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/campaigns/create-campaign-button.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/campaigns/create-campaign-button.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { clientAccessCheck } from "@/lib/client-access-check";
 import { mutatePrefix } from "@/lib/swr/mutate";
 import { useApiMutation } from "@/lib/swr/use-api-mutation";
 import useWorkspace from "@/lib/swr/use-workspace";
@@ -22,9 +23,15 @@ const campaignTypes = Object.values(CAMPAIGN_TYPE_BADGES).map(
 
 export function CreateCampaignButton() {
   const router = useRouter();
-  const { slug } = useWorkspace();
+  const { slug, role } = useWorkspace();
   const { makeRequest, isSubmitting } = useApiMutation<Campaign>();
   const [isOpen, setIsOpen] = useState(false);
+
+  const permissionsError = clientAccessCheck({
+    action: "campaigns.write",
+    role,
+    customPermissionDescription: "create campaigns",
+  }).error;
 
   const createDraftCampaign = async (type: "marketing" | "transactional") => {
     await makeRequest(`/api/campaigns`, {
@@ -40,12 +47,24 @@ export function CreateCampaignButton() {
   };
 
   useKeyboardShortcut("m", () => createDraftCampaign("marketing"), {
-    enabled: isOpen && !isSubmitting,
+    enabled: isOpen && !isSubmitting && !permissionsError,
   });
 
   useKeyboardShortcut("t", () => createDraftCampaign("transactional"), {
-    enabled: isOpen && !isSubmitting,
+    enabled: isOpen && !isSubmitting && !permissionsError,
   });
+
+  if (permissionsError) {
+    return (
+      <Button
+        type="button"
+        variant="primary"
+        className="h-9 w-fit rounded-lg px-3"
+        text="Create campaign"
+        disabledTooltip={permissionsError}
+      />
+    );
+  }
 
   return (
     <Popover

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/commissions/create-commission-button.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/commissions/create-commission-button.tsx
@@ -1,16 +1,27 @@
 "use client";
 
+import { clientAccessCheck } from "@/lib/client-access-check";
+import useWorkspace from "@/lib/swr/use-workspace";
 import { Button, useKeyboardShortcut, useMediaQuery } from "@dub/ui";
 import { useCreateCommissionSheet } from "./create-commission-sheet";
 
 export function CreateCommissionButton() {
   const { isMobile } = useMediaQuery();
+  const { role } = useWorkspace();
   const { createCommissionSheet, setIsOpen: setShowCreateCommissionSheet } =
     useCreateCommissionSheet({
       nested: false,
     });
 
-  useKeyboardShortcut("c", () => setShowCreateCommissionSheet(true));
+  const permissionsError = clientAccessCheck({
+    action: "commissions.write",
+    role,
+    customPermissionDescription: "create commissions",
+  }).error;
+
+  useKeyboardShortcut("c", () => setShowCreateCommissionSheet(true), {
+    enabled: !permissionsError,
+  });
 
   return (
     <>
@@ -21,6 +32,7 @@ export function CreateCommissionButton() {
         text={`Create${isMobile ? "" : " commission"}`}
         shortcut="C"
         className="h-8 px-3 sm:h-9"
+        disabledTooltip={permissionsError || undefined}
       />
     </>
   );

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/messages/layout.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/messages/layout.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { clientAccessCheck } from "@/lib/client-access-check";
 import { usePartnerMessages } from "@/lib/messages/hooks/use-partner-messages";
 import { getPlanCapabilities } from "@/lib/plan-capabilities";
 import useProgram from "@/lib/swr/use-program";
@@ -28,9 +29,15 @@ export default function MessagesLayout({ children }: { children: ReactNode }) {
 }
 
 function CapableLayout({ children }: { children: ReactNode }) {
-  const { slug: workspaceSlug } = useWorkspace();
+  const { slug: workspaceSlug, role } = useWorkspace();
   const { partnerId } = useParams() as { partnerId?: string };
   const { program } = useProgram();
+
+  const permissionsError = clientAccessCheck({
+    action: "messages.write",
+    role,
+    customPermissionDescription: "message partners",
+  }).error;
 
   const router = useRouter();
 
@@ -69,22 +76,32 @@ function CapableLayout({ children }: { children: ReactNode }) {
                   />
                 </div>
               </div>
-              <PartnerSelector
-                selectedPartnerId={partnerId ?? null}
-                setSelectedPartnerId={(id) =>
-                  router.push(`/${workspaceSlug}/program/messages/${id}`)
-                }
-                trigger={
-                  <Button
-                    type="button"
-                    variant="secondary"
-                    icon={<Pen2 className="size-4" />}
-                    className="size-8 rounded-lg p-0"
-                  />
-                }
-                matchTriggerWidth={false}
-                optionClassName="sm:max-w-[320px]"
-              />
+              {permissionsError ? (
+                <Button
+                  type="button"
+                  variant="secondary"
+                  icon={<Pen2 className="size-4" />}
+                  className="size-8 rounded-lg p-0"
+                  disabledTooltip={permissionsError}
+                />
+              ) : (
+                <PartnerSelector
+                  selectedPartnerId={partnerId ?? null}
+                  setSelectedPartnerId={(id) =>
+                    router.push(`/${workspaceSlug}/program/messages/${id}`)
+                  }
+                  trigger={
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      icon={<Pen2 className="size-4" />}
+                      className="size-8 rounded-lg p-0"
+                    />
+                  }
+                  matchTriggerWidth={false}
+                  optionClassName="sm:max-w-[320px]"
+                />
+              )}
             </div>
             <div className="scrollbar-hide grow overflow-y-auto">
               {partnerMessages?.length || isLoading ? (

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/[partnerId]/layout.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/[partnerId]/layout.tsx
@@ -2,6 +2,7 @@
 
 import { deleteProgramInviteAction } from "@/lib/actions/partners/delete-program-invite";
 import { resendProgramInviteAction } from "@/lib/actions/partners/resend-program-invite";
+import { clientAccessCheck } from "@/lib/client-access-check";
 import { getDeletePartnerDisabledTooltip } from "@/lib/partners/utils";
 import { mutatePrefix } from "@/lib/swr/mutate";
 import usePartner from "@/lib/swr/use-partner";
@@ -171,8 +172,26 @@ function PartnerProfileButton({
 }
 
 function PageControls({ partner }: { partner: EnrolledPartnerProps }) {
-  const { slug: workspaceSlug, id: workspaceId } = useWorkspace();
+  const { slug: workspaceSlug, id: workspaceId, role } = useWorkspace();
   const router = useRouter();
+
+  const commissionPermissionsError = clientAccessCheck({
+    action: "commissions.write",
+    role,
+    customPermissionDescription: "create commissions",
+  }).error;
+
+  const clawbackPermissionsError = clientAccessCheck({
+    action: "commissions.write",
+    role,
+    customPermissionDescription: "create clawbacks",
+  }).error;
+
+  const messagesPermissionsError = clientAccessCheck({
+    action: "messages.write",
+    role,
+    customPermissionDescription: "message partners",
+  }).error;
 
   const { createCommissionSheet, setIsOpen: setCreateCommissionSheetOpen } =
     useCreateCommissionSheet({
@@ -182,15 +201,21 @@ function PageControls({ partner }: { partner: EnrolledPartnerProps }) {
   const canCreateCommission = COMMISSION_ELIGIBLE_ENROLLMENT_STATUSES.includes(
     partner.status,
   );
-  const createCommissionDisabledTooltip = canCreateCommission
-    ? undefined
-    : `You can't create a commission for a partner that is ${partner.status}.`;
+  const createCommissionDisabledTooltip =
+    commissionPermissionsError ||
+    (canCreateCommission
+      ? undefined
+      : `You can't create a commission for a partner that is ${partner.status}.`);
 
-  useKeyboardShortcut("c", () => {
-    if (canCreateCommission) {
-      setCreateCommissionSheetOpen(true);
-    }
-  });
+  useKeyboardShortcut(
+    "c",
+    () => {
+      if (canCreateCommission) {
+        setCreateCommissionSheetOpen(true);
+      }
+    },
+    { enabled: !commissionPermissionsError },
+  );
 
   const { createClawbackSheet, setIsOpen: setClawbackSheetOpen } =
     useCreateClawbackSheet({});
@@ -297,15 +322,25 @@ function PageControls({ partner }: { partner: EnrolledPartnerProps }) {
             className="hidden h-8 w-fit px-3 sm:h-9 md:flex"
           />
 
-          <Link href={`/${workspaceSlug}/program/messages/${partner.id}`}>
+          {messagesPermissionsError ? (
             <Button
               variant="secondary"
               text="Message"
               icon={<Msgs className="size-4 shrink-0" />}
-              onClick={() => setIsOpen(false)}
+              disabledTooltip={messagesPermissionsError}
               className="hidden h-8 w-fit px-3 sm:h-9 md:flex"
             />
-          </Link>
+          ) : (
+            <Link href={`/${workspaceSlug}/program/messages/${partner.id}`}>
+              <Button
+                variant="secondary"
+                text="Message"
+                icon={<Msgs className="size-4 shrink-0" />}
+                onClick={() => setIsOpen(false)}
+                className="hidden h-8 w-fit px-3 sm:h-9 md:flex"
+              />
+            </Link>
+          )}
         </>
       )}
 
@@ -343,16 +378,26 @@ function PageControls({ partner }: { partner: EnrolledPartnerProps }) {
             ) : (
               <>
                 <div className="grid gap-px p-2">
-                  <MenuItem
-                    as={Link}
-                    href={`/${workspaceSlug}/program/messages/${partner.id}`}
-                    target="_blank"
-                    icon={Msgs}
-                    onClick={() => setIsOpen(false)}
-                    className="md:hidden"
-                  >
-                    Message
-                  </MenuItem>
+                  {messagesPermissionsError ? (
+                    <MenuItem
+                      icon={Msgs}
+                      disabledTooltip={messagesPermissionsError}
+                      className="md:hidden"
+                    >
+                      Message
+                    </MenuItem>
+                  ) : (
+                    <MenuItem
+                      as={Link}
+                      href={`/${workspaceSlug}/program/messages/${partner.id}`}
+                      target="_blank"
+                      icon={Msgs}
+                      onClick={() => setIsOpen(false)}
+                      className="md:hidden"
+                    >
+                      Message
+                    </MenuItem>
+                  )}
                   <MenuItem
                     icon={InvoiceDollar}
                     onClick={() => {
@@ -370,6 +415,7 @@ function PageControls({ partner }: { partner: EnrolledPartnerProps }) {
                       setClawbackSheetOpen(true);
                       setIsOpen(false);
                     }}
+                    disabledTooltip={clawbackPermissionsError || undefined}
                   >
                     Create clawback
                   </MenuItem>

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/invite-partner-button.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/partners/invite-partner-button.tsx
@@ -1,14 +1,25 @@
 "use client";
 
+import { clientAccessCheck } from "@/lib/client-access-check";
+import useWorkspace from "@/lib/swr/use-workspace";
 import { Button, useKeyboardShortcut, useMediaQuery } from "@dub/ui";
 import { useInvitePartnerSheet } from "./invite-partner-sheet";
 
 export function InvitePartnerButton() {
   const { isMobile } = useMediaQuery();
+  const { role } = useWorkspace();
   const { invitePartnerSheet, setIsOpen: setShowInvitePartnerSheet } =
     useInvitePartnerSheet();
 
-  useKeyboardShortcut("p", () => setShowInvitePartnerSheet(true));
+  const permissionsError = clientAccessCheck({
+    action: "partners.write",
+    role,
+    customPermissionDescription: "invite partners",
+  }).error;
+
+  useKeyboardShortcut("p", () => setShowInvitePartnerSheet(true), {
+    enabled: !permissionsError,
+  });
 
   return (
     <>
@@ -19,6 +30,7 @@ export function InvitePartnerButton() {
         text={`Invite${isMobile ? "" : " partner"}`}
         shortcut="P"
         className="h-8 px-3 sm:h-9"
+        disabledTooltip={permissionsError || undefined}
       />
     </>
   );

--- a/apps/web/lib/api/rbac/permissions.ts
+++ b/apps/web/lib/api/rbac/permissions.ts
@@ -22,6 +22,10 @@ export const PERMISSION_ACTIONS = [
   "folders.write",
   "groups.write",
   "groups.read",
+  "partners.write",
+  "commissions.write",
+  "bounties.write",
+  "campaigns.write",
   "messages.read",
   "messages.write",
   "payouts.write",
@@ -148,6 +152,26 @@ export const ROLE_PERMISSIONS: {
   {
     action: "groups.write",
     description: "manage groups",
+    roles: ["owner", "member"],
+  },
+  {
+    action: "partners.write",
+    description: "manage partners",
+    roles: ["owner", "member"],
+  },
+  {
+    action: "commissions.write",
+    description: "manage commissions",
+    roles: ["owner", "member"],
+  },
+  {
+    action: "bounties.write",
+    description: "manage bounties",
+    roles: ["owner", "member"],
+  },
+  {
+    action: "campaigns.write",
+    description: "manage campaigns",
     roles: ["owner", "member"],
   },
   {

--- a/apps/web/ui/partners/fraud-risks/risk-review-sheet.tsx
+++ b/apps/web/ui/partners/fraud-risks/risk-review-sheet.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { FRAUD_RULES_BY_TYPE } from "@/lib/api/fraud/constants";
+import { clientAccessCheck } from "@/lib/client-access-check";
 import { mutatePrefix } from "@/lib/swr/mutate";
 import useWorkspace from "@/lib/swr/use-workspace";
 import { FraudGroupProps } from "@/lib/types";
@@ -63,7 +64,19 @@ function RiskReviewSheetContent({
   onNext,
 }: RiskReviewSheetProps) {
   const { partner, user } = fraudGroup;
-  const { slug, id: workspaceId } = useWorkspace();
+  const { slug, id: workspaceId, role } = useWorkspace();
+
+  const partnersPermissionsError = clientAccessCheck({
+    action: "partners.write",
+    role,
+    customPermissionDescription: "review risk events",
+  }).error;
+
+  const messagesPermissionsError = clientAccessCheck({
+    action: "messages.write",
+    role,
+    customPermissionDescription: "message partners",
+  }).error;
 
   const showCommissionsOnHold =
     fraudGroup.status === "pending" &&
@@ -128,6 +141,7 @@ function RiskReviewSheetContent({
   // Resolve/ban/reject shortcuts
   useKeyboardShortcut("r", () => setShowResolveFraudGroupModal(true), {
     sheet: true,
+    enabled: !partnersPermissionsError,
   });
 
   useKeyboardShortcut(
@@ -139,7 +153,7 @@ function RiskReviewSheetContent({
         setShowBanPartnerModal(true);
       }
     },
-    { sheet: true },
+    { sheet: true, enabled: !partnersPermissionsError },
   );
 
   const fraudRuleInfo = FRAUD_RULES_BY_TYPE[fraudGroup.type];
@@ -159,17 +173,27 @@ function RiskReviewSheetContent({
           </Sheet.Title>
 
           <div className="flex items-center gap-2">
-            <Link
-              href={`/${slug}/program/messages/${partner.id}`}
-              target="_blank"
-              className={cn(
-                buttonVariants({ variant: "secondary" }),
-                "flex h-9 items-center gap-2 whitespace-nowrap rounded-lg border px-3 text-sm font-medium",
-              )}
-            >
-              <Msgs className="size-4 shrink-0" />
-              <span className="hidden sm:inline">Message</span>
-            </Link>
+            {messagesPermissionsError ? (
+              <Button
+                variant="secondary"
+                text="Message"
+                icon={<Msgs className="size-4 shrink-0" />}
+                disabledTooltip={messagesPermissionsError}
+                className="h-9 w-fit px-3"
+              />
+            ) : (
+              <Link
+                href={`/${slug}/program/messages/${partner.id}`}
+                target="_blank"
+                className={cn(
+                  buttonVariants({ variant: "secondary" }),
+                  "flex h-9 items-center gap-2 whitespace-nowrap rounded-lg border px-3 text-sm font-medium",
+                )}
+              >
+                <Msgs className="size-4 shrink-0" />
+                <span className="hidden sm:inline">Message</span>
+              </Link>
+            )}
 
             <div className="flex items-center">
               <Button
@@ -355,6 +379,7 @@ function RiskReviewSheetContent({
                 shortcut="R"
                 onClick={() => setShowResolveFraudGroupModal(true)}
                 className="h-8 w-fit rounded-lg"
+                disabledTooltip={partnersPermissionsError || undefined}
               />
 
               {partner.status === "pending" ? (
@@ -365,6 +390,7 @@ function RiskReviewSheetContent({
                   variant="danger"
                   onClick={() => setShowRejectPartnerApplicationModal(true)}
                   className="h-8 w-fit rounded-lg"
+                  disabledTooltip={partnersPermissionsError || undefined}
                 />
               ) : (
                 <Button
@@ -374,6 +400,7 @@ function RiskReviewSheetContent({
                   variant="danger"
                   onClick={() => setShowBanPartnerModal(true)}
                   className="h-8 w-fit rounded-lg"
+                  disabledTooltip={partnersPermissionsError || undefined}
                 />
               )}
             </div>

--- a/apps/web/ui/shared/message-input.tsx
+++ b/apps/web/ui/shared/message-input.tsx
@@ -1,3 +1,4 @@
+import { clientAccessCheck } from "@/lib/client-access-check";
 import {
   MAX_ATTACHMENTS_PER_MESSAGE,
   MAX_MESSAGE_LENGTH,
@@ -7,6 +8,7 @@ import {
   getAttachmentTypeLabel,
   isPreviewableImageType,
 } from "@/lib/messages/utils";
+import useWorkspace from "@/lib/swr/use-workspace";
 import {
   ArrowTurnLeft,
   Button,
@@ -75,6 +77,15 @@ export function MessageInput({
   allowedFileTypes?: readonly string[];
   maxAttachments?: number;
 }) {
+  const { id: workspaceId, role } = useWorkspace();
+  const permissionsError = workspaceId
+    ? clientAccessCheck({
+        action: "messages.write",
+        role,
+        customPermissionDescription: "send messages",
+      }).error
+    : false;
+
   const richTextRef = useRef<{ setContent: (content: any) => void }>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [typedMessage, setTypedMessage] = useState(defaultValue || "");
@@ -102,7 +113,12 @@ export function MessageInput({
   const isTooLong = typedMessage.trim().length >= MAX_MESSAGE_LENGTH;
 
   const isSendDisabled =
-    (!hasText && !hasCompletedAttachments) || isTooLong || hasUploading;
+    Boolean(permissionsError) ||
+    (!hasText && !hasCompletedAttachments) ||
+    isTooLong ||
+    hasUploading;
+
+  const canAddFiles = Boolean(onAddFiles) && !permissionsError;
 
   const sendMessage = () => {
     if (isSendDisabled) return;
@@ -181,11 +197,11 @@ export function MessageInput({
       )}
       onDragOver={(e) => {
         handleDragEvent(e);
-        if (onAddFiles) setDragActive(true);
+        if (canAddFiles) setDragActive(true);
       }}
       onDragEnter={(e) => {
         handleDragEvent(e);
-        if (onAddFiles) setDragActive(true);
+        if (canAddFiles) setDragActive(true);
       }}
       onDragLeave={(e) => {
         handleDragEvent(e);
@@ -194,13 +210,13 @@ export function MessageInput({
       onDrop={(e) => {
         handleDragEvent(e);
         setDragActive(false);
-        if (e.dataTransfer.files?.length) {
+        if (canAddFiles && e.dataTransfer.files?.length) {
           handleFiles(e.dataTransfer.files);
         }
       }}
     >
       {/* Drag overlay */}
-      {dragActive && onAddFiles && (
+      {dragActive && canAddFiles && (
         <div className="absolute inset-0 z-10 flex items-center justify-center rounded-xl border-2 border-dashed border-neutral-400 bg-neutral-50/90">
           <div className="text-center">
             <p className="text-sm font-medium text-neutral-600">
@@ -217,6 +233,7 @@ export function MessageInput({
         style="condensed"
         markdown
         autoFocus={autoFocus}
+        editable={!permissionsError}
         placeholder={placeholder}
         editorClassName="block max-h-[min(40dvh,15rem)] w-full resize-none border-none overflow-auto scrollbar-hide p-3 text-base sm:max-h-64 sm:text-sm md:max-h-80 lg:max-h-96"
         initialValue={defaultValue}
@@ -276,12 +293,13 @@ export function MessageInput({
 
         <div className="flex items-center justify-between gap-4 p-3">
           <MessageInputToolbar
+            disabled={Boolean(permissionsError)}
             emojiPickerOpen={emojiPickerOpen}
             setEmojiPickerOpen={setEmojiPickerOpen}
             stripColonOnEmojiPickRef={stripColonOnEmojiPickRef}
             cursorRect={cursorRect}
             onAttachClick={
-              onAddFiles ? () => fileInputRef.current?.click() : undefined
+              canAddFiles ? () => fileInputRef.current?.click() : undefined
             }
           />
           <div className="flex items-center justify-between gap-2">
@@ -331,11 +349,13 @@ export function MessageInput({
               }
               disabled={isSendDisabled}
               disabledTooltip={
-                isTooLong
-                  ? `Message must be less than ${nFormatter(MAX_MESSAGE_LENGTH)} characters`
-                  : hasUploading
-                    ? "Please wait for uploads to complete"
-                    : undefined
+                permissionsError
+                  ? permissionsError
+                  : isTooLong
+                    ? `Message must be less than ${nFormatter(MAX_MESSAGE_LENGTH)} characters`
+                    : hasUploading
+                      ? "Please wait for uploads to complete"
+                      : undefined
               }
               onClick={sendMessage}
               className="h-8 w-fit rounded-lg px-4"
@@ -551,12 +571,14 @@ function MessageInputEditorOverflowFades() {
 }
 
 function MessageInputToolbar({
+  disabled,
   emojiPickerOpen,
   setEmojiPickerOpen,
   stripColonOnEmojiPickRef,
   cursorRect,
   onAttachClick,
 }: {
+  disabled?: boolean;
   emojiPickerOpen: boolean;
   setEmojiPickerOpen: (open: boolean) => void;
   stripColonOnEmojiPickRef: { current: boolean };
@@ -572,6 +594,7 @@ function MessageInputToolbar({
 
   return (
     <RichTextToolbar
+      className={disabled ? "pointer-events-none opacity-50" : undefined}
       toolsStart={
         <EmojiPicker
           openPopover={emojiPickerOpen}
@@ -579,7 +602,7 @@ function MessageInputToolbar({
           onKeyboardDismissFocusEditor={() => editor?.commands.focus()}
           anchorRect={cursorRect}
           onSelect={(emoji) => {
-            if (!editor) return;
+            if (!editor || disabled) return;
             const stripColon = stripColonOnEmojiPickRef.current;
             stripColonOnEmojiPickRef.current = false;
 
@@ -600,7 +623,11 @@ function MessageInputToolbar({
             setTimeout(() => editor.commands.focus(), 0);
           }}
         >
-          <RichTextToolbarButton icon={FaceSmile} label="Emoji" />
+          <RichTextToolbarButton
+            icon={FaceSmile}
+            label="Emoji"
+            disabled={disabled}
+          />
         </EmojiPicker>
       }
       toolsEnd={
@@ -609,6 +636,7 @@ function MessageInputToolbar({
             icon={Paperclip}
             label="Attach file"
             onClick={onAttachClick}
+            disabled={disabled}
           />
         ) : undefined
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added workspace role-based access controls for partner, commission, bounty, campaign, and message actions.
  - Added permission-aware disabled states and explanatory tooltips for restricted buttons and menu items.
  - Added permission checks for creating, editing, deleting, reviewing, and messaging actions.
  - Restricted related keyboard shortcuts when the required permission is unavailable.
  - Prevented unauthorized users from sending messages, adding attachments, or using message editing tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->