### PR TITLE
Feature/partner-search: sync tenant ID edits to the index

### DIFF
--- a/apps/web/lib/actions/partners/update-partner-enrollment.ts
+++ b/apps/web/lib/actions/partners/update-partner-enrollment.ts
@@ -3,6 +3,7 @@
 import { recordAuditLog } from "@/lib/api/audit-logs/record-audit-log";
 import { includeProgramEnrollment } from "@/lib/api/links/include-program-enrollment";
 import { includeTags } from "@/lib/api/links/include-tags";
+import { queuePartnerSearchSync } from "@/lib/api/partners/queue-partner-search-sync";
 import { throwIfExistingTenantEnrollmentExists } from "@/lib/api/partners/throw-if-existing-tenant-id-exists";
 import { getDefaultProgramIdOrThrow } from "@/lib/api/programs/get-default-program-id-or-throw";
 import { getProgramEnrollmentOrThrow } from "@/lib/api/programs/get-program-enrollment-or-throw";
@@ -95,6 +96,10 @@ export const updatePartnerEnrollmentAction = authActionClient
     waitUntil(
       Promise.allSettled([
         recordLink(programEnrollment.links),
+        // Queue an index update because the tenant ID changed
+        ...(tenantId !== existingTenantId
+          ? [queuePartnerSearchSync({ enrollmentIds: [programEnrollment.id] })]
+          : []),
         recordAuditLog({
           workspaceId: workspace.id,
           programId,

--- a/apps/web/scripts/dev/debug-partner-search.ts
+++ b/apps/web/scripts/dev/debug-partner-search.ts
@@ -146,15 +146,11 @@ const PLATFORM_TYPES = [
 ];
 
 /**
- * `searchText` is every searchable value lowercased and space-joined in a fixed
- * order: partner ID, tenant ID, name, email, company, description,
- * platform types, handles, then link keys. Three of those boundaries are
- * recoverable, since the partner ID is prefixed, the email is address-shaped,
- * and the platform types are a known enum, so the blob splits into identity /
- * profile / platforms-and-keys. A tenant ID has no recognizable shape, so it
- * stays inside `identity` ahead of the name. A document without platforms has
- * no recoverable boundary after the email, so everything past it stays together
- * as `profile`.
+ * `searchText` joins the searchable values in order: partner ID, tenant ID,
+ * name, email, company, description, platform types, handles, link keys. Only
+ * the partner ID prefix, the email shape, and the platform enum are
+ * recoverable, so the split into identity / profile / platforms-and-keys is a
+ * heuristic. The tenant ID has no shape and stays in identity.
  */
 function parseIndexedText(searchText: string) {
   const tokens = searchText.split(" ").filter(Boolean);

--- a/apps/web/scripts/dev/debug-partner-search.ts
+++ b/apps/web/scripts/dev/debug-partner-search.ts
@@ -147,28 +147,30 @@ const PLATFORM_TYPES = [
 
 /**
  * `searchText` is every searchable value lowercased and space-joined in a fixed
- * order: partner ID, name, email, company, description, platform types, handles,
- * then link keys. Three of those boundaries are recoverable, since the ID is
- * prefixed, the email is address-shaped, and the platform types are a known
- * enum, so the blob splits into name / profile / platforms-and-keys. A document
- * without platforms has no recoverable boundary after the email, so everything
- * past it stays together as `profile`.
+ * order: partner ID, tenant ID when set, name, email, company, description,
+ * platform types, handles, then link keys. Three of those boundaries are
+ * recoverable, since the partner ID is prefixed, the email is address-shaped,
+ * and the platform types are a known enum, so the blob splits into identity /
+ * profile / platforms-and-keys. A tenant ID has no recognizable shape, so it
+ * stays inside `identity` ahead of the name. A document without platforms has
+ * no recoverable boundary after the email, so everything past it stays together
+ * as `profile`.
  */
 function parseIndexedText(searchText: string) {
   const tokens = searchText.split(" ").filter(Boolean);
   const hasPartnerId = tokens[0]?.startsWith("pn_") ?? false;
   const emailIndex = tokens.findIndex((token) => EMAIL_PATTERN.test(token));
-  // Without an email there is no boundary after the name, so it is assumed to
-  // end at the fourth token, and the profile starts where the name ends.
-  const nameEnd = emailIndex === -1 ? 4 : emailIndex;
-  const profileStart = emailIndex === -1 ? nameEnd : emailIndex + 1;
+  // Without an email there is no boundary after the identity, so it is assumed
+  // to end at the fourth token, and the profile starts where the identity ends.
+  const identityEnd = emailIndex === -1 ? 4 : emailIndex;
+  const profileStart = emailIndex === -1 ? identityEnd : emailIndex + 1;
   const platformIndex = tokens.findIndex(
     (token, index) => index >= profileStart && PLATFORM_TYPES.includes(token),
   );
 
   return {
     tokens,
-    name: tokens.slice(hasPartnerId ? 1 : 0, nameEnd).join(" "),
+    identity: tokens.slice(hasPartnerId ? 1 : 0, identityEnd).join(" "),
     email: emailIndex === -1 ? "" : tokens[emailIndex],
     profile: tokens
       .slice(profileStart, platformIndex === -1 ? undefined : platformIndex)
@@ -212,7 +214,7 @@ function reportProviderHits(
       return {
         rank: index + 1,
         score: hit.score?.toFixed(5),
-        name: parsed.name,
+        identity: parsed.identity,
         email: parsed.email,
         docTokens: parsed.tokens.length,
         queryTerms: summarizeTermMatches(parsed.tokens, normalizedQuery),

--- a/apps/web/scripts/dev/debug-partner-search.ts
+++ b/apps/web/scripts/dev/debug-partner-search.ts
@@ -147,7 +147,7 @@ const PLATFORM_TYPES = [
 
 /**
  * `searchText` is every searchable value lowercased and space-joined in a fixed
- * order: partner ID, tenant ID when set, name, email, company, description,
+ * order: partner ID, tenant ID, name, email, company, description,
  * platform types, handles, then link keys. Three of those boundaries are
  * recoverable, since the partner ID is prefixed, the email is address-shaped,
  * and the platform types are a known enum, so the blob splits into identity /


### PR DESCRIPTION
## Summary

Follow-up to #4474, which made `tenantId` a searchable field. There are two loose ends.

- `updatePartnerEnrollmentAction` changes the tenant ID with no index sync, so an edit in the dashboard left the old value searchable until something else touched the enrollment. It now queues a sync when the tenant ID changes.
- Update to the debug script.

## Rollout

Existing documents do not have `tenantId`. The hook only covers edits from now on, so the index needs a full upsert after this merges:

```
pnpm --filter web run script partners/backfill-partner-search --all
```

Until that runs, a tenant ID search only finds enrollments written after #4474 went live.

## Test plan

- [x] `--searchOnly` against the Acme program shows the `identity` column with the same values as before for documents without a tenant ID.
- [x] Typecheck and prettier on both files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Partner search results now synchronize automatically when a partner’s tenant association changes.
- Search results more accurately reflect the partner’s current tenant identity after enrollment updates, helping keep displayed information consistent with the latest association.
- This improves the accuracy and timeliness of partner information shown in search, reducing outdated tenant associations after enrollment changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
