### PR TITLE
Skip merge-partner email notifications in e2e tests

### DIFF
--- a/apps/web/app/(ee)/api/e2e/trigger-merge-accounts/route.ts
+++ b/apps/web/app/(ee)/api/e2e/trigger-merge-accounts/route.ts
@@ -58,6 +58,7 @@ export const POST = withWorkspace(
         userId,
         sourceEmail,
         targetEmail,
+        skipEmailNotification: true,
       },
       options: {
         flowControl: {

--- a/apps/web/app/(ee)/api/workflows/merge-partner-accounts/route.ts
+++ b/apps/web/app/(ee)/api/workflows/merge-partner-accounts/route.ts
@@ -25,8 +25,7 @@ const inputSchema = z.object({
   userId: z.string(),
   sourceEmail: z.string(),
   targetEmail: z.string(),
-  // When true (e.g. e2e tests), clear the verification cache but skip the
-  // partner-account-merged notification emails. Defaults to sending emails.
+  // When true (e.g. e2e tests) skip the email notification
   skipEmailNotification: z.boolean().optional().default(false),
 });
 
@@ -45,8 +44,7 @@ const CACHE_KEY_PREFIX = "merge-partner-accounts";
  *    (Tinybird/cache) and total commissions.
  * 4. cleanup-source-account: delete the source partner's rewinds, source user,
  *    duplicate-account fraud events, and finally the source partner itself.
- * 5. send-merged-emails: clear the verification cache + notify both accounts
- *    (unless skipEmailNotification is true, e.g. e2e tests).
+ * 5. send-merged-emails: clear the verification cache + notify both accounts.
  */
 
 // POST /api/workflows/merge-partner-accounts

--- a/apps/web/app/(ee)/api/workflows/merge-partner-accounts/route.ts
+++ b/apps/web/app/(ee)/api/workflows/merge-partner-accounts/route.ts
@@ -25,6 +25,9 @@ const inputSchema = z.object({
   userId: z.string(),
   sourceEmail: z.string(),
   targetEmail: z.string(),
+  // When true (e.g. e2e tests), clear the verification cache but skip the
+  // partner-account-merged notification emails. Defaults to sending emails.
+  skipEmailNotification: z.boolean().optional().default(false),
 });
 
 type Input = z.infer<typeof inputSchema>;
@@ -42,13 +45,15 @@ const CACHE_KEY_PREFIX = "merge-partner-accounts";
  *    (Tinybird/cache) and total commissions.
  * 4. cleanup-source-account: delete the source partner's rewinds, source user,
  *    duplicate-account fraud events, and finally the source partner itself.
- * 5. send-merged-emails: clear the verification cache + notify both accounts.
+ * 5. send-merged-emails: clear the verification cache + notify both accounts
+ *    (unless skipEmailNotification is true, e.g. e2e tests).
  */
 
 // POST /api/workflows/merge-partner-accounts
 export const { POST } = serve<Input>(
   async (context) => {
-    const { userId, sourceEmail, targetEmail } = context.requestPayload;
+    const { userId, sourceEmail, targetEmail, skipEmailNotification } =
+      context.requestPayload;
 
     // Step 1: Resolve + validate accounts and build the merge plan
     const plan = await context.run("load-merge-plan", async () => {
@@ -155,6 +160,12 @@ export const { POST } = serve<Input>(
     // Step 5: Clear the verification cache and notify both accounts
     await context.run("send-merged-emails", async () => {
       await redis.del(`${CACHE_KEY_PREFIX}:${userId}`);
+
+      if (skipEmailNotification) {
+        return logAndReturn({
+          outputLog: `Partner account ${sourceEmail} merged into ${targetEmail}. Skipped email notification.`,
+        });
+      }
 
       const resendBatchEmailRes = await sendBatchEmail(
         [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Adds optional `skipEmailNotification` to the merge-partner-accounts workflow payload (defaults to `false`, so production still sends emails).
- When `true`, the workflow still clears the verification cache but skips `PartnerAccountMerged` emails.
- The e2e `/api/e2e/trigger-merge-accounts` route (used by `merge-partner-accounts-workflow.test.ts`) sets `skipEmailNotification: true`.

## Test plan
- [ ] Confirm partner merge from the UI still sends merged-account emails (flag omitted / false).
- [ ] Confirm e2e merge workflow via `/e2e/trigger-merge-accounts` completes without sending notification emails.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://dub.slack.com/archives/C07H0T3SX97/p1788877480283459?thread_ts=1788877480.283459&cid=C07H0T3SX97)

<div><a href="https://cursor.com/agents/bc-fdbc128c-3222-5dea-9eaf-6eff76c06d93?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fdbc128c-3222-5dea-9eaf-6eff76c06d93&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Account-merge workflows now support optionally skipping email notifications.
  - By default, email notifications continue to be sent after an account merge.

- **Bug Fixes**
  - Automated end-to-end account-merge operations no longer send email notifications to the affected accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->