### PR TITLE
Consolidate duplicated unique helpers into @dub/utils

### DIFF
--- a/apps/web/lib/api/partners/queue-partner-search-sync.ts
+++ b/apps/web/lib/api/partners/queue-partner-search-sync.ts
@@ -1,5 +1,5 @@
 import { partnerSearchSyncJob } from "@/lib/jobs/handlers/partner-search-sync-job";
-import { chunk } from "@dub/utils";
+import { chunk, unique } from "@dub/utils";
 import {
   getPartnerSearchProvider,
   PARTNER_SEARCH_SYNC_BATCH_SIZE,
@@ -34,10 +34,6 @@ interface QueuePartnerSearchSyncInput {
   delay?: number;
 }
 
-function unique(values: string[] | undefined): string[] {
-  return Array.from(new Set((values ?? []).filter(Boolean)));
-}
-
 /**
  * Queues an index sync for whatever the caller just changed.
  *
@@ -57,8 +53,8 @@ export async function queuePartnerSearchSync({
     return;
   }
 
-  const enrollments = unique(enrollmentIds);
-  const partners = unique(partnerIds);
+  const enrollments = unique(enrollmentIds?.filter(Boolean));
+  const partners = unique(partnerIds?.filter(Boolean));
 
   if (enrollments.length === 0 && partners.length === 0) {
     return;

--- a/apps/web/lib/api/partners/search/serialize-document.ts
+++ b/apps/web/lib/api/partners/search/serialize-document.ts
@@ -1,4 +1,5 @@
 import { Prisma } from "@prisma/client";
+import { unique } from "@dub/utils";
 import { PartnerSearchDocument } from "./types";
 
 export const partnerSearchDocumentSelect = {
@@ -40,10 +41,6 @@ export const partnerSearchDocumentSelect = {
 export type PartnerSearchDocumentSource = Prisma.ProgramEnrollmentGetPayload<{
   select: typeof partnerSearchDocumentSelect;
 }>;
-
-function unique<T>(values: T[]): T[] {
-  return Array.from(new Set(values));
-}
 
 export function serializePartnerSearchDocument(
   enrollment: PartnerSearchDocumentSource,

--- a/apps/web/lib/api/partners/search/sync.ts
+++ b/apps/web/lib/api/partners/search/sync.ts
@@ -1,4 +1,5 @@
 import { prisma } from "@/lib/prisma";
+import { unique } from "@dub/utils";
 import { getPartnerSearchProvider } from "./provider";
 import {
   partnerSearchDocumentSelect,
@@ -22,10 +23,6 @@ interface SyncPartnerSearchDocumentsOptions {
   searchProvider?: PartnerSearchProvider | null;
 }
 
-function unique(values: string[]): string[] {
-  return Array.from(new Set(values.filter(Boolean)));
-}
-
 /**
  * Brings the index in line with the database for the given enrollments.
  *
@@ -38,7 +35,7 @@ export async function syncPartnerSearchDocuments({
   enrollmentIds,
   searchProvider = getPartnerSearchProvider(),
 }: SyncPartnerSearchDocumentsOptions): Promise<PartnerSearchSyncResult> {
-  const ids = unique(enrollmentIds);
+  const ids = unique(enrollmentIds.filter(Boolean));
 
   if (!searchProvider || ids.length === 0) {
     return { upserted: 0, deleted: 0 };
@@ -93,7 +90,7 @@ export async function findPartnerSearchSyncEnrollmentIds({
   after,
   take = PARTNER_SEARCH_SYNC_BATCH_SIZE,
 }: FindPartnerSearchSyncEnrollmentIdsOptions): Promise<string[]> {
-  const ids = unique(partnerIds);
+  const ids = unique(partnerIds.filter(Boolean));
 
   if (ids.length === 0) {
     return [];

--- a/packages/utils/src/functions/index.ts
+++ b/packages/utils/src/functions/index.ts
@@ -43,4 +43,5 @@ export * from "./time-ago";
 export * from "./to-cents-number";
 export * from "./trim";
 export * from "./truncate";
+export * from "./unique";
 export * from "./urls";

--- a/packages/utils/src/functions/unique.ts
+++ b/packages/utils/src/functions/unique.ts
@@ -1,0 +1,3 @@
+export const unique = <T>(values: T[] | null | undefined): T[] => {
+  return Array.from(new Set(values ?? []));
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Adds a shared `unique()` helper in `@dub/utils` (`packages/utils/src/functions/unique.ts`)
- Replaces the three local copies in partner search:
  - `queue-partner-search-sync.ts`
  - `search/sync.ts`
  - `search/serialize-document.ts`
- Preserves existing falsy-filtering behavior at the ID queue/sync call sites via `.filter(Boolean)`

## Test plan
- [x] `pnpm --filter @dub/utils build`
- [x] `pnpm --filter @dub/utils check-types`
- [x] Vitest: `queue-partner-search-sync.test.ts` and `partner-search-sync.test.ts` (27 tests passed, including dedupe coverage)

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://dub.slack.com/archives/C07H0T3SX97/p1788950784773639?thread_ts=1788950784.773639&cid=C07H0T3SX97)

<div><a href="https://cursor.com/agents/bc-10243467-5df3-599d-8ba0-a095334a7444?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10243467-5df3-599d-8ba0-a095334a7444&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated duplicate-value handling into a shared utility for partner search synchronization.
  * Improved consistency when processing partner and enrollment identifiers by ignoring empty values before deduplication.
  * Existing partner search behavior remains unchanged for valid identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->