### PR TITLE
Removing the extra "is"

### DIFF
--- a/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/bounties/add-edit-bounty/bounty-logic.tsx
+++ b/apps/web/app/app.dub.co/(dashboard)/[slug]/(ee)/program/bounties/add-edit-bounty/bounty-logic.tsx
@@ -123,7 +123,7 @@ export function BountyLogic({ className }: { className?: string }) {
         {attribute && (
           <>
             {" "}
-            is {AWARD_BOUNTY_OPERATORS.gte.label}{" "}
+            {AWARD_BOUNTY_OPERATORS.gte.label}{" "}
             <InlineBadgePopover
               text={
                 value


### PR DESCRIPTION
<img width="1290" height="620" alt="CleanShot 2026-09-11 at 4 11 35 PM@2x" src="https://github.com/user-attachments/assets/ec5d0924-0506-40e2-bdc4-2f974ca82c05" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated bounty condition text to display comparison operators more naturally, such as “greater than” instead of “is greater than.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->