### PR TITLE
Handle Resend partially_verified email domain status

### DIFF
--- a/apps/web/app/(ee)/api/cron/email-domains/verify/route.ts
+++ b/apps/web/app/(ee)/api/cron/email-domains/verify/route.ts
@@ -98,7 +98,8 @@ async function verifyEmailDomain(domain: EmailDomain) {
   const subject =
     updatedDomain.status === "verified"
       ? "Your email domain has been verified"
-      : updatedDomain.status === "failed"
+      : updatedDomain.status === "failed" ||
+          updatedDomain.status === "partially_failed"
         ? "Your email domain verification has failed"
         : "Your email domain status has changed";
 

--- a/apps/web/app/(ee)/api/cron/email-domains/verify/route.ts
+++ b/apps/web/app/(ee)/api/cron/email-domains/verify/route.ts
@@ -4,10 +4,17 @@ import { prisma } from "@/lib/prisma";
 import { sendBatchEmail } from "@dub/email";
 import { resend } from "@dub/email/resend/client";
 import EmailDomainStatusChanged from "@dub/email/templates/email-domain-status-changed";
-import { EmailDomain } from "@prisma/client";
+import { EmailDomain, EmailDomainStatus } from "@prisma/client";
 import { logAndRespond } from "../../utils";
 
 export const dynamic = "force-dynamic";
+
+const EMAIL_DOMAIN_STATUS_SUBJECT: Partial<Record<EmailDomainStatus, string>> =
+  {
+    verified: "Your email domain has been verified",
+    failed: "Your email domain verification has failed",
+    partially_failed: "Your email domain verification has failed",
+  };
 
 // GET /api/cron/email-domains/verify
 // Runs every hour (0 * * * *)
@@ -96,12 +103,8 @@ async function verifyEmailDomain(domain: EmailDomain) {
   }
 
   const subject =
-    updatedDomain.status === "verified"
-      ? "Your email domain has been verified"
-      : updatedDomain.status === "failed" ||
-          updatedDomain.status === "partially_failed"
-        ? "Your email domain verification has failed"
-        : "Your email domain status has changed";
+    EMAIL_DOMAIN_STATUS_SUBJECT[updatedDomain.status] ??
+    "Your email domain status has changed";
 
   const resendResponse = await sendBatchEmail(
     users.map((user) => ({

--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/domains/email/constants.ts
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/settings/domains/email/constants.ts
@@ -7,4 +7,6 @@ export const EMAIL_DOMAIN_STATUS_TO_VARIANT: Record<EmailDomainStatus, string> =
     pending: "pending",
     temporary_failure: "warning",
     not_started: "neutral",
+    partially_verified: "pending",
+    partially_failed: "warning",
   } as const;

--- a/apps/web/prisma/schema/domain.prisma
+++ b/apps/web/prisma/schema/domain.prisma
@@ -66,6 +66,9 @@ enum EmailDomainStatus {
   failed
   temporary_failure
   not_started
+  // Resend aggregate statuses when send/receive (or dual sending CNAMEs) diverge
+  partially_verified
+  partially_failed
 }
 
 model EmailDomain {

--- a/packages/email/src/templates/email-domain-status-changed.tsx
+++ b/packages/email/src/templates/email-domain-status-changed.tsx
@@ -19,7 +19,9 @@ export type EmailDomainStatus =
   | "verified"
   | "failed"
   | "temporary_failure"
-  | "not_started";
+  | "not_started"
+  | "partially_verified"
+  | "partially_failed";
 
 export default function EmailDomainStatusChanged({
   email = "panic@thedis.co",
@@ -35,8 +37,14 @@ export default function EmailDomainStatusChanged({
   newStatus: EmailDomainStatus;
 }) {
   const isVerified = newStatus === "verified";
-  const isFailed = newStatus === "failed" || newStatus === "temporary_failure";
-  const isPending = newStatus === "pending" || newStatus === "not_started";
+  const isFailed =
+    newStatus === "failed" ||
+    newStatus === "temporary_failure" ||
+    newStatus === "partially_failed";
+  const isPending =
+    newStatus === "pending" ||
+    newStatus === "not_started" ||
+    newStatus === "partially_verified";
 
   const heading = isVerified
     ? "Your email domain has been successfully verified"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Resend started returning `partially_verified` (and documents `partially_failed`) as aggregate email domain statuses. Our Prisma `EmailDomainStatus` enum didn't include them, so `prisma.emailDomain.update()` in `/api/email-domains/[domain]/verify` threw `PrismaClientValidationError`.

## Changes
- Add `partially_verified` and `partially_failed` to `EmailDomainStatus`
- Map badge variants for the new statuses in the email domains UI
- Update status-change email copy / cron subject handling for the new values

## Deploy note
PlanetScale needs the new enum values via `prisma db push` (or equivalent) before these statuses can be persisted in production.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://dub.slack.com/archives/C07H0T3SX97/p1789099088022139?thread_ts=1789099088.022139&cid=C07H0T3SX97)

<div><a href="https://cursor.com/agents/bc-ddd42a47-cdad-562a-8729-995b449dc71d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ddd42a47-cdad-562a-8729-995b449dc71d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for partially verified and partially failed email domain statuses.
  - Domain settings now display these statuses with appropriate pending or warning indicators.
  - Email notifications now accurately reflect partial verification and failure outcomes.

- **Bug Fixes**
  - Improved email domain status notifications so partially failed configurations are treated as failures and partially verified configurations as pending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->