### PR TITLE
Add subscriptionCanceledAt

### DIFF
--- a/apps/web/app/(ee)/api/customers/[id]/route.ts
+++ b/apps/web/app/(ee)/api/customers/[id]/route.ts
@@ -50,8 +50,15 @@ export const PATCH = withWorkspace(
     const { includeExpandedFields } =
       getCustomersQuerySchema.parse(searchParams);
 
-    const { name, email, avatar, externalId, stripeCustomerId, country } =
-      updateCustomerBodySchema.parse(await parseRequestBody(req));
+    const {
+      name,
+      email,
+      avatar,
+      externalId,
+      stripeCustomerId,
+      country,
+      subscriptionCanceledAt,
+    } = updateCustomerBodySchema.parse(await parseRequestBody(req));
 
     const customer = await getCustomerOrThrow(
       {
@@ -85,6 +92,7 @@ export const PATCH = withWorkspace(
           externalId,
           stripeCustomerId,
           country,
+          subscriptionCanceledAt,
         },
       });
 

--- a/apps/web/lib/zod/schemas/customers.ts
+++ b/apps/web/lib/zod/schemas/customers.ts
@@ -7,7 +7,7 @@ import {
   getPaginationQuerySchema,
 } from "./misc";
 import { PartnerSchema } from "./partners";
-import { centsSchema } from "./utils";
+import { centsSchema, parseDateSchema } from "./utils";
 
 export const CUSTOMERS_MAX_PAGE_SIZE = 100;
 
@@ -130,7 +130,15 @@ export const createCustomerBodySchema = z.object({
     ),
 });
 
-export const updateCustomerBodySchema = createCustomerBodySchema.partial();
+export const updateCustomerBodySchema = createCustomerBodySchema
+  .partial()
+  .extend({
+    subscriptionCanceledAt: parseDateSchema
+      .nullish()
+      .describe(
+        "The date the customer canceled their subscription. Set to a timestamp to mark the subscription as canceled, or `null` to clear it (e.g. if they resubscribe).",
+      ),
+  });
 
 // used in webhook responses + regular /customers endpoints (without expanded fields)
 export const CustomerSchema = z.object({

--- a/apps/web/playwright/api/customers/customers.spec.ts
+++ b/apps/web/playwright/api/customers/customers.spec.ts
@@ -120,6 +120,35 @@ test("PATCH /customers/{id}", async ({ api }) => {
   }
 });
 
+test("PATCH /customers/{id} - subscriptionCanceledAt", async ({ api }) => {
+  let customerId: string | undefined;
+
+  try {
+    const { data: created } = await createCustomer(api);
+    customerId = created.id;
+
+    const canceledAt = "2026-09-08T18:00:00.000Z";
+
+    const { status, data } = await api.patch<Customer>(
+      `/api/customers/${customerId}`,
+      { subscriptionCanceledAt: canceledAt },
+    );
+
+    expect(status).toEqual(200);
+    expect(data.subscriptionCanceledAt).toEqual(canceledAt);
+
+    const { status: clearStatus, data: cleared } = await api.patch<Customer>(
+      `/api/customers/${customerId}`,
+      { subscriptionCanceledAt: null },
+    );
+
+    expect(clearStatus).toEqual(200);
+    expect(cleared.subscriptionCanceledAt).toBeNull();
+  } finally {
+    await deleteCustomer(api, customerId);
+  }
+});
+
 test("GET /customers – by externalId with includeExpandedFields", async ({
   api,
 }) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Customer subscription cancellation dates can now be set or cleared when updating customer details via the API.
* **Tests**
  * Added API coverage verifying subscription cancellation date updates and clearing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->