### PR TITLE
Feature/partner-search: trim the list hydration queries

### DIFF
--- a/apps/web/lib/api/partners/get-partners.ts
+++ b/apps/web/lib/api/partners/get-partners.ts
@@ -73,8 +73,7 @@ export async function getPartners(
       },
     },
     programPartnerTags: {
-      // A deleted tag keeps its associations until the cleanup job removes
-      // them, and is recognizable only by its null programId
+      // Deleted tags have a null programId until background cleanup removes their associations.
       where: {
         partnerTag: {
           programId,

--- a/apps/web/lib/api/partners/get-partners.ts
+++ b/apps/web/lib/api/partners/get-partners.ts
@@ -73,6 +73,13 @@ export async function getPartners(
       },
     },
     programPartnerTags: {
+      // A deleted tag keeps its associations until the cleanup job removes
+      // them, and is recognizable only by its null programId
+      where: {
+        partnerTag: {
+          programId,
+        },
+      },
       include: {
         partnerTag: true,
       },

--- a/apps/web/lib/api/partners/get-partners.ts
+++ b/apps/web/lib/api/partners/get-partners.ts
@@ -107,8 +107,6 @@ export async function getPartners(
       .slice((page - 1) * pageSize, page * pageSize)
       .map(({ id }) => id);
 
-    // The IDs already passed every filter above. The program scope stays as a
-    // guard, the partner joins do not need to run again.
     const pageEnrollments =
       pageIds.length > 0
         ? await prisma.programEnrollment.findMany({

--- a/apps/web/lib/api/partners/get-partners.ts
+++ b/apps/web/lib/api/partners/get-partners.ts
@@ -69,15 +69,12 @@ export async function getPartners(
   const include = {
     partner: {
       include: {
-        programPartnerTags: {
-          where: {
-            programId,
-          },
-          include: {
-            partnerTag: true,
-          },
-        },
         platforms: true,
+      },
+    },
+    programPartnerTags: {
+      include: {
+        partnerTag: true,
       },
     },
     links: true,
@@ -110,11 +107,13 @@ export async function getPartners(
       .slice((page - 1) * pageSize, page * pageSize)
       .map(({ id }) => id);
 
+    // The IDs already passed every filter above. The program scope stays as a
+    // guard, the partner joins do not need to run again.
     const pageEnrollments =
       pageIds.length > 0
         ? await prisma.programEnrollment.findMany({
             where: {
-              ...candidateWhere,
+              programId,
               id: { in: pageIds },
             },
             include,
@@ -135,15 +134,19 @@ export async function getPartners(
   }
 
   return partners.map(
-    ({ partner, links, partnerGroup, ...programEnrollment }) => ({
+    ({
+      partner,
+      links,
+      partnerGroup,
+      programPartnerTags,
+      ...programEnrollment
+    }) => ({
       ...partner,
       ...programEnrollment,
       id: partner.id,
       createdAt: new Date(programEnrollment.createdAt),
       ...(includeGroup && { group: partnerGroup }),
-      tags: partner.programPartnerTags
-        .map(({ partnerTag }) => partnerTag)
-        .filter((t) => t.programId != null && t.programId === programId),
+      tags: programPartnerTags.map(({ partnerTag }) => partnerTag),
       links,
       netRevenue:
         toCentsNumber(programEnrollment.totalSaleAmount ?? 0) -

--- a/apps/web/tests/partners/get-partners-search.test.ts
+++ b/apps/web/tests/partners/get-partners-search.test.ts
@@ -30,10 +30,10 @@ function enrollment(id: string, partnerId: string) {
     totalCommissions: BigInt(0),
     partner: {
       id: partnerId,
-      programPartnerTags: [],
       platforms: [],
     },
     links: [],
+    programPartnerTags: [],
   };
 }
 

--- a/apps/web/tests/partners/get-partners-search.test.ts
+++ b/apps/web/tests/partners/get-partners-search.test.ts
@@ -76,6 +76,29 @@ describe("getPartners search", () => {
     );
   });
 
+  it("hydrates only tags that still belong to the program", async () => {
+    // Deleting a tag nulls its programId first and removes the associations
+    // in a later job, so the relation must filter on the tag, not the link.
+    mocks.findMany.mockResolvedValue([enrollment("pge_1", "pn_1")]);
+
+    await getPartners(
+      {
+        programId: "prog_test",
+        page: 1,
+        pageSize: 25,
+        sortBy: "totalSaleAmount",
+        sortOrder: "desc",
+      },
+      { searchProvider: null },
+    );
+
+    const { include } = mocks.findMany.mock.calls.at(-1)![0];
+    expect(include.programPartnerTags).toEqual({
+      where: { partnerTag: { programId: "prog_test" } },
+      include: { partnerTag: true },
+    });
+  });
+
   it("keeps a tenant filter on the database search path", async () => {
     // tenantId predates the search provider, so `tenantId` + `search` still
     // resolves entirely in the database rather than inheriting the candidate


### PR DESCRIPTION
## Summary

Two reads in `getPartners` did more work than needed.

- Tags were read through `partner.programPartnerTags` and filtered by program twice: once on the association in the query, once on the tag in memory. The enrollment has its own `programPartnerTags` relation, so the include moves there and the association filter goes, as #4484 did for the search document. The tag filter stays, now inside the relation query. It matters: deleting a tag nulls `PartnerTag.programId` first, and the associations are removed later by a job.
- On the relevance path the page query repeated every filter on IDs the first query had already matched. It now carries the program scope and the page IDs only.

## Test plan

- [x] `get-partners-search` and `get-partners-count-search`, 23 tests. New test asserts the relation filters on `partnerTag.programId`.
- [x] Typecheck clean on the touched files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved partner search accuracy by limiting results to the selected program and relevant pages.
  - Partner search results now display associated partner tags consistently.
  - Tags no longer appear when their program association has been removed.
  - Partner platform information remains available alongside partner details.
- **Tests**
  - Updated search-related test coverage to reflect corrected partner data and tag filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


