### PR TITLE
Feature/partner-search: select partner tags from the enrollment

### DIFF
--- a/apps/web/lib/api/partners/search/serialize-document.ts
+++ b/apps/web/lib/api/partners/search/serialize-document.ts
@@ -1,5 +1,5 @@
-import { Prisma } from "@prisma/client";
 import { unique } from "@dub/utils";
+import { Prisma } from "@prisma/client";
 import { PartnerSearchDocument } from "./types";
 
 export const partnerSearchDocumentSelect = {
@@ -16,14 +16,6 @@ export const partnerSearchDocumentSelect = {
       companyName: true,
       description: true,
       country: true,
-      // Tags are per (program, partner) and this select cannot take a program,
-      // so the serializer narrows them to the enrollment's own program.
-      programPartnerTags: {
-        select: {
-          programId: true,
-          partnerTagId: true,
-        },
-      },
       platforms: {
         select: {
           type: true,
@@ -37,6 +29,11 @@ export const partnerSearchDocumentSelect = {
       key: true,
     },
   },
+  programPartnerTags: {
+    select: {
+      partnerTagId: true,
+    },
+  },
 } satisfies Prisma.ProgramEnrollmentSelect;
 
 export type PartnerSearchDocumentSource = Prisma.ProgramEnrollmentGetPayload<{
@@ -46,7 +43,7 @@ export type PartnerSearchDocumentSource = Prisma.ProgramEnrollmentGetPayload<{
 export function serializePartnerSearchDocument(
   enrollment: PartnerSearchDocumentSource,
 ): PartnerSearchDocument {
-  const { partner, links } = enrollment;
+  const { partner, links, programPartnerTags } = enrollment;
 
   return {
     id: enrollment.id,
@@ -66,9 +63,7 @@ export function serializePartnerSearchDocument(
     tenantId: enrollment.tenantId,
     groupId: enrollment.groupId,
     partnerTagIds: unique(
-      partner.programPartnerTags
-        .filter(({ programId }) => programId === enrollment.programId)
-        .map(({ partnerTagId }) => partnerTagId),
+      programPartnerTags.map(({ partnerTagId }) => partnerTagId),
     ),
   };
 }

--- a/apps/web/tests/partners/partner-search-backfill.test.ts
+++ b/apps/web/tests/partners/partner-search-backfill.test.ts
@@ -24,6 +24,7 @@ function createSource(id: string): PartnerSearchDocumentSource {
     programId: "prog_test",
     partnerId: `pn_${id}`,
     status: "approved" as const,
+    tenantId: null,
     groupId: null,
     partner: {
       name: "Rafi Hasan",
@@ -31,10 +32,10 @@ function createSource(id: string): PartnerSearchDocumentSource {
       companyName: "Dub Partners",
       description: "Developer tools educator",
       country: null,
-      programPartnerTags: [],
       platforms: [],
     },
     links: [],
+    programPartnerTags: [],
   };
 }
 

--- a/apps/web/tests/partners/partner-search-document.test.ts
+++ b/apps/web/tests/partners/partner-search-document.test.ts
@@ -9,6 +9,7 @@ const source: PartnerSearchDocumentSource = {
   programId: "prog_test",
   partnerId: "pn_test",
   status: "approved" as const,
+  tenantId: null,
   groupId: "grp_test",
   partner: {
     name: "Rafi Hasan",
@@ -16,11 +17,6 @@ const source: PartnerSearchDocumentSource = {
     companyName: "Dub Partners",
     description: "Developer tools educator",
     country: "US",
-    programPartnerTags: [
-      { programId: "prog_test", partnerTagId: "ptag_a" },
-      // A tag from a different program must not leak into this document.
-      { programId: "prog_other", partnerTagId: "ptag_other" },
-    ],
     platforms: [
       {
         type: "website",
@@ -33,6 +29,7 @@ const source: PartnerSearchDocumentSource = {
     ],
   },
   links: [{ key: "rafi" }, { key: "rafi-tools" }],
+  programPartnerTags: [{ partnerTagId: "ptag_a" }, { partnerTagId: "ptag_a" }],
 };
 
 describe("serializePartnerSearchDocument", () => {
@@ -49,11 +46,10 @@ describe("serializePartnerSearchDocument", () => {
       platformIdentifiers: ["https://rafi.dev", "@rafi-on-x"],
       linkKeys: ["rafi", "rafi-tools"],
       status: "approved",
+      tenantId: null,
       groupId: "grp_test",
       country: "US",
-      // The tag from prog_other is dropped: tags are per program.
       partnerTagIds: ["ptag_a"],
     });
   });
-
 });

--- a/apps/web/tests/partners/partner-search-sync.test.ts
+++ b/apps/web/tests/partners/partner-search-sync.test.ts
@@ -27,6 +27,7 @@ function createSource(
     programId: "prog_test",
     partnerId: `pn_${id}`,
     status: "approved" as const,
+    tenantId: null,
     groupId: null,
     partner: {
       name: "Rafi Hasan",
@@ -34,10 +35,10 @@ function createSource(
       companyName: "Dub Partners",
       description: "Developer tools educator",
       country: null,
-      programPartnerTags: [],
       platforms: [],
     },
     links: [],
+    programPartnerTags: [],
     ...overrides,
   };
 }
@@ -148,13 +149,9 @@ describe("syncPartnerSearchDocuments", () => {
           companyName: null,
           description: null,
           country: "US",
-          // Tags from another program must not leak into this document.
-          programPartnerTags: [
-            { programId: "prog_test", partnerTagId: "ptag_1" },
-            { programId: "prog_other", partnerTagId: "ptag_other" },
-          ],
           platforms: [{ type: "youtube" as const, identifier: "rafi" }],
         },
+        programPartnerTags: [{ partnerTagId: "ptag_1" }],
       }),
     ]);
 


### PR DESCRIPTION
## Summary

`partnerSearchDocumentSelect` read `programPartnerTags` through `partner`, which returns the partner's tags across every program, and the serializer filtered them back to the enrollment's program. `ProgramEnrollment` has its own `programPartnerTags` relation bound by `(programId, partnerId)`, so selecting there returns only this program's tags and the filter goes away.

The first version of the select did this (735d6515d3, Aug 8). The tags were dropped with the other filters (269e57820d, Aug 9) and re-added under `partner` (37faaf2d44, Aug 14). This restores the original shape.

## Changes

- Move `programPartnerTags` to the enrollment level, `partnerTagId` only.
- Drop the `programId` filter and the comment explaining it.
- Test fixtures build the source at the enrollment level. The cross-program leak case is gone, since the relation cannot return another program's tags.
- Fixtures gain `tenantId: null`, which #4474 added to the select without updating them.

## Test plan

- [x] `partner-search-document`, `partner-search-sync`, `partner-search-backfill`, `get-partners-search`, `turbopuffer-partner-search-provider`: 47 tests pass.
- [x] Typecheck clean on the touched files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved partner search serialization so partner tags are correctly associated with enrollment records.
  - Preserved accurate, deduplicated partner tag results in search documents.
  - Improved handling of search records without an associated tenant.

- **Tests**
  - Updated partner search backfill, document serialization, and synchronization coverage to reflect the current enrollment data structure.
  - Added coverage for enrollment records without a tenant and simplified partner tag data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
