### PR TITLE
Hide members from `viewer`, add `tenantId` to searchable fields

### DIFF
--- a/apps/web/app/api/workspaces/[idOrSlug]/invites/route.ts
+++ b/apps/web/app/api/workspaces/[idOrSlug]/invites/route.ts
@@ -42,6 +42,7 @@ export const GET = withWorkspace(
   },
   {
     requiredPermissions: ["workspaces.read"],
+    requiredRoles: ["owner", "member", "billing"],
   },
 );
 

--- a/apps/web/app/api/workspaces/[idOrSlug]/users/route.ts
+++ b/apps/web/app/api/workspaces/[idOrSlug]/users/route.ts
@@ -49,6 +49,7 @@ export const GET = withWorkspace(
   },
   {
     requiredPermissions: ["workspaces.read"],
+    requiredRoles: ["owner", "member", "billing"],
   },
 );
 

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/members/page.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/members/page.tsx
@@ -16,12 +16,15 @@ import { useInviteWorkspaceUserModal } from "@/ui/modals/invite-workspace-user-m
 import { useRemoveWorkspaceUserModal } from "@/ui/modals/remove-workspace-user-modal";
 import { useWorkspaceUserRoleModal } from "@/ui/modals/update-workspace-user-role";
 import { SearchBoxPersisted } from "@/ui/shared/search-box";
+import { SimpleEmptyState } from "@/ui/shared/simple-empty-state";
 import { UserAvatar } from "@/ui/users/user-avatar";
 import {
   Button,
+  buttonVariants,
   DynamicTooltipWrapper,
   Filter,
   Popover,
+  ShieldSlash,
   Table,
   useKeyboardShortcut,
   usePagination,
@@ -43,6 +46,7 @@ import { ColumnDef, Row } from "@tanstack/react-table";
 import { Command } from "cmdk";
 import { UserMinus } from "lucide-react";
 import { useSession } from "next-auth/react";
+import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import useSWR from "swr";
@@ -53,7 +57,7 @@ export default function WorkspaceMembersPage() {
 
   const { setShowInviteCodeModal, InviteCodeModal } = useInviteCodeModal();
 
-  const { role, plan, planPeriod, usersLimit } = useWorkspace();
+  const { role, plan, planPeriod, usersLimit, slug } = useWorkspace();
   const { data: session } = useSession();
   const { id: workspaceId } = useWorkspace();
   const { users: workspaceUsers } = useWorkspaceUsers();
@@ -71,6 +75,7 @@ export default function WorkspaceMembersPage() {
     isLoading: loading,
   } = useSWR<WorkspaceUserProps[]>(
     workspaceId &&
+      role !== "viewer" &&
       `/api/workspaces/${workspaceId}/${status === "invited" ? "invites" : "users"}?${new URLSearchParams(
         {
           ...(search && { search }),
@@ -84,7 +89,9 @@ export default function WorkspaceMembersPage() {
   );
 
   const { data: invitesForCount } = useSWR<WorkspaceUserProps[]>(
-    workspaceId ? `/api/workspaces/${workspaceId}/invites` : null,
+    workspaceId && role !== "viewer"
+      ? `/api/workspaces/${workspaceId}/invites`
+      : null,
     fetcher,
   );
   const inviteCount = invitesForCount?.length ?? 0;
@@ -285,6 +292,10 @@ export default function WorkspaceMembersPage() {
       del: ["role", "status", "page"],
     });
   };
+
+  if (role === "viewer") {
+    return <AccessDenied slug={slug} />;
+  }
 
   return (
     <>
@@ -558,5 +569,34 @@ function MenuItem({
       <IconComp className="size-4 shrink-0" />
       {label}
     </Command.Item>
+  );
+}
+
+function AccessDenied({ slug }: { slug?: string }) {
+  return (
+    <PageContent title="Members">
+      <SimpleEmptyState
+        title="You don't have access to this page"
+        description="Contact your workspace admin if you have any questions."
+        graphic={
+          <div className="flex size-16 items-center justify-center rounded-2xl border border-neutral-200 bg-neutral-50">
+            <ShieldSlash className="size-6 text-neutral-800" />
+          </div>
+        }
+        addButton={
+          slug ? (
+            <Link
+              href={`/${slug}/settings`}
+              className={cn(
+                buttonVariants({ variant: "primary" }),
+                "flex h-9 items-center whitespace-nowrap rounded-lg border px-4 text-sm",
+              )}
+            >
+              Go to workspace settings
+            </Link>
+          ) : undefined
+        }
+      />
+    </PageContent>
   );
 }

--- a/apps/web/lib/api/partners/search/serialize-document.ts
+++ b/apps/web/lib/api/partners/search/serialize-document.ts
@@ -6,6 +6,7 @@ export const partnerSearchDocumentSelect = {
   programId: true,
   partnerId: true,
   status: true,
+  tenantId: true,
   groupId: true,
   partner: {
     select: {
@@ -57,6 +58,7 @@ export function serializePartnerSearchDocument(
     name: partner.name,
     email: partner.email,
     companyName: partner.companyName,
+    country: partner.country,
     description: partner.description,
     platformTypes: unique(partner.platforms.map(({ type }) => type)),
     platformIdentifiers: unique(
@@ -64,8 +66,8 @@ export function serializePartnerSearchDocument(
     ),
     linkKeys: unique(links.map(({ key }) => key)),
     status: enrollment.status,
+    tenantId: enrollment.tenantId,
     groupId: enrollment.groupId,
-    country: partner.country,
     partnerTagIds: unique(
       partner.programPartnerTags
         .filter(({ programId }) => programId === enrollment.programId)

--- a/apps/web/lib/api/partners/search/types.ts
+++ b/apps/web/lib/api/partners/search/types.ts
@@ -43,11 +43,12 @@ export interface PartnerSearchDocument {
   programId: string;
   partnerId: string;
 
-  // Searchable partner profile fields
+  // Searchable partner profile fields (including tenant ID)
   name: string;
   email: string | null;
   companyName: string | null;
   description: string | null;
+  tenantId: string | null;
 
   // Searchable platform fields
   platformTypes: PlatformType[];

--- a/apps/web/lib/swr/use-workspace-users.ts
+++ b/apps/web/lib/swr/use-workspace-users.ts
@@ -6,10 +6,11 @@ import useWorkspace from "./use-workspace";
 export default function useWorkspaceUsers({
   invites,
 }: { invites?: boolean } = {}) {
-  const { id } = useWorkspace();
+  const { id, role } = useWorkspace();
 
   const { data: users, error } = useSWR<WorkspaceUserProps[]>(
     id &&
+      role !== "viewer" &&
       (invites
         ? `/api/workspaces/${id}/invites`
         : `/api/workspaces/${id}/users`),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Access Control**
  - Workspace members and invitations are accessible to workspace owners, members, and billing roles.
  - Viewer-role users can no longer access the workspace members page.
  - Viewers see an access-denied message with a link to workspace settings.
  - Viewer accounts no longer load workspace member or invitation data when access is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->