### PR TITLE
Clarify UTM overwrite warning in group link settings save modal

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/groups/[groupSlug]/links/group-link-settings.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/groups/[groupSlug]/links/group-link-settings.tsx
@@ -69,7 +69,7 @@ function GroupLinkSettingsForm({ group }: { group: GroupProps }) {
   const { setShowConfirmModal, confirmModal } = useConfirmModal({
     title: "Save changes",
     description:
-      "Are you sure you want to save these link settings changes? This will update all links in this group.",
+      "Are you sure you want to save these link settings changes? This will update all links in this group. Updating the UTM template will overwrite any custom UTM parameters on partner links.",
     onConfirm: () => handleSubmit(onSubmit)(),
     confirmText: "Save changes",
   });

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/groups/[groupSlug]/links/group-link-settings.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/groups/[groupSlug]/links/group-link-settings.tsx
@@ -69,7 +69,7 @@ function GroupLinkSettingsForm({ group }: { group: GroupProps }) {
   const { setShowConfirmModal, confirmModal } = useConfirmModal({
     title: "Save changes",
     description:
-      "Are you sure you want to save these link settings changes? This will update all links in this group. Updating the UTM template will overwrite any custom UTM parameters on partner links.",
+      "Are you sure you want to save these link settings? This will update all links in this group and overwrite any custom UTM parameters on partner links.",
     onConfirm: () => handleSubmit(onSubmit)(),
     confirmText: "Save changes",
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Updates the "Save changes" confirmation modal on the partner group links settings page to warn that saving overwrites any custom UTM parameters on partner links.
- Uses the clarified copy: "Are you sure you want to save these link settings? This will update all links in this group and overwrite any custom UTM parameters on partner links."

## Test plan
- [ ] Open a partner group links settings page (`/program/groups/.../links`)
- [ ] Change link settings and click Save changes
- [ ] Confirm the modal shows the updated copy
- [ ] Cancel and Save still behave as before
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://dub.slack.com/archives/C07H0T3SX97/p1788945911592019?thread_ts=1788945911.592019&cid=C07H0T3SX97)

<div><a href="https://cursor.com/agents/bc-ab97de31-257a-555a-afc4-f3d3a9ac75ab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab97de31-257a-555a-afc4-f3d3a9ac75ab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the group link settings save-confirmation message to clarify that saving changes applies to all group links.
  - The message now also warns that custom UTM parameters on partner links will be overwritten.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->