### PR TITLE
Feature/partner-search: read a partner fan-out page in one query

### DIFF
--- a/apps/web/lib/api/partners/search/sync.ts
+++ b/apps/web/lib/api/partners/search/sync.ts
@@ -91,7 +91,7 @@ export interface SyncPartnersResult {
  * Upserts only. The rows come from the database, so there is nothing to
  * delete.
  */
-export async function syncPartnerSearchDocumentsForPartners({
+export async function syncPartnerEnrollments({
   partnerIds,
   programId,
   after,

--- a/apps/web/lib/api/partners/search/sync.ts
+++ b/apps/web/lib/api/partners/search/sync.ts
@@ -69,31 +69,39 @@ export async function syncPartnerSearchDocuments({
   };
 }
 
-interface FindPartnerSearchSyncEnrollmentIdsOptions {
+interface SyncPartnerSearchDocumentsForPartnersOptions {
   partnerIds: string[];
   programId?: string;
   after?: string;
   take?: number;
+  searchProvider?: PartnerSearchProvider | null;
+}
+
+export interface PartnerSearchPartnerSyncResult {
+  upserted: number;
+  lastEnrollmentId: string | null;
 }
 
 /**
- * One page of enrollment IDs for the given partners, for changes that fan out
+ * One page of documents for the given partners, for changes that fan out
  * beyond a single enrollment: a profile or platform edit touches every program
- * the partner is in.
+ * the partner is in. Paged because that fan-out is unbounded. `programId`
+ * narrows it to one enrollment per partner.
  *
- * Paged because that fan-out is unbounded. `programId` narrows it to one
- * enrollment per partner.
+ * Upserts only. The rows come from the database, so there is nothing to
+ * delete.
  */
-export async function findPartnerSearchSyncEnrollmentIds({
+export async function syncPartnerSearchDocumentsForPartners({
   partnerIds,
   programId,
   after,
   take = PARTNER_SEARCH_SYNC_BATCH_SIZE,
-}: FindPartnerSearchSyncEnrollmentIdsOptions): Promise<string[]> {
+  searchProvider = getPartnerSearchProvider(),
+}: SyncPartnerSearchDocumentsForPartnersOptions): Promise<PartnerSearchPartnerSyncResult> {
   const ids = unique(partnerIds.filter(Boolean));
 
-  if (ids.length === 0) {
-    return [];
+  if (!searchProvider || ids.length === 0) {
+    return { upserted: 0, lastEnrollmentId: null };
   }
 
   const enrollments = await prisma.programEnrollment.findMany({
@@ -104,14 +112,21 @@ export async function findPartnerSearchSyncEnrollmentIds({
       ...(programId && { programId }),
       ...(after && { id: { gt: after } }),
     },
-    select: {
-      id: true,
-    },
+    select: partnerSearchDocumentSelect,
     orderBy: {
       id: "asc",
     },
     take,
   });
 
-  return enrollments.map(({ id }) => id);
+  if (enrollments.length > 0) {
+    await searchProvider.upsert(
+      enrollments.map(serializePartnerSearchDocument),
+    );
+  }
+
+  return {
+    upserted: enrollments.length,
+    lastEnrollmentId: enrollments.at(-1)?.id ?? null,
+  };
 }

--- a/apps/web/lib/api/partners/search/sync.ts
+++ b/apps/web/lib/api/partners/search/sync.ts
@@ -69,7 +69,7 @@ export async function syncPartnerSearchDocuments({
   };
 }
 
-interface SyncPartnerSearchDocumentsForPartnersOptions {
+interface SyncPartnersOptions {
   partnerIds: string[];
   programId?: string;
   after?: string;
@@ -77,7 +77,7 @@ interface SyncPartnerSearchDocumentsForPartnersOptions {
   searchProvider?: PartnerSearchProvider | null;
 }
 
-export interface PartnerSearchPartnerSyncResult {
+export interface SyncPartnersResult {
   upserted: number;
   lastEnrollmentId: string | null;
 }
@@ -97,7 +97,7 @@ export async function syncPartnerSearchDocumentsForPartners({
   after,
   take = PARTNER_SEARCH_SYNC_BATCH_SIZE,
   searchProvider = getPartnerSearchProvider(),
-}: SyncPartnerSearchDocumentsForPartnersOptions): Promise<PartnerSearchPartnerSyncResult> {
+}: SyncPartnersOptions): Promise<SyncPartnersResult> {
   const ids = unique(partnerIds.filter(Boolean));
 
   if (!searchProvider || ids.length === 0) {

--- a/apps/web/lib/api/partners/search/sync.ts
+++ b/apps/web/lib/api/partners/search/sync.ts
@@ -88,8 +88,7 @@ export interface SyncPartnersResult {
  * the partner is in. Paged because that fan-out is unbounded. `programId`
  * narrows it to one enrollment per partner.
  *
- * Upserts only. The rows come from the database, so there is nothing to
- * delete.
+ * Upserts only. The rows come from the database, so there is nothing to delete.
  */
 export async function syncPartnerEnrollments({
   partnerIds,

--- a/apps/web/lib/jobs/handlers/partner-search-sync-job.ts
+++ b/apps/web/lib/jobs/handlers/partner-search-sync-job.ts
@@ -1,8 +1,8 @@
 import {
-  findPartnerSearchSyncEnrollmentIds,
   getPartnerSearchProvider,
   PARTNER_SEARCH_SYNC_BATCH_SIZE,
   syncPartnerSearchDocuments,
+  syncPartnerSearchDocumentsForPartners,
 } from "@/lib/api/partners/search";
 import * as z from "zod/v4";
 import { defineJob } from "../index";
@@ -74,31 +74,28 @@ export const partnerSearchSyncJob = defineJob({
       return;
     }
 
-    const enrollmentIds = await findPartnerSearchSyncEnrollmentIds({
-      partnerIds: input.partnerIds,
-      programId: input.programId,
-      after: input.after,
-      take: PARTNER_SEARCH_SYNC_BATCH_SIZE,
-    });
+    const { upserted, lastEnrollmentId } =
+      await syncPartnerSearchDocumentsForPartners({
+        partnerIds: input.partnerIds,
+        programId: input.programId,
+        after: input.after,
+        take: PARTNER_SEARCH_SYNC_BATCH_SIZE,
+        searchProvider,
+      });
 
-    if (enrollmentIds.length === 0) {
+    if (upserted === 0) {
       return;
     }
 
-    const { upserted, deleted } = await syncPartnerSearchDocuments({
-      enrollmentIds,
-      searchProvider,
-    });
-
     console.log(
-      `[partnerSearchSyncJob] Synced ${upserted} and removed ${deleted} enrollment documents for ${input.partnerIds.length} partner(s).`,
+      `[partnerSearchSyncJob] Synced ${upserted} enrollment documents for ${input.partnerIds.length} partner(s).`,
     );
 
-    if (enrollmentIds.length === PARTNER_SEARCH_SYNC_BATCH_SIZE) {
+    if (upserted === PARTNER_SEARCH_SYNC_BATCH_SIZE && lastEnrollmentId) {
       await partnerSearchSyncJob.dispatch(
         {
           ...input,
-          after: enrollmentIds[enrollmentIds.length - 1],
+          after: lastEnrollmentId,
         },
         {
           delay: 1,

--- a/apps/web/lib/jobs/handlers/partner-search-sync-job.ts
+++ b/apps/web/lib/jobs/handlers/partner-search-sync-job.ts
@@ -1,8 +1,8 @@
 import {
   getPartnerSearchProvider,
   PARTNER_SEARCH_SYNC_BATCH_SIZE,
+  syncPartnerEnrollments,
   syncPartnerSearchDocuments,
-  syncPartnerSearchDocumentsForPartners,
 } from "@/lib/api/partners/search";
 import * as z from "zod/v4";
 import { defineJob } from "../index";
@@ -74,14 +74,13 @@ export const partnerSearchSyncJob = defineJob({
       return;
     }
 
-    const { upserted, lastEnrollmentId } =
-      await syncPartnerSearchDocumentsForPartners({
-        partnerIds: input.partnerIds,
-        programId: input.programId,
-        after: input.after,
-        take: PARTNER_SEARCH_SYNC_BATCH_SIZE,
-        searchProvider,
-      });
+    const { upserted, lastEnrollmentId } = await syncPartnerEnrollments({
+      partnerIds: input.partnerIds,
+      programId: input.programId,
+      after: input.after,
+      take: PARTNER_SEARCH_SYNC_BATCH_SIZE,
+      searchProvider,
+    });
 
     if (upserted === 0) {
       return;

--- a/apps/web/tests/partners/partner-search-sync-job.test.ts
+++ b/apps/web/tests/partners/partner-search-sync-job.test.ts
@@ -7,14 +7,15 @@ const BATCH_SIZE = 3;
 const mocks = vi.hoisted(() => ({
   getPartnerSearchProvider: vi.fn(),
   syncPartnerSearchDocuments: vi.fn(),
-  findPartnerSearchSyncEnrollmentIds: vi.fn(),
+  syncPartnerSearchDocumentsForPartners: vi.fn(),
 }));
 
 vi.mock("@/lib/api/partners/search", () => ({
   PARTNER_SEARCH_SYNC_BATCH_SIZE: 3,
   getPartnerSearchProvider: mocks.getPartnerSearchProvider,
   syncPartnerSearchDocuments: mocks.syncPartnerSearchDocuments,
-  findPartnerSearchSyncEnrollmentIds: mocks.findPartnerSearchSyncEnrollmentIds,
+  syncPartnerSearchDocumentsForPartners:
+    mocks.syncPartnerSearchDocumentsForPartners,
 }));
 
 const searchProvider = { name: "turbopuffer" };
@@ -26,7 +27,9 @@ describe("partnerSearchSyncJob", () => {
     mocks.syncPartnerSearchDocuments
       .mockReset()
       .mockResolvedValue({ upserted: 0, deleted: 0 });
-    mocks.findPartnerSearchSyncEnrollmentIds.mockReset().mockResolvedValue([]);
+    mocks.syncPartnerSearchDocumentsForPartners
+      .mockReset()
+      .mockResolvedValue({ upserted: 0, lastEnrollmentId: null });
   });
 
   it("skips entirely when no provider is configured", async () => {
@@ -38,7 +41,7 @@ describe("partnerSearchSyncJob", () => {
     });
 
     expect(mocks.syncPartnerSearchDocuments).not.toHaveBeenCalled();
-    expect(mocks.findPartnerSearchSyncEnrollmentIds).not.toHaveBeenCalled();
+    expect(mocks.syncPartnerSearchDocumentsForPartners).not.toHaveBeenCalled();
   });
 
   it("syncs the enrollment ids it is given", async () => {
@@ -51,30 +54,28 @@ describe("partnerSearchSyncJob", () => {
       enrollmentIds: ["pge_1", "pge_2"],
       searchProvider,
     });
-    expect(mocks.findPartnerSearchSyncEnrollmentIds).not.toHaveBeenCalled();
+    expect(mocks.syncPartnerSearchDocumentsForPartners).not.toHaveBeenCalled();
   });
 
-  it("resolves a partner fan-out before syncing", async () => {
-    mocks.findPartnerSearchSyncEnrollmentIds.mockResolvedValue([
-      "pge_1",
-      "pge_2",
-    ]);
+  it("syncs a partner fan-out in one read", async () => {
+    mocks.syncPartnerSearchDocumentsForPartners.mockResolvedValue({
+      upserted: 2,
+      lastEnrollmentId: "pge_2",
+    });
 
     await partnerSearchSyncJob.execute({
       type: "partners",
       partnerIds: ["pn_1"],
     });
 
-    expect(mocks.findPartnerSearchSyncEnrollmentIds).toHaveBeenCalledWith({
+    expect(mocks.syncPartnerSearchDocumentsForPartners).toHaveBeenCalledWith({
       partnerIds: ["pn_1"],
       programId: undefined,
       after: undefined,
       take: BATCH_SIZE,
-    });
-    expect(mocks.syncPartnerSearchDocuments).toHaveBeenCalledWith({
-      enrollmentIds: ["pge_1", "pge_2"],
       searchProvider,
     });
+    expect(mocks.syncPartnerSearchDocuments).not.toHaveBeenCalled();
   });
 
   it("continues from the last enrollment when a page comes back full", async () => {
@@ -82,11 +83,10 @@ describe("partnerSearchSyncJob", () => {
       .spyOn(partnerSearchSyncJob, "dispatch")
       .mockResolvedValue({ status: "published", messageId: "msg_1" });
 
-    mocks.findPartnerSearchSyncEnrollmentIds.mockResolvedValue([
-      "pge_1",
-      "pge_2",
-      "pge_3",
-    ]);
+    mocks.syncPartnerSearchDocumentsForPartners.mockResolvedValue({
+      upserted: BATCH_SIZE,
+      lastEnrollmentId: "pge_3",
+    });
 
     await partnerSearchSyncJob.execute({
       type: "partners",
@@ -110,10 +110,10 @@ describe("partnerSearchSyncJob", () => {
       .spyOn(partnerSearchSyncJob, "dispatch")
       .mockResolvedValue({ status: "published", messageId: "msg_1" });
 
-    mocks.findPartnerSearchSyncEnrollmentIds.mockResolvedValue([
-      "pge_1",
-      "pge_2",
-    ]);
+    mocks.syncPartnerSearchDocumentsForPartners.mockResolvedValue({
+      upserted: 2,
+      lastEnrollmentId: "pge_2",
+    });
 
     await partnerSearchSyncJob.execute({
       type: "partners",
@@ -128,14 +128,16 @@ describe("partnerSearchSyncJob", () => {
       .spyOn(partnerSearchSyncJob, "dispatch")
       .mockResolvedValue({ status: "published", messageId: "msg_1" });
 
-    mocks.findPartnerSearchSyncEnrollmentIds.mockResolvedValue([]);
+    mocks.syncPartnerSearchDocumentsForPartners.mockResolvedValue({
+      upserted: 0,
+      lastEnrollmentId: null,
+    });
 
     await partnerSearchSyncJob.execute({
       type: "partners",
       partnerIds: ["pn_1"],
     });
 
-    expect(mocks.syncPartnerSearchDocuments).not.toHaveBeenCalled();
     expect(dispatch).not.toHaveBeenCalled();
   });
 

--- a/apps/web/tests/partners/partner-search-sync-job.test.ts
+++ b/apps/web/tests/partners/partner-search-sync-job.test.ts
@@ -7,15 +7,14 @@ const BATCH_SIZE = 3;
 const mocks = vi.hoisted(() => ({
   getPartnerSearchProvider: vi.fn(),
   syncPartnerSearchDocuments: vi.fn(),
-  syncPartnerSearchDocumentsForPartners: vi.fn(),
+  syncPartnerEnrollments: vi.fn(),
 }));
 
 vi.mock("@/lib/api/partners/search", () => ({
   PARTNER_SEARCH_SYNC_BATCH_SIZE: 3,
   getPartnerSearchProvider: mocks.getPartnerSearchProvider,
   syncPartnerSearchDocuments: mocks.syncPartnerSearchDocuments,
-  syncPartnerSearchDocumentsForPartners:
-    mocks.syncPartnerSearchDocumentsForPartners,
+  syncPartnerEnrollments: mocks.syncPartnerEnrollments,
 }));
 
 const searchProvider = { name: "turbopuffer" };
@@ -27,7 +26,7 @@ describe("partnerSearchSyncJob", () => {
     mocks.syncPartnerSearchDocuments
       .mockReset()
       .mockResolvedValue({ upserted: 0, deleted: 0 });
-    mocks.syncPartnerSearchDocumentsForPartners
+    mocks.syncPartnerEnrollments
       .mockReset()
       .mockResolvedValue({ upserted: 0, lastEnrollmentId: null });
   });
@@ -41,7 +40,7 @@ describe("partnerSearchSyncJob", () => {
     });
 
     expect(mocks.syncPartnerSearchDocuments).not.toHaveBeenCalled();
-    expect(mocks.syncPartnerSearchDocumentsForPartners).not.toHaveBeenCalled();
+    expect(mocks.syncPartnerEnrollments).not.toHaveBeenCalled();
   });
 
   it("syncs the enrollment ids it is given", async () => {
@@ -54,11 +53,11 @@ describe("partnerSearchSyncJob", () => {
       enrollmentIds: ["pge_1", "pge_2"],
       searchProvider,
     });
-    expect(mocks.syncPartnerSearchDocumentsForPartners).not.toHaveBeenCalled();
+    expect(mocks.syncPartnerEnrollments).not.toHaveBeenCalled();
   });
 
   it("syncs a partner fan-out in one read", async () => {
-    mocks.syncPartnerSearchDocumentsForPartners.mockResolvedValue({
+    mocks.syncPartnerEnrollments.mockResolvedValue({
       upserted: 2,
       lastEnrollmentId: "pge_2",
     });
@@ -68,7 +67,7 @@ describe("partnerSearchSyncJob", () => {
       partnerIds: ["pn_1"],
     });
 
-    expect(mocks.syncPartnerSearchDocumentsForPartners).toHaveBeenCalledWith({
+    expect(mocks.syncPartnerEnrollments).toHaveBeenCalledWith({
       partnerIds: ["pn_1"],
       programId: undefined,
       after: undefined,
@@ -83,7 +82,7 @@ describe("partnerSearchSyncJob", () => {
       .spyOn(partnerSearchSyncJob, "dispatch")
       .mockResolvedValue({ status: "published", messageId: "msg_1" });
 
-    mocks.syncPartnerSearchDocumentsForPartners.mockResolvedValue({
+    mocks.syncPartnerEnrollments.mockResolvedValue({
       upserted: BATCH_SIZE,
       lastEnrollmentId: "pge_3",
     });
@@ -110,7 +109,7 @@ describe("partnerSearchSyncJob", () => {
       .spyOn(partnerSearchSyncJob, "dispatch")
       .mockResolvedValue({ status: "published", messageId: "msg_1" });
 
-    mocks.syncPartnerSearchDocumentsForPartners.mockResolvedValue({
+    mocks.syncPartnerEnrollments.mockResolvedValue({
       upserted: 2,
       lastEnrollmentId: "pge_2",
     });
@@ -128,7 +127,7 @@ describe("partnerSearchSyncJob", () => {
       .spyOn(partnerSearchSyncJob, "dispatch")
       .mockResolvedValue({ status: "published", messageId: "msg_1" });
 
-    mocks.syncPartnerSearchDocumentsForPartners.mockResolvedValue({
+    mocks.syncPartnerEnrollments.mockResolvedValue({
       upserted: 0,
       lastEnrollmentId: null,
     });

--- a/apps/web/tests/partners/partner-search-sync.test.ts
+++ b/apps/web/tests/partners/partner-search-sync.test.ts
@@ -192,8 +192,10 @@ describe("syncPartnerEnrollments", () => {
 
     expect(result).toEqual({ upserted: 2, lastEnrollmentId: "pge_2" });
     expect(mocks.findMany).toHaveBeenCalledTimes(1);
+    expect(mocks.findMany.mock.calls[0][0].where).toEqual({
+      partnerId: { in: ["pn_1"] },
+    });
     expect(mocks.findMany.mock.calls[0][0]).toMatchObject({
-      where: { partnerId: { in: ["pn_1"] } },
       select: partnerSearchDocumentSelect,
       orderBy: { id: "asc" },
     });

--- a/apps/web/tests/partners/partner-search-sync.test.ts
+++ b/apps/web/tests/partners/partner-search-sync.test.ts
@@ -1,7 +1,7 @@
 import {
   partnerSearchDocumentSelect,
+  syncPartnerEnrollments,
   syncPartnerSearchDocuments,
-  syncPartnerSearchDocumentsForPartners,
   type PartnerSearchDocumentSource,
   type PartnerSearchProvider,
 } from "@/lib/api/partners/search";
@@ -173,7 +173,7 @@ describe("syncPartnerSearchDocuments", () => {
   });
 });
 
-describe("syncPartnerSearchDocumentsForPartners", () => {
+describe("syncPartnerEnrollments", () => {
   beforeEach(() => {
     mocks.findMany.mockReset();
   });
@@ -185,7 +185,7 @@ describe("syncPartnerSearchDocumentsForPartners", () => {
       createSource("pge_2"),
     ]);
 
-    const result = await syncPartnerSearchDocumentsForPartners({
+    const result = await syncPartnerEnrollments({
       partnerIds: ["pn_1"],
       searchProvider,
     });
@@ -207,7 +207,7 @@ describe("syncPartnerSearchDocumentsForPartners", () => {
     const searchProvider = createProvider();
     mocks.findMany.mockResolvedValueOnce([createSource("pge_1")]);
 
-    await syncPartnerSearchDocumentsForPartners({
+    await syncPartnerEnrollments({
       partnerIds: ["pn_1"],
       programId: "prog_test",
       searchProvider,
@@ -223,7 +223,7 @@ describe("syncPartnerSearchDocumentsForPartners", () => {
     const searchProvider = createProvider();
     mocks.findMany.mockResolvedValueOnce([createSource("pge_3")]);
 
-    await syncPartnerSearchDocumentsForPartners({
+    await syncPartnerEnrollments({
       partnerIds: ["pn_1"],
       after: "pge_2",
       take: 2,
@@ -242,7 +242,7 @@ describe("syncPartnerSearchDocumentsForPartners", () => {
     const searchProvider = createProvider();
     mocks.findMany.mockResolvedValueOnce([]);
 
-    const result = await syncPartnerSearchDocumentsForPartners({
+    const result = await syncPartnerEnrollments({
       partnerIds: ["pn_1"],
       searchProvider,
     });
@@ -254,7 +254,7 @@ describe("syncPartnerSearchDocumentsForPartners", () => {
   it("does not query when there are no partners", async () => {
     const searchProvider = createProvider();
 
-    const result = await syncPartnerSearchDocumentsForPartners({
+    const result = await syncPartnerEnrollments({
       partnerIds: [],
       searchProvider,
     });

--- a/apps/web/tests/partners/partner-search-sync.test.ts
+++ b/apps/web/tests/partners/partner-search-sync.test.ts
@@ -1,6 +1,7 @@
 import {
-  findPartnerSearchSyncEnrollmentIds,
+  partnerSearchDocumentSelect,
   syncPartnerSearchDocuments,
+  syncPartnerSearchDocumentsForPartners,
   type PartnerSearchDocumentSource,
   type PartnerSearchProvider,
 } from "@/lib/api/partners/search";
@@ -172,31 +173,44 @@ describe("syncPartnerSearchDocuments", () => {
   });
 });
 
-describe("findPartnerSearchSyncEnrollmentIds", () => {
+describe("syncPartnerSearchDocumentsForPartners", () => {
   beforeEach(() => {
     mocks.findMany.mockReset();
   });
 
-  it("resolves every enrollment a partner has when no program is given", async () => {
-    mocks.findMany.mockResolvedValueOnce([{ id: "pge_1" }, { id: "pge_2" }]);
+  it("reads and upserts one page of documents in a single query", async () => {
+    const searchProvider = createProvider();
+    mocks.findMany.mockResolvedValueOnce([
+      createSource("pge_1"),
+      createSource("pge_2"),
+    ]);
 
-    const ids = await findPartnerSearchSyncEnrollmentIds({
+    const result = await syncPartnerSearchDocumentsForPartners({
       partnerIds: ["pn_1"],
+      searchProvider,
     });
 
-    expect(ids).toEqual(["pge_1", "pge_2"]);
-
-    const { where, orderBy } = mocks.findMany.mock.calls[0][0];
-    expect(where).toEqual({ partnerId: { in: ["pn_1"] } });
-    expect(orderBy).toEqual({ id: "asc" });
+    expect(result).toEqual({ upserted: 2, lastEnrollmentId: "pge_2" });
+    expect(mocks.findMany).toHaveBeenCalledTimes(1);
+    expect(mocks.findMany.mock.calls[0][0]).toMatchObject({
+      where: { partnerId: { in: ["pn_1"] } },
+      select: partnerSearchDocumentSelect,
+      orderBy: { id: "asc" },
+    });
+    expect(
+      vi.mocked(searchProvider.upsert).mock.calls[0][0].map(({ id }) => id),
+    ).toEqual(["pge_1", "pge_2"]);
+    expect(searchProvider.delete).not.toHaveBeenCalled();
   });
 
   it("narrows to a single program when one is given", async () => {
-    mocks.findMany.mockResolvedValueOnce([{ id: "pge_1" }]);
+    const searchProvider = createProvider();
+    mocks.findMany.mockResolvedValueOnce([createSource("pge_1")]);
 
-    await findPartnerSearchSyncEnrollmentIds({
+    await syncPartnerSearchDocumentsForPartners({
       partnerIds: ["pn_1"],
       programId: "prog_test",
+      searchProvider,
     });
 
     expect(mocks.findMany.mock.calls[0][0].where).toEqual({
@@ -206,12 +220,14 @@ describe("findPartnerSearchSyncEnrollmentIds", () => {
   });
 
   it("pages past the cursor so a large fan-out can resume", async () => {
-    mocks.findMany.mockResolvedValueOnce([{ id: "pge_3" }]);
+    const searchProvider = createProvider();
+    mocks.findMany.mockResolvedValueOnce([createSource("pge_3")]);
 
-    await findPartnerSearchSyncEnrollmentIds({
+    await syncPartnerSearchDocumentsForPartners({
       partnerIds: ["pn_1"],
       after: "pge_2",
       take: 2,
+      searchProvider,
     });
 
     const { where, take } = mocks.findMany.mock.calls[0][0];
@@ -222,10 +238,28 @@ describe("findPartnerSearchSyncEnrollmentIds", () => {
     expect(take).toBe(2);
   });
 
-  it("does not query when there are no partners", async () => {
-    const ids = await findPartnerSearchSyncEnrollmentIds({ partnerIds: [] });
+  it("does not write when the page is empty", async () => {
+    const searchProvider = createProvider();
+    mocks.findMany.mockResolvedValueOnce([]);
 
-    expect(ids).toEqual([]);
+    const result = await syncPartnerSearchDocumentsForPartners({
+      partnerIds: ["pn_1"],
+      searchProvider,
+    });
+
+    expect(result).toEqual({ upserted: 0, lastEnrollmentId: null });
+    expect(searchProvider.upsert).not.toHaveBeenCalled();
+  });
+
+  it("does not query when there are no partners", async () => {
+    const searchProvider = createProvider();
+
+    const result = await syncPartnerSearchDocumentsForPartners({
+      partnerIds: [],
+      searchProvider,
+    });
+
+    expect(result).toEqual({ upserted: 0, lastEnrollmentId: null });
     expect(mocks.findMany).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Partner sync previously read a page of enrollment IDs, then loaded those enrollments again to build the search documents. This change loads the document data in the first read and removes the separate ID lookup. Pagination and index writes remain unchanged. Sync by explicit enrollment IDs still removes index documents for missing enrollments.

## Test plan

- [x] `partner-search-sync`: single read with the document select, program narrowing, cursor paging, empty page, no partners.
- [x] `partner-search-sync-job`: fan-out calls the new function once, continues on a full page, stops on a short or empty page.
- [x] `queue-partner-search-sync` unchanged and passing. 37 tests across the three files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Improvements

- Partner search synchronization now reads enrollment records and updates the search index in a single operation.
- Sync results report records processed and provide reliable continuation information for large batches.
- Empty partner lists or unavailable search services exit cleanly without unnecessary processing.

## Bug Fixes

- Improved pagination to prevent records from being missed or processed repeatedly during multi-batch synchronization.
- Partner search records are updated consistently as enrollment data is synchronized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->