### PR TITLE
Add shared sleep util and replace inline setTimeout Promises

### DIFF
--- a/apps/web/app/(ee)/api/cron/cleanup/link-retention/route.ts
+++ b/apps/web/app/(ee)/api/cron/cleanup/link-retention/route.ts
@@ -3,7 +3,7 @@ import { bulkDeleteLinks } from "@/lib/api/links/bulk-delete-links";
 import { qstash } from "@/lib/cron";
 import { verifyQstashSignature } from "@/lib/cron/verify-qstash";
 import { prisma } from "@/lib/prisma";
-import { APP_DOMAIN_WITH_NGROK } from "@dub/utils";
+import { APP_DOMAIN_WITH_NGROK, sleep } from "@dub/utils";
 import { Domain } from "@prisma/client";
 import { NextResponse } from "next/server";
 import * as z from "zod/v4";
@@ -106,7 +106,7 @@ async function deleteOldLinks(
     ++processedBatches;
 
     // sleep for 250ms
-    await new Promise((resolve) => setTimeout(resolve, 250));
+    await sleep(250);
   }
 
   // Only schedule another run if we hit the batch limit AND we found a full batch

--- a/apps/web/app/(ee)/api/cron/domains/renewal-succeeded/route.ts
+++ b/apps/web/app/(ee)/api/cron/domains/renewal-succeeded/route.ts
@@ -4,7 +4,7 @@ import { setRenewOption } from "@/lib/dynadot/set-renew-option";
 import { prisma } from "@/lib/prisma";
 import { sendBatchEmail } from "@dub/email";
 import DomainRenewed from "@dub/email/templates/domain-renewed";
-import { chunk, log, pluralize } from "@dub/utils";
+import { chunk, log, pluralize, sleep } from "@dub/utils";
 import { RegisteredDomain } from "@prisma/client";
 import { addDays, startOfDay } from "date-fns";
 import * as z from "zod/v4";
@@ -128,7 +128,7 @@ export const POST = withCron(async ({ rawBody }) => {
       });
     }
 
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    await sleep(500);
   }
 
   for (const updateChunk of chunk(succeeded, BATCH_SIZE)) {

--- a/apps/web/app/(ee)/api/cron/domains/transfer/route.ts
+++ b/apps/web/app/(ee)/api/cron/domains/transfer/route.ts
@@ -4,7 +4,7 @@ import { qstash } from "@/lib/cron";
 import { verifyQstashSignature } from "@/lib/cron/verify-qstash";
 import { prisma } from "@/lib/prisma";
 import { recordLink } from "@/lib/tinybird";
-import { APP_DOMAIN_WITH_NGROK, log } from "@dub/utils";
+import { APP_DOMAIN_WITH_NGROK, log, sleep } from "@dub/utils";
 import { NextResponse } from "next/server";
 import * as z from "zod/v4";
 import { sendDomainTransferredEmail } from "./utils";
@@ -103,7 +103,7 @@ export async function POST(req: Request) {
       ]);
 
       // wait 500 ms before making another request
