### PR TITLE
Hide tag-scoped bounties from group landers

### DIFF
--- a/apps/web/lib/bounty/api/get-group-bounty-summaries.ts
+++ b/apps/web/lib/bounty/api/get-group-bounty-summaries.ts
@@ -9,6 +9,7 @@ type BountyEligibilityCandidate = {
   endsAt: Date | null;
   archivedAt: Date | null;
   groups: { groupId: string }[];
+  partnerTags: { partnerTagId: string }[];
 };
 
 export function filterActiveGroupBounties(
@@ -31,6 +32,10 @@ export function filterActiveGroupBounties(
     }
 
     if (bounty.endsAt && bounty.endsAt <= now) {
+      return false;
+    }
+
+    if (bounty.partnerTags.length > 0) {
       return false;
     }
 
@@ -64,6 +69,11 @@ export async function getGroupBountySummaries({
       groups: {
         select: {
           groupId: true,
+        },
+      },
+      partnerTags: {
+        select: {
+          partnerTagId: true,
         },
       },
     },

--- a/apps/web/tests/misc/filter-active-group-bounties.test.ts
+++ b/apps/web/tests/misc/filter-active-group-bounties.test.ts
@@ -16,6 +16,7 @@ function makeCandidate(
     endsAt: Date | null;
     archivedAt: Date | null;
     groups: { groupId: string }[];
+    partnerTags: { partnerTagId: string }[];
   }> = {},
 ) {
   return {
@@ -26,6 +27,7 @@ function makeCandidate(
     endsAt: null,
     archivedAt: null,
     groups: [],
+    partnerTags: [],
     ...overrides,
   };
 }
@@ -150,5 +152,52 @@ describe("filterActiveGroupBounties", () => {
       now: NOW,
     });
     expect(result.map((b) => b.id)).toEqual(["bnty_4", "bnty_5"]);
+  });
+
+  it("excludes tag-scoped bounties with no groups", () => {
+    const bounty = makeCandidate({
+      partnerTags: [{ partnerTagId: "ptag_1" }],
+    });
+    const result = filterActiveGroupBounties([bounty], {
+      groupId: GROUP_ID,
+      now: NOW,
+    });
+    expect(result).toHaveLength(0);
+  });
+
+  it("excludes tag-scoped bounties even when groups match", () => {
+    const bounty = makeCandidate({
+      groups: [{ groupId: GROUP_ID }],
+      partnerTags: [{ partnerTagId: "ptag_1" }],
+    });
+    const result = filterActiveGroupBounties([bounty], {
+      groupId: GROUP_ID,
+      now: NOW,
+    });
+    expect(result).toHaveLength(0);
+  });
+
+  it("includes group-scoped bounties with empty partnerTags", () => {
+    const bounty = makeCandidate({
+      groups: [{ groupId: GROUP_ID }],
+      partnerTags: [],
+    });
+    const result = filterActiveGroupBounties([bounty], {
+      groupId: GROUP_ID,
+      now: NOW,
+    });
+    expect(result).toHaveLength(1);
+  });
+
+  it("includes global bounties with empty partnerTags", () => {
+    const bounty = makeCandidate({
+      groups: [],
+      partnerTags: [],
+    });
+    const result = filterActiveGroupBounties([bounty], {
+      groupId: GROUP_ID,
+      now: NOW,
+    });
+    expect(result).toHaveLength(1);
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Group bounty listings now exclude bounties associated with partner tags.
  * Eligible untagged bounties continue to appear correctly, including global and group-specific bounties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->