### PR TITLE
Add `partner.usersLimit` field

### DIFF
--- a/apps/web/app/(ee)/api/partner-profile/invites/route.ts
+++ b/apps/web/app/(ee)/api/partner-profile/invites/route.ts
@@ -2,10 +2,7 @@ import { DubApiError } from "@/lib/api/errors";
 import { invitePartnerUser } from "@/lib/api/partners/invite-partner-user";
 import { parseRequestBody } from "@/lib/api/utils";
 import { withPartnerProfile } from "@/lib/auth/partner";
-import {
-  MAX_INVITES_PER_REQUEST,
-  MAX_PARTNER_USERS,
-} from "@/lib/constants/partner-profile";
+import { MAX_INVITES_PER_REQUEST } from "@/lib/constants/partner-profile";
 import { prisma } from "@/lib/prisma";
 import { assertRateLimit } from "@/lib/upstash/assert-rate-limit";
 import { RATELIMIT_POLICIES } from "@/lib/upstash/ratelimit-policies";
@@ -132,11 +129,11 @@ export const POST = withPartnerProfile(
 
     if (
       partnerInvitesCount + partnerUsersCount + invites.length >
-      MAX_PARTNER_USERS
+      partner.usersLimit
     ) {
       throw new DubApiError({
         code: "exceeded_limit",
-        message: `You can only have ${MAX_PARTNER_USERS} members in this partner profile.`,
+        message: `You can only have ${partner.usersLimit} members in this partner profile.`,
       });
     }
 

--- a/apps/web/lib/constants/partner-profile.ts
+++ b/apps/web/lib/constants/partner-profile.ts
@@ -1,7 +1,6 @@
 import { ACME_PROGRAM_ID, DEMO_PROGRAM_ID } from "@dub/utils";
 
 export const MAX_INVITES_PER_REQUEST = 5;
-export const MAX_PARTNER_USERS = 10;
 export const MAX_PARTNER_LINKS_FOR_LOCAL_FILTERING = 100; // if over 100 links we should filter on TB directly
 
 export const LARGE_PROGRAM_IDS = ["prog_1K0QHV7MP3PR05CJSCF5VN93X"];

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -516,6 +516,7 @@ export type PartnerSharedPlatformProps = z.infer<
 export type PartnerProps = z.infer<typeof PartnerSchema> & {
   role: PartnerRole;
   userId: string;
+  usersLimit: number;
   platforms: PartnerPlatformProps[];
   defaultPayoutMethod: PartnerPayoutMethod | null;
   tremendousEmail: string | null;

--- a/apps/web/prisma/schema/partner.prisma
+++ b/apps/web/prisma/schema/partner.prisma
@@ -83,6 +83,7 @@ model Partner {
   invoiceSettings     Json?
   changeHistoryLog    Json?
   referredByPartnerId String?
+  usersLimit          Int @default(10)
 
   programs                   ProgramEnrollment[]
   users                      PartnerUser[]

--- a/apps/web/ui/layout/sidebar/partners-sidebar-nav.tsx
+++ b/apps/web/ui/layout/sidebar/partners-sidebar-nav.tsx
@@ -83,9 +83,9 @@ const NAV_GROUPS: SidebarNavGroups<SidebarNavData> = ({
     active: pathname.startsWith("/payouts"),
   },
   {
-    name: "Partner profile",
+    name: "Profile settings",
     description:
-      "Build a great partner profile and get noticed in our partner network.",
+      "Customize your profile, invite your team, and manage your notifications.",
     icon: SquareUserSparkle2,
     href: "/profile",
     active: pathname.startsWith("/profile"),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Partner profiles now support configurable team-member limits, with a default limit of 10 users.
  - Invitations respect each partner profile’s configured user limit and display that limit when capacity is reached.

- **Updates**
  - Renamed the “Partner profile” navigation section to “Profile settings.”
  - Updated the section description to highlight profile customization, team invitations, and notification management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->