### PR TITLE
Skip reserved test domains in Resend

### DIFF
--- a/packages/email/src/send-via-resend.ts
+++ b/packages/email/src/send-via-resend.ts
@@ -3,6 +3,24 @@ import { resend } from "./resend";
 import { VARIANT_TO_FROM_MAP } from "./resend/constants";
 import { ResendBulkEmailOptions, ResendEmailOptions } from "./resend/types";
 
+// Resend 422s reserved test domains:
+// https://resend.com/docs/knowledge-base/what-email-addresses-to-use-for-testing
+const RESEND_BLOCKED_DOMAINS = [
+  "example.com",
+  "example.net",
+  "example.org",
+  "test.com",
+] as const;
+
+const isResendBlockedRecipient = (to: string) => {
+  const domain = to.toLowerCase().trim().split("@").at(1);
+  if (!domain) return false;
+
+  return RESEND_BLOCKED_DOMAINS.some(
+    (blocked) => domain === blocked || domain.endsWith(`.${blocked}`),
+  );
+};
+
 const resendEmailForOptions = (
   opts: ResendEmailOptions,
 ): CreateEmailOptions => {
@@ -68,6 +86,11 @@ export const sendEmailViaResend = async (opts: ResendEmailOptions) => {
     return;
   }
 
+  if (isResendBlockedRecipient(opts.to)) {
+    console.info(`Skipping email to reserved Resend domain: ${opts.to}`);
+    return;
+  }
+
   return await resend.emails.send(resendEmailForOptions(opts));
 };
 
@@ -93,11 +116,17 @@ export const sendBatchEmailViaResend = async (
     };
   }
 
-  // Filter out emails without to address
+  // Filter out emails without to address or reserved Resend domains
   // and format the emails for Resend
+  const skippedRecipients: string[] = [];
   const filteredBatch = emails.reduce(
     (acc, email) => {
       if (!email?.to) {
+        return acc;
+      }
+
+      if (isResendBlockedRecipient(email.to)) {
+        skippedRecipients.push(email.to);
         return acc;
       }
 
@@ -107,6 +136,13 @@ export const sendBatchEmailViaResend = async (
     },
     [] as ReturnType<typeof resendEmailForOptions>[],
   );
+
+  if (skippedRecipients.length > 0) {
+    console.info(
+      `Skipping ${skippedRecipients.length} email(s) to reserved Resend domains:`,
+      skippedRecipients,
+    );
+  }
 
   if (filteredBatch.length === 0) {
     return {

--- a/packages/email/src/send-via-resend.ts
+++ b/packages/email/src/send-via-resend.ts
@@ -21,6 +21,17 @@ const isResendBlockedRecipient = (to: string) => {
   );
 };
 
+// Keep batch cardinality so callers can zip Resend IDs by index.
+// delivered+label@resend.dev is a Resend test sink (no real inbox).
+const rewriteBlockedRecipient = (to: string) => {
+  if (!isResendBlockedRecipient(to)) return to;
+
+  const username = to.toLowerCase().trim().split("@").at(0) || "unknown";
+  const rewritten = `delivered+${username}@resend.dev`;
+  console.info(`Rewriting reserved Resend recipient ${to} → ${rewritten}`);
+  return rewritten;
+};
+
 const resendEmailForOptions = (
   opts: ResendEmailOptions,
 ): CreateEmailOptions => {
@@ -45,7 +56,7 @@ const resendEmailForOptions = (
   // Build base options without rendered outputs (react/text)
   // CreateEmailOptions requires at least one of react or text
   const baseOptions = {
-    to: isPreviewEnv ? "delivered@resend.dev" : to,
+    to: isPreviewEnv ? "delivered@resend.dev" : rewriteBlockedRecipient(to),
     from: from || VARIANT_TO_FROM_MAP[variant],
     subject: `${subject}${isPreviewEnv && gitBranch ? ` [${gitBranch}]` : ""}`,
     bcc,
@@ -86,11 +97,6 @@ export const sendEmailViaResend = async (opts: ResendEmailOptions) => {
     return;
   }
 
-  if (isResendBlockedRecipient(opts.to)) {
-    console.info(`Skipping email to reserved Resend domain: ${opts.to}`);
-    return;
-  }
-
   return await resend.emails.send(resendEmailForOptions(opts));
 };
 
@@ -116,17 +122,11 @@ export const sendBatchEmailViaResend = async (
     };
   }
 
-  // Filter out emails without to address or reserved Resend domains
+  // Filter out emails without to address
   // and format the emails for Resend
-  const skippedRecipients: string[] = [];
   const filteredBatch = emails.reduce(
     (acc, email) => {
       if (!email?.to) {
-        return acc;
-      }
-
-      if (isResendBlockedRecipient(email.to)) {
-        skippedRecipients.push(email.to);
         return acc;
       }
 
@@ -136,13 +136,6 @@ export const sendBatchEmailViaResend = async (
     },
     [] as ReturnType<typeof resendEmailForOptions>[],
   );
-
-  if (skippedRecipients.length > 0) {
-    console.info(
-      `Skipping ${skippedRecipients.length} email(s) to reserved Resend domains:`,
-      skippedRecipients,
-    );
-  }
 
   if (filteredBatch.length === 0) {
     return {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Emails addressed to reserved Resend test domains are now rewritten to Resend’s delivery-testing address before sending.
  * Preview environment emails continue using Resend’s standard delivery-testing address.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->