### PR TITLE
Fix concurrent same-email partner creates returning 500.

### DIFF
--- a/apps/web/lib/api/partners/generate-partner-username.ts
+++ b/apps/web/lib/api/partners/generate-partner-username.ts
@@ -2,6 +2,8 @@ import { prisma } from "@/lib/prisma";
 import { nanoid } from "@dub/utils";
 import slugify from "@sindresorhus/slugify";
 
+const MAX_RETRIES = 3;
+
 export async function generatePartnerUsername({
   email,
   name,
@@ -11,10 +13,9 @@ export async function generatePartnerUsername({
 }) {
   const slugifiedBase = name ? slugify(name) : slugify(email.split("@")[0]);
   let username = `${slugifiedBase}-${nanoid(4).toLowerCase()}`;
-  const maxRetries = 3;
   let retries = 0;
 
-  while (retries <= maxRetries) {
+  while (retries <= MAX_RETRIES) {
     const existingPartner = await prisma.partner.findUnique({
       where: {
         username,
@@ -28,7 +29,7 @@ export async function generatePartnerUsername({
       return username;
     }
 
-    if (retries === maxRetries) {
+    if (retries === MAX_RETRIES) {
       return null;
     }
 

--- a/apps/web/lib/api/partners/get-or-create-partner.ts
+++ b/apps/web/lib/api/partners/get-or-create-partner.ts
@@ -54,17 +54,11 @@ export async function getOrCreatePartner({
         "[getOrCreatePartner] Unique constraint conflict (P2002), falling back to find",
       );
 
-      const partner = await prisma.partner.findUnique({
+      const partner = await prisma.partner.findUniqueOrThrow({
         where: {
           email,
         },
       });
-
-      // No email row means the conflict was on username (or another unique
-      // field), not a concurrent same-email create.
-      if (!partner) {
-        throw error;
-      }
 
       return {
         partner,

--- a/apps/web/lib/api/partners/get-or-create-partner.ts
+++ b/apps/web/lib/api/partners/get-or-create-partner.ts
@@ -50,23 +50,21 @@ export async function getOrCreatePartner({
       error instanceof Prisma.PrismaClientKnownRequestError &&
       error.code === "P2002"
     ) {
-      const target = error.meta?.target as string | undefined;
-
       console.info(
         "[getOrCreatePartner] Unique constraint conflict (P2002), falling back to find",
-        { target },
       );
 
-      // Only fall back to "find by email" when the conflict was actually on email, not username
-      if (!target || !target.includes("email")) {
-        throw error;
-      }
-
-      const partner = await prisma.partner.findUniqueOrThrow({
+      const partner = await prisma.partner.findUnique({
         where: {
           email,
         },
       });
+
+      // No email row means the conflict was on username (or another unique
+      // field), not a concurrent same-email create.
+      if (!partner) {
+        throw error;
+      }
 
       return {
         partner,

--- a/apps/web/playwright/api/partners/get-or-create-partner.spec.ts
+++ b/apps/web/playwright/api/partners/get-or-create-partner.spec.ts
@@ -1,0 +1,54 @@
+import { createId } from "@/lib/api/create-id";
+import { getOrCreatePartner } from "@/lib/api/partners/get-or-create-partner";
+import { prisma } from "@/lib/prisma";
+import { expect } from "@playwright/test";
+import { randomPartnerEmail } from "../../utils";
+import { test } from "../fixtures";
+import { deletePartner } from "./helpers";
+
+test("getOrCreatePartner – concurrent same email shares one partner", async () => {
+  const email = randomPartnerEmail();
+
+  try {
+    const results = await Promise.all(
+      Array.from({ length: 5 }, () =>
+        getOrCreatePartner({
+          email,
+          create: {
+            id: createId({ prefix: "pn_" }),
+            name: email,
+            email,
+          },
+        }),
+      ),
+    );
+
+    const partnerIds = new Set(results.map((result) => result.partner.id));
+
+    expect(partnerIds.size).toBe(1);
+    expect(results.filter((result) => result.created)).toHaveLength(1);
+    expect(results.every((result) => result.partner.email === email)).toBe(
+      true,
+    );
+
+    const rows = await prisma.partner.findMany({
+      where: {
+        email,
+      },
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.id).toBe(results[0].partner.id);
+  } finally {
+    const rows = await prisma.partner.findMany({
+      where: {
+        email,
+      },
+      select: {
+        id: true,
+      },
+    });
+
+    await Promise.all(rows.map((row) => deletePartner(row.id)));
+  }
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved partner creation under concurrent requests to consistently return the shared partner record.
  - Conflicting requests now reliably retrieve the existing partner record.
  - Improved consistency when generating unique partner usernames by applying a standardized retry limit.

- **Tests**
  - Added coverage for simultaneous partner creation requests, including verification of a single database record, matching contact details, and accurate creation status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->