-      await new Promise((resolve) => setTimeout(resolve, 500));
+      await sleep(500);
 
       await qstash.publishJSON({
         url: `${APP_DOMAIN_WITH_NGROK}/api/cron/domains/transfer`,

--- a/apps/web/app/(ee)/api/cron/import/rebrandly/utils.ts
+++ b/apps/web/app/(ee)/api/cron/import/rebrandly/utils.ts
@@ -6,7 +6,11 @@ import { redis } from "@/lib/upstash";
 import { randomBadgeColor } from "@/ui/links/tag-badge";
 import { sendEmail } from "@dub/email";
 import LinksImported from "@dub/email/templates/links-imported";
-import { APP_DOMAIN_WITH_NGROK, linkConstructorSimple } from "@dub/utils";
+import {
+  APP_DOMAIN_WITH_NGROK,
+  linkConstructorSimple,
+  sleep,
+} from "@dub/utils";
 
 export const importTagsFromRebrandly = async ({
   workspaceId,
@@ -52,7 +56,7 @@ export const importTagsFromRebrandly = async ({
   });
 
   // wait 500 ms before making another request
-  await new Promise((resolve) => setTimeout(resolve, 500));
+  await sleep(500);
 
   return await importTagsFromRebrandly({
     workspaceId,
@@ -249,7 +253,7 @@ export const importLinksFromRebrandly = async ({
     });
 
     // wait 500 ms before making another request
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    await sleep(500);
 
     return await qstash.publishJSON({
       url: `${APP_DOMAIN_WITH_NGROK}/api/cron/import/rebrandly`,

--- a/apps/web/app/(ee)/api/cron/import/short/utils.ts
+++ b/apps/web/app/(ee)/api/cron/import/short/utils.ts
@@ -6,7 +6,11 @@ import { redis } from "@/lib/upstash";
 import { randomBadgeColor } from "@/ui/links/tag-badge";
 import { sendEmail } from "@dub/email";
 import LinksImported from "@dub/email/templates/links-imported";
-import { APP_DOMAIN_WITH_NGROK, linkConstructorSimple } from "@dub/utils";
+import {
+  APP_DOMAIN_WITH_NGROK,
+  linkConstructorSimple,
+  sleep,
+} from "@dub/utils";
 
 export const importLinksFromShort = async ({
   workspaceId,
@@ -168,7 +172,7 @@ export const importLinksFromShort = async ({
   });
 
   // wait 500 ms before making another request
-  await new Promise((resolve) => setTimeout(resolve, 500));
+  await sleep(500);
 
   if (!nextPageToken) {
     const workspace = await prisma.project.findUnique({

--- a/apps/web/app/(ee)/api/cron/partners/ban/cancel-commissions.ts
+++ b/apps/web/app/(ee)/api/cron/partners/ban/cancel-commissions.ts
@@ -1,5 +1,6 @@
 import { trackCommissionStatusUpdate } from "@/lib/api/commissions/track-commission-update-activity-log";
 import { prisma } from "@/lib/prisma";
+import { sleep } from "@dub/utils";
 
 // Mark the commissions as canceled
 export async function cancelCommissions({
@@ -84,7 +85,7 @@ export async function cancelCommissions({
       }
 
       // Wait a bit before retrying the same batch
-      await new Promise((resolve) => setTimeout(resolve, 1000));
+      await sleep(1000);
     }
   }
 

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/billing/plan-usage.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/billing/plan-usage.tsx
@@ -40,6 +40,7 @@ import {
   isLegacyBusinessPlan,
   isWorkspaceBillingTrialActive,
   nFormatter,
+  sleep,
 } from "@dub/utils";
 import NumberFlow from "@number-flow/react";
 import Link from "next/link";
@@ -191,7 +192,7 @@ export default function PlanUsage() {
 
       if (res.ok) {
         // sleep for 2 seconds to make sure Stripe webhook was received, and then mutate
-        await new Promise((resolve) => setTimeout(resolve, 2000));
+        await sleep(2000);
         await mutate();
         toast.success("Your subscription will continue as normal.");
       } else {

--- a/apps/web/lib/api-logs/record-api-log.ts
+++ b/apps/web/lib/api-logs/record-api-log.ts
@@ -1,5 +1,5 @@
 import { tb } from "@/lib/tinybird";
-import { log } from "@dub/utils";
+import { log, sleep } from "@dub/utils";
 import * as z from "zod/v4";
 import { createId } from "../api/create-id";
 import { RequestType } from "../types";
@@ -73,9 +73,7 @@ export const recordApiLog = async ({
       return await recordApiLogTB(apiLog);
     } catch (error) {
       if (attempt < maxRetries) {
-        await new Promise((resolve) =>
-          setTimeout(resolve, 100 * Math.pow(2, attempt)),
-        );
+        await sleep(100 * Math.pow(2, attempt));
         continue;
       }
 

--- a/apps/web/lib/api/domains/verify-domain.ts
+++ b/apps/web/lib/api/domains/verify-domain.ts
@@ -1,3 +1,4 @@
+import { sleep } from "@dub/utils";
 export const verifyDomain = async (domain: string) => {
   const res = await fetch(
     `https://api.vercel.com/v9/projects/${process.env.VERCEL_PROJECT_ID}/domains/${domain.toLowerCase()}/verify?teamId=${process.env.TEAM_ID_VERCEL}`,
@@ -22,7 +23,7 @@ export const verifyDomainWithRetry = async (
   let last: any = null;
   for (let i = 0; i < attempts; i++) {
     if (i > 0) {
-      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      await sleep(delayMs);
     }
     try {
       last = await verifyDomain(domain);

--- a/apps/web/lib/api/partners/search/providers/resilience.ts
+++ b/apps/web/lib/api/partners/search/providers/resilience.ts
@@ -1,3 +1,4 @@
+import { sleep } from "@dub/utils";
 import {
   APIConnectionError,
   APIConnectionTimeoutError,
@@ -61,9 +62,7 @@ export async function withTransientRetry<T>(
         throw error;
       }
 
-      await new Promise((resolve) =>
-        setTimeout(resolve, 50 * attempt + Math.random() * 25),
-      );
+      await sleep(50 * attempt + Math.random() * 25);
     }
   }
 

--- a/apps/web/lib/api/utils/with-prisma-retry.ts
+++ b/apps/web/lib/api/utils/with-prisma-retry.ts
@@ -1,3 +1,4 @@
+import { sleep } from "@dub/utils";
 import { Prisma } from "@prisma/client";
 
 const DEFAULT_CONFIG = {
@@ -63,7 +64,7 @@ export async function withPrismaRetry<T>(
       );
 
       // Add delay before retrying
-      await new Promise((resolve) => setTimeout(resolve, delay));
+      await sleep(delay);
     }
   }
 

--- a/apps/web/lib/cron/enqueue-batch-jobs.ts
+++ b/apps/web/lib/cron/enqueue-batch-jobs.ts
@@ -1,4 +1,4 @@
-import { log } from "@dub/utils";
+import { log, sleep } from "@dub/utils";
 import type { PublishBatchRequest } from "@upstash/qstash";
 import { qstash } from ".";
 
@@ -24,9 +24,7 @@ export async function enqueueBatchJobs(jobs: EnqueueBatchJobsProps[]) {
       return await qstash.batchJSON(jobs);
     } catch (error) {
       if (attempt < maxRetries) {
-        await new Promise((resolve) =>
-          setTimeout(resolve, 1000 * Math.pow(2, attempt)),
-        );
+        await sleep(1000 * Math.pow(2, attempt));
         continue;
       }
 

--- a/apps/web/lib/firstpromoter/import-customers.ts
+++ b/apps/web/lib/firstpromoter/import-customers.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@/lib/prisma";
-import { chunk, nanoid } from "@dub/utils";
+import { chunk, nanoid, sleep } from "@dub/utils";
 import { Customer, Link, Project } from "@prisma/client";
 import { createId } from "../api/create-id";
 import { updateLinkStatsForImporter } from "../api/links/update-link-stats-for-importer";
@@ -160,7 +160,7 @@ export async function importCustomers(payload: FirstPromoterImportPayload) {
       }
     }
 
-    await new Promise((resolve) => setTimeout(resolve, 2000));
+    await sleep(2000);
 
     currentPage++;
     processedBatches++;

--- a/apps/web/lib/firstpromoter/update-stripe-customers.ts
+++ b/apps/web/lib/firstpromoter/update-stripe-customers.ts
@@ -1,6 +1,8 @@
 import { prisma } from "@/lib/prisma";
+import { sleep } from "@dub/utils";
 import { Customer, Project } from "@prisma/client";
 import Stripe from "stripe";
+
 import { stripeAppClient } from "../stripe";
 import { logImportError } from "../tinybird/log-import-error";
 import { firstPromoterImporter, MAX_BATCHES } from "./importer";
@@ -81,7 +83,7 @@ export async function updateStripeCustomers(
       ),
     );
 
-    await new Promise((resolve) => setTimeout(resolve, 2000));
+    await sleep(2000);
 
     processedBatches++;
     startingAfter = customers[customers.length - 1].id;

--- a/apps/web/lib/integrations/google-ads/oauth.ts
+++ b/apps/web/lib/integrations/google-ads/oauth.ts
@@ -1,6 +1,6 @@
 import { decrypt, encrypt } from "@/lib/encryption";
 import { prisma } from "@/lib/prisma";
-import { APP_DOMAIN_WITH_NGROK, nanoid } from "@dub/utils";
+import { APP_DOMAIN_WITH_NGROK, nanoid, sleep } from "@dub/utils";
 import { InstalledIntegration } from "@prisma/client";
 import * as z from "zod/v4";
 import { redis } from "../../upstash";
@@ -164,7 +164,7 @@ class GoogleAdsOAuthProvider extends OAuthProvider<
 
     while (Date.now() < deadline) {
       const delay = pollIntervalMs + Math.floor(Math.random() * pollIntervalMs);
-      await new Promise((resolve) => setTimeout(resolve, delay));
+      await sleep(delay);
 
       const credentials = await this.loadCredentials(installationId);
 

--- a/apps/web/lib/integrations/google-ads/upload-conversion.ts
+++ b/apps/web/lib/integrations/google-ads/upload-conversion.ts
@@ -6,6 +6,7 @@ import {
   getSearchParams,
   GOOGLE_ADS_INTEGRATION_ID,
   isZeroDecimalCurrency,
+  sleep,
 } from "@dub/utils";
 import * as z from "zod/v4";
 import { GoogleAdsApi, GoogleAdsClickId } from "./api";
@@ -213,9 +214,7 @@ export const uploadGoogleAdsConversion = async (
         };
       } catch (error) {
         if (attempt < maxRetries) {
-          await new Promise((resolve) =>
-            setTimeout(resolve, 1000 * Math.pow(2, attempt)),
-          );
+          await sleep(1000 * Math.pow(2, attempt));
           continue;
         }
 

--- a/apps/web/lib/jobs/index.ts
+++ b/apps/web/lib/jobs/index.ts
@@ -1,6 +1,6 @@
 import { logger, toErrorFields } from "@/lib/axiom/server";
 import { qstash } from "@/lib/cron";
-import { chunk } from "@dub/utils";
+import { chunk, sleep } from "@dub/utils";
 import * as z from "zod/v4";
 import { QSTASH_BATCH_CHUNK_SIZE } from "./constants";
 import { persistBackgroundJobs } from "./outbox";
@@ -38,9 +38,7 @@ async function withQStashRetry<T>(fn: () => Promise<T>): Promise<T> {
       return await fn();
     } catch (error) {
       if (attempt < QSTASH_PUBLISH_MAX_RETRIES) {
-        await new Promise((resolve) =>
-          setTimeout(resolve, 1000 * Math.pow(2, attempt)),
-        );
+        await sleep(1000 * Math.pow(2, attempt));
         continue;
       }
 

--- a/apps/web/lib/partnerstack/import-commissions.ts
+++ b/apps/web/lib/partnerstack/import-commissions.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@/lib/prisma";
-import { nanoid } from "@dub/utils";
+import { nanoid, sleep } from "@dub/utils";
 import { CommissionStatus, Customer, Link, Program } from "@prisma/client";
 import { convertCurrencyWithFxRates } from "../analytics/convert-currency";
 import { isFirstConversion } from "../analytics/is-first-conversion";
@@ -118,7 +118,7 @@ export async function importCommissions(payload: PartnerStackImportPayload) {
     processedBatches++;
   }
 
-  await new Promise((resolve) => setTimeout(resolve, 1000));
+  await sleep(1000);
 
   await partnerStackImporter.queue({
     ...payload,

--- a/apps/web/lib/partnerstack/import-customers.ts
+++ b/apps/web/lib/partnerstack/import-customers.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@/lib/prisma";
-import { chunk, nanoid } from "@dub/utils";
+import { chunk, nanoid, sleep } from "@dub/utils";
 import { Customer, Link, Project } from "@prisma/client";
 import { createId } from "../api/create-id";
 import { updateLinkStatsForImporter } from "../api/links/update-link-stats-for-importer";
@@ -169,7 +169,7 @@ export async function importCustomers(payload: PartnerStackImportPayload) {
       }
     }
 
-    await new Promise((resolve) => setTimeout(resolve, 2000));
+    await sleep(2000);
 
     processedBatches++;
     currentStartingAfter = customers[customers.length - 1].key;

--- a/apps/web/lib/partnerstack/import-links.ts
+++ b/apps/web/lib/partnerstack/import-links.ts
@@ -1,4 +1,6 @@
 import { prisma } from "@/lib/prisma";
+import { sleep } from "@dub/utils";
+
 import { createLink } from "../api/links";
 import { generatePartnerLink } from "../api/partners/generate-partner-link";
 import { logImportError } from "../tinybird/log-import-error";
@@ -107,7 +109,7 @@ export async function importLinks(payload: PartnerStackImportPayload) {
       );
     }
 
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await sleep(100);
   }
 
   await partnerStackImporter.queue({

--- a/apps/web/lib/partnerstack/import-partners.ts
+++ b/apps/web/lib/partnerstack/import-partners.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@/lib/prisma";
-import { COUNTRIES, COUNTRY_CODES } from "@dub/utils";
+import { COUNTRIES, COUNTRY_CODES, sleep } from "@dub/utils";
 import { PartnerGroup, Program } from "@prisma/client";
 import { createId } from "../api/create-id";
 import { queuePartnerSearchSync } from "../api/partners/queue-partner-search-sync";
@@ -77,7 +77,7 @@ export async function importPartners(payload: PartnerStackImportPayload) {
       programId,
     });
 
-    await new Promise((resolve) => setTimeout(resolve, 2000));
+    await sleep(2000);
 
     processedBatches++;
     currentStartingAfter = partners[partners.length - 1].key;

--- a/apps/web/lib/partnerstack/import-scheduled-commissions.ts
+++ b/apps/web/lib/partnerstack/import-scheduled-commissions.ts
@@ -1,4 +1,6 @@
 import { prisma } from "@/lib/prisma";
+import { sleep } from "@dub/utils";
+
 import { getLeadEvents } from "../tinybird/get-lead-events";
 import { redis } from "../upstash";
 import { PartnerStackApi } from "./api";
@@ -101,7 +103,7 @@ export async function importScheduledCommissions(
 
   // If there are more scheduled commissions to import, sleep for 1 second and continue the loop
   if (hasMore) {
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await sleep(1000);
   } else {
     // else, delete the credentials and exit the loop
     await partnerStackImporter.deleteCredentials(program.workspaceId);

--- a/apps/web/lib/partnerstack/update-stripe-customers.ts
+++ b/apps/web/lib/partnerstack/update-stripe-customers.ts
@@ -1,8 +1,10 @@
 import { prisma } from "@/lib/prisma";
 import { sendEmail } from "@dub/email";
 import ProgramImported from "@dub/email/templates/program-imported";
+import { sleep } from "@dub/utils";
 import { Customer, Project } from "@prisma/client";
 import Stripe from "stripe";
+
 import { stripeAppClient } from "../stripe";
 import { logImportError } from "../tinybird/log-import-error";
 import { MAX_BATCHES, partnerStackImporter } from "./importer";
@@ -89,7 +91,7 @@ export async function updateStripeCustomers(
       ),
     );
 
-    await new Promise((resolve) => setTimeout(resolve, 2000));
+    await sleep(2000);
 
     processedBatches++;
     currentStartingAfter = customers[customers.length - 1].id;

--- a/apps/web/lib/stripe/fund-financial-account.ts
+++ b/apps/web/lib/stripe/fund-financial-account.ts
@@ -1,4 +1,4 @@
-import { currencyFormatter, prettyPrint } from "@dub/utils";
+import { currencyFormatter, prettyPrint, sleep } from "@dub/utils";
 import { stripe } from "./index";
 import { STRIPE_API_VERSION, stripeV2Fetch } from "./stripe-v2-client";
 
@@ -56,7 +56,7 @@ export async function fundFinancialAccount({
   );
 
   // small delay to make sure the funds are fully available in the financial account
-  await new Promise((resolve) => setTimeout(resolve, 5000));
+  await sleep(5000);
 
   return data;
 }

--- a/apps/web/lib/tapfiliate/update-stripe-customers.ts
+++ b/apps/web/lib/tapfiliate/update-stripe-customers.ts
@@ -1,7 +1,9 @@
 import { prisma } from "@/lib/prisma";
+import { sleep } from "@dub/utils";
 import { Customer, Project } from "@prisma/client";
 import Stripe from "stripe";
 import * as z from "zod/v4";
+
 import { stripeAppClient } from "../stripe";
 import { logImportError } from "../tinybird/log-import-error";
 import { TAPFILIATE_MAX_BATCHES, tapfiliateImporter } from "./importer";
@@ -86,7 +88,7 @@ export async function updateStripeCustomers(payload: TapfiliateImportPayload) {
       ),
     );
 
-    await new Promise((resolve) => setTimeout(resolve, 2000));
+    await sleep(2000);
 
     processedBatches++;
     startingAfter = customers[customers.length - 1].id;

--- a/apps/web/lib/tolt/import-commissions.ts
+++ b/apps/web/lib/tolt/import-commissions.ts
@@ -1,7 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { sendEmail } from "@dub/email";
 import ProgramImported from "@dub/email/templates/program-imported";
-import { nanoid } from "@dub/utils";
+import { nanoid, sleep } from "@dub/utils";
 import { CommissionStatus, Customer, Link, Program } from "@prisma/client";
 import { convertCurrencyWithFxRates } from "../analytics/convert-currency";
 import { isFirstConversion } from "../analytics/is-first-conversion";
@@ -94,7 +94,7 @@ export async function importCommissions(payload: ToltImportPayload) {
       ),
     );
 
-    await new Promise((resolve) => setTimeout(resolve, 2000));
+    await sleep(2000);
 
     startingAfter = commissions[commissions.length - 1].id;
     processedBatches++;

--- a/apps/web/lib/tolt/import-customers.ts
+++ b/apps/web/lib/tolt/import-customers.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@/lib/prisma";
-import { chunk, nanoid } from "@dub/utils";
+import { chunk, nanoid, sleep } from "@dub/utils";
 import { Customer, Link, Project } from "@prisma/client";
 import { createId } from "../api/create-id";
 import { updateLinkStatsForImporter } from "../api/links/update-link-stats-for-importer";
@@ -135,7 +135,7 @@ export async function importCustomers(payload: ToltImportPayload) {
       );
     }
 
-    await new Promise((resolve) => setTimeout(resolve, 2000));
+    await sleep(2000);
 
     processedBatches++;
     startingAfter = customers[customers.length - 1].id;

--- a/apps/web/lib/tolt/import-partners.ts
+++ b/apps/web/lib/tolt/import-partners.ts
@@ -1,5 +1,7 @@
 import { prisma } from "@/lib/prisma";
+import { sleep } from "@dub/utils";
 import { Partner, Program } from "@prisma/client";
+
 import { createId } from "../api/create-id";
 import { queuePartnerSearchSync } from "../api/partners/queue-partner-search-sync";
 import { logImportError } from "../tinybird/log-import-error";
@@ -111,7 +113,7 @@ export async function importPartners(payload: ToltImportPayload) {
       );
     }
 
-    await new Promise((resolve) => setTimeout(resolve, 2000));
+    await sleep(2000);
 
     processedBatches++;
     startingAfter = affiliates[affiliates.length - 1].id;

--- a/apps/web/lib/tolt/update-stripe-customers.ts
+++ b/apps/web/lib/tolt/update-stripe-customers.ts
@@ -1,6 +1,8 @@
 import { prisma } from "@/lib/prisma";
+import { sleep } from "@dub/utils";
 import { Customer, Project } from "@prisma/client";
 import Stripe from "stripe";
+
 import { stripeAppClient } from "../stripe";
 import { logImportError } from "../tinybird/log-import-error";
 import { MAX_BATCHES, toltImporter } from "./importer";
@@ -85,7 +87,7 @@ export async function updateStripeCustomers(payload: ToltImportPayload) {
       ),
     );
 
-    await new Promise((resolve) => setTimeout(resolve, 2000));
+    await sleep(2000);
 
     processedBatches++;
     startingAfter = customers[customers.length - 1].id;

--- a/apps/web/playwright/api/groups/helpers.ts
+++ b/apps/web/playwright/api/groups/helpers.ts
@@ -1,6 +1,6 @@
 import { prisma } from "@/lib/prisma";
 import type { EnrolledPartnerProps, GroupProps } from "@/lib/types";
-import { nanoid } from "@dub/utils";
+import { nanoid, sleep } from "@dub/utils";
 import { expect } from "@playwright/test";
 import type { Workflow } from "@prisma/client";
 import { randomName } from "../../utils";
@@ -178,7 +178,7 @@ export async function expectPartnerStaysInGroup({
   expectedGroupId: string;
 }) {
   // Give executeWorkflows (waitUntil after /track/lead) time to run (and skip).
-  await new Promise((resolve) => setTimeout(resolve, 5_000));
+  await sleep(5_000);
 
   const enrollment = await getEnrollment({ partnerId, programId });
   expect(enrollment.groupId).toBe(expectedGroupId);

--- a/apps/web/playwright/api/partners/helpers.ts
+++ b/apps/web/playwright/api/partners/helpers.ts
@@ -3,7 +3,7 @@ import { conn } from "@/lib/planetscale";
 import { prisma } from "@/lib/prisma";
 import type { EnrolledPartnerProps } from "@/lib/types";
 import { DEFAULT_ADDITIONAL_PARTNER_LINKS } from "@/lib/zod/schemas/groups";
-import { nanoid } from "@dub/utils";
+import { nanoid, sleep } from "@dub/utils";
 import { randomName, randomPartnerEmail } from "../../utils";
 import type { ApiClient } from "../fixtures";
 import { TEST_WORKSPACE } from "../setup-test-workspace";
@@ -100,7 +100,7 @@ export async function deletePartnerData(partnerId: string) {
         throw error;
       }
 
-      await new Promise((resolve) => setTimeout(resolve, 250));
+      await sleep(250);
     }
   }
 }

--- a/apps/web/playwright/api/rewards/lead-reward.spec.ts
+++ b/apps/web/playwright/api/rewards/lead-reward.spec.ts
@@ -6,8 +6,10 @@ import type {
   LinkProps,
   RewardConditionsArray,
 } from "@/lib/types";
+import { sleep } from "@dub/utils";
 import { expect } from "@playwright/test";
 import { EventType, Prisma, RewardStructure } from "@prisma/client";
+
 import { randomCustomer } from "../../utils";
 import { deleteCommissionPartner } from "../commissions/helpers";
 import { trackClick, trackLead } from "../conversions/helpers";
@@ -199,7 +201,7 @@ async function expectNoCommission(
   { customerExternalId }: { customerExternalId: string },
 ) {
   // Give the create-partner-commission workflow time to run (and skip).
-  await new Promise((resolve) => setTimeout(resolve, 5_000));
+  await sleep(5_000);
 
   const customer = await prisma.customer.findUnique({
     where: {
@@ -244,7 +246,7 @@ async function expectLeadCommissionCount(
   });
 
   // Give a follow-up create-partner-commission workflow time to run (or skip).
-  await new Promise((resolve) => setTimeout(resolve, 5_000));
+  await sleep(5_000);
 
   await expect
     .poll(async () => {

--- a/apps/web/playwright/api/rewards/sale-reward.spec.ts
+++ b/apps/web/playwright/api/rewards/sale-reward.spec.ts
@@ -5,8 +5,10 @@ import type {
   LinkProps,
   RewardConditionsArray,
 } from "@/lib/types";
+import { sleep } from "@dub/utils";
 import { expect } from "@playwright/test";
 import { EventType, Prisma, RewardStructure } from "@prisma/client";
+
 import { deleteCommissionPartner } from "../commissions/helpers";
 import { trackClick, trackLead, trackSale } from "../conversions/helpers";
 import { test, type ApiClient } from "../fixtures";
@@ -224,7 +226,7 @@ async function expectNoSaleCommission(
   { invoiceId }: { invoiceId: string },
 ) {
   // Give the create-partner-commission workflow time to run (and skip).
-  await new Promise((resolve) => setTimeout(resolve, 5_000));
+  await sleep(5_000);
 
   const commission = await prisma.commission.findFirst({
     where: {
@@ -258,7 +260,7 @@ async function expectSaleCommissionCount(
   });
 
   // Give a follow-up create-partner-commission workflow time to run (or skip).
-  await new Promise((resolve) => setTimeout(resolve, 5_000));
+  await sleep(5_000);
 
   await expect
     .poll(async () => {

--- a/apps/web/scripts/customers/beehiiv/fix-discount-codes.ts
+++ b/apps/web/scripts/customers/beehiiv/fix-discount-codes.ts
@@ -1,4 +1,6 @@
 import { prisma } from "@/lib/prisma";
+import { sleep } from "@dub/utils";
+
 import "dotenv-flow/config";
 import { stripeAppClient } from "../../../lib/stripe";
 
@@ -75,7 +77,7 @@ async function main() {
   }
 
   // sleep for 3 seconds
-  await new Promise((resolve) => setTimeout(resolve, 3000));
+  await sleep(3000);
 
   // recreate the discount codes (since it'll be deleted by promotion_code.updated webhook)
   const { count: createdDiscountCodesCount } =

--- a/apps/web/scripts/dev/simulate-shopify-conversion.ts
+++ b/apps/web/scripts/dev/simulate-shopify-conversion.ts
@@ -1,6 +1,6 @@
 import "dotenv-flow/config";
 
-import { nanoid } from "@dub/utils";
+import { nanoid, sleep } from "@dub/utils";
 import { createHmac } from "crypto";
 
 async function main() {
@@ -15,7 +15,7 @@ async function main() {
     checkoutToken,
   });
 
-  await new Promise((resolve) => setTimeout(resolve, 4000));
+  await sleep(4000);
 
   await trackOrderPaid({
     checkoutToken,

--- a/apps/web/scripts/migrations/backfill-commissions-metadata.ts
+++ b/apps/web/scripts/migrations/backfill-commissions-metadata.ts
@@ -2,6 +2,7 @@ import "dotenv-flow/config";
 
 import { prisma } from "@/lib/prisma";
 import { tb } from "@/lib/tinybird/client";
+import { sleep } from "@dub/utils";
 import { CommissionType, Prisma } from "@prisma/client";
 import * as z from "zod/v4";
 
@@ -37,10 +38,6 @@ const getEventsMetadata = tb.buildPipe({
     metadata: z.string(),
   }),
 });
-
-async function sleep(ms: number) {
-  await new Promise((resolve) => setTimeout(resolve, ms));
-}
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);

--- a/apps/web/tests/utils/verify-commission.ts
+++ b/apps/web/tests/utils/verify-commission.ts
@@ -3,7 +3,9 @@ import {
   VITEST_TEST_TIMEOUT_MS,
 } from "@/lib/constants/misc";
 import { CommissionResponse, Customer } from "@/lib/types";
+import { sleep } from "@dub/utils";
 import { expect } from "vitest";
+
 import { HttpClient } from "./http";
 
 interface VerifyCommissionProps {
@@ -105,9 +107,7 @@ export const verifyCommission = async ({
     }
 
     // Wait before next poll
-    await new Promise((resolve) =>
-      setTimeout(resolve, VITEST_POLL_INTERVAL_MS),
-    );
+    await sleep(VITEST_POLL_INTERVAL_MS);
   }
 
   // Timeout reached - fail the test

--- a/apps/web/tests/utils/verify-fraud-event.ts
+++ b/apps/web/tests/utils/verify-fraud-event.ts
@@ -1,5 +1,6 @@
 import { Customer } from "@/lib/types";
 import { fraudEventSchemas } from "@/lib/zod/schemas/fraud";
+import { sleep } from "@dub/utils";
 import { FraudRuleType, Partner } from "@prisma/client";
 import { HttpClient } from "tests/utils/http";
 import { expect } from "vitest";
@@ -54,9 +55,7 @@ export const verifyFraudEvent = async ({
     }
 
     // Wait before next poll
-    await new Promise((resolve) =>
-      setTimeout(resolve, VITEST_POLL_INTERVAL_MS),
-    );
+    await sleep(VITEST_POLL_INTERVAL_MS);
   }
 
   if (!fraudEvent) {

--- a/apps/web/tests/workflows/award-bounty-workflow.test.ts
+++ b/apps/web/tests/workflows/award-bounty-workflow.test.ts
@@ -1,7 +1,9 @@
 import { EnrolledPartnerProps } from "@/lib/types";
+import { sleep } from "@dub/utils";
 import { Bounty } from "@prisma/client";
 import { E2E_PARTNER_GROUP } from "tests/utils/resource";
 import { describe, expect, onTestFinished, test } from "vitest";
+
 import { randomPartnerEmail } from "../utils/helpers";
 import { IntegrationHarness } from "../utils/integration";
 import { deleteBountyAndSubmissions } from "./utils/delete-bounty-and-submissions";
@@ -122,7 +124,7 @@ describe.sequential("Workflow - AwardBounty", async () => {
 
     await trackE2ELead(http, partnerLink);
 
-    await new Promise((resolve) => setTimeout(resolve, 10000));
+    await sleep(10000);
 
     const { data: submissions } = await http.get<any[]>({
       path: `/bounties/${bounty.id}/submissions`,
@@ -196,7 +198,7 @@ describe.sequential("Workflow - AwardBounty", async () => {
 
     await trackE2ELead(http, partnerLink);
 
-    await new Promise((resolve) => setTimeout(resolve, 10000));
+    await sleep(10000);
 
     const { data: submissions } = await http.get<any[]>({
       path: `/bounties/${bounty.id}/submissions`,

--- a/apps/web/tests/workflows/merge-partner-accounts-workflow.test.ts
+++ b/apps/web/tests/workflows/merge-partner-accounts-workflow.test.ts
@@ -3,7 +3,9 @@ import {
   VITEST_TEST_TIMEOUT_MS,
 } from "@/lib/constants/misc";
 import { EnrolledPartnerProps } from "@/lib/types";
+import { sleep } from "@dub/utils";
 import { describe, expect, test } from "vitest";
+
 import { randomPartnerEmail } from "../utils/helpers";
 import { IntegrationHarness } from "../utils/integration";
 import { E2E_PARTNER_GROUP } from "../utils/resource";
@@ -101,9 +103,7 @@ describe.sequential("Workflow - MergePartnerAccounts", async () => {
           return;
         }
 
-        await new Promise((resolve) =>
-          setTimeout(resolve, VITEST_POLL_INTERVAL_MS),
-        );
+        await sleep(VITEST_POLL_INTERVAL_MS);
       }
 
       throw new Error(

--- a/apps/web/tests/workflows/utils/verify-bounty-submission.ts
+++ b/apps/web/tests/workflows/utils/verify-bounty-submission.ts
@@ -2,7 +2,9 @@ import {
   VITEST_POLL_INTERVAL_MS,
   VITEST_TEST_TIMEOUT_MS,
 } from "@/lib/constants/misc";
+import { sleep } from "@dub/utils";
 import { expect } from "vitest";
+
 import { HttpClient } from "../../utils/http";
 
 interface VerifyBountySubmissionProps {
@@ -56,9 +58,7 @@ export const verifyBountySubmission = async ({
       return submission;
     }
 
-    await new Promise((resolve) =>
-      setTimeout(resolve, VITEST_POLL_INTERVAL_MS),
-    );
+    await sleep(VITEST_POLL_INTERVAL_MS);
   }
 
   const lastState = lastSubmission

--- a/apps/web/tests/workflows/utils/verify-merge-completed.ts
+++ b/apps/web/tests/workflows/utils/verify-merge-completed.ts
@@ -3,7 +3,9 @@ import {
   VITEST_TEST_TIMEOUT_MS,
 } from "@/lib/constants/misc";
 import { EnrolledPartnerProps } from "@/lib/types";
+import { sleep } from "@dub/utils";
 import { expect } from "vitest";
+
 import { HttpClient } from "../../utils/http";
 
 interface VerifyMergeCompletedProps {
@@ -50,9 +52,7 @@ export const verifyMergeCompleted = async ({
       return targetRes.data;
     }
 
-    await new Promise((resolve) =>
-      setTimeout(resolve, VITEST_POLL_INTERVAL_MS),
-    );
+    await sleep(VITEST_POLL_INTERVAL_MS);
   }
 
   throw new Error(

--- a/apps/web/ui/workspaces/subscription-menu.tsx
+++ b/apps/web/ui/workspaces/subscription-menu.tsx
@@ -11,7 +11,7 @@ import {
   SquareXmark,
   StripeIcon,
 } from "@dub/ui";
-import { cn } from "@dub/utils";
+import { cn, sleep } from "@dub/utils";
 import { Command } from "cmdk";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
@@ -69,7 +69,7 @@ export default function SubscriptionMenu() {
       .then(async (res) => {
         if (res.ok) {
           // sleep for 2 seconds to make sure Stripe webhook was received, and then mutate
-          await new Promise((resolve) => setTimeout(resolve, 2000));
+          await sleep(2000);
           await mutate();
           toast.success(
             "Your subscription has been scheduled for cancellation at the end of the current period.",

--- a/packages/utils/src/functions/fetch-with-retry.ts
+++ b/packages/utils/src/functions/fetch-with-retry.ts
@@ -1,3 +1,4 @@
+import { sleep } from "./sleep";
 export async function fetchWithRetry(
   input: RequestInfo | URL,
   init?: RequestInit | undefined,
@@ -32,7 +33,7 @@ export async function fetchWithRetry(
       // Handle rate limiting and server errors
       if (response.status === 429 || response.status >= 500) {
         const delay = retryDelay + Math.pow(i, 2) * 50;
-        await new Promise((resolve) => setTimeout(resolve, delay));
+        await sleep(delay);
         continue;
       }
 
@@ -66,7 +67,7 @@ export async function fetchWithRetry(
 
       // For network errors or timeouts, wait and retry
       const delay = retryDelay + Math.pow(i, 2) * 50;
-      await new Promise((resolve) => setTimeout(resolve, delay));
+      await sleep(delay);
     }
   }
 

--- a/packages/utils/src/functions/index.ts
+++ b/packages/utils/src/functions/index.ts
@@ -36,6 +36,7 @@ export * from "./punycode";
 export * from "./random-value";
 export * from "./regex-escape";
 export * from "./resize-image";
+export * from "./sleep";
 export * from "./smart-truncate";
 export * from "./stable-sort";
 export * from "./text-fetcher";

--- a/packages/utils/src/functions/sleep.ts
+++ b/packages/utils/src/functions/sleep.ts
@@ -1,0 +1,2 @@
+export const sleep = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Adds `sleep(ms)` to `@dub/utils` (`packages/utils/src/functions/sleep.ts`)
- Replaces all `await new Promise((resolve) => setTimeout(resolve, …))` call sites with `await sleep(…)`
- Removes the local `sleep` helper in the commissions metadata backfill script in favor of the shared util

## Test plan
- [ ] Confirm `@dub/utils` typechecks (`pnpm --filter @dub/utils check-types`)
- [ ] Spot-check a few call sites (retry helpers, importers, cron routes) still delay as expected
- [ ] Run relevant unit/API tests that previously used inline sleeps if convenient

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://dub.slack.com/archives/C07H0T3SX97/p1788953669582469?thread_ts=1788953669.582469&cid=C07H0T3SX97)

<div><a href="https://cursor.com/agents/bc-c2131f43-81b8-5ec2-bbc7-b1f7a5229ac6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2131f43-81b8-5ec2-bbc7-b1f7a5229ac6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized timed waits across background processing, imports, retries, polling, and subscription workflows.
  * Preserved existing retry intervals, batch pacing, polling behavior, and user-facing functionality.

* **Chores**
  * Added a shared utility for consistent timed delays.
  * Updated automated tests and maintenance scripts to use the standardized delay handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->